### PR TITLE
Change "alert" warnings to "console.log" warnings. --develop

### DIFF
--- a/htdocs/js/legacy/ww_applet_support.js
+++ b/htdocs/js/legacy/ww_applet_support.js
@@ -638,12 +638,12 @@ ww_applet.prototype.safe_applet_initialize = function(i) {
 		}
 		setTimeout( "ww_applet_list[\""+ appletName + "\"].safe_applet_initialize(" + i +  ")",TIMEOUT);	
 		// warn about loading after failed_attempts_allowed failed attempts or if there is only one attempt left
-        if (i<=1 || i< (ww_applet_list[appletName].maxInitializationAttempts-failed_attempts_allowed)) { alert("Oops, applet is not ready. " +(i-1) +" tries left")};
+        if (i<=1 || i< (ww_applet_list[appletName].maxInitializationAttempts-failed_attempts_allowed)) { console.log("Oops, applet is not ready. " +(i-1) +" tries left")};
      	console.log("Out of safe_applet_initialize for applet " + appletName);
         return "";
 	} else if (applet_loaded==0 && !(i> 0) ) {
 		// it's possible that the isActive() response of the applet is not working properly
-		alert("*We haven't been able to verify that the applet " +appletName + " is loaded.  We'll try to use it anyway but it might not work.\n");
+		console.log("*We haven't been able to verify that the applet " +appletName + " is loaded.  We'll try to use it anyway but it might not work.\n");
 		i=1;
 		applet_loaded=1; // FIXME -- give a choice as to whether to continue or not
 		this.isReady=1;


### PR DESCRIPTION
Convert some JS alerts to console.log calls. This allows applets to be placed in HINTS sections without causing spurious alerts because the applet appears to be missing.  The alerts are still there but are not observed unless one is using developer tools to view the console log.

to test:   View the CSU trig problems as a guest or as a student.  For example at:  
https://devel3.webwork.rochester.edu/webwork2/gage_course/CSU_trig_applets_in_hints

Make sure to refresh the browser cache first.  Check that the hints work as expected.  

Using the developer tools you should be able to see error messages such as "Oops, applet is not ready. X tries left" as well as other messages indicating progress in handling the applet.

It is possible that the console.log messages will not play well with MSIE when the development window
is not open, however there were already a dozen console.log messages in this script and this only
adds two more.
