### PR TITLE
Clean up a warning about uninitialized  for course_info.txt

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
@@ -1820,7 +1820,7 @@ sub save_as_form {  # calls the save_as_handler
 	$shortFilePath   =~ s|^$templatesDir/||;
 	$shortFilePath   =  'local/'.$shortFilePath
 	  unless( $shortFilePath =~m|^local/| ||
-		  $shortFilePath =~m|^set$setID|);  # suggest that modifications be saved to the "local" subdirectory
+		  (defined $setID and $shortFilePath =~m|^set$setID|));  # suggest that modifications be saved to the "local" subdirectory
 	$shortFilePath =~ s|^.*/|| if $shortFilePath =~ m|^/|;  # if it is still an absolute path don't suggest a file path to save to.
    
 


### PR DESCRIPTION
If I go to a course on develop right now, and click to edit the course information text, I get a warning message about $setID not being defined. It arises when the editor is looking to see if the file name is of the form set$setID as part of a check on how to process the file name. This adds a check to ensure $setID is defined before doing this other check, and the warning goes away while editing course_info.txt

Perhaps this should apply to 2.11 too? It's not critical, but it gives the wrong impression to a faculty user who just wants to edit their course info that something is wrong.