### PR TITLE
Insure that display option radio buttons are listed in block form.

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -377,6 +377,7 @@ div.ScrollingRecordList select.ScrollingRecordList { width: 99%; }
 
 .viewOptions label {
     font-size:small;
+    display:block;
 }
 
 /* messages, attempt results, answer previews, etc. go in this DIV */


### PR DESCRIPTION
Geogebraweb calls  clean-css  from bootstrap which forces the radio buttons and labels into inline mode.
This makes the Display Options section ugly

Someone with more CSS knowledge might know of a cleaner way to do this.  What I've tried here
is to insist that in the math4 theme the labels inside the .optionView div are always blocks.
Since this is pretty specific selector it is likely that this css will be the one applied.
