### PR TITLE
DB Key Prefix Length

### DIFF
--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -33,7 +33,7 @@ BEGIN {
 	    course_id         => { type=>"VARCHAR(100) NOT NULL", key=>1},
 	    user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},	
 	    set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
-	    problem_id        => { type=>"VARCHAR(100) NOT NULL", key=>1},
+	    problem_id        => { type=>"INT NOT NULL", key=>1},
 	    source_file       => { type=>"TEXT"},
 	    timestamp         => { type=>"INT" }, 
 	    scores            => { type=>"TINYTEXT"}, 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -146,12 +146,12 @@ sub _create_table_stmt {
 		foreach my $component (@keyfields[$start .. $#keyfields]) {
 			my $sql_field_name = $self->sql_field_name($component);
 			my $sql_field_type = $self->field_data->{$component}{type};
-			my $length_specifier = $sql_field_type =~ /(text|blob)/i ? "(255)" : "";
+			my $length_specifier = $sql_field_type =~ /(text|blob)/i ? "(100)" : "";
 			if ($start == 0 and $length_specifier and $sql_field_type !~ /tiny/i) {
 				warn "warning: UNIQUE KEY component $sql_field_name is a $sql_field_type, which can"
-					. " hold values longer than 255 characters. However, the maximum key prefix"
-					. " length for text/blob fields is 255. Therefore, uniqueness must occur within"
-					. " the first 255 characters of this field.";
+					. " hold values longer than 100 characters. However, in order to support utf8"
+					. " we limit the key prefix for text/blob fields to 100. Therefore, uniqueness"
+					.  "must occur within the first 100 characters of this field.";
 			}
 			push @index_components, "`$sql_field_name`$length_specifier";
 		}


### PR DESCRIPTION
This pull request does two things.  It changes the index prefix of text/blob fields to 100 characters, instead of the 255 it was at before, and it changes the type of problem_id in the past_answers table to int instead of varchar.  Together these mean that there are at most 300 total characters worth of indexed keys, and with 3 bytes per character with utf8, that puts us below the max 1000 byte width for myisam tables. 

-  To test, change your mysql servers default character set to utf8 and try to add a course.  You should get an error about having too wide of a key.  
-  After the pull request you should be able to create a course.   
-  You should also test that the past answer database still works correctly for both old and new courses.  Try submitting a problem answer and viewing past answers.  