### PR TITLE
OPLUtils Change

### DIFF
--- a/bin/OPLUtils.pm
+++ b/bin/OPLUtils.pm
@@ -212,7 +212,8 @@ sub build_library_subject_tree {
 
 				my $sth = $dbh->prepare($selectClause.$whereClause);
 				$sth->execute;
-				my $numFiles= $sth->rows;
+				my $numFiles= scalar @{$sth->fetchall_arrayref()};
+
 				$section_tree->{num_files} = $numFiles;
 
 				my $clone = { %{ $section_tree } };  # need to clone it before pushing into the @subfield array.
@@ -231,7 +232,7 @@ sub build_library_subject_tree {
 
 			my $sth = $dbh->prepare($selectClause.$whereClause);
 			$sth->execute;
-			my $numFiles = $sth->rows;
+			my $numFiles = scalar @{$sth->fetchall_arrayref()};
 			# my $allFiles = $sth->fetchall_arrayref;
 			 $chapter_tree->{num_files} = $numFiles;
 
@@ -253,7 +254,7 @@ sub build_library_subject_tree {
 
 		my $sth = $dbh->prepare($selectClause.$whereClause);
 		$sth->execute;
-		my $numFiles = $sth->rows;
+		my $numFiles = scalar @{$sth->fetchall_arrayref()};
 		$subject_tree->{num_files} = $numFiles;
 
 		$i++;
@@ -346,7 +347,7 @@ sub build_library_textbook_tree {
 
 				my $sth = $dbh->prepare($selectClause.$whereClause);
 				$sth->execute;
-				$section->{num_probs}=$sth->rows;
+				$section->{num_probs}=scalar @{$sth->fetchall_arrayref()};
 
 			}
 			my $whereClause ="WHERE ch.chapter_id='". $chapter->{chapter_id}."' AND "
@@ -354,7 +355,7 @@ sub build_library_textbook_tree {
 
 			my $sth = $dbh->prepare($selectClause.$whereClause);
 			$sth->execute;
-			$chapter->{num_probs}=$sth->rows;
+			$chapter->{num_probs}=scalar @{$sth->fetchall_arrayref()};
 
 			$chapter->{sections}=\@sections;
 		
@@ -363,7 +364,7 @@ sub build_library_textbook_tree {
 
 		my $sth = $dbh->prepare($selectClause.$whereClause);
 		$sth->execute;
-		$textbook->{num_probs}=$sth->rows;
+		$textbook->{num_probs}=scalar @{$sth->fetchall_arrayref()};
 
 		$textbook->{chapters}=\@chapters;
 	}

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -40,7 +40,7 @@ my @modulesList = qw(
 	Benchmark
 	Carp
 	CGI
-	Class:Accessor
+	Class::Accessor
 	Dancer
 	Dancer::Plugin::Database
 	Data::Dumper

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-use 5.012;
+use 5.010;
 
 ################################################################################
 # WeBWorK Online Homework Delivery System


### PR DESCRIPTION
This is a small change to OPLUtils.  There are calls to `$sth->rows` to fetch the number of rows.  However, in general that is fragile because the select statement may not return the number of rows until all of them have been fetched.  See: http://search.cpan.org/~timb/DBI-1.633/DBI.pm#rows

This is a slight workaround.  Test by running OPL-update and making sure that it generates the subject-tree and textbook-tree correctly. 
