### PR TITLE
Undefined Set Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -448,11 +448,11 @@ sub pre_header_initialize {
 	# obtain the merged set for $effectiveUser
 	my $set = $db->getMergedSet($effectiveUserName, $setName); 
 
-	$self->{isOpen} = (($setName eq "Undefined_Set" || 
-			    time >= $set->open_date) && !(
-			   $ce->{options}{enableConditionalRelease} && 
-			   is_restricted($db, $set, $set->set_id, $effectiveUserName)))
-	    || $authz->hasPermissions($userName, "view_unopened_sets");
+	$self->{isOpen} = $authz->hasPermissions($userName, "view_unopened_sets") || 
+	    ($setName eq "Undefined_Set" || 
+	     (time >= $set->open_date && !(
+		  $ce->{options}{enableConditionalRelease} && 
+		  is_restricted($db, $set, $set->set_id, $effectiveUserName))));
 	
 	die("You do not have permission to view unopened sets") unless $self->{isOpen};	
 


### PR DESCRIPTION
One of my previous commits added a check to see if a set is open for Problem.pm but it broke the Undefined Set and viewing a problem from the library browser. This fixes that. 

Test by viewing a problem via the library browser.  
