### PR TITLE
AttemptsTable Fix

### DIFF
--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -139,14 +139,14 @@ of the default summaries are created:
 
 =cut
 
+package WeBWorK::Utils::AttemptsTable;
+use base qw(Class::Accessor);
+
 use strict;
 use warnings;
 use Scalar::Util 'blessed';
 use WeBWorK::Utils 'wwRound';
 use CGI;
-
-package WeBWorK::Utils::AttemptsTable;
-use base qw(Class::Accessor);
 
 # Object contains hash of answer results
 # Object contains display mode

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -141,17 +141,12 @@ of the default summaries are created:
 
 use strict;
 use warnings;
-use Class::Accessor 'antlers';
 use Scalar::Util 'blessed';
 use WeBWorK::Utils 'wwRound';
 use CGI;
 
 package WeBWorK::Utils::AttemptsTable;
 use base qw(Class::Accessor);
-
-# has answers     => (is => 'ro');
-# has displayMode => (is =>'ro');
-# has imgGen      => (is =>'ro');
 
 # Object contains hash of answer results
 # Object contains display mode

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -141,11 +141,13 @@ of the default summaries are created:
 
 use strict;
 use warnings;
-package WeBWorK::Utils::AttemptsTable;
 use Class::Accessor 'antlers';
 use Scalar::Util 'blessed';
 use WeBWorK::Utils 'wwRound';
 use CGI;
+
+package WeBWorK::Utils::AttemptsTable;
+use base qw(Class::Accessor);
 
 # has answers     => (is => 'ro');
 # has displayMode => (is =>'ro');


### PR DESCRIPTION
Added "base" to AttemptsTabe.  This is to address issue #693.  I'm not entirely sure why it works on some installations and not others.  This addition fixes the issue for Danny and is based off this example:
```
  package Foo;
  use base qw(Class::Accessor);
  Foo->follow_best_practice;
  Foo->mk_accessors(qw(name role salary));
```
from http://search.cpan.org/~kasei/Class-Accessor-0.34/lib/Class/Accessor.pm

To test:  Check out the branch, restart, and try to answer a problem.  Make sure that things still work with the attempt table. 