### PR TITLE
Auto hide side menu when resizing window below 768px and auto show when ...

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -122,8 +122,6 @@ ul.nav li a:hover {
 #breadcrumb-navigation {
     float:left;
     display:inline-block;
-    width:90%;
-    width:calc(100% - 35px);
 }
 
 /* Main Content */

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -26,13 +26,17 @@ input[type="checkbox"] {
 #masthead {
 	background-color: #038;
 	margin: 0;
-	padding: 0;
 	padding: 5px;
+    width: calc(100% - 10px);	
 }
 
 /* Bootstrap Overrides */
 .container-fluid {
-	padding: 0.5em;
+	padding-top: 0.5em;
+}
+
+.fix-content-margin {
+   margin-left: 0px !important;
 }
 
 .webwork_logo {
@@ -937,6 +941,4 @@ table#grades_table pre{
     min-width:43px;
 }
 
-#content.span12.fix-content-margin {
-   margin-left: 0px !important;
-}
+

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -936,3 +936,7 @@ table#grades_table pre{
     min-height:35px;
     min-width:43px;
 }
+
+#content.span12.fix-content-margin {
+   margin-left: 0px !important;
+}

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -96,6 +96,10 @@ input[type="checkbox"] {
     border:0px;
 }
 
+ul.nav.nav-list {
+  margin-top: 1ex;
+}
+
 ul.nav li a:hover {
 	background: #e1e1e1;	
 }

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -53,13 +53,14 @@ $(function(){
 	
 	$(window).resize(function(){
 		ANSM.windowwidth = $(window).width();
-		if(ANSM.windowwidth < ANSM.threshold && !ANSM.ltthreshold){
+		ANSM.is_logginpage = $('#toggle-sidebar').hasClass('hidden');
+		if(ANSM.windowwidth < ANSM.threshold && !ANSM.ltthreshold && !ANSM.is_logginpage){
 			$('#site-navigation').addClass('hidden');	
 	    	$('#toggle-sidebar-icon').addClass('icon-chevron-left').removeClass('icon-chevron-right');	
 	    	$('#site-navigation').removeClass('span2');	
 	    	$('#content').removeClass('span10').addClass('span12').addClass('fix-content-margin');
 			ANSM.ltthreshold = 1;
-		}else if(ANSM.windowwidth >= ANSM.threshold && ANSM.ltthreshold){	
+		}else if(ANSM.windowwidth >= ANSM.threshold && ANSM.ltthreshold && !ANSM.is_logginpage){	
 			$('#site-navigation').removeClass('hidden'); 
 	    	$('#toggle-sidebar-icon').removeClass('icon-chevron-left').addClass('icon-chevron-right');		
 			$('#site-navigation').addClass('span2');

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -48,21 +48,19 @@ $(function(){
 	ANSM.ltthreshold = (ANSM.windowwidth < ANSM.threshold) ? 1 : 0;
 	//Initial settings for sidemenu
     if(ANSM.ltthreshold) {
-		$('#toggle-sidebar').click();
-    }	
+		$('#toggle-sidebar').click();		
+    }
 	
 	$(window).resize(function(){
 		ANSM.windowwidth = $(window).width();
 		if(ANSM.windowwidth < ANSM.threshold && !ANSM.ltthreshold){
 			$('#site-navigation').addClass('hidden');	
-			$('#masthead').addClass('span12');
 	    	$('#toggle-sidebar-icon').addClass('icon-chevron-left').removeClass('icon-chevron-right');	
 	    	$('#site-navigation').removeClass('span2');	
 	    	$('#content').removeClass('span10').addClass('span12').addClass('fix-content-margin');
 			ANSM.ltthreshold = 1;
 		}else if(ANSM.windowwidth >= ANSM.threshold && ANSM.ltthreshold){	
 			$('#site-navigation').removeClass('hidden'); 
-			$('#masthead').removeClass('span12');
 	    	$('#toggle-sidebar-icon').removeClass('icon-chevron-left').addClass('icon-chevron-right');		
 			$('#site-navigation').addClass('span2');
 			$('#content').addClass('span10').removeClass('span12').removeClass('fix-content-margin');

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -37,15 +37,38 @@ $(function(){
     $('#toggle-sidebar').removeClass('btn-primary').click(function (event) {
 	    event.preventDefault();
 	    $('#site-navigation').toggleClass('hidden');
-	    $('#toggle-sidebar-icon').toggleClass('icon-chevron-left')
-		.toggleClass('icon-chevron-right');
+	    $('#toggle-sidebar-icon').toggleClass('icon-chevron-left').toggleClass('icon-chevron-right');
 	    $('#site-navigation').toggleClass('span2');
-	    $('#content').toggleClass('span10').toggleClass('span11');
+	    $('#content').toggleClass('span10').toggleClass('span12').toggleClass('fix-content-margin');
 	});
-
-    if($(window).width() < 480) {
-	$('#toggle-sidebar').click();
-    }
+	
+	var ANSM = {};
+	ANSM.threshold = 768;
+	ANSM.windowwidth = $(window).width();
+	ANSM.ltthreshold = (ANSM.windowwidth < ANSM.threshold) ? 1 : 0;
+	//Initial settings for sidemenu
+    if(ANSM.ltthreshold) {
+		$('#toggle-sidebar').click();
+    }	
+	
+	$(window).resize(function(){
+		ANSM.windowwidth = $(window).width();
+		if(ANSM.windowwidth < ANSM.threshold && !ANSM.ltthreshold){
+			$('#site-navigation').addClass('hidden');	
+			$('#masthead').addClass('span12');
+	    	$('#toggle-sidebar-icon').addClass('icon-chevron-left').removeClass('icon-chevron-right');	
+	    	$('#site-navigation').removeClass('span2');	
+	    	$('#content').removeClass('span10').addClass('span12').addClass('fix-content-margin');
+			ANSM.ltthreshold = 1;
+		}else if(ANSM.windowwidth >= ANSM.threshold && ANSM.ltthreshold){	
+			$('#site-navigation').removeClass('hidden'); 
+			$('#masthead').removeClass('span12');
+	    	$('#toggle-sidebar-icon').removeClass('icon-chevron-left').addClass('icon-chevron-right');		
+			$('#site-navigation').addClass('span2');
+			$('#content').addClass('span10').removeClass('span12').removeClass('fix-content-margin');
+			ANSM.ltthreshold = 0;	
+		}
+	});
 
     // if no fish eye then collapse site-navigation 
     if($('#site-links').length > 0 && !$('#site-links').html().match(/[^\s]/)) {


### PR DESCRIPTION
...resizing menu to beyond 768px.  Respects toggle when resizing.  That is if the menu is toggled off by clicking the toggle button and then resizing beyond 768px, the menu will not auto show.  Similarly for when the toggle button has been clicked to show the menu prior to resizing below 768px.  The threshold can be set in the math4.js in the variable ANSM.threshold. Also, margins were fixed. The masthead would overflow outside of the contair-fluid div when resizing below 768px.  The content has class span12 the menu is toggled off.