### PR TITLE
SendMail Bug

### DIFF
--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -182,7 +182,7 @@ $(function(){
     //email page
     $('#send-mail-form').addClass('form-inline');
     $('#send-mail-form .btn').addClass('btn-small').removeClass('btn-primary');
-    $('#send-mail-form input[value="Send Email"]').addClass('btn-primary');
+    $('#send-mail-form #sendEmail_id').addClass('btn-primary');
 
     //Score sets
     $('#scoring-form').addClass('form-inline');

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -72,7 +72,7 @@ sub initialize {
 	my $old_default_msg_file   =    'old_default.msg';
 	
 	# Figure out action from submit data
-	my $action; 
+	my $action = ''; 
 	if ($r->param('sendEmail')) {
 	    $action = 'sendEmail';
 	} elsif ($r->param('saveMessage')) {
@@ -211,9 +211,9 @@ sub initialize {
 	# Determine the file name to save message into
 	#################################################################
 	my $output_file      = 'FIXME no output file specified';	
-	if (defined($action) and $action eq 'saveDefault') {
+	if ($action eq 'saveDefault') {
 		$output_file  = $default_msg_file;
-	} elsif ( defined($action) and ($action eq 'saveMessage' or $action eq 'saveAs')) {
+	} elsif ($action eq 'saveMessage' or $action eq 'saveAs') {
 		if (defined($savefilename) and $savefilename ) {
 			$output_file  = $savefilename;
 		} else {
@@ -333,7 +333,7 @@ sub initialize {
 	my $script_action     = '';
 	
 	
-	if(not defined($action) or $action eq 'openMessage'  
+	if(not $action or $action eq 'openMessage'  
 	   or $action eq 'updateSettings'){  
 
 		return '';

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -39,8 +39,7 @@ use WeBWorK::Utils::FilterRecords qw/filterRecords/;
 use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
-#my $REFRESH_RESIZE_BUTTON = "Set preview to: ";  # handle submit value idiocy
-my $UPDATE_SETTINGS_BUTTON = "Update settings and refresh page"; # handle submit value idiocy
+
 sub initialize {
 	my ($self) = @_;
 	my $r      = $self->r;
@@ -65,15 +64,30 @@ sub initialize {
 	my $scoringDirectory  =    $ce->{courseDirs}->{scoring};
 	my $templateDirectory =    $ce->{courseDirs}->{templates};
 	
-	my $action            =    $r->param('action') ; 
 	my $openfilename      =	   $r->param('openfilename');
 	my $savefilename      =	   $r->param('savefilename');
-	
 	
 	#FIXME  get these values from global course environment (see subroutines as well)
 	my $default_msg_file       =    'default.msg';  
 	my $old_default_msg_file   =    'old_default.msg';
 	
+	# Figure out action from submit data
+	my $action; 
+	if ($r->param('sendEmail')) {
+	    $action = 'sendEmail';
+	} elsif ($r->param('saveMessage')) {
+	    $action = 'saveMessage';
+	} elsif ($r->param('saveAs')) {
+	    $action = 'saveAs';
+	} elsif ($r->param('saveDefault')) {
+	    $action = 'saveDefault';
+	} elsif ($r->param('openMessage')) {
+	    $action = 'openMessage';
+	} elsif ($r->param('updateSettings')) {
+	    $action = 'updateSettings';
+	} elsif ($r->param('previewMessage')) {
+	    $action = 'previewMessage';
+	}
 
 	#  get user record
 	my $ur = $self->{db}->getUser($user);
@@ -197,9 +211,9 @@ sub initialize {
 	# Determine the file name to save message into
 	#################################################################
 	my $output_file      = 'FIXME no output file specified';	
-	if (defined($action) and $action eq 'Save as Default') {
+	if (defined($action) and $action eq 'saveDefault') {
 		$output_file  = $default_msg_file;
-	} elsif ( defined($action) and ($action =~/save/i)) {
+	} elsif ( defined($action) and ($action eq 'saveMessage' or $action eq 'saveAs')) {
 		if (defined($savefilename) and $savefilename ) {
 			$output_file  = $savefilename;
 		} else {
@@ -235,7 +249,7 @@ sub initialize {
 	#warn "Action = $action";
 	my $input_source;
 	if ($action){	
-		$input_source =  ( defined( $r->param('body') ) and $action ne 'Open' ) ? 'form' : 'file';}
+		$input_source =  ( defined( $r->param('body') ) and $action ne 'openMessage' ) ? 'form' : 'file';}
 	else { $input_source = ( defined($r->param('body')) ) ? 'form' : 'file';}
 
 	#############################################################################################
@@ -319,8 +333,8 @@ sub initialize {
 	my $script_action     = '';
 	
 	
-	if(not defined($action) or $action eq $r->maketext('Open')  
-	   or $action eq $r->maketext($UPDATE_SETTINGS_BUTTON )){  
+	if(not defined($action) or $action eq 'openMessage'  
+	   or $action eq 'updateSettings'){  
 
 		return '';
 	}
@@ -335,7 +349,7 @@ sub initialize {
 	#############################################################################################
 
 
-	if ($action eq 'Save' or $action eq 'Save as:' or $action eq 'Save as Default') {
+	if ($action eq 'saveMessage' or $action eq 'saveAs' or $action eq 'saveDefault') {
 	
 		#warn "FIXME Saving files  action = $action  outputFileName=$output_file";
 		
@@ -352,7 +366,7 @@ sub initialize {
 		#################################################################
 		# overwrite protection
 		#################################################################
-		if ($action eq 'Save as:' and -e "$emailDirectory/$output_file") {
+		if ($action eq 'saveAs' and -e "$emailDirectory/$output_file") {
 			$self->addbadmessage(CGI::p("The file $emailDirectory/$output_file already exists and cannot be overwritten",
 			                         "The message was not saved"));
 			return;
@@ -361,7 +375,7 @@ sub initialize {
 		#################################################################
 	    # Back up existing file?
 	    #################################################################
-	    if ($action eq 'Save as Default' and -e "$emailDirectory/$default_msg_file") {
+	    if ($action eq 'saveDefault' and -e "$emailDirectory/$default_msg_file") {
 	    	rename("$emailDirectory/$default_msg_file","$emailDirectory/$old_default_msg_file") or 
 	    	       die "Can't rename $emailDirectory/$default_msg_file to $emailDirectory/$old_default_msg_file ",
 	    	           "Check permissions for webserver on directory $emailDirectory. $!";
@@ -375,10 +389,10 @@ sub initialize {
 			$self->addgoodmessage(CGI::p("Message saved to file <code>${emailDirectory}/$output_file</code>."));
 		}    
 
-	} elsif ($action eq 'Preview message') {
+	} elsif ($action eq 'previewMessage') {
 		$self->{response}         = 'preview';
 	
-	} elsif ($action eq 'Send Email') {
+	} elsif ($action eq 'sendEmail') {
 		# verify format of From address (one valid rfc2822 address)
 		my @parsed_from_addrs = Email::Address->parse($self->{from});
 		unless (@parsed_from_addrs == 1) {
@@ -610,7 +624,7 @@ sub print_form {
 
 			 CGI::td({},
 			     CGI::strong($r->maketext("Message file: ")), $input_file,"\n",CGI::br(),
-				 CGI::submit(-name=>'action', -value=>$r->maketext('Open')), '&nbsp;&nbsp;&nbsp;&nbsp;',"\n",
+				 CGI::submit(-name=>'openMessage', -value=>$r->maketext('Open')), '&nbsp;&nbsp;&nbsp;&nbsp;',"\n",
 				 CGI::popup_menu(-name=>'openfilename', 
 				                 -values=>\@sorted_messages, 
 				                 -default=>$input_file
@@ -635,7 +649,7 @@ sub print_form {
 				$r->maketext("Editor rows: "), CGI::textfield(-name=>'rows', -size=>3, -value=>$rows),
 				$r->maketext(" columns: "), CGI::textfield(-name=>'columns', -size=>3, -value=>$columns),
 				CGI::br(),
-				CGI::submit(-name=>'action', -value=>$r->maketext($UPDATE_SETTINGS_BUTTON)),
+				CGI::submit(-name=>'updateSettings', -value=>$r->maketext("Update settings and refresh page")),
 				 
 			),
 	#############################################################################################
@@ -651,7 +665,7 @@ sub print_form {
 		                                   -default=>'studentID', -linebreak=>0), 
 							CGI::br(),$scrolling_user_list,
 							CGI::i($r->maketext("Preview set to: ")), $preview_record->last_name,'(', $preview_record->user_id,')',
-							CGI::submit(-name=>'action', -value=>'preview',-label=>$r->maketext('Preview message')),'&nbsp;&nbsp;',
+							CGI::submit(-name=>'previewMessage', -value=>'preview',-label=>$r->maketext('Preview message')),'&nbsp;&nbsp;',
 					),
 	); # end Tr
 	
@@ -708,12 +722,12 @@ sub print_form {
 	#############################################################################################	
 	print    CGI::table( { -border=>2,-cellpadding=>4},
 				 CGI::Tr( {},
-					 CGI::td({}, CGI::submit(-name=>'action', -value=>$r->maketext('Send Email')) ), "\n",
-					 CGI::td({}, CGI::submit(-name=>'action', -value=>$r->maketext('Save'))," to $output_file"), " \n",
-					 CGI::td({}, CGI::submit(-name=>'action', -value=>$r->maketext('Save as:')),
+					 CGI::td({}, CGI::submit(-name=>'sendEmail', -id=>"sendEmail_id", -value=>$r->maketext('Send Email')) ), "\n",
+					 CGI::td({}, CGI::submit(-name=>'saveMessage', -value=>$r->maketext('Save'))," to $output_file"), " \n",
+					 CGI::td({}, CGI::submit(-name=>'saveAs', -value=>$r->maketext('Save as:')),
 					         CGI::textfield(-name=>'savefilename', -size => 20, -value=> "$output_file", -override=>1)
 					 ), "\n",
-					 CGI::td(CGI::submit(-name=>'action', -value=>$r->maketext('Save as Default'))),
+					 CGI::td(CGI::submit(-name=>'saveDefault', -value=>$r->maketext('Save as Default'))),
 				) 
 	);
 			   


### PR DESCRIPTION
Refactored SendMail.  Previous setup used the "value" of the submit buttons to figure out the action, which broke when the value changed, e.g. in a different locale. Current setup uses the name of the button to determine action.