### PR TITLE
Bugfixes

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -73,6 +73,12 @@
 
 <div class="row-fluid">
 
+<!-- Run masthead class js because it gets rendered early -->
+<script type="text/javascript">
+  // Changes links in masthead
+  $('#loginstatus a').addClass('btn btn-small');
+  $('#loginstatus a').append(' <span class="icon icon-signout" data-alt="signout"></span>'); 
+</script>
 
   <div id="content" class="span12">
 		

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -187,7 +187,7 @@ sub htmlMessage($$$@) {
 	$warnings = htmlEscape($warnings);
 	$exception = htmlEscape($exception);
 	
-	my @warnings = defined $warnings ? split m|&lt;br /&gt;|, $warnings : ();  #fragile
+	my @warnings = defined $warnings ? split m|<br />|, $warnings : ();  #fragile
 	$warnings = htmlWarningsList(@warnings);
 	my $backtrace = htmlBacktrace(@backtrace);
 	
@@ -288,7 +288,7 @@ Formats a list of warning strings as list items for HTML output.
 sub htmlWarningsList(@) {
 	my (@warnings) = @_;
 	foreach my $warning (@warnings) {
-		$warning = htmlEscape($warning);
+		$warning = $warning;
 		$warning = "<li><code>$warning</code></li>";
 	}
 	return join "\n", @warnings;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1802,8 +1802,6 @@ sub output_achievement_message{
 	my $authz = $r->authz;
 	my $user = $r->param('user');
 	
-	
-
 	#If achievements enabled, and if we are not in a try it page, check to see if there are new ones.and print them
 	if ($ce->{achievementsEnabled} && $will{recordAnswers} 
 	    && $submitAnswers && $problem->set_id ne 'Undefined_Set') {


### PR DESCRIPTION
This fixes two small bugs. 

-  If you visit a gateway the log out button is now improperly formatted.  This pull request fixes that. 
-  Warning output when process via Apache/Webwork.pm (not ContentGenerator.pm) has double html encoding.  This fixes that.  If you put something like 
```
warn("<script>alert('hi')</script>);
warn("This has <=>");
die('die!');
```
in, say, Problem.pm then the resulting warning out put will be badly formatted before this patch.  