### PR TITLE
Reduce Scoring Date Fix

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -987,12 +987,12 @@ sub initialize {
 	my $error = 0;	
 	if (defined $r->param('submit_changes')) {
 		my @names = ("open_date", "due_date", "answer_date", "reduced_scoring_date");
-		
-		my %dates = map { $_ => $r->param("set.$setID.$_") } @names;
+
+		my %dates = map { $_ => $r->param("set.$setID.$_") || ''} @names;
 
 		%dates = map { 
 			my $unlabel = $undoLabels{$_}->{$dates{$_}}; 
-			$_ => defined $unlabel ? $setRecord->$_ : $self->parseDateTime($dates{$_}) 
+			$_ => (defined($unlabel) || !$dates{$_}) ? $setRecord->$_ : $self->parseDateTime($dates{$_}) 
 		} @names;
 
 		($open_date, $due_date, $answer_date, $reduced_scoring_date) = map { $dates{$_}||0 } @names;
@@ -1187,7 +1187,7 @@ sub initialize {
 				my $unlabel = $undoLabels{$field}->{$param};
 				$param = $unlabel if defined $unlabel;
 				if ($field =~ /_date/ ) {
-				    $param = $self->parseDateTime($param) unless defined $unlabel;
+				    $param = $self->parseDateTime($param) unless (defined $unlabel || !$param);
 				} 
 				if ($field =~ /restricted_release/) {
 				    $self->check_sets($db,$param) if $param;


### PR DESCRIPTION
Fixes a problem where you couldn't save anything on the set detail page if the reduced scoring feature was turned off.  Test by making sure you can save changes to the set detail page with the feature off (and on).  
