### PR TITLE
randomize which practice user is used

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -323,7 +323,7 @@ sub get_credentials {
 		my @allowedGuestUsers = grep { $ce->status_abbrev_has_behavior($_->status, "allow_course_access") } @GuestUsers;
 		my @allowedGestUserIDs = map { $_->user_id } @allowedGuestUsers;
 		
-		foreach my $userID (@allowedGestUserIDs) {
+		foreach my $userID (List::Util::shuffle(@allowedGestUserIDs)) {
 			if (not $self->unexpired_session_exists($userID)) {
 				my $newKey = $self->create_session($userID);
 				$self->{initial_login} = 1;


### PR DESCRIPTION
This pull requests randomizes the list of potential guest users before checking them to see if they can be used upon a click of the guest login button. This way users see a variety of seeds of problems when they log in as guest multiple times, rather than usually just seeing practice1 seeds every time.

I tested with 9 guest login accounts, 30 guest login accounts, and 1 guest login account. I logged in as guest, logged out, and logged in again many times and the specific login id changed each time (except with only 1 guest). And also nothing is broken for courses with no guest login.
