### PR TITLE
Set defs search depth

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -821,6 +821,14 @@ $options{useDateTimePicker} = 1;
 
 $options{enableConditionalRelease} = 0;
 
+# In the hmwk sets editor, how deep to search within templates for .def files;
+# 0 means only within templates
+$options{setDefSearchDepth} = 0;
+
+# In the hmwk sets editor, delve into the OPL while searching for .def files?
+$options{useOPLdefFiles} = 0;
+
+
 ##########################################################################################
 #### Default settings for the problem grader page
 ##########################################################################################

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -371,4 +371,15 @@ $problemDefaults{showMeAnother} = -1;
 #$allowFacebooking = 1;
 #$facebookAppId = your_app_id_here;
 
+################################################################################
+# Searching for set.def files to import 
+################################################################################
+## Uncomment below so that when the homework sets editor searches for set def
+## files, it searches beyond templates; it can search deeper subfolders of 
+## templates, and optionally also descend into Library
+
+#$options{setDefSearchDepth}=4;
+#$options{useOPLdefFiles}=1;
+
+
 1; #final line of the file to reassure perl that it was read properly.

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -647,8 +647,8 @@ sub read_dir {  # read a directory
 sub getCSVList {
 	my ($self) = @_;
 	my $ce = $self->{ce};
-        my $dir = $ce->{courseDirs}->{templates};
-        return grep { not m/^\./ and m/\.lst$/ and -f "$dir/$_" } WeBWorK::Utils::readDirectory($dir);
+	my $dir = $ce->{courseDirs}->{templates};
+	return grep { not m/^\./ and m/\.lst$/ and -f "$dir/$_" } WeBWorK::Utils::readDirectory($dir);
 }
 
 sub getDefList {

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -665,6 +665,7 @@ sub getDefList {
         return if ($File::Find::dir =~ /$topdir\/Library/) and not $searchOPL;
         my @d = $File::Find::dir =~ /\//g; #count slashes to gauge depth
         my $depth = @d;
+        $depth-- if $_ eq $topdir;
         $File::Find::prune = 1 if $depth >= $max_depth;
         push @found_set_defs, $_ if m|/set[^/]*\.def$|;
     };

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -628,7 +628,7 @@ sub getTableParams {
 	
 	my %tableParams;
 	foreach my $param ($r->param) {
-		next unless $param =~ m/^(?:set)\./;
+		next unless $param =~ m/^(?:.*set)\./;
 		$tableParams{$param} = [ $r->param($param) ];
 	}
 	return %tableParams;
@@ -1758,7 +1758,7 @@ sub readSetDef {
 
 	my $setName = '';
 
-	if ($fileName =~ m|^set([.\w-]+)\.def$|) {
+	if ($fileName =~ m|^.*set([.\w-]+)\.def$|) {
 		$setName = $1;
 	} else {
 		$self->addbadmessage( 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -639,7 +639,7 @@ sub getTableParams {
 	
 	my %tableParams;
 	foreach my $param ($r->param) {
-		next unless $param =~ m/^(?:set)\./;
+		next unless $param =~ m/^(?:.*set)\./;
 		$tableParams{$param} = [ $r->param($param) ];
 	}
 	return %tableParams;
@@ -1822,7 +1822,7 @@ sub readSetDef {
 	
 	my $r = $self->r;
 
-	if ($fileName =~ m|^set([.\w-]+)\.def$|) {
+	if ($fileName =~ m|^.*set([.\w-]+)\.def$|) {
 		$setName = $1;
 	} else {
 		$self->addbadmessage( 


### PR DESCRIPTION
Prior to this pull request, when importing `.def` files, only the `templates` folder (and no subfolder) are scanned for `.def` files. This adds `$options{setDefSearchDepth}=0;` and `$options{useOPLdefFiles}=0;` to `defaults.conf` which can be changed in `localOverrides.conf` or `course.conf`. `$options{setDefSearchDepth}` sets a search depth within subfolders (and symlinks) within `templates`. The idea is now you can store `.def` files in a subfolder of `templates` or in a central location on the server via a symlink.

Because this can take you into the OPL (where there are some `.def` files), you may want to exclude the OPL with `$options{useOPLdefFiles}`. (In fact every `.def` file I encountered in the OPL was broken with bad file paths and/or answer dates that came before the due date.)

I tested this with Hmwk Sets Editor2. When I went to test it with Hmwk Sets Editor, I had error warnings because of `.def` files that included a `description` line, and it appears Hmwk Sets Editor can't deal with that. Is this an oversight or are we not maintaining Hmwk Sets Editor anymore?

Test by restarting Apache, going to Hmwk Sets Editor2 in a course, and trying to import problem sets with various combinations of:
* different values for `$options{setDefSearchDepth}` and `$options{useOPLdefFiles}`. Setting the depth to 4 should make some OPL `.def` files appear. (But keep in mind that the OPL set.def files are probably not actually good if you then try to visit the set.) Also you might try putting some `.def` files in `templates` at depth 1 or 2.
* importing one or many sets.

And maybe do it with both Hmwk Sets Editor and Hmwk Sets Editor2.