### PR TITLE
Set 0 Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -28,6 +28,7 @@ use base qw(WeBWorK::ContentGenerator);
 use MIME::Base64 qw( encode_base64 decode_base64);
 use WeBWorK::Debug;
 use WeBWorK::Utils qw(readFile);
+use PGUtil qw(not_null);
 
 our $UNIT_TESTS_ON      = 0;  # should be called DEBUG??  FIXME
 
@@ -216,7 +217,7 @@ sub pre_header_initialize {
             new_password   			=> $r->param('new_password') || undef,
             userpassword   			=> $r->param('userpassword') || undef,	# defaults to studentid if empty
 	     	set_props	    		=> $r->param('set_props') || undef,
-	     	set_id	    			=> $r->param('set_id') || undef,
+	     	set_id	    			=> not_null($r->param('set_id')) ? $r->param('set_id') : undef,
 	     	due_date	    		=> $r->param('due_date') || undef,
 	     	set_header     		   	=> $r->param('set_header') || undef,
 	        hardcopy_header 	   	=> $r->param('hardcopy_header') || undef,


### PR DESCRIPTION
Post release bugfixing continues.  Fixed a problem where the set name 0 was interpreted as null by xmlrpc.  This allows you to add problems to sets named "0" via the library browser now.  