### PR TITLE
handle corrupt previous answers in decodeAnswers

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -877,7 +877,7 @@ sub decodeAnswers($) {
 	my $serialized = shift;
 	return unless defined $serialized and $serialized;
 	my $array_ref = eval{ Storable::thaw($serialized) };
-	if ($@) {
+	if ($@ or !defined $array_ref) {
 		# My hope is that this next warning is no longer needed since there are few legacy base64 days and the fix seems transparent.
 		# warn "problem fetching answers -- possibly left over from base64 days. Not to worry -- press preview or submit and this will go away  permanently for this question.   $@";
 		return ();


### PR DESCRIPTION
We got a report that a user was unable to open a problem they had previously
attempted and they were receiving this error instead:

	Can't use an undefined value as an ARRAY reference at
	/opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 871.

The error refers to decodeAnswers, which is trying to use the result of a
Storable::thaw call without verifying that it succeeded (it returns undef on
some errors).

This change makes decodeAnswers catch those errors.