### PR TITLE
Setpermissions

### DIFF
--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -51,6 +51,7 @@ chomp($me);
 my $servergroup =  $ce->{server_groupID};
 
 my $wwroot = $ENV{WEBWORK_ROOT};
+my $pgroot = $ce->{pg_dir};
 
 # Course directories
 system("chown -R $me ".$ce->{webwork_courses_dir});
@@ -66,6 +67,14 @@ for my $dir ( "DATA", "htdocs/tmp", "logs", "tmp", "conf", "lib/WeBWorK/DB/Recor
 	system("chmod g+s $wwroot/$dir");
 }
 
+# Other special directories under pg
+for my $dir ( "macros" ) {
+  system("chown -R $me $pgroot/$dir");
+        system("chgrp -R $servergroup $pgroot/$dir");
+        system("chmod -R g+w $pgroot/$dir");
+        system("chmod g+s $pgroot/$dir");
+}
+
 # Individual files under webwork2
 for my $file ( "VERSION" ) {
         system("chgrp $servergroup $wwroot/$file");
@@ -73,12 +82,12 @@ for my $file ( "VERSION" ) {
 
 # Individual files under pg
 for my $file ( "VERSION" ) {
-        system("chgrp $servergroup ".$ce->{pg_dir}."/$file");
+        system("chgrp $servergroup $pgroot/$file");
 }
 
 # A special directory under pg (so the server can compile the chromatic program)
-system("chgrp $servergroup ".$ce->{pg_dir}."/lib/chromatic");
-system("chmod g+w ".$ce->{pg_dir}."/lib/chromatic");
+system("chgrp $servergroup $pgroot/lib/chromatic");
+system("chmod g+w $pgroot/lib/chromatic");
 
 # The server should not be able to write to the OPL (for most sites)
 


### PR DESCRIPTION
I've been having trouble with file permissions lately that the `setfilepermissions` script was not helping with. Every time I would check out a branch, many files changed owner:group to me:me, and the webserver couldn't access them.

I tracked down the files that were causing trouble for me and added them to the script. If there is something wrong with this approach (like it's too much to be setting permissions for the entire `conf/` folder) let me know. Also, it's possible that even more should be added to this script, but those files haven't caused _me_ any issues.

I added:
- the `webwork2` and `pg` `VERSION` files
- recursively, `webwork2/conf/`
- recursively, `webwork2/lib/WeBWorK/DB/Record/`
- recursively, `webwork2/htdocs/themes/`
