### PR TITLE
Hardcopyfix

### DIFF
--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -18,6 +18,7 @@ var basicRequestObject = {
 var taxo=[];  // Global variable to hold it
 var loadtaxo = $.ajax({
   dataType: "json",
+  async: false,
   url: "/webwork2_files/DATA/tagging-taxonomy.json", 
   success: function(data) {
     taxo = data;

--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -18,7 +18,6 @@ var basicRequestObject = {
 var taxo=[];  // Global variable to hold it
 var loadtaxo = $.ajax({
   dataType: "json",
-  async: false,
   url: "/webwork2_files/DATA/tagging-taxonomy.json", 
   success: function(data) {
     taxo = data;

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1260,7 +1260,11 @@ sub write_problem_tex {
 		
 		foreach my $ansName (@ans_entry_order) {
 			my $correctAnswer = $pg->{answers}->{$ansName}->{correct_ans};
-			$correctTeX .= "\\item\\begin{verbatim}$correctAnswer\\end{verbatim}\n";
+			if ($correctAnswer =~ m/^\s*\\\(/) {
+				$correctTeX .= "\\item $correctAnswer\n";
+			} else {
+				$correctTeX .= "\\item\\begin{verbatim}$correctAnswer\\end{verbatim}\n";
+			}
 			# FIXME: What about vectors (where TeX will complain about < and > outside of math mode)?
 		}
 		


### PR DESCRIPTION
Put  a problem like

Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.5.pg

in a problem set and get hardcopy showing correct answers.  The student would get correct answers which are in latex, but they put in verbatim, so they see the raw latex which is very hard to read, even if you are well versed in latex.  This change makes it so the hardcopy module detects this and usually puts correct answers in verbatim, unless they are already in math mode.