### PR TITLE
Change the default database engine type

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -154,7 +154,7 @@ $externalPrograms{mysqldump} ="/usr/bin/mysqldump";
 # The format is dbi:mysql:[databasename] for databases on the local machine
 # For a remote database the format is dbi:mysql:[databasename]:[hostname]:[port]
 $database_dsn ="dbi:mysql:webwork";
-$database_storage_engine = 'myisam';
+$database_storage_engine = 'innodb';
 
 # The following two variables must match the GRANT statement run on the mysql server as described above.
 $database_username ="webworkWrite";


### PR DESCRIPTION
Changed the default database engine type to InnoDB, which seems to be more robust than mysiam.