### PR TITLE
Check that course_info.txt file is inside the template directory before ...

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -49,7 +49,7 @@ sub info {
 	
 	if (defined $course_info and $course_info) {
 		my $course_info_path = $ce->{courseDirs}->{templates} . "/$course_info";
-		
+			
 		#print CGI::start_div({-class=>"info-wrapper"});
 		#print CGI::start_div({class=>"info-box", id=>"InfoPanel"});
 		
@@ -72,7 +72,7 @@ sub info {
 		} else {
 			print CGI::h2($r->maketext("Course Info"));
 		}
-		
+		die "course info path is unsafe!" unless path_is_subdir($course_info_path, $ce->{courseDirs}->{templates}, 1); 
 		if (-f $course_info_path) { #check that it's a plain  file
 			my $text = eval { readFile($course_info_path) };
 			if ($@) {


### PR DESCRIPTION
...serving contents.

Die if the file is not under the templates directory.  Other files
were carefully checked, this one was omitted by accident.

The sites.conf file is still not protected -- that code can read any file and the location can be changed in course.conf, overriding default.config.
A reasonable fix for this is to set the permissions for course.conf so that it cannot be edited using FileManager (i.e. not editable by the server). Editing
that file from the web is dangerous in any case.

The die command gives error information that includes the line where it is called and a stack trace.  We should be able to turn this off for production.
