### PR TITLE
Tell which term is not defined in the taxonomy in library alert

### DIFF
--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -50,7 +50,7 @@ function readfromtaxo(who, valarray) {
 	}
   }
   if(failed) {
-    alert('Provided value is not in my taxonomy.');
+    alert('Provided value "' + valarray[0] + '" is not in my subject taxonomy. ' );
 	return([]);
   }
   if(who == 'chapters') {
@@ -65,7 +65,7 @@ function readfromtaxo(who, valarray) {
 	}
   }
   if(failed) {
-    alert('Provided value is not in my taxonomy.');
+    alert('Provided value "'+ valarray[1] + '" is not in my chapter taxonomy. ' );
 	return([]);
   }
   if(who == 'sections') {


### PR DESCRIPTION
at least you'll know why the alert is annoying you. It will tell you the missing term. 