### PR TITLE
Yet Still Even More Release 2.11 Bugfixes

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -369,9 +369,8 @@ table.classlist-table .tbody {
     margin-top: 0px;
 }
 
-.problem_set_table {
-    display:block;
-    overflow:auto;
+.problem_set_table td, .problem_set_table th {
+    padding: 8px 3px 8px 3px;
 }
 
 .problem_set_table td a {

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -83,8 +83,7 @@ legend {
 #masthead {
 	background-color: #038;
 	margin: 0;
-	padding: 0;
-	padding: 5px;
+	padding: 5px 0px 5px 0px;
 }
 
 .webwork_logo {
@@ -118,7 +117,8 @@ legend {
 }
 
 #loginstatus {
-    	padding-top:.5ex;
+        padding-top:.5ex;
+        padding-right: .5em;
 	color: white;
 	text-align: right;
 	font-size: 0.85em;

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -369,6 +369,11 @@ table.classlist-table .tbody {
     margin-top: 0px;
 }
 
+.problem_set_table {
+    display:block;
+    overflow:auto;
+}
+
 .problem_set_table td a {
     font-weight:bold;
     font-size:13px;

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -62,7 +62,7 @@ $(function(){
 
     // Fix bug with skip to main content link in chrome
     $('#stmc-link').click(function() {
-	$('#content').attr('tabIndex', -1).focus();
+	$('#page-title').attr('tabIndex', -1).focus();
     });
 
     // Turn submit inputs into buttons
@@ -88,7 +88,7 @@ $(function(){
     });
     $('a.help-popup').popover({trigger : 'hover'}).click(function (event) {
 	event.preventDefault();
-    }).html('<i class="icon-question-sign"/>');
+    }).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
 
     // Sets login form input to bigger size
     $('#login_form input').addClass('input-large');    

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -76,7 +76,7 @@ var tabberOptions = {manualStartup:true};
 </head>
 
 <body>
-<a href="#content" id="stmc-link" class="sr-only sr-only-focusable">Skip to main content</a>
+<a href="#page-title" id="stmc-link" class="sr-only sr-only-focusable">Skip to main content</a>
 <!--#if can="output_wztooltip_JS"--> <!-- Please remind this -->
 	<!--#output_wztooltip_JS-->
 <!--#endif-->
@@ -166,7 +166,7 @@ var tabberOptions = {manualStartup:true};
 	<!-- Page Title -->
 	<!--#if can="title"-->
 	<div class="row-fluid"><div class="span12">
-		<h1 class='page-title'><!--#title --></h1>
+		<h1 id='page-title' class='page-title'><!--#title --></h1>
 	</div></div>
 	<!--#endif-->
 

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -744,10 +744,8 @@ sub links {
 			}
 
 			
-			if ($authz->hasPermissions($userID, "change_password") or $authz->hasPermissions($userID, "change_email_address")) {
 				print CGI::li(&$makelink("${pfx}Options", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
-			}
-			
+					
 			print CGI::li(&$makelink("${pfx}Grades", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 			
 			if ($ce->{achievementsEnabled}) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -457,7 +457,7 @@ sub scoreSet {
 	
 	# Write the problem data
 	my $dueDateString = $self->formatDateTime($setRecord->due_date);
-	my ($dueDate, $dueTime) = $dueDateString =~ m/^([^\s]*)\s*([^\s]*)$/;
+	my ($dueDate, $dueTime) = $dueDateString =~ /^(.*) at (.*)$/;
 	my $valueTotal = 0;
 	my %userStatusTotals = ();
 	my %userSuccessIndex = ();
@@ -471,9 +471,13 @@ sub scoreSet {
 		
 		my $column = 5 + $problem * $columnsPerProblem;
 		if ($scoringItems->{header}) {
+		        my $prettyProblemID = $globalProblem->problem_id;
+		        if ($isJitarSet) {
+			  $prettyProblemID = join('.',jitar_id_to_seq($prettyProblemID));
+			}
 			$scoringData[0][$column] = "";
 			$scoringData[1][$column] = $setRecord->set_id;
-			$scoringData[2][$column] = $globalProblem->problem_id;
+			$scoringData[2][$column] = $prettyProblemID;
 			$scoringData[3][$column] = $dueDate;
 			$scoringData[4][$column] = $dueTime;
 			$scoringData[5][$column] = $globalProblem->value;
@@ -482,7 +486,7 @@ sub scoreSet {
 				for (my $row = 0; $row < 6; $row++) {
 					for (my $col = $column+1; $col <= $column + 2; $col++) {
 						if ($row == 2) {
-							$scoringData[$row][$col] = $globalProblem->problem_id;
+							$scoringData[$row][$col] = $prettyProblemID;
 						} else {
 							$scoringData[$row][$col] = "";
 						}

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1073,7 +1073,7 @@ sub make_data_row {
 		      -onClick=>"return addme(\"$sourceFileName\", \'one\')")),
 			"\n",CGI::span({-style=>"text-align: left; cursor: pointer"},CGI::span({id=>"filepath$cnt"},"Show path ...")),"\n",
 				 '<script type="text/javascript">settoggle("filepath'.$cnt.'", "Show path ...", "Hide path: '.$sourceFileName.'")</script>',
-			CGI::span({-style=>"float:right ; text-align: right"}, 
+			CGI::span({-style=>"float:right ; text-align: right ; margin-right:.8em;"}, 
 				$inSet, $MOtag, $mlt, $rerand,
                         $edit_link, " ", $try_link,
 			CGI::span({-name=>"dont_show", 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1746,10 +1746,13 @@ sub output_score_summary{
 
 	    # print information if this set has restricted progression and if you need
 	    # to finish this problem (and maybe its children) to proceed
-	    if ($set->restrict_prob_progression() && $next_id <= $#problemIDs && is_jitar_problem_closed($db,$ce,$effectiveUser, $set->set_id, $problemIDs[$next_id])) {
+	    if ($set->restrict_prob_progression() &&
+		$next_id <= $#problemIDs &&
+		is_jitar_problem_closed($db,$ce,$effectiveUser, $set->set_id, $problemIDs[$next_id])) {
 		if ($hasChildren) {
 		    print CGI::br().$r->maketext('You will not be able to proceed to problem [_1] until you have completed, or run out of attempts, for this problem and its graded subproblems.',join('.',@{$problemSeqs[$next_id]}));
-		} else {
+		  } elsif (scalar(@seq) == 1 ||
+			   $problem->counts_parent_grade()) {
 		    print CGI::br().$r->maketext('You will not be able to proceed to problem [_1] until you have completed, or run out of attempts, for this problem.',join('.',@{$problemSeqs[$next_id]}));
 		}
 	    }

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -517,12 +517,6 @@ sub problemListRow($$$$$) {
 	$status = 'unknown(FIXME)' if $@; # use a blank if problem status was not defined or not numeric.
 	# FIXME  -- this may not cover all cases.
 
-	if ($isJitarSet && $problemLevel == 0) {
-
-	} else {
-	    $rawStatus = $problem->status;
-	}
-
 	my $adjustedStatus = '';
 	if (!$isJitarSet || $problemLevel == 0) {
 	  $adjustedStatus = jitar_problem_adjusted_status($problem, $db);

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -208,10 +208,10 @@ sub body {
 
 # now set the headers for the table
 	my $nameHeader = $sort eq "name"
-		? CGI::u($r->maketext("Name"))
+		? CGI::span($r->maketext("Name"))
 		: CGI::a({href=>$self->systemLink($urlpath, params=>{sort=>"name"})}, $r->maketext("Name"));
 	my $statusHeader = $sort eq "status"
-		? CGI::u($r->maketext("Status"))
+		? CGI::span($r->maketext("Status"))
 		: CGI::a({href=>$self->systemLink($urlpath, params=>{sort=>"status"})}, $r->maketext("Status"));
 # print the start of the form
 	if ($authz->hasPermissions($user, "view_multiple_sets")) { 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1579,10 +1579,11 @@ sub jitar_problem_adjusted_status {
 sub jitar_problem_finished {
     my ($userProblem,  $db) = @_;
 
-    # the problem is open if you can still make attempts
-    return 0 if ($userProblem->max_attempts == -1 ||
+    # the problem is open if you can still make attempts and you dont have a 100%
+    return 0 if ($userProblem->status < 1 &&
+		 ($userProblem->max_attempts == -1 ||
 	$userProblem->max_attempts > ($userProblem->num_correct + 
-				      $userProblem->num_incorrect));
+				      $userProblem->num_incorrect)));
 
     # find children 
     my @problemSeq = jitar_id_to_seq($userProblem->problem_id);


### PR DESCRIPTION
-  No longer show progression message on subproblems which don't count towards the parent grade. 
  -  To test: Create a just in time set with restricted progression and have a problem with two child problems, one which counts for the parent grade and one which doesn't.  When viewing the problems you should get a "you cannot proceed" message on the problem page for only the one which counts for the parent grade. 

-  Fixed a bug where restricted progression didnt work properly. 
  -  To test:  Have problems 1, 1.1 and 1.2 with all three problems having a max attempts limit and *both* child problems must count toward the parent.  Run out the attempts on the parent problem and a subproblem, but get the other subproblem right while still having attempts remaining.  Before the patch you will not be able to proceed to the next problem and after you will. 

-  Changed how scores are displayed on Problem Set page for just in time sets.  Now status of all problems is shown, as well as adjusted status for top level problems and  a flag if child problems count to the parent grad.e 
  -  To test:  create a just in time set and look at the problem set page.   Check that columns all work. 

-  Cleaned up single set csvs in "Scoring Tools".  
  -  To test:  after the patch you should see a due date and due time in single set scoring csvs.  Also, for jitar sets you should see the problem number, not some big integer.  

-  Added some code to improve formatting of the Problem Set page when the window is smallish but not tablet sized (about 1000px wide).  For just in time sets the Problems table was getting obscured by the Set Info page.  I reduced the padding on that table.  This doesn't get rid of the clipping but it minimizes it.  
  -  To test:  Create a just in time set and view the ProblemSet page and shrink your window.  You should see the table get compressed, then there will be about a small interval where the set info box clips over the table, then the window should go into "phone mode" and the Set Info box should drop below the table. 

-  Changed code so that User Settings is always shown, since it pretty much always has something the user can do.  

- Small CSS Tweaks:  
  -  Tweaked the masthead css so that it no longer overflows the container.  This should get rid of the bottom scrollbar that appears no matter how wide the window is.  Check that the login button renders nicely and there is no scrollbar. 
  -  On IE the vertical scrollbar actually covers up page content.  This is annoying in the library browser where the scrollbar can cover up the "X"'s and make them hard to use.  Added some css to inset the library browser icons a bit to avoid this.  Check to see that it renders nicely.  
 -  The "skip to main content" link now skips to the page title.  Before it skipped to before the breadcrumbs.  