### PR TITLE
Increase space allotted to keywords in the database.

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -186,7 +186,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{keyword}, '
 	keyword_id int(15) NOT NULL auto_increment,
-	keyword varchar(65) NOT NULL,
+	keyword varchar(256) NOT NULL,
 	KEY (keyword),
 	PRIMARY KEY (keyword_id)
 '],


### PR DESCRIPTION
There was a report of OPL-updating because a pg file had keywords which were too long.  This would fix it.