### PR TITLE
Fix bug 3394, display of ans_array matrices in math3 theme

### DIFF
--- a/htdocs/themes/math3/math3.css
+++ b/htdocs/themes/math3/math3.css
@@ -599,6 +599,10 @@ table.attemptResults th {
 }
 
 /* override above settings in tables used to display ans_array results */
+.ans_array_open, .ans_array_close {
+  font-size: 67%
+}
+
 table.attemptResults td td,
 table.attemptResults td th,
 table.ArrayLayout td {


### PR DESCRIPTION
Brackets around matrices with ans_array were way too big.  Try

 Library/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_31.pg

in math3.