### PR TITLE
Develop fix null password

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -627,7 +627,6 @@ sub checkPassword {
 		# check against WW password database
 		my $possibleCryptPassword = crypt $possibleClearPassword, $Password->password;
 		my $dbPassword = $Password->password;
-		my $dbPassword = $Password->password;   
 		# This next line explicitly insures that 
 		# blank or null passwords from the database can never 
 		# succeed in matching an entered password

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -580,7 +580,7 @@ sub maybe_send_cookie {
 	
 	# (c) the user asked to have a cookie sent and is not a guest user.
 	my $user_requests_cookie = ($self->{login_type} ne "guest"
-		and $r->param("send_cookie"));
+		and ( $r->param("send_cookie")//0 )); # prevent warning if "send_cookie" param is not defined.
 
 	# (d) session management is done via cookies.
 	my $session_management_via_cookies = 
@@ -626,7 +626,14 @@ sub checkPassword {
 	if (defined $Password) {
 		# check against WW password database
 		my $possibleCryptPassword = crypt $possibleClearPassword, $Password->password;
-		if ($possibleCryptPassword eq $Password->password) {
+		my $dbPassword = $Password->password;
+		my $dbPassword = $Password->password;   
+		# This next line explicitly insures that 
+		# blank or null passwords from the database can never 
+		# succeed in matching an entered password
+		# Use case: Moodle wwassignment stores null passwords and forces the creation 
+		# of a key -- Moodle wwassignment does not use  passwords for authentication, only keys.
+		if (($dbPassword =~/\S/) && $possibleCryptPassword eq $Password->password) {
 			$self->write_log_entry("AUTH WWDB: password accepted");
 			return 1;
 		} else {


### PR DESCRIPTION
Explicitly check whether the password stored in the database is null.  A null password can never be matched -- the only way to access this user account is to be handed a session key

Use case:  Moodle creates users with null passwords and creates a session key which it hands off to the browser.

Test: For many perl's the crypt function simply handled null entries and refused to match them against any entered password.  We were relying on this feature.  In at least one case the local perl did not behave this way and allowed any entered password to match against a null entry in the database.  Test to make sure this change does no harm.