### PR TITLE
PG IO Cleanup

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -32,7 +32,7 @@ use DateTime::TimeZone;
 use Date::Parse;
 use Date::Format;
 use File::Copy;
-use File::Spec;
+use File::Spec::Functions qw(canonpath);
 use Time::Zone;
 use MIME::Base64;
 use Errno;
@@ -349,11 +349,11 @@ sub path_is_subdir($$;$) {
 		}
 	}
 	
-	$path = File::Spec->canonpath($path);
+	$path = canonpath($path);
 	$path .= "/" unless $path =~ m|/$|;
 	return 0 if $path =~ m#(^\.\.$|^\.\./|/\.\./|/\.\.$)#;
 	
-	$dir = File::Spec->canonpath($dir);
+	$dir = canonpath($dir);
 	$dir .= "/" unless $dir =~ m|/$|;
 	return 0 unless $path =~ m|^$dir|;
 	


### PR DESCRIPTION
This is a tweak to WeBWorK that goes along with PG pull request 219.  

Basically this replaces a particular object oriented Perl package by its regular "function" alternative.  It should have no effect on WeBWorK2. 

To Test: 
-  Open a problem in a problem editor.  
-  Save it as another problem. 
-  Save it as another problem with a relative path not in the courses directory .e.g. `../../../../../`.  You should see an error. 