### PR TITLE
Change Library Directory Name

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -123,7 +123,7 @@ $webworkFiles{screenSnippets}{setHeader}         = "$webworkDirs{conf}/snippets/
 #$problemLibrary{root}        = "/opt/webwork/libraries/NationalProblemLibrary";
 #$problemLibrary{version}     = "2";
 # uncomment these lines below and comment out the line above if using OPL instead of NPL
-$problemLibrary{root}       = "/opt/webwork/library/webwork-open-problem-library/OpenProblemLibrary";
+$problemLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
 $problemLibrary{version}    = "2.5";  
 
 # Additional library buttons can be added to the Library Browser (SetMaker.pm)


### PR DESCRIPTION
Changed
```
$problemLibrary{root}       = "/opt/webwork/library/webwork-open-problem-library/OpenProblemLibrary";
```
to 
```
 $problemLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
```
`localoverrides.conf.dist` to make it fit with other stuff (ww_install, defaults.config, the OPL reop)