### PR TITLE
Don't log passwords

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -179,10 +179,19 @@ sub dispatch($) {
 	
 	debug("The raw params:\n");
 	foreach my $key ($r->param) {
-	        next if ($key eq 'passwd');
+	    #make it so we dont debug plain text passwords
+	    my $vals;	    
+	    if ($key eq 'passwd'||
+		$key eq 'confirmPassword' ||
+		$key eq 'currPassword' ||
+		$key eq 'newPassword' || 
+		$key =~ /\.new_password/) {
+		$vals = '**********';
+	    } else {
 		my @vals = $r->param($key);
-		my $vals = join(", ", map { "'$_'" } @vals);
-		debug("\t$key => $vals\n");
+		$vals = join(", ", map { "'$_'" } @vals);
+	    }
+	    debug("\t$key => $vals\n");
 	}
 	
 	#mungeParams($r);

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -408,7 +408,7 @@ sub get_credentials {
 		$self->{password} = $r->param("passwd");
 		$self->{login_type} = "normal";
 		$self->{credential_source} = "params";
-		debug("params user '", $self->{user_id}, "' password '", $self->{password}, "' key '", $self->{session_key}, "'");
+		debug("params user '", $self->{user_id}, "' key '", $self->{session_key}, "'");
 		return 1;
 	}
 	
@@ -610,7 +610,7 @@ sub set_params {
 	$r->param("key", $self->{session_key});
 	$r->param("passwd", "");
 	
-	debug("params user='", $r->param("user"), "' key='", $r->param("key"), "' passwd='", $r->param("passwd"), "'");
+	debug("params user='", $r->param("user"), "' key='", $r->param("key"), "'");
 }
 
 ################################################################################


### PR DESCRIPTION
Its a security risk for the debug module to print plain text passwords to the log file, and it doesn't help with debugging that much.  This keeps the passwords from being printed in all of the instances I could think of. 

(The debug log prints all parameters submitted to a page, so any page where you have a password as an explicit or hidden parameter should be addressed.) 

Test by running and making sure you cant find your password in the debug.log file after visiting any page you can think of that involves a password. 
