### PR TITLE
More Apache 2.4

### DIFF
--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -158,8 +158,7 @@ if ($webwork_url eq "") {
          SetHandler perl-script
          PerlSetVar dispatch_to "WebworkSOAP"
          PerlSetVar options "compress_threshold => 10000"
-         Order Allow,Deny
-         Allow from All
+         Require all granted
  </Location>
 
 ####################################################################
@@ -170,8 +169,7 @@ if ($webwork_url eq "") {
          PerlSetVar options "compress_threshold => 10000"
          PerlHandler WebworkSOAP::WSDL
          SetHandler perl-script
-         Order Allow,Deny
-         Allow from All
+         Require all granted
  </Location>
 
 
@@ -189,8 +187,7 @@ PerlModule WebworkWebservice
 	PerlHandler Apache::XMLRPC::Lite
 	PerlSetVar dispatch_to "WebworkXMLRPC"
 	PerlSetVar options "compress_threshold => 10000"
-	Order Allow,Deny
-	Allow from All
+        Require all granted
 </Location>
 
 
@@ -204,8 +201,7 @@ PerlModule WebworkWebservice
 #	PerlHandler Apache::SOAP
 #	PerlSetVar dispatch_to "WebworkXMLRPC" 
 #	PerlSetVar options "compress_threshold => 10000"
-#	Order Allow,Deny
-#	Allow from All
+#       Require all granted
 #</Location>
 
 ####################################################################


### PR DESCRIPTION
So the graph of the previous pull looked like it worked. 

I am less sure about these changes, so I am going to leave them up for someone to verify/test.  

Basically Apache 2.4 doesnt use "Order Allow,Deny Allow from All" blocks anymore.  They have been replaced by Require all granted.  This is probably how its supposed to work with WebworkSOAP and WebworkWebservice but I either don't have those running or am unsure how to test them.
