### PR TITLE
Develop

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -104,7 +104,7 @@ $webworkFiles{screenSnippets}{setHeader}         = "$webworkDirs{conf}/snippets/
 # because the names of the tables in the database have changed.
 #$problemLibrary{root}        = "/opt/webwork/libraries/NationalProblemLibrary";
 #$problemLibrary{version}     = "2";
-# uncomment these lines above and comment out the line below if using NPL instead of OPL
+# uncomment these lines above and comment out the two lines below if using NPL instead of OPL
 $problemLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
 $problemLibrary{version}    = "2.5";  
 


### PR DESCRIPTION
Fix up wording in comments.

Note, contrary to the comments, there is no actual difference to the user to setting the library version to 2.5 instead of 2.  It changes the names of the database tables internally, but it has no effect on the system (provided you run OPL-update after making a switch).
