### PR TITLE
Add showResources button to Problem.pm page

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -700,10 +700,10 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 	create_and_delete_courses      => "professor",
 	fix_course_databases           => "professor",
 	modify_tags                    => undef,
-        edit_restricted_files          => "admin",
+    edit_restricted_files          => "admin",
 	
 	##### Behavior of the interactive problem processor #####
-	
+	show_resource_info                              => "admin",
 	show_correct_answers_before_answer_date         => "ta",
 	show_solutions_before_answer_date               => "ta",
 	avoid_recording_answers                         =>  "nobody", # record the grade/status/state of everyone's entries.


### PR DESCRIPTION
Add showResources  checkBox to Problem page for those with admin privileges (permissionLevel 20).   Need to pull the matching PR for pg in order for this to work.   

The checkBox will name  the resources that have been 
used by the pg problem and recorded by PGalias along with additional information.  PGalias doesn't handle all of the file types yet.  Let me know which important ones are missing.