### PR TITLE
Fixed broken disabled buttons

### DIFF
--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -5,6 +5,9 @@ $(function(){
     $('.nav_button').addClass('btn btn-primary');
     $('.classlist').addClass('table table-condensed classlist-table');
     
+    // Make grey_buttons disabled buttons
+    $('.gray_button').addClass('btn disabled').removeClass('gray_button');
+
     // replace pencil gifs by something prettier
     $('td a:has(img[src$="edit.gif"])').each(function () { $(this).html($(this).html().replace(/<img.*>/," <i class='icon-pencil'></i>")); });
 


### PR DESCRIPTION
The prev/next buttons on the problem.pm page didnt look right in math4 when they were supposed to be greyed out. 
