### PR TITLE
Past Answers and Gateways

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1293,6 +1293,7 @@ sub body {
 	my $urlpath = $r->urlpath;
 	my $user = $r->param('user');
 	my $effectiveUser = $r->param('effectiveUser');
+	my $courseID = $urlpath->arg("courseID");
 
 	# report everything with the same time that we started with
 	my $timeNow = $self->{timeNow};
@@ -1633,6 +1634,19 @@ sub body {
 						     "\t$timeNow\t",
 						     "$answerString"), 
 						);
+				#add to PastAnswer db
+				my $pastAnswer = $db->newPastAnswer();
+				$pastAnswer->course_id($courseID);
+				$pastAnswer->user_id($problems[$i]->user_id);
+				$pastAnswer->set_id($setVName);
+				$pastAnswer->problem_id($problems[$i]->problem_id);
+				$pastAnswer->timestamp($timeNow);
+				$pastAnswer->scores($scores);
+				$pastAnswer->answer_string($answerString);
+				$pastAnswer->source_file($problems[$i]->source_file);
+				
+				$db->addPastAnswer($pastAnswer);
+
 			}
 		}
 	}


### PR DESCRIPTION
Added code to make GatewayQuiz store answers in past_answer database.

Note:  This means that the Answer Log page can now be used with gateway quizzes.  This still has to be done "manually", i.e. there is no past answer button on the Gateway Quiz page. 
