### PR TITLE
Showing paths in hardcopies

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -974,6 +974,7 @@ sub write_problem_tex {
 	my $db = $r->db;
 	my $authz  = $r->authz;
 	my $userID = $r->param("user");
+	my $eUserID = $r->param("effectiveUser");
 	my $versioned = $self->{versioned};
 	my %canShowScore = %{$self->{canShowScore}};
 
@@ -1051,6 +1052,7 @@ sub write_problem_tex {
 			showSolutions   => $showSolutions      ? 1 : 0, # (or what? -sam)
 			processAnswers  => ($showCorrectAnswers || $printStudentAnswers) ? 1 : 0,
 			permissionLevel => $db->getPermissionLevel($userID)->permission,
+			effectivePermissionLevel => $db->getPermissionLevel($eUserID)->permission,
 		};
 
 	if ( $versioned && $MergedProblem->problem_id != 0 ) {


### PR DESCRIPTION
One of our professors complained that hardcopies in one course would show the PG path per problem and in another course they wouldn't.  The previous admin would set $pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} to a static list of the admin names in each course.  Not very happy with this, I tracked this down to this missing option in the hardcopy generation code.  With it added, professors get the file path added to each problem when they request a hardcopy.
