### PR TITLE
Add message at bottom of Library browser searches explaining how more like this works.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1731,6 +1731,7 @@ sub body {
 		print CGI::p(CGI::span({-id=>'what_shown'}, CGI::span({-id=>'firstshown'}, $first_shown+1)."-".CGI::span({-id=>'lastshown'}, $last_shown+1))." of ".CGI::span({-id=>'totalshown'}, $total_probs).
 			" shown.", $prev_button, " ", $next_button,
 		);
+		print CGI::p('Some problems shown above represent multiple similar problems from the database.  If the (top) information line for a problem has a letter M for "More", hover your mouse over the M  to see how many similar problems are hidden, or click on the M to see the problems.  If you click to view these problems, the M becomes an L, which can be clicked on to hide the problems again.');
 	}
 	#	 }
 	print CGI::end_form(), "\n";


### PR DESCRIPTION
Since more-like-this was introduced, several people have been confused by the fact that the number of problems shown does not match the number of database matches.  This adds an explanation at the bottom of the page just below the note "4 of 10 shown", so it is next to the offending comment, but is out of the way (bottom of page) of people who already know how it works.

To test, do a search in the library browser and look at the bottom of the page.