### PR TITLE
Remove warning that cookie userID and sessionID do not match. 

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -346,7 +346,8 @@ sub get_credentials {
 
 	if (defined $cookieUser and defined $r->param("user") ) {
 		if ($cookieUser ne $r->param("user")) {
-			croak ("cookieUser = $cookieUser and paramUser = ". $r->param("user") . " are different.");
+			#croak ("cookieUser = $cookieUser and paramUser = ". $r->param("user") . " are different.");
+			$self->maybe_kill_cookie; # use parameter "user" rather than cookie "user";
 		}
 # I don't understand this next segment.
 # If both key and $cookieKey exist then why not just ignore the cookieKey?


### PR DESCRIPTION
 Resolve in favor of the sessionID and then kill the current cookie.

This safety precaution has caused a good deal of trouble, particularly when a user logs in to webwork from moodle
but also from webwork using the same browser.    It's not clear to me that it provides significant safety either.