### PR TITLE
Even More 2.11 Bugfixes

### DIFF
--- a/htdocs/js/apps/MathView/mathview.js
+++ b/htdocs/js/apps/MathView/mathview.js
@@ -122,7 +122,7 @@ function MathViewer(field,button,container,userOptions) {
     if (this.options.decoratedTextBoxAsInput) {
 	this.inputTextBox = $(field);
     } else {
-	this.inputTextBox = $('<input>',{type : 'text', class : 'mv-input', size:'40'});
+	this.inputTextBox = $('<input>',{type : 'text', class : 'mv-input', size:'32'});
     }
 
     MathJax.Hub.Config({

--- a/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
+++ b/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
@@ -12,6 +12,8 @@ $(function(){
 	    .addClass('hidden-desktop hidden-tablet');
 	$('#pg_editor_frame_id').contents().find('#content')
 	    .removeClass('span10').addClass('span12');
+	$("#pg_editor_frame_id").contents().find('#toggle-sidebar')
+	    .addClass('hidden');
     });
 });
 

--- a/htdocs/themes/math3/math3.css
+++ b/htdocs/themes/math3/math3.css
@@ -1071,3 +1071,80 @@ span.required-field {
     margin-left: 0px;
 }
 
+/* Problem Set Detail 2 CSS */
+
+#psd_list {
+    padding-left: 0px;
+}
+
+#psd_list li {
+    list-style-type: none;
+}
+
+.pdr_placeholder {
+    height: 100px;
+    width: 90%;
+    border-style: dashed;
+    border-width: 1px;	
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+}
+
+.pdr_handle {    
+    cursor: move;
+    margin-right:2px;
+    font-size:large;
+}
+
+.pdr_collapse {
+    cursor: pointer;
+    width: 10px;
+    font-size:large;
+    display: none;
+    font-family: FontAwesome;
+}
+
+.psd_list_row.mjs-nestedSortable-collapsed > div > div > div > table > tbody > tr > td > span.pdr_collapse:after {
+    content: '\f054';
+}
+
+.psd_list_row.mjs-nestedSortable-expanded > div > div > div > table > tbody > tr > td > span.pdr_collapse:after {
+    content: '\f078';
+}
+
+
+#psd_toolbar {
+    margin-right:10px;
+}
+
+#psd_toolbar a.btn {
+    margin-left:0px;
+    margin-right:0px;
+}
+
+#psd_list li.mjs-nestedSortable-collapsed > ol {
+    display: none;
+    }
+
+#psd_list li.mjs-nestedSortable-branch .pdr_collapse {
+    display: inline-block;
+    }
+
+#psd_list li.mjs-nestedSortable-leaf .pdr_collapse {
+    display: none;
+}
+
+.psr_render_area {
+    margin-top: 10px;
+    overflow: hidden;
+}
+
+#problem_set_form a i {
+    margin-right: 3px;
+}
+
+#problem_set_form a.btn {
+    margin-right: 10px;
+}

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1730,7 +1730,7 @@ sub hidden_fields {
 	foreach my $param (@fields) {
 	    my @values = $r->param($param);
 	    foreach my $value (@values) {
-		next unless $value;
+		next unless defined($value);
 #		$html .= CGI::hidden($param, $value); # (can't name these items when using real CGI) 
 		$html .= CGI::hidden(-name=>$param, -default=>$value, -id=>"hidden_".$param); # (can't name these items when using real CGI) 
 	    }

--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -215,7 +215,6 @@ sub body {
 	    foreach my $set (@unfilteredsets) {
 		if ($set->assignment_type() eq 'default') {
 		    push @sets, $set;
-		    warn("Insert ".$set->set_id);
 		}
 	    }	    
 

--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -215,6 +215,7 @@ sub body {
 	    foreach my $set (@unfilteredsets) {
 		if ($set->assignment_type() eq 'default') {
 		    push @sets, $set;
+		    warn("Insert ".$set->set_id);
 		}
 	    }	    
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
@@ -1547,7 +1547,7 @@ sub add_problem_handler {
 							   problemID      => $targetProblemNumber, #added to end of set
 		);
 		$self->assignProblemToAllSetUsers($problemRecord);
-		$self->addgoodmessage("Added $sourceFilePath to ". $targetSetName. " as problem "..($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)) : $targetProblemNumber)) ;
+		$self->addgoodmessage("Added $sourceFilePath to ". $targetSetName. " as problem ".($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)) : $targetProblemNumber)) ;
 		$self->{file_type}   = 'problem'; # change file type to problem -- if it's not already that
 
 		#################################################

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -1116,7 +1116,7 @@ sub initialize {
 		    defined($r->param("set.$setID.enable_reduced_scoring")) ? 
 		    $r->param("set.$setID.enable_reduced_scoring") : 
 		    $setRecord->enable_reduced_scoring;
-		
+
 		if ($enable_reduced_scoring && 
 		    $reduced_scoring_date 
 		    && ($reduced_scoring_date > $due_date 
@@ -1125,11 +1125,6 @@ sub initialize {
 		    $error = $r->param('submit_changes');
 		}
 
-		if ($reduced_scoring_date && ($reduced_scoring_date > $due_date || $reduced_scoring_date < $open_date)) {
-			$self->addbadmessage($r->maketext("The reduced scoring date should be between the open date and due date."));
-			$error = $r->param('submit_changes');
-		}
-		
 		# make sure the dates are not more than 10 years in the future
 		my $curr_time = time;
 		my $seconds_per_year = 31_556_926;

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1151,6 +1151,7 @@ sub create_handler {
 		$newSetRecord->answer_date($dueDate + 60*$ce->{pg}{answersOpenAfterDueDate});
 		$newSetRecord->visible(DEFAULT_VISIBILITY_STATE());	# don't want students to see an empty set
 		$newSetRecord->enable_reduced_scoring(DEFAULT_ENABLED_REDUCED_SCORING_STATE());
+		$newSetRecord->assignment_type('default');
 		$db->addGlobalSet($newSetRecord);
 	} elsif ($type eq "copy") {
 		return CGI::div({class => "ResultsWithError"}, $r->maketext("Failed to duplicate set: no set selected for duplication!")) unless $oldSetID =~ /\S/;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1438,6 +1438,7 @@ sub pre_header_initialize {
 				
 				$newSetRecord->visible(1);
 				$newSetRecord->enable_reduced_scoring(0);
+				$newSetRecord->assignment_type('default');
 				eval {$db->addGlobalSet($newSetRecord)};
 				if ($@) {
 					$self->addbadmessage("Problem creating set $newSetName<br> $@");

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1408,8 +1408,10 @@ sub pre_header_initialize {
 			$r->param('local_sets',$newSetName);  ## use of two parameter param
 			debug("new value of local_sets is ", $r->param('local_sets'));
 			my $newSetRecord	 = $db->getGlobalSet($newSetName);
-			if (defined($newSetRecord)) {
-	            $self->addbadmessage("The set name $newSetName is already in use.  
+			if (! $newSetName) {
+			    $self->addbadmessage("You did not specify a new set name.  ");
+			} elsif (defined($newSetRecord)) {
+			    $self->addbadmessage("The set name $newSetName is already in use.  
 	            Pick a different name if you would like to start a new set.");
 			} else {			# Do it!
 				# DBFIXME use $db->newGlobalSet

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1898,39 +1898,25 @@ sub output_comments{
 		    my $comment = $userPastAnswer->comment_string;
 		    $comment = CGI::escapeHTML($comment);
 		    my $formFields = { WeBWorK::Form->new_from_paramable($r)->Vars };
-		    my $user = $db->getUser($eUserID);
+		    print CGI::start_div({id=>"answerComment", class=>"answerComments"});
+		    print CGI::b("Instructor Comment:"),  CGI::br();
+		    print $comment;
+		    print <<EOS;
+	<script type="text/javascript">
+	    MathJax.Hub.Register.StartupHook('AsciiMath Jax Config', function () {
+		var AM = MathJax.InputJax.AsciiMath.AM;
+		for (var i=0; i< AM.symbols.length; i++) {
+		    if (AM.symbols[i].input == '**') {
+			AM.symbols[i] = {input:"**", tag:"msup", output:"^", tex:null, ttype: AM.TOKEN.INFIX};
+		    }
+		}
+					     });
+	MathJax.Hub.Config(["input/Tex","input/AsciiMath","output/HTML-CSS"]);
+	
+	MathJax.Hub.Queue([ "Typeset", MathJax.Hub,'answerComment']);
+	</script>
+EOS
 
-		    local $ce->{pg}->{specialPGEnvironmentVars}->{problemPreamble}{HTML} = ''; 
-		    local $ce->{pg}->{specialPGEnvironmentVars}->{problemPostamble}{HTML} = '';
-		    my $source = "DOCUMENT();\n loadMacros(\"PG.pl\",\"PGbasicmacros.pl\",\"MathObjects.pl\");\n BEGIN_TEXT\n";
-		    $source .= $comment . "\nEND_TEXT\n ENDDOCUMENT();";
-		    my $pg = WeBWorK::PG->new(
-			$ce,
-			$user,
-			$key,
-			$set,
-			$problem,
-			$set->psvn, # FIXME: this field should be removed
-			$formFields,
-			{ # translation options
-			    displayMode     => $displayMode,
-			    showHints       => 0,
-			    showSolutions   => 0,
-			    refreshMath2img => 1,
-			    processAnswers  => 0,
-			    permissionLevel => 0,
-			    effectivePermissionLevel => 0,
-			    r_source => \$source,
-			},
-			);
-		    
-		    
-		    my $htmlout = $pg->{body_text};
-		    
-		    print CGI::div({class=>"answerComments"},
-		    CGI::b("Instructor Comment:"),
-		    CGI::br(),
-		    $htmlout);
 		}
 	}
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -386,17 +386,21 @@ sub body {
 	    print CGI::caption($r->maketext("Problems"));
 	    my  $AdjustedStatusPopover = "&nbsp;".CGI::a({class=>'help-popup',href=>'#', 'data-content'=>$r->maketext('The adjusted status of a problem is the larger of the problem\'s status and the weighted average of the status of those problems which count towards the parent grade.  If a problem does count towards its parent grade, then that score is listed in the column to the right.')  ,'data-placement'=>'top', 'data-toggle'=>'popover'},'&#9072');
 	    
-	    print CGI::Tr({},
-			  
-			  CGI::th($r->maketext("Name")),
+	    my $thRow = [ CGI::th($r->maketext("Name")),
 			  CGI::th($r->maketext("Attempts")),
 			  CGI::th($r->maketext("Remaining")),
 			  CGI::th($r->maketext("Worth")),
 			  CGI::th($isJitarSet ? $r->maketext("Adjusted Status").$AdjustedStatusPopover :
-				  $r->maketext("Status")),
-			  $isJitarSet  ? CGI::th($r->maketext("Credit For Parent")) : CGI::th(""),
-			      $canScoreProblems ? CGI::th($r->maketext("Grader")) : ''
-		);
+				  $r->maketext("Status")) ];
+	    if ($isJitarSet) {
+		push @$thRow, CGI::th($r->maketext("Credit For Parent"));
+	    }
+
+	    if ($canScoreProblems) {
+		push @$thRow, CGI::th($r->maketext("Grader"));
+	    }
+
+	    print CGI::Tr({}, @$thRow);
 		
 	    @problemNumbers = sort { $a <=> $b } @problemNumbers;
 
@@ -540,18 +544,22 @@ sub problemListRow($$$$$) {
 	    $graderLink = CGI::td('');
 	}
 
-	return CGI::Tr({},
-#		CGI::td({-nowrap=>1, -align=>"left"},$interactive),
-#		CGI::td({-nowrap=>1, -align=>"center"},
-		CGI::td($interactive),
-		CGI::td([
-				$attempts,
-				$remaining,
-				$value,
-				$status, 
-		                $statusForParent,
-		       $graderLink ? $graderLink : ''
-			]));
+	my $problemRow = [CGI::td($interactive),
+			  CGI::td([
+			      $attempts,
+			      $remaining,
+			      $value,
+			      $status])];
+	if ($isJitarSet) {
+	    push @$problemRow, CGI::td($statusForParent);
+	}
+
+	if ($canScoreProblems) {
+	    push @$problemRow, $graderLink;
+	}
+	    
+	
+	return CGI::Tr({}, @$problemRow);
 }
 
 1;

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -454,7 +454,7 @@ our %pathTypes = (
 	},
 
         instructor_problem_grader => {
-		name    => 'Manual Grader for Set $setID Problem $problemID',
+		name    => 'Manual Grader',
 		parent  => 'instructor_tools',
 		kids    => [ qw// ],
 		match   => qr|^grader/([^/]+)/([^/]+)/|,


### PR DESCRIPTION
- Fixed an issue where answers of 0 were not being preserved after timeout. 
 -  To test set your timeout value to be low, enter a 0 for any problem answer, wait, and hit check answers.  Before the patch after logging back in the submitted answer will be blank, after the patch it should have a zero.  
- Made a better error when there is no set name when creating a set via the library browser. 
  -  To test make a set via the library browser but don't input a set name.  
-  Fixed an issue with the success message when appending a problem via PGProblemEditor3
  -  To test append a problem with PGProblemEditor3.  
-  Fixed an issue with columns on the Problem Set page.  
  -  To test, make a set with an essay answer.  Check the formatting of Problem Set.  Submit an answer and check the formatting of Problem Set with the grader link.  Change the set type to Jitar and check the formatting again.  
-  Changed how essay answer comments were rendered on  the Problem page. It should be faster and more generic.  Test by assigning an essay answer, grading it with a comment, and checking that it renders on the problem page correctly.  
-  Added css to make problem set detail 2 work in math3.  
  -  To test, change to math3 and visit the problem set detail 2 page.  Everything should function, although it doesn't look quite as good.  