### PR TITLE
Update documentation to show that "session_cookies" not "key" is the def...

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -777,18 +777,27 @@ $gatewayGracePeriod = 120;
 ## cookies is more appropriate when external authentication systems
 ## are used, e.g., LDAP, LTIBasic, etc.
 ##
-## The reason one might want to use cookies for session management
-## is to avoid having to obtain a write lock on the Key database
-## every time a request is received in order to update the timestamp
-## in the Key database.  When cookies are used for session management,
-## one obtains a write lock on the Key database for the original
-## login request in order to write the new session key and its initial
-## timestamp to the Key database, but on subsequent requests,
-## one merely obtains a read lock on the Key database in order
-## to verify that the session key in the session cookie is the
-## same as the session key in the Key database.  The session timestamp
-## is maintained in the cookie, not in the Key database, which will
-## only show the timestamp of the original login.
+
+## The following ability to update the cookie timestamp instead of the timestamp in the database
+## has been disabled for now.  It opens a potential security hole. 
+## Setting $session_management_via="session_cookies" sets a session cookie automatically
+## even if you don't ask for it explicitly and this login cookie contains a session_key which
+## allows you to reenter your course (within 20 minutes or so) even if you move away from the 
+## webwork HTML page and loose the session_key embedded in the HTML page.
+## However the time stamp in the cookie is not used currently used for anything.
+## 
+#### NOT CURRENT:  The reason one might want to use cookies for session management
+#### is to avoid having to obtain a write lock on the Key database
+#### every time a request is received in order to update the timestamp
+#### in the Key database.  When cookies are used for session management,
+#### one obtains a write lock on the Key database for the original
+#### login request in order to write the new session key and its initial
+#### timestamp to the Key database, but on subsequent requests,
+#### one merely obtains a read lock on the Key database in order
+#### to verify that the session key in the session cookie is the
+#### same as the session key in the Key database.  The session timestamp
+#### is maintained in the cookie, not in the Key database, which will
+#### only show the timestamp of the original login.
 
 
 

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -790,12 +790,20 @@ $gatewayGracePeriod = 120;
 ## is maintained in the cookie, not in the Key database, which will
 ## only show the timestamp of the original login.
 
-## For session management using session_cookies,
-## uncomment the line   $session_management_via = "session_cookie"
-## in the localOverrides.conf file, which will have the effect
-## of overriding the  $session_management_via = "key" below.
 
-$session_management_via = "key";
+
+## For session management using session_cookies, uncomment the first of the 
+## following lines.  
+## For session management using keys stored
+## in the  key  database and, possibly, enduring cookies if any have been set,
+## uncomment the second line.
+
+## These choices can be overridden locally in the localOverrides.conf file.
+## The default is to use "session_cookie".
+
+$session_management_via = "session_cookie";
+#$session_management_via = "key";
+
 
 ################################################################################
 # PG subsystem options
@@ -1155,17 +1163,6 @@ $webworkURLRoot = $webworkURLs{root};
 $pgRoot         = $pg{directories}{root};
 
 
-################################################################################
-# Session Management
-################################################################################
-
-## For session management using session_cookies, uncomment the first of the 
-## following lines.  For session management using keys stored
-## in the  key  database and, possibly, enduring cookies,
-## uncomment the second line.
-
-$session_management_via = "session_cookie";
-#$session_management_via = "key";
 
 ################################################################################
 # Webservices

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -347,15 +347,15 @@ $problemDefaults{showMeAnother} = -1;
 # Session Management
 ################################################################################
 
-## For session management using session_cookies, uncomment the following line,
-## which will override the setting  $session_management_via = "key"
-## in defaults.config.
-## 
 ## For a discussion of session_management_via session_cookies or the
 ## Key database, see the   Session Managment section
 ## of defaults.config.dist
 
-#$session_management_via = "session_cookie";
+## For session management using the key databasse table, uncomment the following line,
+## which will override the setting  $session_management_via = "session_cookie"
+## set in defaults.config.
+
+#  $session_management_via = "key";
 
 ################################################################################
 # Achievement Facebook Integration

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -748,15 +748,18 @@ sub check_session {
 	my $keyMatches = (defined $possibleKey and $possibleKey eq $Key->key);
 	
 	my $timestampValid=0;
-	if ($ce -> {session_management_via} eq "session_cookie" and defined($self->{cookie_timestamp})) {
-		$timestampValid = (time <= $self -> {cookie_timestamp} + $ce->{sessionKeyTimeout});
-	} else {
+# first part of if clause is disabled for now until we figure out long term fix for using cookies
+# safely (see pull request #576)   This means that the database key time is always being used
+# even when in "session_cookie" mode
+#	if ($ce -> {session_management_via} eq "session_cookie" and defined($self->{cookie_timestamp})) {
+#		$timestampValid = (time <= $self -> {cookie_timestamp} + $ce->{sessionKeyTimeout});
+#	} else {
 		$timestampValid = (time <= $Key->timestamp()+$ce->{sessionKeyTimeout});
 		if ($keyMatches and $timestampValid and $updateTimestamp) {
 			$Key->timestamp(time);
 			$db->putKey($Key);
 		}
-	}
+#	}
 	return (1, $keyMatches, $timestampValid);
 }
 


### PR DESCRIPTION
...ault value of $session_managment_via

This is a minimal fix for the moment.

The documentation about how the timestamp is maintained in session_cookies mode is not yet in alignment with the way the code works.  Before fixing that discrepancy (by changing the code and/or the documentation) we need to decide whether the cookie_timestamp or the database timestamp should take priority, or perhaps we should take the later one.

If one starts a session as an instructor for example and then starts a session as a student there are warning messages about conflicts between the cookie data and the hidden variable data embedded in the html page.  It seems to me the latter should take priority -- at least in this  case.  Comments?