### PR TITLE
for admin course, changed Homework Sets menu name to Course Administrati...

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -703,7 +703,9 @@ sub links {
 	if (defined $courseID) {
 		if ($authen->was_verified) {
 			print CGI::start_li(); # Homework Sets
-			print &$makelink("${pfx}ProblemSets", text=>$r->maketext("Homework Sets"), urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
+                        my $primaryMenuName = "Homework Sets";
+                        $primaryMenuName = "Course Administration" if ($ce->{courseName} eq 'admin');
+			print &$makelink("${pfx}ProblemSets", text=>$r->maketext($primaryMenuName), urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
 			print CGI::end_li();
 			if (defined $setID) {
 			    print CGI::start_li();


### PR DESCRIPTION
...on

This pull request is mainly an experiment to see if I could get the git flow process working. 

With this, the admin course will have its menu start with 'Course Administration' rather than 'Homework Sets', which takes you to the Course Administration page. Is there a reason these two things are conflated in the first place? Why not leave 'Homework Sets' as it is, and then _if_ the course is the admin course, have an extra menu item to the Course Administration page?
