### PR TITLE
OPL-update missing tables, update check_modules.

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -56,12 +56,12 @@ my %NPLtables = (
  path => 'NPL-path',
  pgfile => 'NPL-pgfile',
  keyword => 'NPL-keyword',
- pgfile-keyword => 'NPL-pgfile-keyword',
+ pgfile_keyword => 'NPL-pgfile-keyword',
  textbook => 'NPL-textbook',
  chapter => 'NPL-chapter',
  section => 'NPL-section',
  problem => 'NPL-problem',
- pgfile-problem => 'NPL-pgfile-problem',
+ pgfile_problem => 'NPL-pgfile-problem',
 );
 
 
@@ -97,19 +97,20 @@ sub dbug {
 
 ##Figure out which set of tables to use
 
+my %tables;
 if( -e "$libraryRoot/VERSION") {
   include("$libraryRoot/VERSION");
   if($OPL_VERSION eq '2.5.0') {
-	my %tables = %OPLtables;
+	%tables = %OPLtables;
 	my $lib = 'OPL';
 	print "Got OPLtables!\n";
   } else {
-	my %tables = %NPLtables;
+	%tables = %NPLtables;
 	my $lib = 'NPL';
 	print "Got NPLtables! (1)\n";
   }
-else {
-	my %tables = %NPLtables;
+} else {
+	%tables = %NPLtables;
 	my $lib = 'NPL';
 	print "Got NPLtables! (2)\n";
 }

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -61,9 +61,11 @@ my @modulesList = qw(
 	Getopt::Std
 	HTML::Entities
 	HTML::Tagset
+	HTML::Template
 	IO::File
 	Iterator
 	Iterator::Util
+	JSON
 	Locale::Maketext::Lexicon
 	Locale::Maketext::Simple
 	Mail::Sender

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -230,7 +230,7 @@ $problemDefaults{max_attempts} = -1;
 # These configurations can be placed in course.conf file to tune the behavior for individual courses
 # The items below can be used to override the settings in defaults.config
 # One can also use $showeditors{classlisteditor1}=0; to override
- %showeditors = (
+%showeditors = (
  	classlisteditor1   => 1,
 # 	classlisteditor2   => 1,
 #	classlisteditor3   => 1,
@@ -245,7 +245,7 @@ $problemDefaults{max_attempts} = -1;
     pgproblemeditor1   => 1,
 # 	pgproblemeditor2   => 1,
 # 	pgproblemeditor3   => 1,
-# );
+);
 
 ################################################################################
 # Directory for temporary files


### PR DESCRIPTION
OPL-update's backward compatibility feature with NPL couldn't find the
table names due to some typos and a %tables that went out of scope too
quickly.

Looks like there are now new Perl modules required. Added the
HTML::Template and JSON modules to check_modules.pl.

Also fixed typo in localOverrides.conf.dist which made %showeditors
problematic.
