### PR TITLE
Make datepicker optional (click on button to drop down datepicker)

### DIFF
--- a/lib/WeBWorK/Utils/DatePickerScripts.pm
+++ b/lib/WeBWorK/Utils/DatePickerScripts.pm
@@ -65,6 +65,8 @@ var update = function() {
 	answer_rule.addClass("changed");
 }
 open_rule.datetimepicker({
+              showOn: "button",
+      buttonText: "C",
 	ampm: true,
 	timeFormat: 'hh:mmtt',
 	timeSuffix: ' $open_timezone',
@@ -87,6 +89,8 @@ open_rule.datetimepicker({
     }*/
  });
 due_rule.datetimepicker({
+              showOn: "button",
+      buttonText: "C",
 	ampm: true,
 	timeFormat: 'hh:mmtt',
 	timeSuffix: ' $due_timezone',
@@ -108,6 +112,8 @@ due_rule.datetimepicker({
 });
 
 answer_rule.datetimepicker({
+              showOn: "button",
+      buttonText: "C",
 	ampm: true,
 	timeFormat: 'hh:mmtt',
 	timeSuffix: ' $answer_timezone',


### PR DESCRIPTION
Right now, it's impossible to just type a date; you must use the datepicker.  This makes the datepicker available via a click, but does not force you to use it.
