### PR TITLE
Problem Add Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -539,11 +539,11 @@ sub addProblemToSet {
 	my $value = $value_default;
 	if (defined($args{value})){$value = $args{value};}  # 0 is a valid value for $args{value}  
 
-	my $maxAttempts = $args{maxAttempts} || $max_attempts_default;
-	my $showMeAnother = $args{showMeAnother} || $showMeAnother_default;
+	my $maxAttempts = $args{maxAttempts} // $max_attempts_default;
+	my $showMeAnother = $args{showMeAnother} // $showMeAnother_default;
 	my $problemID = $args{problemID};
-	my $countsParentGrade = $args{countsParentGrade} || $counts_parent_grade_default;
-	my $attToOpenChildren = $args{attToOpenChildren} || $att_to_open_children_default;
+	my $countsParentGrade = $args{countsParentGrade} // $counts_parent_grade_default;
+	my $attToOpenChildren = $args{attToOpenChildren} // $att_to_open_children_default;
 
 	unless ($problemID) {
 


### PR DESCRIPTION
Some values in `addProblemToSet` should be defined or and not or, otherwise perfectly reasonable values of zero are replaced with a potentially non-zero default. 

To test:  Import a set with a showMeAnother/attToOpenChildren as zero (with nonzero default values) and check that it works.  