### PR TITLE
LTI Bug

### DIFF
--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -637,7 +637,7 @@ sub authenticate
 								$db -> addUserSet($userSet);
 								}
 							}
-						else
+						elsif ( $globalSet -> open_date < $open_cut and $globalSet -> due_date < $due_cut )
 							{
 							if (not $db -> existsUserSet($userID, $globalSet -> set_id ) ) {
 								$userSet = $db -> newUserSet();

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -637,7 +637,7 @@ sub authenticate
 								$db -> addUserSet($userSet);
 								}
 							}
-						elsif ( $globalSet -> open_date < $open_cut and $globalSet -> due_date < $due_cut )
+						elsif ( $globalSet -> open_date < $open_cut )
 							{
 							if (not $db -> existsUserSet($userID, $globalSet -> set_id ) ) {
 								$userSet = $db -> newUserSet();


### PR DESCRIPTION
Fixes the bug at http://bugs.webwork.maa.org/show_bug.cgi?id=3588

To test: 
1.  Import a homework set but date shift so that the open date is far in the future.  Only assign the set to yourself. 
2.  Log into WeBWorK via LTI as a new student (so that sets are automatically assigned to you.)  
3.  Log in as the instructor again and see how many students are assigned to the set from 1.  Before the patch the newly created student should be assigned to it (but will be missing problem data).  After the patch you should still be the only one assigned to the set. 

P.S.  Yes there are two commits to add 41 characters of code.  I should have tested before committing the first time!