### PR TITLE
User Detail Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -70,7 +70,7 @@ sub initialize {
 	    # add sets to the assigned list if the parameter is checked or the
 	    # assign all button is pushed.  (already assigned sets will be
 	    # skipped later) 
-	    push @assignedSets, $setID if defined($r->param("set.$setID.assignment")) || $r->param("assignAll");
+	    push @assignedSets, $setID if defined($r->param("set.$setID.assignment"));
 	}
 
 	# note: assignedSets are those sets that are assigned in the submitted form
@@ -349,7 +349,9 @@ sub body {
 	print $self->hidden_authen_fields();
 
 	print CGI::div(
-	    CGI::submit({name=>"assignAll", value => $r->maketext("Assign All Sets to Current User")})), CGI::br();
+	    CGI::submit({name=>"assignAll", value => $r->maketext("Assign All Sets to Current User"),
+			 onClick => "\$('input[name*=\"assignment\"]').attr('checked',1);"
+			})), , CGI::br();
 
 
 	########################################


### PR DESCRIPTION
On User Detail I added an "assign all sets" button.  The button works correctly, in that it assigns the sets.  However, in chrome and chromium for some reason the check boxes for the assigned sets are not checked.  I can't figure out why the existing code doesn't work so I implemented the assign all button in an alternative fashion using jquery. 

To test:  Go to the user detail page for a user which doesn't have all sets assigned.  (Classlist editor, click the number of homework sets) and assign all.  Before the patch on some browsers some of the check boxes will not be checked.  After the patch all the check boxes will be checked.  