### PR TITLE
Throwing a random integer into the set name "Undefined set"

### DIFF
--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -390,7 +390,7 @@ sub checkSet {
 		     $set->version_id eq $verNum ) {
 			# then we can just use this set and skip the rest
 
-		} elsif ( $setName eq 'Undefined_Set' and 
+		} elsif ( $setName =~ /^\d*Undefined_Set$/ and 
 			  $self->hasPermissions($userName, "access_instructor_tools") ) {
 				# this is the case of previewing a problem
 				#    from a 'try it' link
@@ -417,7 +417,7 @@ sub checkSet {
 		} else {
 			if ( $db->existsUserSet($effectiveUserName,$setName) ) {
 				$set = $db->getMergedSet($effectiveUserName,$setName);
-			} elsif ( $setName eq 'Undefined_Set' and 
+			} elsif ( $setName =~ /^\d*Undefined_Set$/ and 
 				$self->hasPermissions($userName, "access_instructor_tools") ) {
 				# this is the weird case of the library
 				#   browser, when we don't actually have

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -997,8 +997,9 @@ sub make_data_row {
 	$displayMode = $self->r->ce->{pg}->{options}->{displayMode}
 		if not defined $displayMode or $displayMode eq "None";
 	my $module = ( $isGatewaySet ) ? "GatewayQuiz" : "Problem";
+	my $randsetname = int(rand(100000)).'Undefined_Set';
 	my %pathArgs = ( courseID =>$urlpath->arg("courseID"),
-			setID=>"Undefined_Set" );
+			setID=>$randsetname );
 	$pathArgs{problemID} = "1" if ( ! $isGatewaySet );
 
 	my $try_link = CGI::a({href=>$self->systemLink(

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -503,7 +503,7 @@ sub pre_header_initialize {
 	die($self->{invalidSet}) if $self->{invalidSet};
 
 	$self->{isOpen} = $authz->hasPermissions($userName, "view_unopened_sets") || 
-	    ($setName eq "Undefined_Set" || 
+	    ($setName =~ /^\d*Undefined_Set$/ || 
 	     (time >= $set->open_date && !(
 		  $ce->{options}{enableConditionalRelease} && 
 		  is_restricted($db, $set, $effectiveUserName))));
@@ -1080,7 +1080,7 @@ sub nav {
 		push @links, $r->maketext("Previous Problem"), "", $r->maketext("navPrevGrey");
 	}
 
-	if (defined($setID) && $setID ne 'Undefined_Set') {
+	if (defined($setID) && $setID !~ m/^\d*Undefined_Set$/) {
 		push @links, $r->maketext("Problem List"), $r->location . $urlpath->parent->path, $r->maketext("navProbList");
 	} else {
 		push @links, $r->maketext("Problem List"), "", $r->maketext("navProbListGrey");
@@ -1245,7 +1245,7 @@ sub output_editorLink{
 	# if we are here without a real homework set, carry that through
 	my $forced_field = [];
 	$forced_field = ['sourceFilePath' =>  $r->param("sourceFilePath")] if
-		($set->set_id eq 'Undefined_Set');
+		($set->set_id =~ m/^\d*Undefined_Set$/);
 	if ($authz->hasPermissions($user, "modify_problem_sets") and $ce->{showeditors}->{pgproblemeditor1}) {
 		my $editorPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::Instructor::PGProblemEditor", $r, 
 			courseID => $courseName, setID => $set->set_id, problemID => $problem->problem_id);
@@ -1801,7 +1801,7 @@ sub output_achievement_message{
 	
 	#If achievements enabled, and if we are not in a try it page, check to see if there are new ones.and print them
 	if ($ce->{achievementsEnabled} && $will{recordAnswers} 
-	    && $submitAnswers && $problem->set_id ne 'Undefined_Set') {
+	    && $submitAnswers && $problem->set_id !~ m/^\d*Undefined_Set$/) {
 	    my $achievementMessage = WeBWorK::AchievementEvaluator::checkForAchievements($problem, $pg, $db, $ce);
 	    print $achievementMessage;
 	}

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -249,7 +249,7 @@ sub process_editorLink{
 	# if we are here without a real homework set, carry that through
 	my $forced_field = [];
 	$forced_field = ['sourceFilePath' =>  $r->param("sourceFilePath")] if
-		($set->set_id eq 'Undefined_Set');
+		($set->set_id =~ m/^\d*Undefined_Set$/);
 	if ($authz->hasPermissions($user, "modify_problem_sets")) {
 		my $editorPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::Instructor::PGProblemEditor2",
 			courseID => $courseName, setID => $set->set_id, problemID => $problem->problem_id);

--- a/lib/WeBWorK/Utils/Tasks.pm
+++ b/lib/WeBWorK/Utils/Tasks.pm
@@ -74,11 +74,12 @@ Given a database, make a temporary problem set for that database.
 
 sub fake_set { 
 	my $db = shift; 
+	my $setname = shift || int(rand(1000000)).fakeSetName;
  
 	my $set = $db->newGlobalSet(); 
 	$set = global2user($db->{set_user}->{record}, $set); 
 	$set->psvn(123); 
-	$set->set_id(fakeSetName); 
+	$set->set_id($setname); 
 	$set->open_date(time());
 	$set->due_date(time());
 	$set->answer_date(time());
@@ -131,7 +132,9 @@ sub fake_problem {
 	#debug("In fake_problem");
 
 	$problem = global2user($db->{problem_user}->{record}, $problem); 
-	$problem->set_id(fakeSetName); 
+	my $myfakesetname = fakeSetName;
+	$myfakesetname = $options{fake_set_name} if defined($options{fake_set_name});
+	$problem->set_id($myfakesetname); 
 	$problem->value(""); 
 	$problem->max_attempts("-1"); 
 	$problem->showMeAnother("-1"); 
@@ -274,8 +277,9 @@ sub renderProblems {
 		return map { {body_text=>''} } @problem_list;
 	}
 	
+	my $randSetName = int(rand(1000000)).fakeSetName;
 	my $user = $args{user} || fake_user($db);
-	my $set = $args{'this_set'} || fake_set($db);
+	my $set = $args{'this_set'} || fake_set($db, $randSetName);
 	my $problem_seed = $args{'problem_seed'} || $r->param('problem_seed') || 0;
 	my $showHints = $args{showHints} || 0;
 	my $showSolutions = $args{showSolutions} || 0;
@@ -286,7 +290,7 @@ sub renderProblems {
 	# remove any pretty garbage around the problem
 	local $ce->{pg}{specialPGEnvironmentVars}{problemPreamble} = {TeX=>'',HTML=>''};
 	local $ce->{pg}{specialPGEnvironmentVars}{problemPostamble} = {TeX=>'',HTML=>''};
-	my $problem = fake_problem($db, 'problem_seed'=>$problem_seed);
+	my $problem = fake_problem($db, 'problem_seed'=>$problem_seed, 'fake_set_name'=> $randSetName);
 	$problem->{value} = -1;
 	my $formFields = { WeBWorK::Form->new_from_paramable($r)->Vars };
 	


### PR DESCRIPTION
Currently, when you view a problem in the library browser, or in a "try it" window, or viewing from an editor window, webwork pretends the name of the problem set is Undefined_Set.  Since images are links to actual images where the link name is built out of user/seed/set name/etc., there can be collisions when there are multiple places using images in this way.

The prepends random integers to the "fake set name" Undefined_Set, which should reduce the chance of a collision to a very small number.  Most of the changes are spots where webwork has to detect the special set name Undefined_Set to allow for the added digits.

A good place to find images in files is single variable calculus/limits and contin./finding limits using graphs.
 