### PR TITLE
More 2.11 Bugfixes

### DIFF
--- a/courses.dist/modelCourse/templates/set0.def
+++ b/courses.dist/modelCourse/templates/set0.def
@@ -7,13 +7,13 @@ enableReducedScoring = N
 paperHeaderFile   = set0/paperHeaderFile0.pg
 screenHeaderFile  = set0/screenHeaderFile0.pg
 description       = 
-restrictProbProgression = 
-emailInstructor   = 
+restrictProbProgression = 0
+emailInstructor   = 0
 
 problemListV2 
 problem_start
 source_file = set0/prob1.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 1
@@ -22,7 +22,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob1a.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 2
@@ -31,7 +31,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob1b.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 3
@@ -40,7 +40,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob2.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 4
@@ -49,7 +49,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob3.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 5
@@ -58,7 +58,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob4/prob4.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 6
@@ -67,7 +67,7 @@ att_to_open_children = 1
 problem_end
 problem_start
 source_file = set0/prob5.pg
-value = 0
+value = 1
 max_attempts = -1
 showMeAnother = -1
 problem_id = 7

--- a/courses.dist/modelCourse/templates/set0.def
+++ b/courses.dist/modelCourse/templates/set0.def
@@ -12,65 +12,65 @@ emailInstructor   = 0
 
 problemListV2 
 problem_start
+problem_id = 1
 source_file = set0/prob1.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 1
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 2
 source_file = set0/prob1a.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 2
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 3
 source_file = set0/prob1b.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 3
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 4
 source_file = set0/prob2.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 4
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 5
 source_file = set0/prob3.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 5
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 6
 source_file = set0/prob4/prob4.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 6
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 7
 source_file = set0/prob5.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 7
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end

--- a/courses.dist/modelCourse/templates/set0.def
+++ b/courses.dist/modelCourse/templates/set0.def
@@ -1,14 +1,77 @@
-setNumber=0
-openDate = 1/7/00 at 6:00am
-dueDate = 1/20/09 at 6:00am
-answerDate = 1/21/09 at 6:00am
-paperHeaderFile = set0/paperHeaderFile0.pg
-screenHeaderFile = set0/screenHeaderFile0.pg
-problemList =
-set0/prob1.pg,    0
-set0/prob1a.pg,   0
-set0/prob1b.pg,   0
-set0/prob2.pg,   0
-set0/prob3.pg,   0
-set0/prob4/prob4.pg,   0
-set0/prob5.pg,   0
+assignmentType      = default
+openDate          = 01/07/2000 at 06:00am EST
+reducedScoringDate = 01/20/2009 at 06:00am EST
+dueDate           = 01/20/2009 at 06:00am EST
+answerDate        = 01/21/2009 at 06:00am EST
+enableReducedScoring = N
+paperHeaderFile   = set0/paperHeaderFile0.pg
+screenHeaderFile  = set0/screenHeaderFile0.pg
+description       = 
+restrictProbProgression = 
+emailInstructor   = 
+
+problemListV2 
+problem_start
+source_file = set0/prob1.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 1
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob1a.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 2
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob1b.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 3
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob2.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 4
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob3.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 5
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob4/prob4.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 6
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = set0/prob5.pg
+value = 0
+max_attempts = -1
+showMeAnother = -1
+problem_id = 7
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+

--- a/courses.dist/modelCourse/templates/setDemo.def
+++ b/courses.dist/modelCourse/templates/setDemo.def
@@ -7,8 +7,8 @@ enableReducedScoring = N
 paperHeaderFile   = setDemo/paperHeaderFile1.pg
 screenHeaderFile  = setDemo/screenHeaderFile1.pg
 description       = 
-restrictProbProgression = 
-emailInstructor   = 
+restrictProbProgression = 0
+emailInstructor   = 0
 
 problemListV2 
 problem_start

--- a/courses.dist/modelCourse/templates/setDemo.def
+++ b/courses.dist/modelCourse/templates/setDemo.def
@@ -1,24 +1,86 @@
-setNumber=Demo
-openDate = 1/10/98 at 6:00am
-dueDate = 1/1/06 at 2:00am
-answerDate = 1/1/06 at 2:00am
-paperHeaderFile = setDemo/paperHeaderFile1.pg
-screenHeaderFile = setDemo/screenHeaderFile1.pg
+assignmentType      = default
+openDate          = 01/10/1998 at 06:00am EST
+reducedScoringDate = 01/01/2006 at 02:00am EST
+dueDate           = 01/01/2006 at 02:00am EST
+answerDate        = 01/01/2006 at 02:00am EST
+enableReducedScoring = N
+paperHeaderFile   = setDemo/paperHeaderFile1.pg
+screenHeaderFile  = setDemo/screenHeaderFile1.pg
+description       = 
+restrictProbProgression = 
+emailInstructor   = 
 
-problemList =
-
-setDemo/srw1_9_4.pg,            1
-setDemo/limits.pg,              1
-setDemo/s2_2_1.pg,              1
-setDemo/c4s5p2.pg,              1
-setDemo/sample_units_ans.pg,    1
-setDemo/nsc2s10p2.pg,           1
-setDemo/prob5.pg,               1
-setDemo/sample_myown_ans.pg,    1
- 
-
-
-
-
-
+problemListV2 
+problem_start
+source_file = setDemo/srw1_9_4.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 1
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/limits.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 2
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/s2_2_1.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 3
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/c4s5p2.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 4
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/sample_units_ans.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 5
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/nsc2s10p2.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 6
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/prob5.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 7
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setDemo/sample_myown_ans.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 8
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
 

--- a/courses.dist/modelCourse/templates/setDemo.def
+++ b/courses.dist/modelCourse/templates/setDemo.def
@@ -12,74 +12,74 @@ emailInstructor   = 0
 
 problemListV2 
 problem_start
+problem_id = 1
 source_file = setDemo/srw1_9_4.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 1
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 2
 source_file = setDemo/limits.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 2
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 3
 source_file = setDemo/s2_2_1.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 3
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 4
 source_file = setDemo/c4s5p2.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 4
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 5
 source_file = setDemo/sample_units_ans.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 5
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 6
 source_file = setDemo/nsc2s10p2.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 6
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 7
 source_file = setDemo/prob5.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 7
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 8
 source_file = setDemo/sample_myown_ans.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 8
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end

--- a/courses.dist/modelCourse/templates/setMAAtutorial.def
+++ b/courses.dist/modelCourse/templates/setMAAtutorial.def
@@ -7,8 +7,8 @@ enableReducedScoring = N
 paperHeaderFile   = setMAAtutorial/MAAtutorialSetHeader.pg
 screenHeaderFile  = setMAAtutorial/MAAtutorialSetHeader.pg
 description       = 
-restrictProbProgression = 
-emailInstructor   = 
+restrictProbProgression = 0
+emailInstructor   = 0
 
 problemListV2 
 problem_start

--- a/courses.dist/modelCourse/templates/setMAAtutorial.def
+++ b/courses.dist/modelCourse/templates/setMAAtutorial.def
@@ -1,23 +1,167 @@
-openDate = 1/10/97 at 6:00am
-dueDate = 1/1/05 at 2:00am
-answerDate = 1/1/05 at 2:00am
-paperHeaderFile = setMAAtutorial/MAAtutorialSetHeader.pg
-screenHeaderFile = setMAAtutorial/MAAtutorialSetHeader.pg
-problemList =
-setMAAtutorial/hello.pg,   1
-setMAAtutorial/standardexample.pg,   1
-setMAAtutorial/simplemultiplechoiceexample.pg,  1
-setMAAtutorial/multiplechoiceexample.pg,   1
-setMAAtutorial/matchinglistexample.pg,   1
-setMAAtutorial/truefalseexample.pg,    1
-setMAAtutorial/popuplistexample.pg,    1
-setMAAtutorial/ontheflygraphicsexample1.pg,    1
-setMAAtutorial/ontheflygraphicsexample2.pg,    1
-setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg,      1
-setMAAtutorial/hermitegraphexample.pg,         1
-setMAAtutorial/htmllinksexample/htmllinksexample.pg,           1
-setMAAtutorial/javascriptexample1.pg,    1
-setMAAtutorial/javascriptexample2.pg,    1
-setMAAtutorial/vectorfieldexample.pg,			1
-setMAAtutorial/conditionalquestionexample.pg,   1
-setMAAtutorial/javaappletexample.pg,    1
+assignmentType      = default
+openDate          = 01/10/1997 at 06:00am EST
+reducedScoringDate = 01/01/2005 at 02:00am EST
+dueDate           = 01/01/2005 at 02:00am EST
+answerDate        = 01/01/2005 at 02:00am EST
+enableReducedScoring = N
+paperHeaderFile   = setMAAtutorial/MAAtutorialSetHeader.pg
+screenHeaderFile  = setMAAtutorial/MAAtutorialSetHeader.pg
+description       = 
+restrictProbProgression = 
+emailInstructor   = 
+
+problemListV2 
+problem_start
+source_file = setMAAtutorial/hello.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 1
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/standardexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 2
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/simplemultiplechoiceexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 3
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/multiplechoiceexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 4
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/matchinglistexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 5
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/truefalseexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 6
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/popuplistexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 7
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/ontheflygraphicsexample1.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 8
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/ontheflygraphicsexample2.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 9
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 10
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/hermitegraphexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 11
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/htmllinksexample/htmllinksexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 12
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/javascriptexample1.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 13
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/javascriptexample2.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 14
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/vectorfieldexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 15
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/conditionalquestionexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 16
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setMAAtutorial/javaappletexample.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 17
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+

--- a/courses.dist/modelCourse/templates/setMAAtutorial.def
+++ b/courses.dist/modelCourse/templates/setMAAtutorial.def
@@ -12,155 +12,155 @@ emailInstructor   = 0
 
 problemListV2 
 problem_start
+problem_id = 1
 source_file = setMAAtutorial/hello.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 1
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 2
 source_file = setMAAtutorial/standardexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 2
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 3
 source_file = setMAAtutorial/simplemultiplechoiceexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 3
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 4
 source_file = setMAAtutorial/multiplechoiceexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 4
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 5
 source_file = setMAAtutorial/matchinglistexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 5
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 6
 source_file = setMAAtutorial/truefalseexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 6
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 7
 source_file = setMAAtutorial/popuplistexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 7
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 8
 source_file = setMAAtutorial/ontheflygraphicsexample1.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 8
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 9
 source_file = setMAAtutorial/ontheflygraphicsexample2.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 9
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 10
 source_file = setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 10
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 11
 source_file = setMAAtutorial/hermitegraphexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 11
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 12
 source_file = setMAAtutorial/htmllinksexample/htmllinksexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 12
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 13
 source_file = setMAAtutorial/javascriptexample1.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 13
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 14
 source_file = setMAAtutorial/javascriptexample2.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 14
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 15
 source_file = setMAAtutorial/vectorfieldexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 15
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 16
 source_file = setMAAtutorial/conditionalquestionexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 16
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 17
 source_file = setMAAtutorial/javaappletexample.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 17
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end

--- a/courses.dist/modelCourse/templates/setOrientation.def
+++ b/courses.dist/modelCourse/templates/setOrientation.def
@@ -7,8 +7,8 @@ enableReducedScoring = N
 paperHeaderFile   = setOrientation/setHeader.pg
 screenHeaderFile  = setOrientation/setHeader.pg
 description       = 
-restrictProbProgression = 
-emailInstructor   = 
+restrictProbProgression = 0
+emailInstructor   = 0
 
 problemListV2 
 problem_start

--- a/courses.dist/modelCourse/templates/setOrientation.def
+++ b/courses.dist/modelCourse/templates/setOrientation.def
@@ -1,23 +1,149 @@
-setNumber=Orientation
-openDate = 6/26/04 at 11:30am
-dueDate = 4/4/15 at 12:20pm
-answerDate = 4/5/15 at 12:00pm
-paperHeaderFile = setOrientation/setHeader.pg
-screenHeaderFile = setOrientation/setHeader.pg
+assignmentType      = default
+openDate          = 06/26/2004 at 11:30am EDT
+reducedScoringDate = 04/04/2015 at 12:20pm EDT
+dueDate           = 04/04/2015 at 12:20pm EDT
+answerDate        = 04/05/2015 at 12:00pm EDT
+enableReducedScoring = N
+paperHeaderFile   = setOrientation/setHeader.pg
+screenHeaderFile  = setOrientation/setHeader.pg
+description       = 
+restrictProbProgression = 
+emailInstructor   = 
 
-problemList =
-setOrientation/prob01.pg, 1
-setOrientation/prob02.pg, 1
-setOrientation/prob03.pg, 1
-setOrientation/prob04.pg, 1
-setOrientation/prob05/prob05.pg, 1
-setOrientation/prob06.pg, 1
-setOrientation/prob07.pg, 1
-setOrientation/prob08.pg, 1
-setOrientation/prob09.pg, 1
-setOrientation/prob10.pg, 1
-setOrientation/prob11.pg, 1
-setOrientation/prob12.pg, 1
-setOrientation/prob13.pg, 1
-setOrientation/prob14/prob14.pg, 1
-setOrientation/prob15.pg, 1
+problemListV2 
+problem_start
+source_file = setOrientation/prob01.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 1
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob02.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 2
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob03.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 3
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob04.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 4
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob05/prob05.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 5
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob06.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 6
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob07.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 7
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob08.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 8
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob09.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 9
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob10.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 10
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob11.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 11
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob12.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 12
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob13.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 13
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob14/prob14.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 14
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+problem_start
+source_file = setOrientation/prob15.pg
+value = 1
+max_attempts = -1
+showMeAnother = -1
+problem_id = 15
+counts_parent_grade = 0
+att_to_open_children = 1 
+problem_end
+

--- a/courses.dist/modelCourse/templates/setOrientation.def
+++ b/courses.dist/modelCourse/templates/setOrientation.def
@@ -12,137 +12,137 @@ emailInstructor   = 0
 
 problemListV2 
 problem_start
+problem_id = 1
 source_file = setOrientation/prob01.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 1
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 2
 source_file = setOrientation/prob02.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 2
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 3
 source_file = setOrientation/prob03.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 3
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 4
 source_file = setOrientation/prob04.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 4
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 5
 source_file = setOrientation/prob05/prob05.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 5
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 6
 source_file = setOrientation/prob06.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 6
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 7
 source_file = setOrientation/prob07.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 7
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 8
 source_file = setOrientation/prob08.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 8
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 9
 source_file = setOrientation/prob09.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 9
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 10
 source_file = setOrientation/prob10.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 10
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 11
 source_file = setOrientation/prob11.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 11
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 12
 source_file = setOrientation/prob12.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 12
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 13
 source_file = setOrientation/prob13.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 13
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 14
 source_file = setOrientation/prob14/prob14.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 14
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end
 problem_start
+problem_id = 15
 source_file = setOrientation/prob15.pg
 value = 1
 max_attempts = -1
 showMeAnother = -1
-problem_id = 15
 counts_parent_grade = 0
 att_to_open_children = 1 
 problem_end

--- a/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
+++ b/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
@@ -23,20 +23,26 @@ addOnLoadEvent( function () {
 	   matter if we keep the target up to date before submit is pressed.
 	*/
 
+	// action0 = view
+	// action1 = update
+	// action2 = new version
+	// action3 = append
+	// action 4 = revert
+	
 	var inWindow = $("#newWindow").attr('checked');
 	var target = "pg_editor_frame";
 	if (inWindow) {
-	    if ($('#save_as_form_id').attr('checked')) {
+	    if ($('#action2').attr('checked') ||
+		$('#action3').attr('checked') ||
+		$('#action4').attr('checked')) {
 		target = "WW_New_Edit";
 	    } else {
 		target = "WW_View";
 	    }
 	} 
-	else if ($('#save_as_form_id').attr('checked')
-		 || ($('#revert_form_id').length > 0 &&
-		     $('#revert_form_id').attr('checked')) 
-		 || ($('#add_problem_form_id').length > 0 &&
-		     $('#add_problem_form_id').attr('checked')))
+	else if ($('#action2').attr('checked')
+		 || $('#action3').attr('checked') 
+		 || $('#action4').attr('checked'))
 	{
 	    target = "";
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1965,7 +1965,7 @@ sub readSetDef {
 		# validate reduced credit date
 		$reducedScoringDate = $self->parseDateTime($reducedScoringDate) if ($reducedScoringDate);
 
-		if ($reducedScoringDate && ($reducedScoringDate <= $time1 || $reducedScoringDate => $time2)) {
+		if ($reducedScoringDate && ($reducedScoringDate < $time1 || $reducedScoringDate > $time2)) {
 		    warn $r->maketext("The reduced credit date should be between the open date [_1] and due date [_2]", $openDate, $dueDate);
 		} elsif (!$reducedScoringDate) {
 		    $reducedScoringDate = $time2 - 60*$r->{ce}->{pg}{ansEvalDefaults}{reducedScoringPeriod};

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1703,7 +1703,7 @@ sub importSetsFromDef {
 
 		debug("$set_definition_file: reading set definition file");
 		# read data in set definition file
-		my ($setName, $paperHeaderFile, $screenHeaderFile, $openDate, $dueDate, $answerDate, $ra_problemData, $assignmentType, $attemptsPerVersion, $timeInterval, $versionsPerInterval, $versionTimeLimit, $problemRandOrder, $problemsPerPage, $hideScore, $hideWork,$timeCap,$restrictIP,$restrictLoc,$relaxRestrictIP,$description,$emailInstructor,$restrictProbProgression) = $self->readSetDef($set_definition_file);
+		my ($setName, $paperHeaderFile, $screenHeaderFile, $openDate, $dueDate, $answerDate, $ra_problemData, $assignmentType, $enableReducedScoring, $reducedScoringDate, $attemptsPerVersion, $timeInterval, $versionsPerInterval, $versionTimeLimit, $problemRandOrder, $problemsPerPage, $hideScore, $hideWork,$timeCap,$restrictIP,$restrictLoc,$relaxRestrictIP,$description,$emailInstructor,$restrictProbProgression) = $self->readSetDef($set_definition_file);
 		my @problemList = @{$ra_problemData};
 
 		# Use the original name if form doesn't specify a new one.
@@ -1734,7 +1734,8 @@ sub importSetsFromDef {
 		$newSetRecord->due_date($dueDate);
 		$newSetRecord->answer_date($answerDate);
 		$newSetRecord->visible(DEFAULT_VISIBILITY_STATE);
-		$newSetRecord->enable_reduced_scoring(DEFAULT_ENABLED_REDUCED_SCORING_STATE);
+		$newSetRecord->reduced_scoring_date($reducedScoringDate);
+		$newSetRecord->enable_reduced_scoring($enableReducedScoring);
 		$newSetRecord->description($description);
 		$newSetRecord->email_instructor($emailInstructor);
 		$newSetRecord->restrict_prob_progression($restrictProbProgression);
@@ -1860,15 +1861,15 @@ sub readSetDef {
 	my $paperHeaderFile = '';
 	my $screenHeaderFile = '';
 	my $description = '';
-	my ($dueDate, $openDate, $answerDate);
+	my ($dueDate, $openDate, $reducedScoringDate, $answerDate);
 	my @problemData;	
 
 # added fields for gateway test/versioned set definitions:
-	my ( $assignmentType, $attemptsPerVersion, $timeInterval, 
+	my ( $assignmentType, $attemptsPerVersion, $timeInterval, $enableReducedScoring, 
 	     $versionsPerInterval, $versionTimeLimit, $problemRandOrder,
 	     $problemsPerPage, $restrictLoc, $emailInstructor, $restrictProbProgression, $countsParentGrade, $attToOpenChildren, $problemID, $showMeAnother, $listType
 	     ) = 
-		 ('')x8;  # initialize these to ''
+		 ('')x16;  # initialize these to ''
 	my ( $timeCap, $restrictIP, $relaxRestrictIP ) = ( 0, 'No', 'No');
 # additional fields currently used only by gateways; later, the world?
 	my ( $hideScore, $hideWork, ) = ( 'N', 'N' );
@@ -1905,7 +1906,11 @@ sub readSetDef {
 			} elsif ($item eq 'openDate') {
 				$openDate = $value;
 			} elsif ($item eq 'answerDate') {
-				$answerDate = $value;
+			        $answerDate = $value;
+			} elsif ($item eq 'enableReducedScoring') {
+			        $enableReducedScoring = $value;
+			} elsif ($item eq 'reducedScoringDate') {
+				$reducedScoringDate = $value;
 			} elsif ($item eq 'assignmentType') {
 				$assignmentType = $value;
 			} elsif ($item eq 'attemptsPerVersion') {
@@ -1957,6 +1962,26 @@ sub readSetDef {
 			warn $r->maketext("The open date: [_1], due date: [_2], and answer date: [_3] must be defined and in chronological order.", $openDate, $dueDate, $answerDate);
 		}
 
+		# validate reduced credit date
+		$reducedScoringDate = $self->parseDateTime($reducedScoringDate) if ($reducedScoringDate);
+
+		if ($reducedScoringDate && ($reducedScoringDate < $time1 || $reducedScoringDate > $time2)) {
+		    warn $r->maketext("The reduced credit date should be between the open date [_1] and due date [_2]", $openDate, $dueDate);
+		} elsif (!$reducedScoringDate) {
+		    $reducedScoringDate = $time2 - 60*$r->{ce}->{pg}{ansEvalDefaults}{reducedScoringPeriod};
+		}
+
+		if ($enableReducedScoring ne '' && $enableReducedScoring eq 'Y') {
+		    $enableReducedScoring = 1;
+		} elsif ($enableReducedScoring ne '' && $enableReducedScoring eq 'N') {
+		    $enableReducedScoring = 0;
+		} elsif ($enableReducedScoring ne '') {
+		    warn($r->maketext("The value [_1] for enableReducedScoring is not valid; it willb e replaced with 'N'.",$enableReducedScoring)."\n");
+		    $enableReducedScoring = 0;
+		} else {
+		    $enableReducedScoring = DEFAULT_ENABLED_REDUCED_SCORING_STATE;
+		}
+	       
 		# Check header file names
 		$paperHeaderFile =~ s/(.*?)\s*$/$1/;   #remove trailing white space
 		$screenHeaderFile =~ s/(.*?)\s*$/$1/;   #remove trailing white space
@@ -1976,11 +2001,7 @@ sub readSetDef {
 			warn($r->maketext("The value [_1] for the hideScore option is not valid; it will be replaced with 'N'.", $hideScore)."\n");
 			$hideScore = 'N';
 		}
-		if ( $hideWork ne 'N' && $hideWork ne 'Y' && 
-		     $hideWork ne 'BeforeAnswerDate' ) {
-			warn($r->maketext("The value [_1] for the hideWork option is not valid; it will be replaced with 'N'.", $hideWork)."\n");
-			$hideWork = 'N';
-		}
+
 		if ( $timeCap ne '0' && $timeCap ne '1' ) {
 			warn($r->maketext("The value [_1] for the capTimeLimit option is not valid; it will be replaced with '0'.", $timeCap)."\n");
 			$timeCap = '0';
@@ -2169,7 +2190,10 @@ sub readSetDef {
 		 $time2,
 		 $time3,
 		 \@problemData,
-		 $assignmentType, $attemptsPerVersion, $timeInterval, 
+		 $assignmentType,
+		 $enableReducedScoring,
+		 $reducedScoringDate,
+		 $attemptsPerVersion, $timeInterval, 
 		 $versionsPerInterval, $versionTimeLimit, $problemRandOrder,
 		 $problemsPerPage, 
 		 $hideScore,
@@ -2225,12 +2249,14 @@ SET:	foreach my $set (keys %filenames) {
 		my $openDate     = $self->formatDateTime($setRecord->open_date);
 		my $dueDate      = $self->formatDateTime($setRecord->due_date);
 		my $answerDate   = $self->formatDateTime($setRecord->answer_date);
+		my $reducedScoringDate =  $self->formatDateTime($setRecord->reduced_scoring_date);
 		my $description = $setRecord->description;
 		if ($description) {
 		    $description =~ s/\r?\n/<n>/g;
 		}
 
 		my $assignmentType = $setRecord->assignment_type;
+		my $enableReducedScoring = $setRecord->enable_reduced_scoring ? 'Y' : 'N';
 		my $setHeader    = $setRecord->set_header;
 		my $paperHeader  = $setRecord->hardcopy_header;
 		my $emailInstructor = $setRecord->email_instructor;
@@ -2324,8 +2350,10 @@ EOG
 		my $fileContents = <<EOF;
 assignmentType      = $assignmentType
 openDate          = $openDate
+reducedScoringDate = $reducedScoringDate
 dueDate           = $dueDate
 answerDate        = $answerDate
+enableReducedScoring = $enableReducedScoring
 paperHeaderFile   = $paperHeader
 screenHeaderFile  = $setHeader$gwFields
 description       = $description

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1965,7 +1965,7 @@ sub readSetDef {
 		# validate reduced credit date
 		$reducedScoringDate = $self->parseDateTime($reducedScoringDate) if ($reducedScoringDate);
 
-		if ($reducedScoringDate && ($reducedScoringDate < $time1 || $reducedScoringDate > $time2)) {
+		if ($reducedScoringDate && ($reducedScoringDate <= $time1 || $reducedScoringDate => $time2)) {
 		    warn $r->maketext("The reduced credit date should be between the open date [_1] and due date [_2]", $openDate, $dueDate);
 		} elsif (!$reducedScoringDate) {
 		    $reducedScoringDate = $time2 - 60*$r->{ce}->{pg}{ansEvalDefaults}{reducedScoringPeriod};

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -2144,6 +2144,14 @@ sub readSetDef {
 						countsParentGrade => $countsParentGrade
 				 });
 			    
+			    # reset the various values
+			    $name = '';
+			    $problemID = '';
+			    $weight = '';
+			    $attemptLimit = '';
+			    $showMeAnother = '';
+			    $attToOpenChildren = '';
+			    $countsParentGrade = '';
 			    
 			} else {
 			    warn $r->maketext("readSetDef error, can't read the line: ||[_1]||", $line);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1844,8 +1844,8 @@ sub readSetDef {
 	
 	my $r = $self->r;
 
-	if ($fileName =~ m|^.*set([.\w-]+)\.def$|) {
-		$setName = $1;
+	if ($fileName =~ m|^(.*/)?set([.\w-]+)\.def$|) {
+		$setName = $2;
 	} else {
 		$self->addbadmessage( 
 		    qq{The setDefinition file name must begin with   <CODE>set</CODE>},

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -2001,7 +2001,11 @@ sub readSetDef {
 			warn($r->maketext("The value [_1] for the hideScore option is not valid; it will be replaced with 'N'.", $hideScore)."\n");
 			$hideScore = 'N';
 		}
-
+		if ( $hideWork ne 'N' && $hideWork ne 'Y' && 
+		     $hideWork ne 'BeforeAnswerDate' ) {
+			warn($r->maketext("The value [_1] for the hideWork option is not valid; it will be replaced with 'N'.", $hideWork)."\n");
+			$hideWork = 'N';
+		}
 		if ( $timeCap ne '0' && $timeCap ne '1' ) {
 			warn($r->maketext("The value [_1] for the capTimeLimit option is not valid; it will be replaced with '0'.", $timeCap)."\n");
 			$timeCap = '0';

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -2300,11 +2300,11 @@ SET:	foreach my $set (keys %filenames) {
 			# the labelled list makes it easier to add variables and 
 			# easier to tell when they are missing
 			$problemList     .= "problem_start\n";
+			$problemList     .= "problem_id = $problem_id\n";
 			$problemList     .= "source_file = $source_file\n";
 			$problemList     .= "value = $value\n";
 			$problemList     .= "max_attempts = $max_attempts\n";
 			$problemList     .= "showMeAnother = $showMeAnother\n";
-			$problemList     .= "problem_id = $problem_id\n";
 			$problemList     .= "counts_parent_grade = $countsParentGrade\n";
 			$problemList     .= "att_to_open_children = $attToOpenChildren \n";
 			$problemList     .= "problem_end\n"


### PR DESCRIPTION
This is another bugfix pull for Release 2.11.  I'm trying to limit them to 3 or 4 things per pull to keep it manageable.  This time around: 

1.  Fixed a bug where if a value was not defined for a problem in a set def file then the value of the previous problem would be used.  
  -  To test.  Import the following def file. Before the patch the showMeAnother value for problems 3 and 4 will be 3.  After the patch it should be -1/Never/whatever the default is on your server.  
  ```
assignmentType      = default
openDate          = 11/20/2014 at 11:59pm EST
dueDate           = 11/27/2016 at 11:59pm EST
answerDate        = 11/27/2016 at 11:59pm EST
paperHeaderFile   = defaultHeader
screenHeaderFile  = defaultHeader
description       = 
restrictProbProgression = 0
emailInstructor   = 0
enableReducedScoring = Y

problemListV2 
problem_start
source_file = Library/UMN/algebraKaufmannSchwitters/ks_5_2_79.pg
value = 1
max_attempts = -1
showMeAnother = -1
problem_id = 1
counts_parent_grade = 0
att_to_open_children = 0 
problem_end
problem_start
source_file = Library/ma117DB/set1/srw1_1_51a.pg
value = 1
max_attempts = -1
showMeAnother = 3
problem_id = 2
counts_parent_grade = 0
att_to_open_children = 0 
problem_end
problem_start
source_file = Library/ma117DB/set1/srw1_1_51b.pg
value = 1
max_attempts = -1
problem_id = 3
counts_parent_grade = 0
att_to_open_children = 0 
problem_end
problem_start
source_file = Library/ma117DB/set1/srw1_1_53b.pg
value = 1
max_attempts = -1
problem_id = 4
counts_parent_grade = 0
att_to_open_children = 0 
problem_end
  ```
2.  Added the new reduced scoring parameters to the import/export functionality of Homework Set Editor.  Previously this data was not saved on import/export. 
  -  To test import the above def file.  Before the patch it will have a reduced scoring date far in the past (1970).  After the patch the reduced scoring date should be the due date minus the default reduced scoring period (maybe 0).  
  -  Also add the lines 
`reducedScoringDate = 11/25/2016 at 11:59pm EST` and `enableReducedScoring = Y` to the def file and re-import it.  It should have the appropriate date and reduced scoring should be enabled. 
  -  Export a set and make sure the reduced scoring date and enable reduced scoring variables show up in the def file.  
  -  Note:  I'm not keeping the Old Homework Sets editor up to date any more so these changes will not appear there.  

3.  I rebuilt the def files for the default sets in modelCourse.  These new def files show off the newer def format and some of the more recent options.  If people are using these def files as a basis to write their own then these will be much better. 
  -  To test:  Create a course, import the default sets and make sure they look ok.  

4.  I fixed a bug where using "New Version" or "Append" in PG Problem Editor 3 would open the new editor in the modal window.  
  -  To test:  Edit a problem  using PG problem editor 3.  Before the patch if you use New Version or Append it will always open the editor in the modal window.  After the patch it will either replace your current window or open in a new window, depending on if you have the check box ticked.  