### PR TITLE
swapped how Rename File and Copy File auto suggest new names

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -601,7 +601,7 @@ sub Copy {
 		}
 	}
 
-	$self->Confirm($r->maketext("Copy file as:"),$original,"Copy");
+	$self->Confirm($r->maketext("Copy file as:"),uniqueName($dir,$original),"Copy");
 	print CGI::hidden({name=>"files",value=>$original});
 }
 
@@ -626,7 +626,7 @@ sub Rename {
 		}
 	}
 
-	$self->Confirm($r->maketext("Rename file as:"),uniqueName($dir,$original),"Rename");
+	$self->Confirm($r->maketext("Rename file as:"),$original,"Rename");
 	print CGI::hidden({name=>"files",value=>$original});
 }
 


### PR DESCRIPTION
It has always irritated me how Rename and Copy in the File Manager make their auto-suggestions for new names, so I decided to do something about it with a super small pull request.

Currently, if I click to rename `foo.bar`, the auto-suggestion is for `foo.bar_1`. Usually, what I would want to do is rename it to something like `foo.lst`, and the `_1` is just extra stuff to backspace.

Meanwhile if I click to copy `foo.bar`, the auto-suggestion is for `foo.bar`. But that's never going to be OK since I need a new name for the new copy.

Swapping these make way more sense to me. I might even actually be happy with `foo.bar_1` as the name of the copy of `foo.bar`.

This can be tested by going to the File Manager and seeing the behavior when you select a file, and then either click to Rename it or Copy it.
