### PR TITLE
Add status menu to tagwidget for OPL editors

### DIFF
--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -196,6 +196,7 @@ sub pre_header_initialize {
 		    library_chapters	    => $r->param("library_chapters") ||undef,
 		    library_sections	    => $r->param("library_sections") ||undef,
 		    library_levels		    => $r->param("library_levels") ||undef,
+		    library_status		    => $r->param("library_status") ||undef,
 		    library_textbook	    => $r->param("library_textbook") ||undef,
 		    library_keywords	    => $r->param("library_keywords") ||undef,
 		    library_textchapter     => $r->param("library_textchapter") ||undef,

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -142,7 +142,7 @@ sub setProblemTags {
 		$tags->settag('DBchapter', $chap, 1);
 		$tags->settag('DBsection', $sect, 1);
 		$tags->settag('Level', $level, 1);
-		$tags->settag('Status', $status, 0) if $status;
+		$tags->settag('Status', $status, 1);
 		eval {
 			$tags->write();
 			1;

--- a/lib/WebworkWebservice/LibraryActions.pm
+++ b/lib/WebworkWebservice/LibraryActions.pm
@@ -466,8 +466,9 @@ sub setProblemTags {
 	my $dbchap = $rh->{library_chapters};
 	my $dbsect = $rh->{library_sections};
 	my $level = $rh->{library_levels};
+	my $stat = $rh->{library_status};
 	# result is [success, message] with success = 0 or 1
-	my $result = WeBWorK::Utils::ListingDB::setProblemTags($path, $dbsubj, $dbchap, $dbsect, $level);
+	my $result = WeBWorK::Utils::ListingDB::setProblemTags($path, $dbsubj, $dbchap, $dbsect, $level, $stat);
 	my $out = {};
 	$out->{text} = encode_base64($result->[1]);
 	return($out);


### PR DESCRIPTION
This creates a new menu in the tagging widget which provides drop-down menus for tagging problems.  The new menu is for the Status of an OPL submission.  The overall process is as follows
   1. Person adds to Contrib, makes a pull request, it gets accepted 
   2. Managing editor copies files to the Pending directory in the OPL git repository
   3. OPL editors look at problems and use the status menu to accept/reject the problem (if accepted, also set taxonomy menus and level)
   4. Managing editor then moves accepted problems to the main OPL, deletes rejected ones from Pending and notes them in a file of problems which are not accepted (so they don't go back into Pending unless it is being forced)

By default, we don't want other users using this feature, so it presumes the course where the editor works has a link called Pending pointing to the OPL Pending directory on their server (with server having write permissions to those files).  Ideally, the server is configured with a "special button" for Pending.

In the end, this pull request just makes the menu and will save the results.  If the problem is not under templates/Pending, the new menu should not appear, otherwise it will.