### PR TITLE
Develop wwsh

### DIFF
--- a/bin/putadmin
+++ b/bin/putadmin
@@ -1,0 +1,10 @@
+
+$db->putUser($db->newUser(user_id=>"admin", first_name=>"Prof", last_name=>"Admin",email_address=>"", student_id=>"admin", status=>"C",section=>"", recitation=>"",comment=>"administrator"));
+
+$db->putPassword($db->newPassword(user_id=>"admin", password=>crypt("admin", "dc")));
+
+$db->putPermissionLevel($db->newPermissionLevel(user_id=>"admin", permission=>"10"));
+
+
+print "data changed for user admin\n" ;
+

--- a/bin/wwsh
+++ b/bin/wwsh
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -d
+#!/usr/bin/perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
@@ -17,36 +17,41 @@
 
 =head1 NAME
 
-wwdb - command-line interface to the WeBWorK libraries.
+wwsh - command-line interface to the WeBWorK libraries.
 
 =cut
+
+use strict;
+use warnings;
 
 
 
 BEGIN {
-	DB::parse_options("NonStop=1");
-	unless ($ENV{WEBWORK_ROOT}) {
-		die "WEBWORK_ROOT not found in environment.\n";
-	}
+	die "WEBWORK_ROOT not found in environment.\n"
+		unless exists $ENV{WEBWORK_ROOT};
 }
+
+our $ce;
+our $db;
 
 use lib "$ENV{WEBWORK_ROOT}/lib";
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use Data::Dumper;
 
-our $ce;
-our $db;
-
 my $courseID = shift @ARGV;
-unless ($courseID) {
-	die "usage: $0 courseID\n";
+my $scriptFile   = shift @ARGV;
+print "courseID $courseID and $scriptFile\n";
+unless ($courseID and $scriptFile) {
+	die "usage: $0 courseID  scriptFile\n";
 }
 
 $ce = WeBWorK::CourseEnvironment->new({
 	webwork_dir => $ENV{WEBWORK_ROOT},
 	courseName => $courseID,
 });
+
+
 $db = WeBWorK::DB->new($ce->{dbLayout});
 
 print <<'EOF';
@@ -54,6 +59,15 @@ wwsh - The WeBWorK Shell
 Available objects: $ce (WeBWorK::CourseEnvironment)
                    $db (WeBWorK::DB)
 Available modules: Data::Dumper
-EOF
 
-DB::parse_options("NonStop=0");
+EOF
+print "scriptFile:  $scriptFile\n--------------------------------\n";
+do "$scriptFile";
+if ($@) {
+	print "errors ", $@,"\n" ;
+} else {
+	print "--------------------------------\ndone\n";
+}
+
+
+ 

--- a/bin/wwsh
+++ b/bin/wwsh
@@ -41,7 +41,7 @@ use Data::Dumper;
 
 my $courseID = shift @ARGV;
 my $scriptFile   = shift @ARGV;
-print "courseID $courseID and $scriptFile\n";
+
 unless ($courseID and $scriptFile) {
 	die "usage: $0 courseID  scriptFile\n";
 }
@@ -61,7 +61,7 @@ Available objects: $ce (WeBWorK::CourseEnvironment)
 Available modules: Data::Dumper
 
 EOF
-print "scriptFile:  $scriptFile\n--------------------------------\n";
+print "courseID: $courseID and scriptFile:  $scriptFile\n--------------------------------\n";
 do "$scriptFile";
 if ($@) {
 	print "errors ", $@,"\n" ;


### PR DESCRIPTION
Modify wwsh so that it takes courseID and the path to a script file.

It no longer uses perl -d to give an interactive shell.  This stopped working (at least for me) around perl 5.16.

To test.  Try to add an administrator from the command line to an existing course
wwsh maa101 addadmin

Then update the password

wwsh maa101 putadmin

Remember to remove the admin user from the maa101 course since the password is generic.  This is a major use case for wwsh.  To add an emergency administrator when you have been locked out of a course.