### PR TITLE
Set Import Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1846,6 +1846,8 @@ sub readSetDef {
 	
                 #####################################################################
                 # Gateway/version variable cleanup: convert times into seconds
+		$assignmentType ||= 'default';
+
 		$timeInterval = WeBWorK::Utils::timeToSec( $timeInterval )
 		    if ( $timeInterval );
 		$versionTimeLimit = WeBWorK::Utils::timeToSec($versionTimeLimit)

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1931,6 +1931,8 @@ sub readSetDef {
 	
                 #####################################################################
                 # Gateway/version variable cleanup: convert times into seconds
+		$assignmentType ||= 'default';
+
 		$timeInterval = WeBWorK::Utils::timeToSec( $timeInterval )
 		    if ( $timeInterval );
 		$versionTimeLimit = WeBWorK::Utils::timeToSec($versionTimeLimit)


### PR DESCRIPTION
When importing "regular" homework, the sets were having their assignment_type set to '' and not 'default'.

Note: This fixes a fairly severe bug with achievement items.  
