### PR TITLE
Strip whitespace from start and end of each field when importing classlist files

### DIFF
--- a/lib/WeBWorK/File/Classlist.pm
+++ b/lib/WeBWorK/File/Classlist.pm
@@ -45,7 +45,8 @@ sub parse_classlist($) {
 	
 	my (@records);
 
-	my $csv = Text::CSV->new({ binary => 1 }); # binary for utf8 compat
+	my $csv = Text::CSV->new({ binary => 1, allow_whitespace => 1 });
+	   # binary for utf8 compat, allow_whitespace to strip all whitespace from start and end of each field
 	
 	while (<$fh>) {
 		chomp;


### PR DESCRIPTION
Replace line 48 of /opt/webwork/webwork2/lib/WeBWorK/File/Classlist.pm

```
    my $csv = Text::CSV->new({ binary => 1 }); # binary for utf8 compat
```

by the two lines

```
    my $csv = Text::CSV->new({ binary => 1, allow_whitespace => 1 });
   # binary for utf8 compat, allow_whitespace to strip all whitespace from start and end of each field
```

This fixes the bug in reading classlist files when e.g. someone has a space before or after a status (e.g. ,C  ,)
and later gets an error when e.g. assigning sets to the new student becasue of an unknows status
