### PR TITLE
Guest User Check Permission

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -693,10 +693,11 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
         # controls if old answers can be shown
 	can_show_old_answers                            => "student",
 	check_answers_before_open_date                  => "ta",
-	check_answers_after_open_date_with_attempts     => "ta",
+	check_answers_after_open_date_with_attempts     => "guest",
 	check_answers_after_open_date_without_attempts  => "guest",
 	check_answers_after_due_date                    => "guest",
 	check_answers_after_answer_date                 => "guest",
+        can_check_and_submit_answers                    => "ta", 
 	create_new_set_version_when_acting_as_student   => undef,
 	print_path_to_problem                           => "professor", # see "Special" PG environment variables
 	always_show_hint								=> "professor", # see "Special" PG environment variables

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -821,6 +821,13 @@ $options{useDateTimePicker} = 1;
 
 $options{enableConditionalRelease} = 0;
 
+##########################################################################################
+#### Default settings for the problem grader page
+##########################################################################################
+
+# gap betweens cores in score dropdown - e.g. 5 gives 5, 10, 15, 20
+$options{problemGraderScoreDelta} = 5;
+
 ###########################################################################################
 #### Default settings for the PG translator
 #### This section controls the display of equations, HINTS, answers, SOLUTIONS, 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -237,6 +237,14 @@ sub can_checkAnswers {
 	    $tmplSet, $submitAnswers) = @_;
 	my $authz = $self->r->authz;
 
+	# if we can record answers then we dont need to be able to check them
+	# unless we have that specific permission. 
+	if ($self->can_recordAnswers($User,$PermissionLevel,$EffectiveUser,
+				     $Set,$Problem,$tmplSet,$submitAnswers) 
+	    && !$authz->hasPermissions($User->user_id, "can_check_and_submit_answers")) {
+	    return 0;
+	}
+
 	my $timeNow = ( defined($self->{timeNow}) ) ? $self->{timeNow} : time();
    # get the sag time after the due date in which we'll still grade the test
 	my $grace = $self->{ce}->{gatewayGracePeriod};

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1765,7 +1765,7 @@ sub body {
 	#    problems when checking answers
 	my $attemptScore = 0;
 
-	if ( $submitAnswers || $checkAnswers ) {
+	if ( $will{submitAnswers} || $will{checkAnswers} ) {
 		my $i=0;
 		foreach my $pg ( @pg_results ) {
 			my $pValue = $problems[$i]->value() ? $problems[$i]->value() : 1;
@@ -1824,7 +1824,7 @@ sub body {
 	##### start output of test headers: 
 	##### display information about recorded and checked scores
 	$attemptScore = wwRound(2,$attemptScore);
-	if ( $submitAnswers ) {
+	if ( $will{submitAnswers} ) {
 		# the distinction between $can{recordAnswers} and ! $can{} has 
 		#    been dealt with above and recorded in @scoreRecordedMessage
 		my $divClass = 'ResultsWithoutError';
@@ -1877,7 +1877,7 @@ sub body {
 			print CGI::end_div();
 		}
 
-	} elsif ( $checkAnswers ) {
+	} elsif ( $will{checkAnswers} ) {
 		if ( $can{showScore} ) {
 			print CGI::start_div({class=>'gwMessage'});
 			print CGI::strong("Your score on this (checked, not ",
@@ -2125,7 +2125,7 @@ sub body {
 								  $pg->{flags}->{showPartialCorrectAnswers} && $canShowProblemScores,
 								  $canShowProblemScores, 1);
 					
-				} elsif ( $checkAnswers ) {
+				} elsif ( $will{checkAnswers} ) {
 					$recordMessage = CGI::span({class=>"resultsWithError"},
 								   "ANSWERS ONLY CHECKED -- ", 
 								   "ANSWERS NOT RECORDED");

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -313,10 +313,10 @@ sub body {
 	    
 	    
 	    my %dropDown;
-	    #construct the drop down.  Right now it does all numbers from 
-	    # 1 to 100, but this could be changed by config
-	    for (my $i=100; $i>=0; $i--) {
-		    $dropDown{$i}=$i;
+	    my $delta = $ce->{options}{problemGraderScoreDelta};
+	    #construct the drop down.  
+	    for (my $i=int(100/$delta); $i>=0; $i--) {
+		    $dropDown{$i*$delta}=$i*$delta;
 	    }
 
 	    print CGI::Tr({-valign=>"top"}, 
@@ -347,7 +347,7 @@ sub body {
 	    print CGI::Tr(CGI::td([CGI::hr(), CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"&nbsp;"]));
 
 
-#  Text field for gradex
+#  Text field for grade
 #				      CGI::input({type=>"text",
 #						  name=>"$userID.score",
 #						  value=>"$score",

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -161,6 +161,13 @@ sub can_checkAnswers {
 	my $authz = $self->r->authz;
 	my $thisAttempt = $submitAnswers ? 1 : 0;
 	
+	# if we can record answers then we dont need to be able to check them
+	# unless we have that specific permission. 
+	if ($self->can_recordAnswers($User,$EffectiveUser,$Set,$Problem,$submitAnswers) 
+	    && !$authz->hasPermissions($User->user_id, "can_check_and_submit_answers")) {
+	    return 0;
+	}
+	
 	if (before($Set->open_date)) {
 		return $authz->hasPermissions($User->user_id, "check_answers_before_open_date");
 	} elsif (between($Set->open_date, $Set->due_date)) {
@@ -1698,13 +1705,13 @@ sub output_summary{
 			$pg->{flags}->{showPartialCorrectAnswers}, 1, 1);	    
 	    print $results;
 	    
-	} elsif ($checkAnswers) {
-        if ($showMeAnother{CheckAnswers} and $can{showMeAnother}){
-            # if the student is checking answers to a new problem, give them a reminder that they are doing so
-            print CGI::div({class=>'showMeAnotherBox'},$r->maketext("You are currently checking answers to a different version of your problem - these 
+	} elsif ($will{checkAnswers}) {
+	    if ($showMeAnother{CheckAnswers} and $can{showMeAnother}){
+		# if the student is checking answers to a new problem, give them a reminder that they are doing so
+		print CGI::div({class=>'showMeAnotherBox'},$r->maketext("You are currently checking answers to a different version of your problem - these 
                                                                      will not be recorded, and you should remember to return to your original 
                                                                      problem once you are done here.")),CGI::br();
-        }
+	    }
 	    # print this if user previewed answers
 	    print CGI::div({class=>'ResultsWithError'},$r->maketext("ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED")), CGI::br();
 	    print $self->attemptResults($pg, 1, $will{showCorrectAnswers}, 1, 1, 1);


### PR DESCRIPTION
Adds a new permission `can_check_and_submit_answers`.  This is set to `ta` by default and controls who can see both the check and submit button.  If a user has the permission to see each individually, but not both, it shows the submit button.  This allows `check_answers_after_open_date_with_attempts` to be set to `guest`.  This way guest users can check answers on open sets, students can submit them, but not check them, and ta and above can do both. Check by assigning a set and logging in as guest.  With the default permissions you should be able to check answers.  Check that students cannot check answers until they run out of attempts or after the due date.  (Note: On gateways the check and grade buttons are never shown together.) 

This also adds the configuration variable `$options{problemGraderScoreDelta} = 5;` which controls the delta for the score selection drop down on the problem grader page.  Check by visiting the problem grader page and seeing if the drop down responds correctly when the config variable is changed.  
