### PR TITLE
Improve tagging menu system

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -438,6 +438,9 @@ if(open(IN, "$libraryRoot/Textbooks")) {
 my $clsep = '<<<';
 my $clinner = '__';
 my @cllist = ();
+# Record full taxonomy for tagging menus (does not include cross-lists)
+my $tagtaxo = [];
+my ($chaplist, $seclist) = ([],[]);
 
 my $canopenfile = 0;
 if(open(IN, "$libraryRoot/Taxonomy2")) {
@@ -477,17 +480,28 @@ if($canopenfile) {
 		# instead they go in a list of crosslists to deal with after
 		# the full taxonomy is read in
 		if($count == 0) { #DBsubject
-			$taxo->{$line} = {} if $oktag;
 			$cursub = $line;
+			if($oktag) {
+				$taxo->{$line} = {};
+				($chaplist, $seclist) = ([],[]);
+				push @{$tagtaxo}, {name=>$line, subfields=>$chaplist};
+			}
 			$subj = safe_get_id($tables{dbsubject}, 'DBsubject_id',
 				qq(WHERE name = ?), [$line], 1, "", $line);
 		} elsif($count == 1) { #DBchapter
-			$taxo->{$cursub}->{$line} = {} if $oktag;
+			if($oktag) {
+				$taxo->{$cursub}->{$line} = {};
+				$seclist=[];
+				push @{$chaplist}, {name=>$line, subfields=>$seclist};
+			}
 			$curchap = $line;
 			$chap = safe_get_id($tables{dbchapter}, 'DBchapter_id',
 				qq(WHERE name = ? and DBsubject_id = ?), [$line, $subj], 1, "", $line, $subj);
 		} else { #DBsection
-			$taxo->{$cursub}->{$curchap}->{$line} = [] if $oktag;
+			if($oktag) {
+				$taxo->{$cursub}->{$curchap}->{$line} = [];
+				push @{$seclist}, {name=>$line};
+			}
 			$sect = safe_get_id($tables{dbsection}, 'DBsection_id',
 				qq(WHERE name = ? and DBchapter_id = ?), [$line, $chap], 1, "", $line, $chap);
 		}
@@ -495,6 +509,14 @@ if($canopenfile) {
 	close(IN);
 }
 #### End of taxonomy/taxonomy2
+
+#### Save the official taxonomy in json format
+my $webwork_htdocs = $ce->{webwork_dir}."/htdocs";
+my $file = "$webwork_htdocs/DATA/tagging-taxonomy.json";
+open(OUTF, ">$file") or die "Cannot open $file";
+print OUTF to_json($tagtaxo,{pretty=>1}) or die "Cannot write to $file";
+close(OUTF);
+print "Saved taxonomy to $file.\n";
 
 #### Now deal with cross-listed sections
 for my $clinfo (@cllist) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1046,7 +1046,7 @@ sub make_data_row {
 		my $sourceFilePath = $templatedir .'/'. $sourceFileName;
 		$sourceFilePath =~ s/'/\\'/g;
 		my $site_url = $r->ce->{webworkURLs}->{htdocs};
-		$tagwidget .= CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}). CGI::end_script();
+		#$tagwidget .= CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}). CGI::end_script();
 		$tagwidget .= CGI::start_script({type=>"text/javascript"}). "mytw$cnt = new tag_widget('$tagid','$sourceFilePath')".CGI::end_script();
 	}
 
@@ -1698,6 +1698,10 @@ sub output_JS {
   print "\n";
   print qq!<script src="$webwork_htdocs_url/js/apps/SetMaker/setmaker.js"></script>!;
   print "\n";
+  if ($self->r->authz->hasPermissions(scalar($self->r->param('user')), "modify_tags")) {
+	my $site_url = $ce->{webworkURLs}->{htdocs};
+	print qq!<script src="$site_url/js/apps/TagWidget/tagwidget.js"></script>!;
+  }
   return '';
 
 }

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1831,8 +1831,6 @@ sub output_tag_info{
 		my $templatedir = $r->ce->{courseDirs}->{templates};
 		my $sourceFilePath = $templatedir .'/'. $self->{problem}->{source_file};
 		$sourceFilePath =~ s/'/\\'/g;
-		my $site_url = $r->ce->{webworkURLs}->{htdocs};
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}), CGI::end_script();
 		print CGI::start_script({type=>"text/javascript"}), "mytw = new tag_widget('tagger','$sourceFilePath')",CGI::end_script();
 	}
 	return "";
@@ -2013,6 +2011,11 @@ sub output_JS{
            <script type="textx/javascript" src="$site_url/js/vendor/underscore/underscore.js"></script>
            <script type="text/javascript" src="$site_url/js/legacy/vendor/knowl.js"></script>};
 
+	# This is for tagging menus (if allowed)
+	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {
+		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/vendor/underscore/underscore.js"}), CGI::end_script();
+		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}), CGI::end_script();
+	}
 
 	# This is for any page specific js.  Right now its just used for achievement popups
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Problem/problem.js"}), CGI::end_script();

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2008,12 +2008,11 @@ sub output_JS{
 	# This is for knowls
         # Javascript and style for knowls
         print qq{
-           <script type="textx/javascript" src="$site_url/js/vendor/underscore/underscore.js"></script>
+           <script type="text/javascript" src="$site_url/js/vendor/underscore/underscore.js"></script>
            <script type="text/javascript" src="$site_url/js/legacy/vendor/knowl.js"></script>};
 
 	# This is for tagging menus (if allowed)
 	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/vendor/underscore/underscore.js"}), CGI::end_script();
 		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}), CGI::end_script();
 	}
 

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -33,7 +33,7 @@ BEGIN {
 	    course_id         => { type=>"VARCHAR(100) NOT NULL", key=>1},
 	    user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},	
 	    set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
-	    problem_id        => { type=>"VARCHAR(100) NOT NULL", key=>1},
+	    problem_id        => { type=>"INT NOT NULL", key=>1},
 	    source_file       => { type=>"TEXT"},
 	    timestamp         => { type=>"INT" }, 
 	    scores            => { type=>"TINYTEXT"}, 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -146,12 +146,12 @@ sub _create_table_stmt {
 		foreach my $component (@keyfields[$start .. $#keyfields]) {
 			my $sql_field_name = $self->sql_field_name($component);
 			my $sql_field_type = $self->field_data->{$component}{type};
-			my $length_specifier = $sql_field_type =~ /(text|blob)/i ? "(255)" : "";
+			my $length_specifier = $sql_field_type =~ /(text|blob)/i ? "(100)" : "";
 			if ($start == 0 and $length_specifier and $sql_field_type !~ /tiny/i) {
 				warn "warning: UNIQUE KEY component $sql_field_name is a $sql_field_type, which can"
-					. " hold values longer than 255 characters. However, the maximum key prefix"
-					. " length for text/blob fields is 255. Therefore, uniqueness must occur within"
-					. " the first 255 characters of this field.";
+					. " hold values longer than 100 characters. However, in order to support utf8"
+					. " we limit the key prefix for text/blob fields to 100. Therefore, uniqueness"
+					.  "must occur within the first 100 characters of this field.";
 			}
 			push @index_components, "`$sql_field_name`$length_specifier";
 		}

--- a/lib/WeBWorK/Utils/Tags.pm
+++ b/lib/WeBWorK/Utils/Tags.pm
@@ -30,11 +30,11 @@ use IO::File;
 
 our @EXPORT    = ();
 our @EXPORT_OK = qw();
-#	list_set_versions
-#);
 
 use constant BASIC => qw( DBsubject DBchapter DBsection Date Institution Author MLT MLTleader Level Language Static MO Status );
 use constant NUMBERED => qw( TitleText AuthorText EditionText Section Problem );
+
+# KEYWORDS and RESOURCES are treated specially since each takes a list of values
 
 my $basics = join('|', BASIC);
 my $numbered = join('|', NUMBERED);
@@ -44,6 +44,7 @@ sub istagline {
   my $line = shift;
   return 1 if($line =~ /$re/);
   return 1 if($line =~ /#\s*\bKEYWORDS?\s*\(\s*'?(.*?)'?\s*\)/);
+  return 1 if($line =~ /#\s*\bRESOURCES?\s*\(\s*'?(.*?)'?\s*\)/);
   return 1 if($line =~ /#\s*\b($numbered)\d+\s*\(\s*'?(.*?)'?\s*\)/);
   return 0;
 }
@@ -130,6 +131,20 @@ sub settag {
   }
 }
 
+# Similar, but add a resource to the list
+sub addresource {
+  my $self = shift;
+  my $resc = shift;
+
+  if(not defined($self->{resources})) {
+    $self->{resources} = [$resc];
+  } else {
+    unless(grep(/^$resc$/, @{$self->{resources}} )) {
+      push @{$self->{resources}}, $resc;
+    }
+  }
+}
+
 sub printtextinfo {
   my $textref = shift;
   print "{";
@@ -203,6 +218,7 @@ sub new {
     $self->{$tagname} = '';
   }
   $self->{keywords} = [];
+  $self->{resources} = [];
   #$self->{Language} = 'eng'; # Default to English
 
 
@@ -213,6 +229,15 @@ sub new {
         my @keyword = keywordcleaner($1);
 		@keyword = grep { not /^\s*'?\s*'?\s*$/ } @keyword;
         $self->{keywords} = [@keyword];
+        $lasttag = $lineno;
+        last SWITCH;
+      }
+      if (/#\s*\bRESOURCES\((.*)\)/i) {
+        my @resc = keywordcleaner($1); # splits on comma
+		s/["'\s]*$//g for (@resc);
+		s/^["'\s]*//g for (@resc);
+		@resc = grep { not /^\s*'?\s*'?\s*$/ } @resc;
+        $self->{resources} = [@resc];
         $lasttag = $lineno;
         last SWITCH;
       }
@@ -371,6 +396,13 @@ sub dumptags {
     }
   }
   print $fh "## KEYWORDS(".join(',', @{$self->{keywords}}).")\n" if(scalar(@{$self->{keywords}}));
+  my @resc;
+  if(scalar(@{$self->{resources}})) {
+	@resc = @{$self->{resources}};
+	s/^/'/g for (@resc);
+	s/$/'/g for (@resc);
+    print $fh "## RESOURCES(".join(',', @resc).")\n";
+  }
 }
 
 # Write the file


### PR DESCRIPTION
This does several things related to tagging menus:

  1. move loading of tagwidget.js code to the header (i.e. to output_JS) in the two content generators which use it (still conditioned on the user having permission to modify tags)
  2. load underscore.js in Problem.pm if we are loading tagwidget since it uses it
  3. have OPL-update generate a json file with the full taxonomy (but not showing cross-lists)
  4. use this json file in the tagwidget

(1) is mainly aesthetic, but also avoids multiple reloading of the code in the library browser.

(2) fixes a bug (the tagwidget was throwing an error when the tagging menus appeared on a single problem page).

(3) This creates the json file, akin to the ones Peter added.  Together with (4), this makes the updating of tagging menus much faster since the taxonomy is only pulled once instead of lots of ajax/database calls.  

This also fixes a bug.  The tagging menu needs to be different from the search menus in the library browser in two ways: the search menus have empty "sections" or "chapters" removed, but they need to be there when someone is tagging problems; and cross-listed sections should appear when a user is searching, but nothing should be tagged into these "virtual sections".  Before, the tagging menus just used the search menus, and now they get it right.  For example, go to "Complex analysis"/"Complex equations" and view problems.  The search menu has only "Linear" but the tagging menus have "Quadratic" and "Non-linear" as well.

