### PR TITLE
Reduced Credit Tweak

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -334,7 +334,8 @@ sub body {
 
 	my $enable_reduced_scoring =  $ce->{pg}{ansEvalDefaults}{enableReducedScoring} && $set->enable_reduced_scoring;
 	my $reduced_scoring_date = $set->reduced_scoring_date;
-	if ($reduced_scoring_date and $enable_reduced_scoring) {
+	if ($reduced_scoring_date and $enable_reduced_scoring
+	    and $reduced_scoring_date != $set->due_date) {
 		my $dueDate = $self->formatDateTime($set->due_date());
 		my $reducedScoringValue = $ce->{pg}->{ansEvalDefaults}->{reducedScoringValue};
 		my $reducedScoringPerCent = int(100*$reducedScoringValue+.5);

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -503,7 +503,8 @@ sub setListRow {
 			$status = $r->maketext("now open, due ") . $self->formatDateTime($set->due_date,undef,$ce->{studentDateDisplayFormat});
 			my $enable_reduced_scoring =  $ce->{pg}{ansEvalDefaults}{enableReducedScoring} && $set->enable_reduced_scoring;
 			my $reduced_scoring_date = $set->reduced_scoring_date;
-			if ($reduced_scoring_date and $enable_reduced_scoring) {
+			if ($reduced_scoring_date and $enable_reduced_scoring
+			    and $reduced_scoring_date != $set->due_date) {
 			    my $beginReducedScoringPeriod =  $self->formatDateTime($reduced_scoring_date);
 #				$status .= '. <FONT COLOR="#cc6600">Reduced Scoring starts ' . $beginReducedScoringPeriod . '</FONT>';
 			    $status .= CGI::div({-class=>"ResultsAlert"}, $r->maketext("Reduced Scoring Starts: [_1]", $beginReducedScoringPeriod));


### PR DESCRIPTION
A small tweak.  Now if the reduced credit date is the same as the due date the reduced credit messages do not appear.  The purpose of this is so that instructors can turn on reduced credit, set the reduced credit date to be the due date, and then extend the due date individually for specific users to allow them a later due date with reduced credit.  (You could always do this, but this prevents spurious warnings from popping up for other users when you do.)

Test by making a homework set with the reduced credit date the same as the due date and checking to see that you don't get warnings on the ProblemSets or ProblemSet page and that reduced credit works when you override it for a given user. 

P.S.  Since Pete is working with reduced credit a lot this would be a good pull request for him to work with. 
