### PR TITLE
Develop rename update

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1055,8 +1055,8 @@ sub rename_course_confirm {
 	my $dbLayoutName = $ce->{dbLayoutName};
 	my $db = new WeBWorK::DB($ce->{dbLayouts}->{$dbLayoutName});
 	my $oldDB =new WeBWorK::DB($ce2->{dbLayouts}->{$dbLayoutName});
-	my $rename_oldCourseTitle = $oldDB->getSettingValue('courseTitle');
-	my $rename_oldCourseInstitution = $oldDB->getSettingValue('courseInstitution');
+	my $rename_oldCourseTitle = $oldDB->getSettingValue('courseTitle')//'""';
+	my $rename_oldCourseInstitution = $oldDB->getSettingValue('courseInstitution')//'""';
 	
 	my ($change_course_title_str, $change_course_institution_str)=("");
 	if ( $rename_newCourseTitle_checkbox) {
@@ -1087,9 +1087,9 @@ sub rename_course_confirm {
 
 		print CGI::div({style=>"text-align: left"},
 			    CGI::hr(),			    
-			    CGI::h4("Make these changes in  course $rename_oldCourseID"),
-			    CGI::div($change_course_title_str),
-			    CGI::div($change_course_institution_str),
+			    CGI::h4("Make these changes in  course: $rename_oldCourseID"),
+			    CGI::p($change_course_title_str),
+			    CGI::p($change_course_institution_str),
 				CGI::submit(-name=>"decline_retitle_course", -value=>"Don't make changes"),
 				"&nbsp;",
 				CGI::submit(-name=>"confirm_retitle_course", -value=>"Make changes") ,
@@ -1294,7 +1294,10 @@ sub rename_course_validate {
 	if ($rename_newCourseInstitution eq "" and $rename_newCourseInstitution_checkbox eq 'on')  {
 		push @errors, "You must specify a new institution for the course.";
 	}
-
+	unless ($rename_newCourseID or $rename_newCourseID_checkbox or $rename_newCourseTitle_checkbox ) {
+		push @errors, "No changes specified.  You must mark the 
+		checkbox of the item(s) to be changed and enter the change data.";
+	}
 	
 	return @errors;
 }

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1368,12 +1368,14 @@ sub do_rename_course {
 	my $rename_newCourseID            = $r->param("rename_newCourseID")     || "";
 	my $rename_newCourseTitle         = $r->param("rename_newCourseTitle")     || "";
 	my $rename_newCourseInstitution   = $r->param("rename_newCourseInstitution")     || "";
+	my $title_checkbox                = $r->param("rename_newCourseTitle_checkbox")  || ""   ;
+	my $institution_checkbox          = $r->param("rename_newCourseInstitution_checkbox")  || ""  ;
 	
 	# define new courseTitle and new courseInstitution
-	my $optional_arguments = {
-								courseTitle       => $rename_newCourseTitle,
-								courseInstitution => $rename_newCourseInstitution,
-							};
+	my %optional_arguments = {};
+	$optional_arguments{courseTitle}       = $rename_newCourseTitle if $title_checkbox;
+	$optional_arguments{courseInstitution} = $rename_newCourseInstitution if $institution_checkbox;
+
 	my $ce2 = new WeBWorK::CourseEnvironment({
 		%WeBWorK::SeedCE,
 		courseName => $rename_oldCourseID,
@@ -1385,8 +1387,6 @@ sub do_rename_course {
 	# below this line, we would grab values from getopt and put them in this hash
 	# but for now the hash can remain empty
 	my %dbOptions;
-		warn "store new title and institution in database ", 
-	      join(" ", $rename_newCourseID,  %$optional_arguments);
 
 	eval {
 		renameCourse(
@@ -1394,7 +1394,7 @@ sub do_rename_course {
 			ce            => $ce2,
 			dbOptions     => \%dbOptions,
 			newCourseID   => $rename_newCourseID,
-			%$optional_arguments,
+			%optional_arguments,
 		);
 	};
 	if ($@) {
@@ -1405,6 +1405,9 @@ sub do_rename_course {
 		);
 	} else {
 		print CGI::div({class=>"ResultsWithoutError"},
+			($title_checkbox) ? CGI::div("The title of the course $rename_newCourseID is now $rename_newCourseTitle"):'', 
+			($institution_checkbox) ? CGI::div("The institution associated with the course $rename_newCourseID is now $rename_newCourseInstitution"):'', 
+
 			CGI::p("Successfully renamed the course $rename_oldCourseID to $rename_newCourseID"),
 		);
 		 writeLog($ce, "hosted_courses", join("\t",

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1371,18 +1371,31 @@ sub do_rename_course {
 	my $title_checkbox                = $r->param("rename_newCourseTitle_checkbox")  || ""   ;
 	my $institution_checkbox          = $r->param("rename_newCourseInstitution_checkbox")  || ""  ;
 	
-	# define new courseTitle and new courseInstitution
-	my %optional_arguments = {};
-	$optional_arguments{courseTitle}       = $rename_newCourseTitle if $title_checkbox;
-	$optional_arguments{courseInstitution} = $rename_newCourseInstitution if $institution_checkbox;
 
 	my $ce2 = new WeBWorK::CourseEnvironment({
 		%WeBWorK::SeedCE,
 		courseName => $rename_oldCourseID,
 	});
-	
+
 	my $dbLayoutName = $ce->{dbLayoutName};
+
+	# define new courseTitle and new courseInstitution
+	my %optional_arguments = ();
+	my ($title_message, $institution_message);
+	if ($title_checkbox) {
+		$optional_arguments{courseTitle}       = $rename_newCourseTitle;
+		$title_message = qq!CGI::div("The title of the course $rename_newCourseID is now $rename_newCourseTitle")!, 
 	
+	} else {
+		
+	}
+	if ($institution_checkbox) {
+		$optional_arguments{courseInstitution} = $rename_newCourseInstitution;
+		$institution_message = qq!CGI::div("The institution associated with the course $rename_newCourseID is now $rename_newCourseInstitution")!, 
+
+	}
+
+		
 	# this is kinda left over from when we had 'gdbm' and 'sql' database layouts
 	# below this line, we would grab values from getopt and put them in this hash
 	# but for now the hash can remain empty
@@ -1405,9 +1418,8 @@ sub do_rename_course {
 		);
 	} else {
 		print CGI::div({class=>"ResultsWithoutError"},
-			($title_checkbox) ? CGI::div("The title of the course $rename_newCourseID is now $rename_newCourseTitle"):'', 
-			($institution_checkbox) ? CGI::div("The institution associated with the course $rename_newCourseID is now $rename_newCourseInstitution"):'', 
-
+			$title_message,
+			$institution_message,
 			CGI::p("Successfully renamed the course $rename_oldCourseID to $rename_newCourseID"),
 		);
 		 writeLog($ce, "hosted_courses", join("\t",

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -44,6 +44,7 @@ our @EXPORT_OK = qw(
 	listArchivedCourses
 	addCourse
 	renameCourse
+	retitleCourse
 	deleteCourse
 	archiveCourse
 	unarchiveCourse

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -340,6 +340,9 @@ sub addCourse {
 %options may also contain:
 
  skipDBRename => $skipDBRename,
+ courseTitle => $courseTitle
+ courseInstitution => $courseInstitution
+
 
 Rename the course named $courseID to $newCourseID.
 
@@ -486,12 +489,74 @@ sub renameCourse {
 	
 	unless ($skipDBRename) {
 		my $oldDB = new WeBWorK::DB($oldCE->{dbLayouts}{$dbLayoutName});
+		
 		my $rename_db_result = $oldDB->rename_tables($newCE->{dbLayouts}{$dbLayoutName});
 		die "$oldCourseID: course database renaming failed.\n" unless $rename_db_result;
+		#update title and institution
+		my $newDB = new WeBWorK::DB($newCE->{dbLayouts}{$dbLayoutName});
+		eval {
+			if (exists( $options{courseTitle}) and $options{courseTitle}) {
+			    warn "new title |$options{courseTitle}|";
+				$newDB->setSettingValue('courseTitle',$options{courseTitle});
+			}
+			if (exists( $options{courseInstitution}) and $options{courseInstitution}) {
+			    warn "new institution |$options{courseInstitution}|";
+				$newDB->setSettingValue('courseInstitution',$options{courseInstitution});
+			}
+		};  warn "Problems from resetting course title and institution = $@" if $@;
 	}
 }
 
 ################################################################################
+=item retitleCourse
+
+	Simply changes the title and institution of the course. 
+
+Options must contain:
+
+ courseID => $courseID,
+ ce => $ce,
+ dbOptions => $dbOptions,
+ 
+ 
+Options may contain
+ newCourseTitle => $courseTitle,
+ newCourseInstitution => $courseInstitution,
+
+
+=cut 
+
+sub retitleCourse {
+	my %options = @_;
+	# renameCourseHelper needs:
+	#    $courseID ($oldCourseID)
+	#    $ce ($oldCE)
+	#    $dbLayoutName ($ce->{dbLayoutName})
+	#    %options ($dbOptions)
+	#    courseTitle
+	#    courseInstitution
+	my $courseID = $options{courseID};
+	my $ce       = $options{ce};
+	my %dbOptions = defined $options{dbOptions} ? %{ $options{dbOptions} } : ();
+	warn "running retitleCourse -- nothing done yet";	
+	# get the database layout out of the options hash
+	my $dbLayoutName = $ce->{dbLayoutName};
+	my $db = new WeBWorK::DB($ce->{dbLayouts}{$dbLayoutName});
+		eval {
+			if (exists( $options{courseTitle}) and $options{courseTitle}) {
+			    warn "new title |$options{courseTitle}|";
+				$db->setSettingValue('courseTitle',$options{courseTitle});
+			}
+			if (exists( $options{courseInstitution}) and $options{courseInstitution}) {
+			    warn "new institution |$options{courseInstitution}|";
+				$db->setSettingValue('courseInstitution',$options{courseInstitution});
+			}
+		};  warn "Problems from resetting course title and institution = $@" if $@;
+
+	
+
+
+}
 
 =item deleteCourse(%options)
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -497,11 +497,9 @@ sub renameCourse {
 		my $newDB = new WeBWorK::DB($newCE->{dbLayouts}{$dbLayoutName});
 		eval {
 			if (exists( $options{courseTitle}) and $options{courseTitle}) {
-			    warn "new title |$options{courseTitle}|";
 				$newDB->setSettingValue('courseTitle',$options{courseTitle});
 			}
 			if (exists( $options{courseInstitution}) and $options{courseInstitution}) {
-			    warn "new institution |$options{courseInstitution}|";
 				$newDB->setSettingValue('courseInstitution',$options{courseInstitution});
 			}
 		};  warn "Problems from resetting course title and institution = $@" if $@;
@@ -539,17 +537,15 @@ sub retitleCourse {
 	my $courseID = $options{courseID};
 	my $ce       = $options{ce};
 	my %dbOptions = defined $options{dbOptions} ? %{ $options{dbOptions} } : ();
-	warn "running retitleCourse -- nothing done yet";	
+
 	# get the database layout out of the options hash
 	my $dbLayoutName = $ce->{dbLayoutName};
 	my $db = new WeBWorK::DB($ce->{dbLayouts}{$dbLayoutName});
 		eval {
 			if (exists( $options{courseTitle}) and $options{courseTitle}) {
-			    warn "new title |$options{courseTitle}|";
 				$db->setSettingValue('courseTitle',$options{courseTitle});
 			}
 			if (exists( $options{courseInstitution}) and $options{courseInstitution}) {
-			    warn "new institution |$options{courseInstitution}|";
 				$db->setSettingValue('courseInstitution',$options{courseInstitution});
 			}
 		};  warn "Problems from resetting course title and institution = $@" if $@;


### PR DESCRIPTION
This adds the ability to change the courseTitle and the courseInstitution in addition to changing the courseID for the course. Changing the courseID involves renaming several tables in the database, changing the title or the institution simply changes a field in the database. title and institution were set when a course was created and recorded in the database but their was no way to change their values.

To test:  

There are four items to be chosen in order to rename the database.  oldCourseID (from a scrolling menu)
newCourseID, newCourseTitle and newCourseInstitution.  Each of the last three has both a checkbox to indicate that it is to be changed and an input field for the new value. 

You always need to select an old courseID but there are many combinations of checkbox and input field that need to be checked.  If the checkbox is checked and the corresponding input field is empty there should be an error message (after submit).  If the input field has data but the checkbox is not checked then no operation should occur.  If the checkbox is not checked and the input field is empty there should not be an error.  Finally if the checkbox is checked and the input field is not empty then the report should indicate that the title or institution or ID has been changed. There are 64 combinations to check.  

After the initial submit there should be an accurate report of what errors need to be corrected (e.g. a field needs to be filled in) and what changes will be made. 

Cancel buttons should take you back to the first rename page with the checkboxs and input fields in their original state.

If you have direct access to the database make sure that reported changes are actually made.