### PR TITLE
Add new OPL macro files to defaults.config

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1009,6 +1009,8 @@ $pg{directories}{macrosPath} = [
    "$courseDirs{templates}/Library/macros/UMass-Amherst",
    "$courseDirs{templates}/Library/macros/PCC",
    "$courseDirs{templates}/Library/macros/Alfred",
+   "$courseDirs{templates}/Library/macros/Wiley",
+   "$courseDirs{templates}/Library/macros/UBC",
    "$courseDirs{templates}/Library/macros/Hope",
 ];
 


### PR DESCRIPTION
The title sums it up.

Library/AlfredUniv/PDE/separable/wave/zeropartial.pg

uses a macro from the first and 

UBC/STAT/STAT300/hw04/stat300_hw04_q02.pg

uses the second, although the UBC problem still won't work unless you set up the rserve client/interface.