### PR TITLE
Fix admin database

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -1010,6 +1010,13 @@ sub initNonNativeTables {
 	# Find the names of the non-native database tables 
 	foreach my $table (sort keys %$db) {
 	    next unless $db->{$table}{params}{non_native}; # only look at non-native tables
+	    # hack: these two tables are virtual and don't need to be created 
+	    # for the admin course or in the database in general
+	    # if they were created in earlier versions for the admin course 
+	    # you can use mysql to drop the field version_id manually
+	    # this will get rid of a spurious error
+	    next if $table eq 'problem_version' or $table eq 'set_version';
+	   
 	    my $database_table_name = (exists $db->{$table}->{params}->{tableOverride})? $db->{$table}->{params}->{tableOverride}:$table;
 	    #warn "table is $table";
 	    #warn "checking $database_table_name";
@@ -1038,7 +1045,7 @@ sub initNonNativeTables {
 		    if (!$database_field_exists) { 
 			$fields_ok = 0;
 			$fieldStatus{$field} =[ONLY_IN_A];
-			warn "$field from $database_table_name is only in schema, not in database, so adding it ... ";
+			warn "$field from $database_table_name (aka |$table|) is only in schema, not in database, so adding it ... ";
 			if ( $db->{$table}->can("add_column_field") ) {
 			    if ($db->{$table}->add_column_field($field_name)) {
 				warn "added column $field_name to table $database_table_name";


### PR DESCRIPTION
Fix extra version_id field in problem_user and set_user tables of admin.

This does not remove these fields from those tables but it prevents them from being created.

Here is the story.  Every time upgrade tables is run the admin course updates the non-native tables (the ones that are global to the site and not tied to a specific course).  The problem_version and set_version tables are virtual tables (and defined as non-native so that courses don't try to create them). The admin course however does create these tables and since they are aliased to problem_user and set_user these tables acquire an extra field that should not be there.

This adds a hack to the updates for admin course (defined in CourseManagement.pm) which specifically skips those two tables.  If more virtual tables are created this list will need to be added to.
