### PR TITLE
Apache Version Conf Variable

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -59,6 +59,13 @@ $server_userID     = 'www-data';
 $server_groupID    = 'wwdata';
 
 
+#  Uncomment out the following line to set your apache version number manually.
+#  WeBWorK will automatically get the apache version directly from the server
+#  banner.  If you remove the version from the server banner you will have to
+#  set it directly here
+
+#$server_apache_version = '';
+
 ################################################################################
 # Paths to external programs 
 ################################################################################

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -64,7 +64,7 @@ $server_groupID    = 'wwdata';
 #  banner.  If you remove the version from the server banner you will have to
 #  set it directly here
 
-#$server_apache_version = '';
+#$server_apache_version = ''; # e.g. '2.22.1'
 
 ################################################################################
 # Paths to external programs 

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -905,13 +905,25 @@ sub write_log_entry {
 	
 	my ($remote_host, $remote_port);
 
-	# If its apache 2.4 then it has to also mod perl 2.0 or better
 	my $APACHE24 = 0;
-	if (MP2 && Apache2::ServerUtil::get_server_banner() =~ 
-	  m:^Apache/(\d\.\d+\.\d+):) {
-	    $APACHE24 = version->parse($1) >= version->parse('2.4.00');
-	}
+	# If its apache 2.4 then it has to also mod perl 2.0 or better
+	if (MP2) {
+	    my $version;
 
+	    # check to see if the version is manually defined
+	    if (defined($ce->{server_apache_version}) &&
+		$ce->{server_apache_version}) {
+		$version = $ce->{server_apache_version};
+	    # otherwise try and get it from the banner
+	    } elsif (Apache2::ServerUtil::get_server_banner() =~ 
+	  m:^Apache/(\d\.\d+):) {
+		$version = $1;
+	    }
+
+	    if ($version) {
+		$APACHE24 = version->parse($version) >= version->parse('2.4');
+	    }
+	}
 	# If its apache 2.4 then the API has changed
 	if ($APACHE24) {
 	    	$remote_host = $r->connection->client_addr->ip_get || "UNKNOWN";

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -203,14 +203,26 @@ sub body {
 		
 		# get info about remote user (stolen from &WeBWorK::Authen::write_log_entry)
 		my ($remote_host, $remote_port);
-
-		# If its apache 2.4 then it has to also mod perl 2.0 or better
+		
 		my $APACHE24 = 0;
-		if (MP2 && Apache2::ServerUtil::get_server_banner() =~ 
-		  m:^Apache/(\d\.\d+\.\d+):) {
-		    $APACHE24 = version->parse($1) >= version->parse('2.4.00');
+		# If its apache 2.4 then it has to also mod perl 2.0 or better
+		if (MP2) {
+		    my $version;
+		    
+		    # check to see if the version is manually defined
+		    if (defined($ce->{server_apache_version}) &&
+			$ce->{server_apache_version}) {
+			$version = $ce->{server_apache_version};
+			# otherwise try and get it from the banner
+		    } elsif (Apache2::ServerUtil::get_server_banner() =~ 
+			   m:^Apache/(\d\.\d+):) {
+			$version = $1;
+		    }
+		    
+		    if ($version) {
+			$APACHE24 = version->parse($version) >= version->parse('2.4');
+		    }
 		}
-
 		# If its apache 2.4 then the API has changed
 		if ($APACHE24) {
 		    $remote_host = $r->connection->client_addr->ip_get || "UNKNOWN";

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -258,18 +258,29 @@ sub initialize {
 		# Sanity check: body must contain non-white space
 		$self->addbadmessage(CGI::p('You didn\'t enter any message.')) unless ($r->param('body') =~ /\S/);
 		$r_text               =    \$body;
-
+		
 	}
 	
 	my $remote_host;
-	# If its apache 2.4 then it has to also mod perl 2.0 or better
 	my $APACHE24 = 0;
+	# If its apache 2.4 then it has to also mod perl 2.0 or better
 	if (MP2) {
-	    Apache2::ServerUtil::get_server_banner() =~ 
-		       m:^Apache/(\d\.\d+\.\d+):;
-	    $APACHE24 = version->parse($1) >= version->parse('2.4.00');
+	    my $version;
+	    
+	    # check to see if the version is manually defined
+	    if (defined($ce->{server_apache_version}) &&
+		$ce->{server_apache_version}) {
+		$version = $ce->{server_apache_version};
+		# otherwise try and get it from the banner
+	    } elsif (Apache2::ServerUtil::get_server_banner() =~ 
+		   m:^Apache/(\d\.\d+):) {
+		$version = $1;
+	    }
+	    
+	    if ($version) {
+		$APACHE24 = version->parse($version) >= version->parse('2.4');
+	    }
 	}
-
 	# If its apache 2.4 then the API has changed
 	if ($APACHE24) {
 	    $remote_host = $r->connection->client_addr->ip_get || "UNKNOWN";

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -438,15 +438,13 @@ sub body {
 
 		my $setName = ( $setVersion ) ? "$setID (test $setVersion)" : $setID;
 
-		my $exists = defined($MergedSetRecord);
-		warn($exists);
 		print CGI::Tr(
 			CGI::td({ -align => "center" }, [
 				($setVersion) ? "" : CGI::checkbox({ type => 'checkbox',
 								name => "set.$fullSetID.assignment",
 								label => '',
 								value => 'assigned',
-								defined($MergedSetRecord) ? ('checked','checked') : () }),
+								checked => (defined $MergedSetRecord)}),
 				defined($MergedSetRecord) ? CGI::b(CGI::a({href=>$url},$setName, ) ) : CGI::b($setID, ),
 				join "\n", $self->DBFieldTable($GlobalSetRecord, $UserSetRecord, $MergedSetRecord, "set", $setID, \@dateFields, $rh_dateFieldLabels),
 			])

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -54,7 +54,8 @@ sub initialize {
 	my $permissionLevelTemplate = $self->{permissionLevelTemplate} = $db->newPermissionLevel;
 	
 	# first check to see if a save form has been submitted
-	return '' unless $r->param('save_button');
+	return '' unless ($r->param('save_button') ||
+			  $r->param('assignAll'));
 	
 	# As it stands we need to check each set to see if it is still assigned 
 	# the forms are not currently set up to simply transmit changes
@@ -66,7 +67,10 @@ sub initialize {
 	
 	my @assignedSets = ();
 	foreach my $setID (@setIDs) {
-		push @assignedSets, $setID if defined($r->param("set.$setID.assignment"));
+	    # add sets to the assigned list if the parameter is checked or the
+	    # assign all button is pushed.  (already assigned sets will be
+	    # skipped later) 
+	    push @assignedSets, $setID if defined($r->param("set.$setID.assignment")) || $r->param("assignAll");
 	}
 
 	# note: assignedSets are those sets that are assigned in the submitted form
@@ -338,6 +342,17 @@ sub body {
 	}
 	
 	########################################
+	# Assigned sets form
+	########################################
+
+	print CGI::start_form( {method=>'post',action=>$userDetailUrl, name=>'UserDetail', id=>'UserDetail'}),"\n";
+	print $self->hidden_authen_fields();
+
+	print CGI::div(
+	    CGI::submit({name=>"assignAll", value => $r->maketext("Assign All Sets to Current User")})), CGI::br();
+
+
+	########################################
 	# Print warning
 	########################################
 	print CGI::div({-class=>'ResultsWithError'},
@@ -352,12 +367,7 @@ sub body {
 		      reassign the set, the student will receive a new version of each problem.
 		      Make sure this is what you want to do before unchecking sets."
 	);
-	########################################
-	# Assigned sets form
-	########################################
 
-	print CGI::start_form( {method=>'post',action=>$userDetailUrl, name=>'UserDetail', id=>'UserDetail'}),"\n";
-	print $self->hidden_authen_fields();
 	print CGI::p(CGI::submit(-name=>'save_button',-label=>$r->maketext('Save changes'),));
 	
 	print CGI::start_table({ border=> 1,cellpadding=>5}),"\n";
@@ -428,13 +438,15 @@ sub body {
 
 		my $setName = ( $setVersion ) ? "$setID (test $setVersion)" : $setID;
 
+		my $exists = defined($MergedSetRecord);
+		warn($exists);
 		print CGI::Tr(
 			CGI::td({ -align => "center" }, [
 				($setVersion) ? "" : CGI::checkbox({ type => 'checkbox',
 								name => "set.$fullSetID.assignment",
 								label => '',
 								value => 'assigned',
-								checked => (defined $MergedSetRecord)}),
+								defined($MergedSetRecord) ? ('checked','checked') : () }),
 				defined($MergedSetRecord) ? CGI::b(CGI::a({href=>$url},$setName, ) ) : CGI::b($setID, ),
 				join "\n", $self->DBFieldTable($GlobalSetRecord, $UserSetRecord, $MergedSetRecord, "set", $setID, \@dateFields, $rh_dateFieldLabels),
 			])


### PR DESCRIPTION
This pull request does two relatively minor things
-  It adds a "Assign All Sets to Current User" button to the UserDetail page.  Check by clicking on the "Assigned Sets" link next to a user and checking to see that it does what it is supposed to.  

- It adds an optional (and commented out by default) `$server_apache_version` variable to site.conf.  When this is defined it will be used to determine the server version.  This is primarily for servers which do not have the version number in the banner for whatever reason.  Check by verifying that Authen, SendMail and Feedback still work, then set the server version string to something its not (pre 2.4 if you are post 2.4 and post 2.4 otherwise) and check that it breaks those pages.  