### PR TITLE
Add path to new macro files from Hope

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -995,6 +995,7 @@ $pg{directories}{macrosPath} = [
    "$courseDirs{templates}/Library/macros/UMass-Amherst",
    "$courseDirs{templates}/Library/macros/PCC",
    "$courseDirs{templates}/Library/macros/Alfred",
+   "$courseDirs{templates}/Library/macros/Hope",
 ];
 
 # The applet search path. If a full URL is given, it is used unmodified. If an


### PR DESCRIPTION
These macro files are now in the OPL and used by problems in Contrib.  With this change, we can start adding some of the pg files to the OPL.
