### PR TITLE
Achievement Item Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -220,7 +220,7 @@ sub body {
 
 	    # Generate array of problem counts
 	    for (my $i=0; $i<=$#sets; $i++) {		
-		$setProblemCount[$i] = $db->countUserProblems($userID,$sets[$i]->set_id);
+		$setProblemCount[$i] = WeBWorK::Utils::max($db->listUserProblems($userID,$sets[$i]->set_id));
 	    }
 
 	    print CGI::h2("Items");


### PR DESCRIPTION
Fixed a bug where I used count instead of max(list) and it was causing the dropdowns to not have enough numbers.  Since its a small change and is affecting active users I'm submitting it to master. 

To test: 
1) Enable achievements and achievement items and import achievements (with items). 
2) assign the achievements to yourself and submit an answer to a problem to get a level and an item. 
3) Fill a set with some number of problems (say 5) and delete some from the middle.  
4) Go to the achievement page, select use item, and select the set from the dropdown.  Before the patch the problem number dropdown should not go all the way to the last problem (it would be 3 in our example) and after it should . 
