### PR TITLE
Replace some alerts with  console.log() --master

### DIFF
--- a/htdocs/js/legacy/ww_applet_support.js
+++ b/htdocs/js/legacy/ww_applet_support.js
@@ -638,12 +638,12 @@ ww_applet.prototype.safe_applet_initialize = function(i) {
 		}
 		setTimeout( "ww_applet_list[\""+ appletName + "\"].safe_applet_initialize(" + i +  ")",TIMEOUT);	
 		// warn about loading after failed_attempts_allowed failed attempts or if there is only one attempt left
-        if (i<=1 || i< (ww_applet_list[appletName].maxInitializationAttempts-failed_attempts_allowed)) { alert("Oops, applet is not ready. " +(i-1) +" tries left")};
+        if (i<=1 || i< (ww_applet_list[appletName].maxInitializationAttempts-failed_attempts_allowed)) { console.log("Oops, applet is not ready. " +(i-1) +" tries left")};
      	console.log("Out of safe_applet_initialize for applet " + appletName);
         return "";
 	} else if (applet_loaded==0 && !(i> 0) ) {
 		// it's possible that the isActive() response of the applet is not working properly
-		alert("*We haven't been able to verify that the applet " +appletName + " is loaded.  We'll try to use it anyway but it might not work.\n");
+		console.log("*We haven't been able to verify that the applet " +appletName + " is loaded.  We'll try to use it anyway but it might not work.\n");
 		i=1;
 		applet_loaded=1; // FIXME -- give a choice as to whether to continue or not
 		this.isReady=1;


### PR DESCRIPTION
Replace some alerts with  console.log()  so that flash applets can be placed inside hints without causing spurious alert messages when the applet is not yet loaded.   A hotfix companion to  pull #563.   