### PR TITLE
Upgrade AskSage error reporting and portability

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -100,7 +100,8 @@ $externalPrograms{pngtopnm} = "$netpbm_prefix/pngtopnm";
 # url checker
 ####################################################
 
-$externalPrograms{checkurl} = "/usr/bin/lwp-request -d -mHEAD "; # or "/usr/local/bin/w3c -head "
+$externalPrograms{checkurl}     = "/usr/bin/lwp-request -d -mHEAD "; # or "/usr/local/bin/w3c -head "
+$externalPrograms{curlCommand}  = "/usr/bin/curl";
 
 ####################################################
 # image conversions utiltiies

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -203,6 +203,7 @@ sub defineProblemEnvir {
 	$envir{externalPng2EpsPath}  = $ce->{externalPrograms}->{png2eps};
 	$envir{externalGif2PngPath}  = $ce->{externalPrograms}->{gif2png};
 	$envir{externalCheckUrl}     = $ce->{externalPrograms}->{checkurl};
+	$envir{externalCurlCommand}          = $ce->{externalPrograms}->{curlCommand};
 	# Directories and URLs
 	# REMOVED: courseName
 	# ADDED: dvipngTempDir


### PR DESCRIPTION
In particular pass location of curl (used in sage call) from site.conf since the location can be different on different machines.
Create error messages when debug is set to 1
