### PR TITLE
Fixed shibboleth target URL to go to the course selected on login.

### DIFF
--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -99,7 +99,7 @@ sub get_credentials {
 		} else {
 			debug("Couldn't shib header or user_id");
 			my $q = new CGI;
-			my $go_to = $ce->{shibboleth}{login_script}."?target=".$q->url();
+			my $go_to = $ce->{shibboleth}{login_script}."?target=".$q->url().$r->urlpath->path;
 			$self->{redirect} = $go_to;
 			print $q->redirect($go_to);
 			return 0;


### PR DESCRIPTION
We are using shibboleth for our webwork installation at the University of Oregon and I found that the target URL in the shibboleth configuration is sending the user back to the root instead of the course they are trying to log into. I was able to fix it by figuring out the variable of the path and concatenating it to the the target URL.
