### PR TITLE
Reduced Scoring Validation Bug

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -332,7 +332,7 @@ sub new {
 	name => "Ring of Reduction",
 	#Reduced credit needs to be set up in course configuration for this
 	# item to work,
-	description => "Enable reduced scoring for a homework set.  This will allow you to submit answers for partial credit for limited time after the due date.",
+	description => "Enable reduced scoring for a homework set.  This will allow you to submit answers for partial credit for 24 hours after the due date.",
 	%options,
     };
     
@@ -394,9 +394,8 @@ sub use_item {
 	($set);
 
 
-    # enable reduced scoring on the set and add the reduced scoring period 
-    # to the due date.  
-    my $additionalTime = 60*$ce->{pg}{ansEvalDefaults}{reducedScoringPeriod};
+    # enable reduced scoring on the set add 24 hours to the due date.
+    my $additionalTime = 86400;
     $set->enable_reduced_scoring(1);
     $set->reduced_scoring_date($set->due_date());
     $set->due_date($set->due_date()+$additionalTime);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1058,9 +1058,9 @@ sub initialize {
 
 		my $enable_reduced_scoring = 
 		    $ce->{pg}{ansEvalDefaults}{enableReducedScoring} && 
-		    defined($r->param("set.$setID.enable_reduced_scoring")) ? 
+		    (defined($r->param("set.$setID.enable_reduced_scoring")) ? 
 		    $r->param("set.$setID.enable_reduced_scoring") : 
-		    $setRecord->enable_reduced_scoring;
+		    $setRecord->enable_reduced_scoring);
 
 		if ($enable_reduced_scoring && 
 		    $reduced_scoring_date 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -1130,12 +1130,12 @@ sub initialize {
 
 		my $enable_reduced_scoring = 
 		    $ce->{pg}{ansEvalDefaults}{enableReducedScoring} && 
-		    defined($r->param("set.$setID.enable_reduced_scoring")) ? 
+		    (defined($r->param("set.$setID.enable_reduced_scoring")) ? 
 		    $r->param("set.$setID.enable_reduced_scoring") : 
-		    $setRecord->enable_reduced_scoring;
+		    $setRecord->enable_reduced_scoring);
 
-		if ($enable_reduced_scoring && 
-		    $reduced_scoring_date 
+		if ($enable_reduced_scoring &&
+		    $reduced_scoring_date
 		    && ($reduced_scoring_date > $due_date 
 			|| $reduced_scoring_date < $open_date)) {
 		    $self->addbadmessage($r->maketext("The reduced scoring date should be between the open date and due date."));

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1531,9 +1531,9 @@ sub saveEdit_handler {
 		# check that the reduced scoring date is in the right place
 		my $enable_reduced_scoring = 
 		    $ce->{pg}{ansEvalDefaults}{enableReducedScoring} && 
-		    defined($r->param("set.$setID.enable_reduced_scoring")) ? 
+		    (defined($r->param("set.$setID.enable_reduced_scoring")) ? 
 		    $r->param("set.$setID.enable_reduced_scoring") : 
-		    $Set->enable_reduced_scoring;
+		     $Set->enable_reduced_scoring);
 		
 		if ($enable_reduced_scoring && 
 		    $Set->reduced_scoring_date

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -359,10 +359,10 @@ sub body {
 		my $beginReducedScoringPeriod =  $self->formatDateTime($reduced_scoring_date);
 		
 		if (before($reduced_scoring_date)) {
-		  print CGI::div({class=>"ResultsAlert"}, $r->maketext("After the reduced scoring peroid begins all work counts for [_3]% of its value.  The set is due [_2]", $beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent));
+		  print CGI::div({class=>"ResultsAlert"}, $r->maketext("After the reduced scoring peroid begins all work counts for [_1]% of its value.", $reducedScoringPerCent));
 		  
 		} elsif (between($reduced_scoring_date,$set->due_date())) {
-		  print CGI::div({class=>"ResultsAlert"},$r->maketext("This set is in its reduced scoring period.  All work counts for [_2]% of its value.",$beginReducedScoringPeriod,$reducedScoringPerCent));
+		  print CGI::div({class=>"ResultsAlert"},$r->maketext("This set is in its reduced scoring period.  All work counts for [_1]% of its value.",$reducedScoringPerCent));
 		} else {
 		  print CGI::div({class=>"ResultsAlert"},$r->maketext("This set had a reduced scoring period that started on [_1] and ended on [_2].  During that period all work counted for [_3]% of its value.",$beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent));
 		}

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -433,8 +433,8 @@ sub setListRow {
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
 	      } else {
 		$interactive = $r->maketext("Take [_1] test", $display_name);
-		$control = "";
 	      }
+	      $control = "";
 	      
 	    } elsif ( $t < $set->due_date() ) {
 	      
@@ -455,6 +455,7 @@ sub setListRow {
 		# reset the link
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL},
 				      $r->maketext("Take [_1] test", $display_name));
+		$control = "";
 	      } else {
 		$control = "";
 		$interactive = $r->maketext("Take [_1] test", $display_name);
@@ -469,7 +470,7 @@ sub setListRow {
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
 	      }
 	    }
-	  } 	  
+	  } 
 	  # old conditional
 	} elsif (time < $set->open_date) {
 	  $status = $r->maketext("will open on [_1]", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));
@@ -488,7 +489,6 @@ sub setListRow {
 	  
 	  if (!@restricted) {
 	    $setIsOpen = 1;
-	    $interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
 	  } else {
 	    my $restriction = ($set->restricted_status)*100;
 	    $control = "" unless $preOpenSets;


### PR DESCRIPTION
Because of missing ()'s the reduced scoring date was being validated even if the feature wasn't enabled.  

To test:  On each of ProblemSetDetail, ProblemSetDetail2 and ProblemSetList2 do the following: 
1.  Enable reduced scoring for the course and for the set. 
2.  Try to set the reduced scoring date to something not between the open and due date.  You should get an error. 
3.  Turn off reduced scoring for the set.  You should be able to then save the reduced scoring date to something outside the open/due range.  
4.  Turn on reduced scoring for the set and fix the date. 
5.  Turn off reduced scoring for the course and change all of the dates the open date is past the old reduced scoring date.  There shouldn't be any errors.  

In addition I made a first attempt at dealing with the confusion surrounding reduced credit dates.  A number of people have said that to them it makes more sense for the "Reduced Scoring Date" to come after the "Due Date".  The problem with making this change is that Due Date has been synonymous with "Set Close Date" as long as WeBWorK has been around.  Changing it so that sets close either on the due date or the reduced scoring date is a project. 

However, I did make changes to how reduced scoring dates are reported to students to try and reinforce how the reduced scoring date works.  In general the reduced scoring date is now given as much prominence as the due date.  In particular I changed it so that: 
-  For homework and gateways if there is am enabled reduced scoring date, and it is between the reduced scoring date then the reduced scoring date is shown on the Problem Sets page.  I chose **not** to display the due date in this case so that there is no possibility that students confuse the two dates.  
-  If there is an enabled reduced scoring date and it is between the reduced scoring date and the due date then the due date is shown, along with a message that the reduced scoring period started.  
-  If there is an enabled reduced scoring date and it is between the open date and reduced scoring date then the Problem Set page now displays the reduced scoring date in the main page title.  There is a message about what the reduced scoring date means, as well as the actual due date printed below.  If students want to know the actual final due date of the set then this is where they would find it. 
-  If there is an enabled reduced scoring date and it is between the reduced scoring date and the due date then the due date is displayed in the title.  There is also a message that the reduced scoring period has started. 
In addition, I  ended up also redoing a lot of the code that generated the due date status text in ProblemSets since there was a lot of duplication.  

To Test: 
1.  Look at the status column entry on the Problem Sets Page (and the title and message on the Problem Set page when appropriate) in a variety of situations.  Technically any combination of the following is possible: 
-  The set is either a regular homework, a gateway, or a specific version of a gateway. 
-  The current time is between the open date and reduced scoring date, between the reduced scoring date and the due date, between the due date and the answer date, and after the answer date. 
-  Reduced scoring is enabled or disabled. 
-  Restrict Set Progression is enabled or disabled and if its enabled then there is one or more than one prerequisite set.  