### PR TITLE
Beta version of a Gradebook.

### DIFF
--- a/webwork3/bin/app.pl
+++ b/webwork3/bin/app.pl
@@ -14,6 +14,7 @@ use WeBWorK::Authen;
 use Routes::Authentication qw/buildSession setCourseEnvironment setCookie/; 
 use Routes::Course;
 use Routes::Library;
+use Routes::GradeBook;
 use Routes::ProblemSets;
 use Routes::User;
 use Routes::Settings;

--- a/webwork3/lib/Routes/GradeBook.pm
+++ b/webwork3/lib/Routes/GradeBook.pm
@@ -1,0 +1,64 @@
+### ProblemSet routes
+##
+#  These are the routes for related GradeBook functions in the RESTful webservice
+#
+##
+
+package Routes::GradeBook;
+
+use strict;
+use warnings;
+use Dancer ':syntax';
+use Utils::Convert qw/convertObjectToHash convertArrayOfObjectsToHash convertBooleans/;
+use Utils::ProblemSets qw/reorderProblems addGlobalProblems addUserSet addUserProblems deleteProblems createNewUserProblem/;
+use WeBWorK::Utils qw/parseDateTime decodeAnswers/;
+use Array::Utils qw(array_minus); 
+use Routes::Authentication qw/checkPermissions setCourseEnvironment/;
+use Utils::CourseUtils qw/getCourseSettings/;
+use Dancer::Plugin::Database;
+use Dancer::Plugin::Ajax;
+use List::Util qw/first max/;
+
+our @set_props = qw/set_id set_header hardcopy_header open_date reduced_scoring_date due_date answer_date visible enable_reduced_scoring assignment_type attempts_per_version time_interval versions_per_interval version_time_limit version_creation_time version_last_attempt_time problem_randorder hide_score hide_score_by_problem hide_work time_limit_cap restrict_ip relax_restrict_ip restricted_login_proctor/;
+our @user_set_props = qw/user_id set_id psvn set_header hardcopy_header open_date reduced_scoring_date due_date answer_date visible enable_reduced_scoring assignment_type description restricted_release restricted_status attempts_per_version time_interval versions_per_interval version_time_limit version_creation_time problem_randorder version_last_attempt_time problems_per_page hide_score hide_score_by_problem hide_work time_limit_cap restrict_ip relax_restrict_ip restricted_login_proctor hide_hint/;
+our @user_props = qw/first_name last_name student_id user_id email_address permission status section recitation comment/;
+our @problem_props = qw/problem_id flags value max_attempts source_file/;
+our @boolean_set_props = qw/visible enable_reduced_scoring/;
+
+###
+#  return all problem sets (as objects) for course *course_id* 
+#
+#  User user must have at least permissions>=10
+#
+##
+
+get '/courses/:course_id/gradebook' => sub {
+
+    checkPermissions(10,session->{user});
+
+    my $result1={};
+    
+    my @userIDs = vars->{db}->listUsers();
+    for my $userID (@userIDs){
+        $result1->{$userID}{user_id} = $userID;
+        my @userSets = vars->{db}->listUserSets($userID);
+        for my $userSet (@userSets){
+            my @problems = vars->{db}->getAllMergedUserProblems($userID,$userSet);
+            my $score = 0;
+            for my $problem (@problems){
+                $score = $score + $problem -> {status};
+            }        
+            $result1->{$userID}{$userSet.'_score'} = $score; #here we set the score
+        }
+    }
+
+    #Reformat $result1 into an anonymous array of hashes
+    my @result2;
+    foreach my $key (keys $result1){
+        push(@result2, $result1->{$key});
+    }
+    return convertArrayOfObjectsToHash(\@result2);
+};
+
+
+return 1;

--- a/webwork3/public/js/apps/CourseManager/config.json
+++ b/webwork3/public/js/apps/CourseManager/config.json
@@ -29,6 +29,13 @@
 		"id": "problemSetsManager"
 	},
 	{
+		"name": "GradeBook",
+		"path": "main-views/GradeBookView",
+		"default_sidebar": "",
+		"other_sidebars": [],
+		"id": "gradebook"
+	},
+	{
 		"name": "Student Progress",
 		"path": "main-views/StudentProgressView",
 		"default_sidebar": "",

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -1,4 +1,4 @@
-//  This is the main view for the Student Progress Page.
+//  This is the main view for the GradeBook Page.
 
 define(['backbone', 'underscore','views/MainView','config','views/CollectionTableView','models/GradeBook','models/UserSetList'], 
 function(Backbone, _,MainView,config,CollectionTableView,GradeBook,UserSetList){
@@ -7,7 +7,6 @@ var GradeBookView = MainView.extend({
 		var self = this;
 		_(this).bindAll("buildTable","render","changeDisplay","tableSetup");	
 		MainView.prototype.initialize.call(this,options);		
-		_(options).extend({state: "gradebook"});
 		this.state.set({type: 'gradebook'});
 		this.changeDisplay();
 		this.tableSetup();				
@@ -60,7 +59,7 @@ var GradeBookView = MainView.extend({
 	    return this;
 	},
 	getDefaultState: function () {
-		//return {set_id: this.state.get('set_id'), user_id: this.state.get('user_id'), type: this.state.get('type'), page_num: 0};
+		//return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
 	},
 	changeDisplay: function(){
 		var self = this;
@@ -90,8 +89,14 @@ var GradeBookView = MainView.extend({
 					if(admin_model){	
 	    	    	var admin_model_keys = _.keys(admin_model['attributes']);
     	    		var setnames = _.without(admin_model_keys,'user_id');  
+    	    		console.log(setnames);
+    	    		setnames = setnames.sort(function(a, b){
+    					if(a < b) return -1;
+					    if(a > b) return 1;
+					    return 0;
+					});
        				_.each(setnames, function(name){
-	       				self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer",callback: 1});
+	       				self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer",callback: 1});	       				
 		       		});	      	
 				self.render();
 				}

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -6,10 +6,10 @@ var GradeBookView = MainView.extend({
 	initialize: function (options){
 		var self = this;
 		_(this).bindAll("buildTable","render","changeDisplay","tableSetup");	
-		MainView.prototype.initialize.call(this,options);		
-		this.state.set({type: 'gradebook'});
+		MainView.prototype.initialize.call(this,options);	
+		this.state.set({type: 'gradebook'});	
 		this.changeDisplay();
-		this.tableSetup();				
+		this.tableSetup();			
 		this.state.on({
 			"change:type": this.changeDisplay, 
 			"change:set_id change:user_id change:type": this.tableSetup,
@@ -32,34 +32,34 @@ var GradeBookView = MainView.extend({
 				$('a.gradebook-button').removeClass('hidden');								
 				break;
 		}				
-		if(this.collection){
-			this.progressTable = new CollectionTableView({columnInfo: this.cols, collection: this.collection, 
-	                    paginator: {page_size: 10, button_class: "btn btn-default", row_class: "btn-group"}}).render();
-			this.progressTable.on("page-changed",function(num){
-	        			self.state.set({page_num: num});
-	        			self.showHideColumns();
-	        		}).gotoPage(this.state.get("page_num")).$el.addClass("table table-bordered table-condensed")
-			this.$el.append(this.progressTable.el);
+		this.progressTable = new CollectionTableView({columnInfo: this.cols, collection: this.collection, 
+                paginator: {page_size: 10, button_class: "btn btn-default", row_class: "btn-group"}}).render();
+		this.progressTable.on("page-changed",function(num){
+	        self.state.set({page_num: num});
+	        self.showHideColumns();
+	    }).gotoPage(this.state.get("page_num")).$el.addClass("table table-bordered table-condensed")
+		this.$el.append(this.progressTable.el);
 	
-	        // set up some styling
-	        this.progressTable.$(".paginator-row td").css("text-align","center");
-	        this.progressTable.$(".paginator-page").addClass("btn");
-			this.progressTable.on("show-set-users", function(setname){		
-				self.state.set({set_id: setname});
-		    	self.state.set({type: "users"});					
-			});		        
-		} else {
-			console.log('There was no collection passed into CollectionTableView');
-		}
+	    // set up some styling
+	    this.progressTable.$(".paginator-row td").css("text-align","center");
+	    this.progressTable.$(".paginator-page").addClass("btn");
+		this.progressTable.on("show-set-users", function(setname){		
+			self.state.set({set_id: setname});
+		   	self.state.set({type: "users"});					
+		});		        
 		MainView.prototype.render.apply(this);	
 		this.$('.gradebook-button').on("click", function(){
 		    self.state.set({type: 'gradebook'});
+		});		
+		// this resets the GradeBook to the gradebook state and triggers  
+		// the necessary functions to render the correct table.	
+		$(window).unload(function(){
+		    self.state.set({type: 'gradebook'});
 		});			
-		this.stickit(this.state);					
 	    return this;
 	},
 	getDefaultState: function () {
-		//return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
+		return {page_num: 0};
 	},
 	changeDisplay: function(){
 		var self = this;

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -6,8 +6,8 @@ var GradeBookView = MainView.extend({
 	initialize: function (options){
 		var self = this;
 		_(this).bindAll("buildTable","render","changeDisplay","tableSetup");	
-		MainView.prototype.initialize.call(this,options);	
-		console.log(options);		
+		MainView.prototype.initialize.call(this,options);		
+		this.state.set({type: 'gradebook'});
 		this.tableSetup();		
 		this.state.on({
 			"change:type": this.changeDisplay, 
@@ -18,21 +18,20 @@ var GradeBookView = MainView.extend({
 		var self = this;		
 		this.$el.html($("#gradebook-template").html());	
 		this.$el.prepend('<h1 class="title"></h1>');				
-		this.$('h1.title').after('<a class="gradebook-button"></a>');	
-		this.$('a.gradebook-button').addClass('hidden').html("<a href=# class='btn btn-default'>GradeBook</a>");			
-		this.stickit(this.state);			
+		this.$('h1.title').after('<a class="gradebook-button"></a>');		
+		this.$('a.gradebook-button').addClass('hidden').html("<a href=# class='btn btn-default'>GradeBook</a>");					
 		switch(self.state.get('type')){
 			case "gradebook":
-				$('h1.title').html('GradeBook');
-				$('a.gradebook-button').addClass('hidden');				
+				$('h1.title').html('GradeBook');	
+				$('a.gradebook-button').addClass('hidden');																
 				break;
 			case "sets":
 				$('h1.title').html(self.state.get('user_id'));
-				$('a.gradebook-button').removeClass('hidden');				
+				$('a.gradebook-button').removeClass('hidden');							
 				break;				
 			case "users":
 				$('h1.title').html(self.state.get('set_id'));				
-				$('a.gradebook-button').removeClass('hidden');				
+				$('a.gradebook-button').removeClass('hidden');								
 				break;
 		}				
 		if(this.collection){
@@ -52,20 +51,17 @@ var GradeBookView = MainView.extend({
 		}
 		MainView.prototype.render.apply(this);	
 		this.$('.gradebook-button').on("click", function(){
-			console.log('---button pressed----');
 		    self.state.set({type: 'gradebook'});
-			console.log(self.state.get('type'));		    
 		});			
 		this.progressTable.on("show-set-users", function(setname){
 			self.state.set({set_id: setname});
-			console.log(setname);
-			console.log(self.state.get('type'));
 		    self.state.set({type: "users"});
-		});			
+		});	
+		this.stickit(this.state);					
 	    return this;
 	},
 	getDefaultState: function () {
-		return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
+		//return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
 	},
 	changeDisplay: function(){
 		var self = this;
@@ -81,16 +77,13 @@ var GradeBookView = MainView.extend({
 	},	
 	buildTable: function () {
 		var self = this;
-		console.log(this.state.get("type"));
 		if (this.state.get("type")==="sets"){
 				(this.collection = new UserSetList([],{user: self.state.get("user_id"), type: "sets", loadProblems: true}))
 				.fetch({success: function(data){self.render();}});	
 		} else if (this.state.get("type")==="users"){
-			console.log(self.state.get("set_id"));	
 		var _set = this.problemSets.findWhere({set_id: this.state.get("set_id")});				
 				(this.collection = new UserSetList([],{problemSet: _set, type: "users", loadProblems: true}))
 					.fetch({success: function (data){self.render();}});	
-		console.log(this.collection);
 		} else if (this.state.get("type")==="gradebook"){				
 				this.collection = new GradeBook([],{type: "gradebook",loadProblems: true});		
 				this.collection.fetch({success: function (data){
@@ -107,18 +100,14 @@ var GradeBookView = MainView.extend({
 		//Help template goes here?
 	},	
 	tableSetup: function () {
-        var self = this;
-        console.log(self.state);        
+        var self = this; 
         switch(self.state.get('type')){
         	case "gradebook":
         		this.cols = [{name: "Login Name", key: "user_id", classname: "login-name", datatype: "string",
         		    stickit_options: {update: function($el, val, model, options) {
                     	$el.html("<a href='#' onclick='return false' class='goto-user' data-username='"+val+"'>" + val + "</a>");
                     	$el.children("a").on("click",function() {  
-                    		console.log(val);
-                    		console.log($(this).data('username'));
-                    		self.state.set({user_id: $(this).data('username')});
-                    		console.log(self.state);                    	               	                  	
+                    		self.state.set({user_id: $(this).data('username')});     	               	                  	
                     		self.state.set({type: "sets"});
                     	});}
                 	}
@@ -126,7 +115,6 @@ var GradeBookView = MainView.extend({
         		this.buildTable();        
 				break;
 			case "users":
-				console.log('users');
 				this.cols = [
             		{name: "Login Name", key: "user_id", classname: "login-name", datatype: "string"},
             		{name: "Set Name", key: "set_id", classname: "set-id", datatype:"string"},
@@ -159,8 +147,6 @@ var GradeBookView = MainView.extend({
             	}
             }},
         ];
-        	console.log('---the columns----');
-        	console.log(this.cols);
                		this.buildTable();   
 			  break;	
 			case "sets":

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -11,8 +11,8 @@ var GradeBookView = MainView.extend({
 	},
 	render: function (){
 		var self = this;
-		this.$(".collection-table").remove();		
-		this.$el.html($("#gradebook-template").html());
+		this.$(".collection-table").remove();	
+		this.$el.html($("#gradebook-template").html());		
 		this.stickit(this.state,this.bindings);
 		if(this.collection){
 			this.progressTable = new CollectionTableView({columnInfo: this.cols, collection: this.collection, 
@@ -26,29 +26,17 @@ var GradeBookView = MainView.extend({
 	        // set up some styling
 	        this.progressTable.$(".paginator-row td").css("text-align","center");
 	        this.progressTable.$(".paginator-page").addClass("btn");
-	        this.showHideColumns();
 		} else {
-			this.buildTable();
+			console.log('There was no collection passed into CollectionTableView');
 		}
-		MainView.prototype.render.apply(this);
+		MainView.prototype.render.apply(this);	
 	    return this;
 	},
 	getDefaultState: function () {
-		return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
-	},
-	showHideColumns: function () {
-		this.$(".login-name,.set-id").removeClass("hidden");
-        switch(this.state.get("type")){
-			case "users":
-				this.$(".login-name").addClass("hidden");
-				break;
-			case "sets":
-				this.$(".set-id").addClass("hidden");
-				break;
-		}
+		return {type: "gradebook", page_num: 0};
 	},
 	getHelpTemplate: function () {
-
+		//Help template goes here?
 	},
 	tableSetup: function () {
         var self = this;
@@ -57,15 +45,12 @@ var GradeBookView = MainView.extend({
         ];        
 		this.collection = new GradeBook([],{type: "gradebook",loadProblems: true});		
 		this.collection.fetch({success: function (data){
-			console.log(self.collection);
-			var admin_model = self.collection.get("admin");
-        	console.log(admin_model);			
+			var admin_model = self.collection.get("admin");		
         	var admin_model_keys = _.keys(admin_model['attributes']);
-        	setnames = _.without(admin_model_keys,'user_id');  
-       		var set_columns = _.each(setnames, function(name){
+        	var setnames = _.without(admin_model_keys,'user_id');  
+       		_.each(setnames, function(name){
        			self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer"});
-       		});
-       		console.log(self.cols);		      	
+       		});	      	
 			self.render();}});
     }
 

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -1,19 +1,23 @@
 //  This is the main view for the Student Progress Page.
 
-define(['backbone', 'underscore','views/MainView','config','views/CollectionTableView','models/GradeBook'], 
-function(Backbone, _,MainView,config,CollectionTableView,GradeBook){
+define(['backbone', 'underscore','views/MainView','config','views/CollectionTableView','models/GradeBook','models/UserSetList'], 
+function(Backbone, _,MainView,config,CollectionTableView,GradeBook,UserSetList){
 var GradeBookView = MainView.extend({
 	initialize: function (options){
 		var self = this;
-		_(this).bindAll("render");
-		MainView.prototype.initialize.call(this,options);
-		this.tableSetup();
+		_(this).bindAll("buildTable","render","changeDisplay");	
+		MainView.prototype.initialize.call(this,options);	
+		console.log(options);		
+		this.tableSetup();			
+		this.state.on({
+			"change:type": this.changeDisplay, 
+			"change:set_id change:type": this.buildTable,
+		})	
 	},
 	render: function (){
-		var self = this;
-		this.$(".collection-table").remove();	
+		var self = this;		
 		this.$el.html($("#gradebook-template").html());		
-		this.stickit(this.state,this.bindings);
+		this.stickit(this.state);		
 		if(this.collection){
 			this.progressTable = new CollectionTableView({columnInfo: this.cols, collection: this.collection, 
 	                    paginator: {page_size: 10, button_class: "btn btn-default", row_class: "btn-group"}}).render();
@@ -29,29 +33,136 @@ var GradeBookView = MainView.extend({
 		} else {
 			console.log('There was no collection passed into CollectionTableView');
 		}
-		MainView.prototype.render.apply(this);	
+		MainView.prototype.render.apply(this);							
 	    return this;
 	},
 	getDefaultState: function () {
-		return {type: "gradebook", page_num: 0};
+		return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
 	},
+	changeDisplay: function(){
+		var self = this;
+		this.$(".collection-table").remove();
+		switch(this.state.get("type")){
+			case "sets":
+				this.tableSetup();
+				break;
+			case "users":
+				this.tableSetup();
+				break;
+		}
+	},	
+	buildTable: function () {
+		var self = this;
+		console.log(this.state.get("type"));
+		if (this.state.get("type")==="sets"){
+				(this.collection = new UserSetList([],{user: self.state.get("user_id"), type: "sets", loadProblems: true}))
+				.fetch({success: function(data){self.render();}});	
+		} else if (this.state.get("type")==="users"){
+				(this.collection = new UserSetList([],{problemSet: _set, type: "users",loadProblems: true}))
+					.fetch({success: function (data){self.render();}});	
+		} else if (this.state.get("type")==="gradebook"){				
+				this.collection = new GradeBook([],{type: "gradebook",loadProblems: true});		
+				this.collection.fetch({success: function (data){
+					var admin_model = self.collection.get("admin");		
+	    	    	var admin_model_keys = _.keys(admin_model['attributes']);
+    	    		var setnames = _.without(admin_model_keys,'user_id');  
+       				_.each(setnames, function(name){
+	       				self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer"});
+		       		});	      	
+				self.render();}});		
+		}
+	},	
 	getHelpTemplate: function () {
 		//Help template goes here?
-	},
+	},	
 	tableSetup: function () {
         var self = this;
-        this.cols = [
-            {name: "Login Name", key: "user_id", classname: "login-name", datatype: "string"}
-        ];        
-		this.collection = new GradeBook([],{type: "gradebook",loadProblems: true});		
-		this.collection.fetch({success: function (data){
-			var admin_model = self.collection.get("admin");		
-        	var admin_model_keys = _.keys(admin_model['attributes']);
-        	var setnames = _.without(admin_model_keys,'user_id');  
-       		_.each(setnames, function(name){
-       			self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer"});
-       		});	      	
-			self.render();}});
+        console.log(this.state);        
+        switch(this.state.get('type')){
+        	case "gradebook":
+        		this.cols = [{name: "Login Name", key: "user_id", classname: "login-name", datatype: "string",
+        		    stickit_options: {update: function($el, val, model, options) {
+                    	$el.html("<a href='#' onclick='return false' class='goto-user' data-username='"+val+"'>" + val + "</a>");
+                    	$el.children("a").on("click",function() {  
+                    		console.log(val);
+                    		console.log($(this).data('username'));
+                    		self.state.set({user_id: $(this).data('username')});
+                    		console.log(self.state);                    	               	                  	
+                    		self.state.set({type: "sets"});
+                    	});}
+                	}
+        		}];
+        		this.buildTable();        
+				break;
+			case "users":
+				console.log('users');
+				this.cols = [
+            		{name: "Login Name", key: "user_id", classname: "login-name", datatype: "string"},
+            		{name: "Set Name", key: "set_id", classname: "set-id", datatype:"string"},
+            		{name: "Score", key: "score", classname: "score", datatype: "integer", stickit_options: {
+            			update: function($el, val, model, options) {
+            				if(model.get("problems").size()===0){
+            					$el.html("");
+            					return;
+            				}
+        		 	var status = _(model.get("problems").pluck("status")
+        		 			.map(function(s) { return s===""?0:parseFloat(s);})).reduce(function(p,q) {return p+q;});
+					var total = _(model.get("problems").pluck("value")).reduce(function(p,q) { return parseFloat(p)+parseFloat(q);}); 
+            		$el.html(config.displayFloat(status,2) + "/" + total);
+            	}
+            }},
+            {name: "Problems", key: "problems", classname: "problems", datatype: "string", stickit_options: {
+            	update: function($el, val, model, options) {
+            		if(model.get("problems").size()===0){
+            			$el.html("");
+            			return;
+            		}
+            		$el.html(model.get("problems").map(function(p){
+            			var status = p.get("status")===""? 0: parseFloat(p.get("status"));
+            			if(p.get("attempted")=="0" || p.get("attempted")==="") { return "  .";}
+            			else if(p.get("status")==p.get("value")){ return "  C";}
+            			else {
+            				return " "+(parseInt(100*status/parseFloat(p.get("value"))));
+            			}
+            		}).join(""));
+            	}
+            }},
+        ];
+			  break;	
+			case "sets":
+			this.cols = [
+            		{name: "Set Name", key: "set_id", classname: "set-id", datatype:"string"},
+            		{name: "Score", key: "score", classname: "score", datatype: "integer", stickit_options: {
+            			update: function($el, val, model, options) {
+            				if(model.get("problems").size()===0){
+            					$el.html("");
+            					return;
+            				}
+        		 	var status = _(model.get("problems").pluck("status")
+        		 			.map(function(s) { return s===""?0:parseFloat(s);})).reduce(function(p,q) {return p+q;});
+					var total = _(model.get("problems").pluck("value")).reduce(function(p,q) { return parseFloat(p)+parseFloat(q);}); 
+            		$el.html(config.displayFloat(status,2) + "/" + total);
+            	}
+            }},
+            {name: "Problems", key: "problems", classname: "problems", datatype: "string", stickit_options: {
+            	update: function($el, val, model, options) {
+            		if(model.get("problems").size()===0){
+            			$el.html("");
+            			return;
+            		}
+            		$el.html(model.get("problems").map(function(p){
+            			var status = p.get("status")===""? 0: parseFloat(p.get("status"));
+            			if(p.get("attempted")=="0" || p.get("attempted")==="") { return "  .";}
+            			else if(p.get("status")==p.get("value")){ return "  C";}
+            			else {
+            				return " "+(parseInt(100*status/parseFloat(p.get("value"))));
+            			}
+            		}).join(""));
+            	}
+            }},
+        	];
+			  break;				  
+    	}
     }
 
 });

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -1,0 +1,75 @@
+//  This is the main view for the Student Progress Page.
+
+define(['backbone', 'underscore','views/MainView','config','views/CollectionTableView','models/GradeBook'], 
+function(Backbone, _,MainView,config,CollectionTableView,GradeBook){
+var GradeBookView = MainView.extend({
+	initialize: function (options){
+		var self = this;
+		_(this).bindAll("render");
+		MainView.prototype.initialize.call(this,options);
+		this.tableSetup();
+	},
+	render: function (){
+		var self = this;
+		this.$(".collection-table").remove();		
+		this.$el.html($("#gradebook-template").html());
+		this.stickit(this.state,this.bindings);
+		if(this.collection){
+			this.progressTable = new CollectionTableView({columnInfo: this.cols, collection: this.collection, 
+	                    paginator: {page_size: 10, button_class: "btn btn-default", row_class: "btn-group"}}).render();
+			this.progressTable.on("page-changed",function(num){
+	        			self.state.set({page_num: num});
+	        			self.showHideColumns();
+	        		}).gotoPage(this.state.get("page_num")).$el.addClass("table table-bordered table-condensed")
+			this.$el.append(this.progressTable.el);
+	
+	        // set up some styling
+	        this.progressTable.$(".paginator-row td").css("text-align","center");
+	        this.progressTable.$(".paginator-page").addClass("btn");
+	        this.showHideColumns();
+		} else {
+			this.buildTable();
+		}
+		MainView.prototype.render.apply(this);
+	    return this;
+	},
+	getDefaultState: function () {
+		return {set_id: "", user_id: "", type: "gradebook", page_num: 0};
+	},
+	showHideColumns: function () {
+		this.$(".login-name,.set-id").removeClass("hidden");
+        switch(this.state.get("type")){
+			case "users":
+				this.$(".login-name").addClass("hidden");
+				break;
+			case "sets":
+				this.$(".set-id").addClass("hidden");
+				break;
+		}
+	},
+	getHelpTemplate: function () {
+
+	},
+	tableSetup: function () {
+        var self = this;
+        this.cols = [
+            {name: "Login Name", key: "user_id", classname: "login-name", datatype: "string"}
+        ];        
+		this.collection = new GradeBook([],{type: "gradebook",loadProblems: true});		
+		this.collection.fetch({success: function (data){
+			console.log(self.collection);
+			var admin_model = self.collection.get("admin");
+        	console.log(admin_model);			
+        	var admin_model_keys = _.keys(admin_model['attributes']);
+        	setnames = _.without(admin_model_keys,'user_id');  
+       		var set_columns = _.each(setnames, function(name){
+       			self.cols.push({name: name.split('_')[0], key: name, classname: name, datatype: "integer"});
+       		});
+       		console.log(self.cols);		      	
+			self.render();}});
+    }
+
+});
+
+return GradeBookView;
+});

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -18,16 +18,21 @@ var GradeBookView = MainView.extend({
 		var self = this;		
 		this.$el.html($("#gradebook-template").html());	
 		this.$el.prepend('<h1 class="title"></h1>');				
+		this.$('h1.title').after('<a class="gradebook-button"></a>');	
+		this.$('a.gradebook-button').addClass('hidden').html("<a href=# class='btn btn-default'>GradeBook</a>");			
 		this.stickit(this.state);			
 		switch(self.state.get('type')){
 			case "gradebook":
-				$('h1.title').html(self.state.get('type'));
+				$('h1.title').html('GradeBook');
+				$('a.gradebook-button').addClass('hidden');				
 				break;
 			case "sets":
 				$('h1.title').html(self.state.get('user_id'));
+				$('a.gradebook-button').removeClass('hidden');				
 				break;				
 			case "users":
 				$('h1.title').html(self.state.get('set_id'));				
+				$('a.gradebook-button').removeClass('hidden');				
 				break;
 		}				
 		if(this.collection){
@@ -45,7 +50,12 @@ var GradeBookView = MainView.extend({
 		} else {
 			console.log('There was no collection passed into CollectionTableView');
 		}
-		MainView.prototype.render.apply(this);				
+		MainView.prototype.render.apply(this);	
+		this.$('.gradebook-button').on("click", function(){
+			console.log('---button pressed----');
+		    self.state.set({type: 'gradebook'});
+			console.log(self.state.get('type'));		    
+		});			
 		this.progressTable.on("show-set-users", function(setname){
 			self.state.set({set_id: setname});
 			console.log(setname);

--- a/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
+++ b/webwork3/public/js/apps/CourseManager/main-views/GradeBookView.js
@@ -89,7 +89,6 @@ var GradeBookView = MainView.extend({
 					if(admin_model){	
 	    	    	var admin_model_keys = _.keys(admin_model['attributes']);
     	    		var setnames = _.without(admin_model_keys,'user_id');  
-    	    		console.log(setnames);
     	    		setnames = setnames.sort(function(a, b){
     					if(a < b) return -1;
 					    if(a > b) return 1;

--- a/webwork3/public/js/models/GradeBook.js
+++ b/webwork3/public/js/models/GradeBook.js
@@ -1,0 +1,21 @@
+/** 
+ *  This is a backbone collection of GradeBookRow
+ *
+ *   There are two types of UserSetLists:  
+ *      users: a list of userSets for a given problemsSet (that is a list of users) 
+ *      sets: a list of userSets for a given user (this is a list of problemSets) 
+ *   
+ *   If the type is not defined, then an error will be thrown. 
+ */
+
+
+define(['backbone','models/GradeBookRow','config'], function(Backbone,GradeBookRow,config){
+    var GradeBook = Backbone.Collection.extend({
+        model: GradeBookRow,
+        url: function () {
+            return config.urlPrefix + "courses/" + config.courseSettings.course_id + "/gradebook";                   
+            }
+        });
+
+    return GradeBook;
+});

--- a/webwork3/public/js/models/GradeBookRow.js
+++ b/webwork3/public/js/models/GradeBookRow.js
@@ -1,0 +1,21 @@
+/**
+  * This is a model for GradeBookRow. 
+  * 
+  * 
+  */
+
+define(['backbone', 'underscore','config'], 
+    function(Backbone, _,config){
+    var GradeBookRow = Backbone.Model.extend({
+        defaults: {
+            user_id: ""
+        },
+        idAttribute: "user_id",
+        url: function () {
+            return config.urlPrefix + "courses/" + config.courseSettings.course_id + "/users/" + this.get("user_id") +
+            "/sets/" + this.get("set_id");
+        }
+    });
+
+    return GradeBookRow;
+});

--- a/webwork3/public/js/views/CollectionTableView.js
+++ b/webwork3/public/js/views/CollectionTableView.js
@@ -104,7 +104,6 @@ define(['backbone', 'underscore','config','stickit'], function(Backbone, _,confi
 			}
 		},
 		render: function () {
-			console.log("in CollectionTableView.render");
 			var self = this, i;
 			this.$el.empty();
 			var tbody = $("<tbody>");

--- a/webwork3/public/js/views/CollectionTableView.js
+++ b/webwork3/public/js/views/CollectionTableView.js
@@ -6,7 +6,7 @@
  * The following must also be passed into the View:
  *  
  * columnInfo:  An array of {name: _name, key: _key, editable: boolean, classnames: _classnames,
- 		datatype: _datatype, binding: _binding} where 
+ 		datatype: _datatype, binding: _binding, callback: boolean} where 
  	-  _name will be the header of the column
  	-  _key is the field name of the model 
  	-  _editable is a boolean for whether or not the column is editable
@@ -137,7 +137,9 @@ define(['backbone', 'underscore','config','stickit'], function(Backbone, _,confi
 				}
 				var th = $("<th data-class-name='" + className + "'>").addClass(className)
 					.html(col.colHeader? col.colHeader: col.name + spanIcon);
+				if(col.callback){
 					th.wrapInner("<a class='"+col.name+"' href=#>");
+				}
 				if(col.title){
 					th.attr("title",col.title);
 				}

--- a/webwork3/public/js/views/CollectionTableView.js
+++ b/webwork3/public/js/views/CollectionTableView.js
@@ -138,6 +138,7 @@ define(['backbone', 'underscore','config','stickit'], function(Backbone, _,confi
 				}
 				var th = $("<th data-class-name='" + className + "'>").addClass(className)
 					.html(col.colHeader? col.colHeader: col.name + spanIcon);
+					th.wrapInner("<a class='"+col.name+"' href=#>");
 				if(col.title){
 					th.attr("title",col.title);
 				}
@@ -268,6 +269,9 @@ define(['backbone', 'underscore','config','stickit'], function(Backbone, _,confi
 			"click th": function (evt) {
 				this.sortTable(evt).render();
 				this.trigger("table-sorted",this.sortInfo);
+			},
+			"click th a": function (evt) {
+				this.trigger("show-set-users",evt.target.className);
 			},
 			"click .first-page": "firstPage",
 			"click .prev-page": "prevPage",

--- a/webwork3/views/course_manager.tt
+++ b/webwork3/views/course_manager.tt
@@ -281,6 +281,8 @@ at the bottom of the screen and click "Save Changes". </p>
 
 [% INCLUDE main/settings.tt %]
 
+[% INCLUDE main/gradebook.tt %]
+
 [% INCLUDE main/student_progress.tt %]
 
 [% INCLUDE sidebars/course_manager.tt %]

--- a/webwork3/views/main/gradebook.tt
+++ b/webwork3/views/main/gradebook.tt
@@ -1,0 +1,11 @@
+<!-- These are the student progress templates -->
+
+
+<script type="text/template" id="gradebook-template">
+</script>
+
+
+
+<script type="text/template" id="student-progress-help-template">
+<h4>GradeBook Help</h4>
+</script>

--- a/webwork3/views/main/gradebook.tt
+++ b/webwork3/views/main/gradebook.tt
@@ -1,7 +1,12 @@
 <!-- These are the student progress templates -->
 
-
 <script type="text/template" id="gradebook-template">
+<div class="row">
+  <div class="col-md-2">
+   <h1 class="title"></h1>
+	<a class = "btn btn-default gradebook-button">GradeBook</a>   
+  </div>
+</div>
 </script>
 
 


### PR DESCRIPTION
Gradebook view renders student login names vs. assignment scores. Columns are all sortable asc/desc.

Some more things to do:
- Link the column heading name to the student progress view containing statistics for all students for the set corresponding to the column heading name.
- Link the row label name (login name) to the student progress view containing statistics for all sets for the student with login name corresponding to the row label name.
- Column headings for sets should be sorted, at least alphabetically.  Now it just returns some random order.
- Add a column for totals (in percent?)

Questions:
- Should we make certain CRUD functions available on this page, like delete assignment or delete student?
  - for example highlighting a column and pressing a delete button removes the set for all users, or have an icon in the column heading that when pressed, deletes the set for all users.  More precisely, for columns, we can add an icon that gives a dropdown menu of column specific functions like sorting and including some CRUD functions.  For example, consider an instructor viewing the GradeBook that decides they want to delete a set.  They'll click an icon next to that set and select delete from corresponding dropdown menu.  This would involve less clicks than navigating to the problem set manager, and clicking the delete button.
  - Similarly for deleting students (GradeBookRows). Perhaps something like this:
    ![rowcrud](https://cloud.githubusercontent.com/assets/3240137/4855970/12fa6e42-60b0-11e4-891c-91c96596942c.png)
  - Can we extend the CollectionTableView to include a footer for say, set averages? But this is column specific, so maybe include it in the dropdown menu suggested above.  
