### PR TITLE
Gateway Bug Redux (master) 

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -359,7 +359,7 @@ sub setListRow {
 				      courseID => $courseName, setID => $urlname);
 	} else {
 
-	    $problemSetPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::GatewayQuiz", $r, 
+	    $problemSetPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::ProctoredGatewayQuiz", $r, 
 				      courseID => $courseName, setID => $urlname);
 	}
 
@@ -385,9 +385,9 @@ sub setListRow {
 		if ( $gwtype == 1 );
 
   # the conditional here should be redundant.  ah well.
-	$interactiveURL =~ s|/quiz_mode/|/proctored_quiz_mode/| if 
-	    ( defined( $set->assignment_type() ) && 
-	      $set->assignment_type() eq 'proctored_gateway' );
+#	$interactiveURL =~ s|/quiz_mode/|/proctored_quiz_mode/| if 
+#	    ( defined( $set->assignment_type() ) && 
+#	      $set->assignment_type() eq 'proctored_gateway' );
 	my $display_name = $name;
 	$display_name =~ s/_/ /g;
 # this is the link to the homework assignment, it has tooltip with the hw description 

--- a/lib/WeBWorK/ContentGenerator/ProctoredGatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/ProctoredGatewayQuiz.pm
@@ -1,0 +1,28 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm,v 1.54 2008/07/01 13:12:56 glarose Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package WeBWorK::ContentGenerator::ProctoredGatewayQuiz;
+use base qw(WeBWorK::ContentGenerator::GatewayQuiz);
+
+=head1 NAME
+
+WeBWorK::ContentGenerator::ProctoredGatewayQuiz - 
+this is a wrapper for GatewayQuiz.pm and has no content
+
+=cut
+
+
+1;

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -269,7 +269,7 @@ our %pathTypes = (
 		match   => qr|^proctored_quiz_mode/([^/]+)/|,
 		capture => [ qw/setID/ ],
 		produce => 'proctored_quiz_mode/$setID/',
-		display => 'WeBWorK::ContentGenerator::GatewayQuiz',
+		display => 'WeBWorK::ContentGenerator::ProctoredGatewayQuiz',
 	},
 	proctored_gateway_proctor_login => {
 		name    => 'Proctored Gateway Quiz $setID Proctor Login',


### PR DESCRIPTION
Of course writing up the pull request post for the last bug gave me a much better idea of how to fix it.   Do-over!

This is an annoying bug that breaks gateways for anybody on newer perl versions.  The issue is that in URLPath.pm both the `quiz_mode` and `proctored_quiz_mode` path types use the `GatewayQuiz` module so when someone does `newFromModule` it could get either of them.  In the past it has always gotten the `quiz_mode` path and there were hacks to make `proctored_quiz_mode` work (like line 388 of Problem.pm) for proctored quizzes.   Now that modules are loaded in more random orders newer systems are returning `proctored_quiz_mode` for all of the url paths, even regular gateway quizzes.   This is fixed by making `ProctoredGatewayQuiz.pm` a wrapper for `GatewayQuiz.pm` so that the url types `quiz_mode` and `proctored_quiz_mode` can have separate modules.

To Test: 
-  Make a gateway quiz and a proctored gateway quiz
-  Check that the link for the gateway quiz on the problem sets page has `quiz_mode` in the url and the proctored quiz has `proctored_quiz_mode` in the url. 
-  Check that you can submit answers for both.  
