### PR TITLE
changed css for skip to main content to not push down

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -60,7 +60,12 @@ legend {
 }
 .sr-only-focusable:active,
 .sr-only-focusable:focus {
-  position: static;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 1px solid #999;
+  background-color: #FFFFDD;
+  padding: 10px;
   width: auto;
   height: auto;
   margin: 0;


### PR DESCRIPTION
Haris suggested this way to handle the CSS on the skip to main content link. Rather than push down all of the other content when it is revealed, this is more of an overlay. Not sure if this is how the coloring should be handled, but this coloring appears to work well with each of math4, math4-green, and math4-red.

If there are no problems with this, is it small enough to bring to release/2.10?