### PR TITLE
Release 2.11 Bugfixes 3

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -257,24 +257,6 @@ $problemDefaults{max_attempts} = -1;
 # setting this to -1 disables the showMeAnother button
 $problemDefaults{showMeAnother} = -1;   
 
-# The default prPeriod value (re-randomization period) to use for the newly created problem.
-# It is suggested to use the value of -1, which means that the course-wide setting would be used
-# Setting this to -1 defaults to the use of course-wide settings (suggested)
-# Setting this to 0 disables periodic randomization regardless of the course-wide setting
-# Setting this to a positive value will override the course-wide setting
-$problemDefaults{prPeriod} = -1;
-
-
-################################################################################
-# Periodic re-randomization
-################################################################################
-# switch to enable periodic re-randomization
-$pg{options}{enablePeriodicRandomization} = 0;
-# course-wide default period for re-randomization, should be an integer
-# the value of 0 disables re-randomization
-$pg{options}{periodicRandomizationPeriod} = 5;
-
-
 ################################################################################
 # "Special" PG environment variables. (Stuff that doesn't fit in anywhere else.)
 ################################################################################

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -66,7 +66,10 @@ $server_groupID    = 'wwdata';
 
 #$server_apache_version = ''; # e.g. '2.22.1'
 
+# Set this to override the default admin email set by apache.  
 $webwork_server_admin_email ='';
+
+
 ################################################################################
 # Paths to external programs 
 ################################################################################

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1012,7 +1012,7 @@ sub rename_course_form {
 		CGI::Tr({},
 			CGI::td( CGI::checkbox(
 				{name=>"rename_newCourseInstitution_checkbox", 
-				 label=>'Change institution to:', 
+				 label=>'Change Institution to:', 
 				 checked=>$rename_newCourseInstitution_checkbox,
 				 value=>'on'
 				 }) ),
@@ -1294,7 +1294,7 @@ sub rename_course_validate {
 	if ($rename_newCourseInstitution eq "" and $rename_newCourseInstitution_checkbox eq 'on')  {
 		push @errors, "You must specify a new institution for the course.";
 	}
-	unless ($rename_newCourseID or $rename_newCourseID_checkbox or $rename_newCourseTitle_checkbox ) {
+	unless ($rename_newCourseID or $rename_newCourseID_checkbox or $rename_newCourseTitle_checkbox or $rename_newCourseInstitution_checkbox) {
 		push @errors, "No changes specified.  You must mark the 
 		checkbox of the item(s) to be changed and enter the change data.";
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -373,7 +373,7 @@ sub body {
 		),
 		CGI::Tr({class=>"ButtonRow"}, [
 			CGI::td([
-				CGI::submit(-name=>"sets_assigned_to_user", -label=>$r->maketext("View/Edit"))." ".$r->maketext("all sets for one <b>user</b>(set dates, scores)"),
+				CGI::submit(-name=>"sets_assigned_to_user", -label=>$r->maketext("View/Edit"))." ".$r->maketext("all set dates for one <b>user</b>"),
 				CGI::submit(-name=>"users_assigned_to_set", -label=>$r->maketext("View/Edit"))." ".$r->maketext("all users for one <b>set</b>"),
 			]),
 			CGI::td([

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -189,7 +189,7 @@ sub body {
 		my @problemNumbers;
 
 		my $setRecord = $db->getGlobalSet($setName);
-		my $isJitarSet = ( $setRecord->assignment_type eq 'jitar' ) ? 1 : 0;
+		my $isJitarSet = ($setRecord && $setRecord->assignment_type eq 'jitar' ) ? 1 : 0;
 
 		# search for matching problems
 		my @allProblems = $db->listUserProblems($studentUser, $setName);


### PR DESCRIPTION
More bugfixes for release 2.11

1.  Fixed an undefined variable bug in show answers. 
  -  To test:  Create a gateway, create a version, enter some answers, then click show past answers.  Before the fix you should get an error and after it should work. 
2.  Fixed a small bug with the rename feature. 
  -  To test:  Rename a course but only change the institution.  Before the fix you should get error messages and after you should be allowed to change only the institution.  
3.  Fixed a bug with restrict to IP and apache 2.4  For apache 2.4 the api for getting the request ip address changed.  To test.  
   -  Set up some remote addresses in the admin course, and set up a homework to use the restrict ip feature. 
   -  Log in as a student and try to access a homework with a restricted ip.  Before the patch if you are using apache 2.4 you should get an error about an undefined method.  After the patch it should work normally.  Ideally this test should also be repeated on a pre 2.4 server to check and make sure there aren't regressions.  