### PR TITLE
Labels for PG fields.  

### DIFF
--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -233,13 +233,13 @@ $(function(){
     /* This code adds a screen reader only label to a pg form element that 
        isn't already wrapped in a label.  The label text is the current 
        aria-label text */
-    $('.codeshard').each(function () {
+    $('.codeshard').add('.pg-select').each(function () {
 	if ($(this).parent().is('label')) {
 	    $(this).parent().attr('for',$(this).attr('id'));
 	} else {
 	    $(this).before($('<label>',{class : 'sr-only',
-				      for : $(this).attr('id')})
-			 .html($(this).attr('aria-label')));
+					for : $(this).attr('id')})
+			   .html($(this).attr('aria-label')));
 	}
     });
 

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -229,6 +229,20 @@ $(function(){
     if ($('.codeshard').length == 1) {
 	$('.codeshard').attr('aria-label','answer');
     }
+    
+    /* This code adds a screen reader only label to a pg form element that 
+       isn't already wrapped in a label.  The label text is the current 
+       aria-label text */
+    $('.codeshard').each(function () {
+	if ($(this).parent().is('label')) {
+	    $(this).parent().attr('for',$(this).attr('id'));
+	} else {
+	    $(this).before($('<label>',{class : 'sr-only',
+				      for : $(this).attr('id')})
+			 .html($(this).attr('aria-label')));
+	}
+    });
+
 
     /* Glyphicon accessibility */
     jQuery('span.icon').each(function() {


### PR DESCRIPTION
This pull request is for Alex, mostly. 

After thinking about it I put together a bit of a bandaid that adds screen reader only label for PG problem input fields.  In practice this doesn't really add anything that aria-label doesn't do, but it does help validate against automated accessiblity checkers.  I dont *think* it causes any other problems with rendering or the like.  Does this get most of the way to addressing your concerns?  It doesn't do selects, or checkboxes, and the label text isn't particularly friendly.  