### PR TITLE
Develop fix undef msgs

### DIFF
--- a/clients/checkProblem.pl
+++ b/clients/checkProblem.pl
@@ -267,10 +267,11 @@ if (@ARGV) {
 	}
     $xmlrpc_client->encodeSource($source);
     
-    
 	if ( $xmlrpc_client->xmlrpcCall('renderProblem', $input) )    {
 	        $output = $xmlrpc_client->{output};
-		if (defined($output->{flags}->{error_flag}) and $output->{flags}->{error_flag} ) {
+	    if (not defined $output) {  #FIXME make sure this is the right error message if site is unavailable
+	    	$return_string = "Could not connect to rendering site";
+	    } elsif (defined($output->{flags}->{error_flag}) and $output->{flags}->{error_flag} ) {
 			$return_string = "0\t $filePath has errors\n";
 		} elsif (defined($output->{errors}) and $output->{errors} ){
 			$return_string = "0\t $filePath has syntax errors\n";
@@ -281,9 +282,9 @@ if (@ARGV) {
 				$return_string .= (pop @debug_messages ) ||'' ; #avoid error if array was empty
 				if (@debug_messages) {
 					$return_string .= join(" ", @debug_messages);
-		} else {
-					$return_string = "";
-		}
+				} else {
+							$return_string = "";
+				}
 			}
 			if (defined($output->{flags}->{WARNING_messages}) ) {
 				my @warning_messages = @{$output->{flags}->{WARNING_messages}};
@@ -291,10 +292,10 @@ if (@ARGV) {
 					$@=undef;
 				if (@warning_messages) {
 					$return_string .= join(" ", @warning_messages);
-	} else {
+				} else {
 					$return_string = "";
 				}
-	}
+			}
 			$return_string = "0\t ".$return_string."\n" if $return_string;   # add a 0 if there was an warning or debug message.
 		}
 		unless ($return_string) {

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1444,7 +1444,7 @@ $ConfigValues = [
 		{ var => 'pg{ansEvalDefaults}{enableReducedScoring}',
 		  doc => 'Enable Reduced Scoring',
 		  doc2 => 'This sets whether the Reduced Scoring system will be enabled.  If enabled you will need to set the default length of the reduced scoring period and the value of work done in the reduced scoring period below.  <p> To use this, you also have to enable Reduced Scoring for individual assignments and set their Reduced Scoring Dates by editing the set data.<p> This works with the avg_problem_grader (which is the the default grader) and the  std_problem_grader (the all or nothing grader).  It will work with custom graders if they are written appropriately.',
-		  type => boolean
+		  type => 'boolean'
 		},
 		{ var => 'pg{ansEvalDefaults}{reducedScoringValue}',
 		  doc => 'Value of work done in Reduced Scoring Period' ,

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -54,7 +54,7 @@ use WeBWorK::URLPath;
 use WeBWorK::CGI;
 use WeBWorK::Utils qw(runtime_use writeTimingLogEntry);
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # Apache2 needs upload class
@@ -64,6 +64,8 @@ BEGIN {
 		Apache2::Upload->import();
 		require Apache2::RequestUtil;
 		Apache2::RequestUtil->import();
+	} else {
+		require "mod_perl.pm"; # should we still support apache mod_perl1?
 	}
 }
 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
@@ -242,4 +242,7 @@ sub keyparts_to_where {
 *sql_table_name=  *WeBWorK::DB::Schema::NewSQL::Std::sql_table_name;
 *sql_field_name=  *WeBWorK::DB::Schema::NewSQL::Std::sql_field_name;
 
+
+sub DESTROY {
+}
 1;

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -827,5 +827,7 @@ sub handle_error {
 	}
 }
 
+sub DESTROY {
+}
 1;
 

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -262,7 +262,7 @@ sub defineProblemEnvir {
 	}
 	
 	# Other things...
-	$envir{QUIZ_PREFIX}              = $options->{QUIZ_PREFIX}; # used by quizzes
+	$envir{QUIZ_PREFIX}              = $options->{QUIZ_PREFIX}//''; # used by quizzes
 	$envir{PROBLEM_GRADER_TO_USE}    = $ce->{pg}->{options}->{grader};
 	$envir{PRINT_FILE_NAMES_FOR}     = $ce->{pg}->{specialPGEnvironmentVars}->{PRINT_FILE_NAMES_FOR};
 

--- a/lib/WeBWorK/PG/Local.pm
+++ b/lib/WeBWorK/PG/Local.pm
@@ -44,9 +44,13 @@ use WeBWorK::Utils qw(readFile writeTimingLogEntry);
 #use WeBWorK::Utils::RestrictedMailer;
 use WeBWorK::Utils::DelayedMailer;
 
-use mod_perl;
-use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
+BEGIN{
+ 	unless (exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2) {
+		require "mod_perl.pm";  # used only for mod_perl1  should we continue to support this?
+	}
 
+	use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
+}
 # Problem processing will time out after this number of seconds.
 use constant TIMEOUT => $WeBWorK::PG::Local::TIMEOUT || 10;
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -156,6 +156,7 @@ sub runtime_use($;@) {
 # Windows uses CRLF, Mac uses CR, UNIX uses LF. (CR is ASCII 15, LF if ASCII 12)
 sub force_eoln($) {
 	my ($string) = @_;
+	$string = $string//'';
 	$string =~ s/\015\012?/\012/g;
 	return $string;
 }
@@ -164,7 +165,7 @@ sub readFile($) {
 	my $fileName = shift;
 	local $/ = undef; # slurp the whole thing into one string
 	open my $dh, "<", $fileName
-		or die "failed to read file $fileName: $!";
+		or croak "failed to read file $fileName: $!";
 	my $result = <$dh>;
 	close $dh;
 	return force_eoln($result);


### PR DESCRIPTION
Minor fixes to define things so as to eliminate "undefined" warnings.  

boolean as a bareword replaced by 'boolean' in defaults.conf

DESTROY() subroutines defined in some database subroutines.

