### PR TITLE
Fix security issue when using bypassShib in Shibboleth module

### DIFF
--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -119,7 +119,7 @@ sub get_credentials {
 sub site_checkPassword { 
 	my ( $self, $userID, $clearTextPassword ) = @_;
 
-	if ( $self->{r}->ce->{shiboff} ) {
+	if ( $self->{r}->ce->{shiboff}  || $self->{r}->param('bypassShib') ) {
 		return $self->SUPER::checkPassword( @_ );
 	} else {
 		# this is easy; if we're here at all, we've authenticated


### PR DESCRIPTION
It is possible in certain cases for anyone to who knows a valid user name to log in to webwork course without knowing a correct password.
