### PR TITLE
Editor Tweaks

### DIFF
--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -106,7 +106,7 @@ var tabberOptions = {manualStartup:true};
 <div class="row-fluid">
 
 <!-- Navigation -->
-<div id="site-navigation" class="span2" role="navigation" aria-label="main navigation">
+<div id="site-navigation" class="span2 hidden" role="navigation" aria-label="main navigation">
   <!--#if can="links"-->
         <div id="site-links">
 	  <!--#links-->
@@ -138,6 +138,8 @@ var tabberOptions = {manualStartup:true};
 
   // Display options formatting
   $('.facebookbox input:submit').addClass('btn-small');
+
+  $('#site-navigation').removeClass('hidden');
   
 </script>
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -350,8 +350,10 @@ sub initialize {
 	
 	$self->{editMode} = $r->param("editMode") || 0;
 	
+
 	return CGI::div({class=>"ResultsWithError"}, CGI::p($r->maketext("You are not authorized to modify homework sets.")))
-		if $self->{editMode} and not $authz->hasPermissions($user, "modify_problem_sets");
+	  if $self->{editMode} and not $authz->hasPermissions($user, "modify_problem_sets");
+
 	
 	$self->{exportMode} = $r->param("exportMode") || 0;
 
@@ -431,6 +433,15 @@ sub body {
 	
 	return CGI::div({class => "ResultsWithError"}, $r->maketext("You are not authorized to access the instructor tools."))
 		unless $authz->hasPermissions($user, "access_instructor_tools");
+
+	return CGI::div({class=>"ResultsWithError"}, CGI::p($r->maketext("You are not authorized to modify homework sets.")))
+	  if $self->{editMode} and not $authz->hasPermissions($user, "modify_problem_sets");
+
+	return CGI::div({class=>"ResultsWithError"}, CGI::p($r->maketext("You are not authorized to modify set definition files.")))
+		if $self->{exportMode} and not $authz->hasPermissions($user, "modify_set_def_files");
+	
+
+
 	
 	# This table can be consulted when display-ready forms of field names are needed.
 	my %prettyFieldNames = map { $_ => $_ } 
@@ -2341,7 +2352,11 @@ sub recordEditHTML {
 	my $problemListURL  = $self->systemLink($urlpath->new(type=>'instructor_set_detail', args=>{courseID => $courseName, setID => $Set->set_id} ));
 	my $problemSetListURL = $self->systemLink($urlpath->new(type=>'instructor_set_list2', args=>{courseID => $courseName, setID => $Set->set_id})) . "&editMode=1&visible_sets=" . $Set->set_id;
 	my $imageURL = $ce->{webworkURLs}->{htdocs}."/images/edit.gif";
-        my $imageLink = CGI::a({href => $problemSetListURL}, CGI::img({src=>$imageURL, border=>0}));
+        my $imageLink = '';
+
+	if ($authz->hasPermissions($user, "modify_problem_sets")) {
+	  $imageLink = CGI::a({href => $problemSetListURL}, CGI::img({src=>$imageURL, border=>0}));
+	}
 	
 	my @tableCells;
 	my %fakeRecord;

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
@@ -1651,7 +1651,11 @@ sub recordEditHTML {
 	my $userListURL = $self->systemLink($urlpath->new(type=>'instructor_user_list2', args=>{courseID => $courseName} )) . "&editMode=1&visible_users=" . $User->user_id;
 
 	my $imageURL = $ce->{webworkURLs}->{htdocs}."/images/edit.gif";
-        my $imageLink = CGI::a({href => $userListURL}, CGI::img({src=>$imageURL, border=>0, alt=>"Link to Edit Page for ".$User->user_id}));
+        my $imageLink = '';
+
+	if ($authz->hasPermissions($user, "modify_student_data")) {
+	  $imageLink = CGI::a({href => $userListURL}, CGI::img({src=>$imageURL, border=>0, alt=>"Link to Edit Page for ".$User->user_id}));
+	}
 	
 	my @tableCells;
 	


### PR DESCRIPTION
This pull request does three things: 

-  Added some checks to the Homework Sets Editor so that if you are in edit mode with insufficient permissions it doesn't spit out undefined variable errors.  
  -  To test go the homework sets as a ta and click the pencil.  Before the patch you should get errors.  Patch and then reload the page. There should be a nicer message. 
-  Added checks so the pencil icons are not displayed unless you have permissions. 
  -  To test, go to Classlist Editor and Hmwrk Sets Editor as a professor, the pencils should be there.  As a TA they should not.  
-  Added a little tweak to math4 so that the side navigation bar won't be shown in a half formatted state.  
  -  This is hard to test.  Go to the library browser and load up a bunch of problems.  On some setups this will cause the left hand navigation bar to "half load" so that it is there but not formatted correctly.  After this change the bar will be hidden until after its formatting js has run.  