### PR TITLE
Ww3 feature/before after fix

### DIFF
--- a/bin/startDancer
+++ b/bin/startDancer
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-perl -I /opt/webwork/webwork2/lib -I /opt/webwork/pg/lib /opt/webwork/webwork2/webwork3/bin/app.pl
+export MOD_PERL_API_VERSION=2
+
+perl -I $WEBWORK_ROOT/lib -I $WEBWORK_ROOT/../pg/lib $WEBWORK_ROOT/webwork3/bin/app.pl

--- a/conf/webwork.apache2-config.dist
+++ b/conf/webwork.apache2-config.dist
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright ï¿½ 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -38,6 +38,8 @@
 #ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
 
 PerlModule mod_perl2
+
+SetEnv MOD_PERL_API_VERSION 2
 
 <Perl>
 

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright ï¿½ 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -38,6 +38,8 @@
 #ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
 
 PerlModule mod_perl2
+
+SetEnv MOD_PERL_API_VERSION 2
 
 <Perl>
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -39,7 +39,7 @@ use Errno;
 use File::Path qw(rmtree);
 use Storable;
 use Carp;
-use Dancer qw(:script);
+#use Dancer qw(:script);
 
 use constant MKDIR_ATTEMPTS => 10;
 

--- a/webwork3/bin/app.pl
+++ b/webwork3/bin/app.pl
@@ -19,6 +19,11 @@ use Routes::User;
 use Routes::Settings;
 use Routes::PastAnswers;
 
+BEGIN {
+    $ENV{MOD_PERL_API_VERSION}=2;
+    
+}
+
 set serializer => 'JSON';
 
 hook 'before' => sub {

--- a/webwork3/public/dispatch.fcgi
+++ b/webwork3/public/dispatch.fcgi
@@ -9,6 +9,9 @@ use Plack::Handler::FCGI;
 set apphandler => 'PSGI';
 set environment => 'development';
 
+# this makes sure that the application knows that we are running apache2. 
+$ENV{MOD_PERL_API_VERSION}=2;
+
 my $psgi = path($RealBin, '..', 'bin', 'app.pl');
 my $app = do($psgi);
 die "Unable to read startup script: $@" if $@;


### PR DESCRIPTION
This is a fix for issue #470.  

To check, there is a new line in webwork.apache2-config.dist (and webwork.apache2.4-config.dist) that adds the line: `SetEnv MOD_PERL_API_VERSION 2`

You will need to add this line to your non .dist version and restart the server.  You shouldn't get the warning in issue #470 anymore. 

I figure this is safe because if anyone is running apache2.2 or 2.4 then they will be running mod_perl2.  This variable gets picked up in Dancer that wasn't being set another way. 