### PR TITLE
SHA512 Password Hashing

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -904,8 +904,12 @@ sub pretty_print_rh($) {
 
 sub cryptPassword($) {
 	my ($clearPassword) = @_;
-	#Use an MD5 salt to force crypt to use MD5 and allow for longer passwords. 
-	my $salt = '$1$'.join("", ('.','/','0'..'9','A'..'Z','a'..'z')[rand 64, rand 64, rand 64, rand 64, rand 64, rand 64, rand 64, rand 64]);
+	#Use an SHA512 salt with 16 digits 
+	my $salt = '$6$';
+	for (my $i=0; $i<16; $i++) {
+	    $salt .= ('.','/','0'..'9','A'..'Z','a'..'z')[rand 64];
+	}
+
 	my $cryptPassword = crypt($clearPassword, $salt);
 	return $cryptPassword;
 }


### PR DESCRIPTION
Changes cryptPassword to use an SHA512 type salt with 16 digits, which causes crypt to use SHA512 hashing, allowing for longer passwords.  (And SHA512 is better than DES, in any case).  

Things to test: 
-  Check out branch and check you can log in with old password. 
-  Set a new password (longer than 8 characters) and check that you can log in with new password, but that you need to type all of the characters.  
-  Set passwords using Add Student, the Classlist Manager, and the Course Admin Page and check that they all end up with MD5 hashes in the password database.  (The hashes should start with $6$).  Check anything else you can think of that can be used to set a password (or add a student)

This change should be pretty safe.  The whole thing is backwards compatible so that passwords hashed using DES will still work correctly.  (Fun fact: its forwards compatible too.  Passwords set with this branch will still work even if you go back to a previous branch.)   The biggest issue I can think of is that, even though I checked for this using a grep, there is something somewhere which doesn't use the cryptPassword function to set a password (WebworkSOAP maybe?).  Even this is not a huge issue since it will use the older hashing scheme and will still function. 

P.S. for Jason.  I checked and CRYPT_SHA512 function does 5000 iterations of the hashing function by default.  
