### PR TITLE
2.12 Bugfixes

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -133,13 +133,13 @@ if($libraryVersion eq '2.5') {
 @create_tables = (
 [$tables{dbsubject}, '
 	DBsubject_id int(15) NOT NULL auto_increment,
-	name varchar(127) NOT NULL,
+	name varchar(255) NOT NULL,
 	KEY DBsubject (name),
 	PRIMARY KEY (DBsubject_id)
 '],
 [$tables{dbchapter}, '
 	DBchapter_id int(15) NOT NULL auto_increment,
-	name varchar(127) NOT NULL,
+	name varchar(255) NOT NULL,
 	DBsubject_id int(15) DEFAULT 0 NOT NULL,
 	KEY DBchapter (name),
 	KEY (DBsubject_id),
@@ -156,8 +156,8 @@ if($libraryVersion eq '2.5') {
 [$tables{author}, '
 	author_id int (15) NOT NULL auto_increment,
 	institution tinyblob,
-	lastname varchar (100) NOT NULL,
-	firstname varchar (100) NOT NULL,
+	lastname varchar (255) NOT NULL,
+	firstname varchar (255) NOT NULL,
 	email varchar (255),
 	KEY author (lastname, firstname),
 	PRIMARY KEY (author_id)
@@ -165,8 +165,8 @@ if($libraryVersion eq '2.5') {
 [$tables{path}, '
 	path_id int(15) NOT NULL auto_increment,
 	path varchar(255) NOT NULL,
-	machine varchar(127),
-	user varchar(127),
+	machine varchar(255),
+	user varchar(255),
 	KEY (path),
 	PRIMARY KEY (path_id)
 '],
@@ -179,14 +179,14 @@ if($libraryVersion eq '2.5') {
 	filename varchar(255) NOT NULL,
 	morelt_id int(127) DEFAULT 0 NOT NULL,
 	level int(15),
-	language varchar(15),
+	language varchar(255),
 	static TINYINT,
 	MO TINYINT,
 	PRIMARY KEY (pgfile_id)
 '],
 [$tables{keyword}, '
 	keyword_id int(15) NOT NULL auto_increment,
-	keyword varchar(65) NOT NULL,
+	keyword varchar(255) NOT NULL,
 	KEY (keyword),
 	PRIMARY KEY (keyword_id)
 '],
@@ -199,18 +199,18 @@ if($libraryVersion eq '2.5') {
 [$tables{textbook}, '
 	textbook_id int (15) NOT NULL auto_increment,
 	title varchar (255) NOT NULL,
-	edition int (3) DEFAULT 0 NOT NULL,
-	author varchar (63) NOT NULL,
-	publisher varchar (127),
+	edition int (15) DEFAULT 0 NOT NULL,
+	author varchar (255) NOT NULL,
+	publisher varchar (255),
 	isbn char (15),
-	pubdate varchar (27),
+	pubdate varchar (255),
 	PRIMARY KEY (textbook_id)
 '],
 [$tables{chapter}, '
 	chapter_id int (15) NOT NULL auto_increment,
 	textbook_id int (15),
 	number int(3),
-	name varchar(127) NOT NULL,
+	name varchar(255) NOT NULL,
 	page int(4),
 	KEY (textbook_id, name),
 	KEY (number),
@@ -220,7 +220,7 @@ if($libraryVersion eq '2.5') {
 	section_id int(15) NOT NULL auto_increment,
 	chapter_id int (15),
 	number int(3),
-	name varchar(127) NOT NULL,
+	name varchar(255) NOT NULL,
 	page int(4),
 	KEY (chapter_id, name),
 	KEY (number),
@@ -237,7 +237,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{morelt}, '
 	morelt_id int(15) NOT NULL auto_increment,
-	name varchar(127) NOT NULL,
+	name varchar(255) NOT NULL,
 	DBsection_id int(15),
 	leader int(15), # pgfile_id of the MLT leader
 	KEY (name),
@@ -755,6 +755,8 @@ sub pgfiles {
 				$query = "SELECT textbook_id FROM `$tables{textbook}` WHERE title = \"$text\" AND edition = \"$edition\" AND author=\"$textauthor\"";
 				my $textbook_id = $dbh->selectrow_array($query);
 				if (!defined($textbook_id)) {
+ 				        # make sure edition is an integer
+				        $edition = 0 unless $edition;
 					$dbh->do("INSERT INTO `$tables{textbook}`
 					VALUES(
 						NULL,

--- a/bin/check_latex.tex
+++ b/bin/check_latex.tex
@@ -25,7 +25,7 @@
 \usepackage{epsf}   
 \usepackage{epsfig}   % needed for eps graphics in CAPA
 \usepackage{pslatex}
-
+\usepackage{fullpage} % needed for ``single column'' hardcopy format
 
 \pagestyle{plain}
 \textheight 9in

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -43,6 +43,7 @@ my @modulesList = qw(
 	Carp
 	CGI
 	Class::Accessor
+        Crypt::SSLeay
 	Dancer
 	Dancer::Plugin::Database
 	Data::Dumper

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1686,37 +1686,38 @@ $ConfigValues = [
 
 	],
 	
-	['Editor',
-		{ var => 'editor{author}',
-		  doc => 'Default name of the problem author',
-		  doc2 => 'In the PGSimpleEditor, this will automatically fill the problem Author field.',
-		  width => 45,
-		  type => 'text'
-		},
-		{ var => 'editor{authorInstitute}',
-		  doc => 'Institute of the problem author',
-		  doc2 => 'In the PGSimpleEditor, this will automatically fill the institute field of the problem author',
-		  width => 45,
-		  type => 'text'
-		 },
-		{ var => 'editor{textTitle}',
-		  doc => 'Text Title of the problems',
-		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text title field',
-		  width => 45,
-		  type => 'text'
-		},
-		{ var => 'editor{textEdition}',
-		  doc => 'Text Edition of the problems',
-		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text edition field',
-		  width => 45,
-		  type => 'text'
-		},
-		{ var => 'editor{textAuthor}',
-		  doc => 'Text Author of the problems',
-		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text author field',
-		  width => 45,
-		  type => 'text'
-		}]		
+#  PGSimple is not used for now GG
+#	['Editor',
+#		{ var => 'editor{author}',
+#		  doc => 'Default name of the problem author',
+#		  doc2 => 'In the PGSimpleEditor, this will automatically fill the problem Author field.',
+#		  width => 45,
+#		  type => 'text'
+#		},
+#		{ var => 'editor{authorInstitute}',
+#		  doc => 'Institute of the problem author',
+#		  doc2 => 'In the PGSimpleEditor, this will automatically fill the institute field of the problem author',
+#		  width => 45,
+#		  type => 'text'
+#		 },
+#		{ var => 'editor{textTitle}',
+#		  doc => 'Text Title of the problems',
+#		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text title field',
+#		  width => 45,
+#		  type => 'text'
+#		},
+#		{ var => 'editor{textEdition}',
+#		  doc => 'Text Edition of the problems',
+#		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text edition field',
+#		  width => 45,
+#		  type => 'text'
+#		},
+#		{ var => 'editor{textAuthor}',
+#		  doc => 'Text Author of the problems',
+#		  doc2 => 'In the PGSimpleEditor, this will automatically fill the text author field',
+#		  width => 45,
+#		  type => 'text'
+#		}]		
 ];
 
 

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1508,6 +1508,11 @@ $ConfigValues = [
 	   doc2 => 'Enables use of the Show Me Another button, which offers the student a newly-seeded version of the current problem, complete with solution (if it exists for that problem).',
 	   type => 'boolean'
 	 },
+	 { var => 'pg{options}{showMeAnotherDefault}',
+	   doc => 'Default number of attempts before Show Me Another can be used (-1 => Never)',
+	   doc2 => 'This is the default number of attempts before show me another becomes available to students.  It can be set to -1 to disable show me another by default.',
+	   type => 'number'
+	 },
 	 { var => 'pg{options}{showMeAnotherMaxReps}',
 	   doc => 'Maximum times Show me Another can be used per problem (-1 => unlimited)',
 	   doc2 => 'The Maximum number of times Show me Another can be used per problem by a student. If set to -1 then there is no limit to the number of times that Show Me Another can be used.',

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -66,9 +66,6 @@ $server_groupID    = 'wwdata';
 
 #$server_apache_version = ''; # e.g. '2.22.1'
 
-# Set this to override the default admin email set by apache.  
-$webwork_server_admin_email ='';
-
 # The following variable is the address that will be listed in server error 
 # messages that come from WeBWorK: 
 #	 "An error occured while processing your request. 
@@ -82,7 +79,7 @@ $webwork_server_admin_email ='';
 # ServerAdmin address defined in httpd.conf is used.
 
  
-#$webwork_server_admin_email ='';
+$webwork_server_admin_email ='';
 ################################################################################
 # Paths to external programs 
 ################################################################################

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -104,7 +104,7 @@ $externalPrograms{git} = "/usr/bin/git";
 ####################################################
 $externalPrograms{latex}    ="/usr/bin/latex";
 $externalPrograms{pdflatex} ="/usr/bin/pdflatex --shell-escape";
-$externalPrograms{dvipng}   ="/usr/bin//dvipng";
+$externalPrograms{dvipng}   ="/usr/bin/dvipng";
 
 ####################################################
 # NetPBM - basic image manipulation utilities

--- a/courses.dist/modelCourse/templates/Contrib
+++ b/courses.dist/modelCourse/templates/Contrib
@@ -1,1 +1,0 @@
-/opt/webwork/libraries/webwork-open-problem-library/Contrib

--- a/courses.dist/modelCourse/templates/course_info.txt
+++ b/courses.dist/modelCourse/templates/course_info.txt
@@ -1,3 +1,1 @@
-this information is written in the file:
-
-[coursesDirectory]/courseName/templates/course_info.txt
+Put information about your course here.  Click the edit button above to add your own message.

--- a/courses.dist/modelCourse/templates/email/welcome.msg
+++ b/courses.dist/modelCourse/templates/email/welcome.msg
@@ -11,8 +11,7 @@ Your course is at
 Your login name is $LOGIN and your initial password is $SID
 
 You should change your password, once you have logged in, by clicking on the
-password/email link in the upper left.  After entering your new password,
-press the Change User Options button to save your change.
+User Settings link in the upper left.  
 
 Some help pages about WeBWorK are at URL
 	http://webwork.maa.org/wiki/Category:Students

--- a/courses.dist/modelCourse/templates/setDemo/s2_2_1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/s2_2_1.pg
@@ -24,19 +24,13 @@ $funct1 = "2*$a1*x-$b1";
 BEGIN_TEXT
 If \( f(x) =  $a1 x^2 - $b1 x -$c1 \), find \( f'( x ) \).
 $BR $BR \{ans_rule(48) \}
-$BR
+$BR $BR
 END_TEXT
 
 $ans = $funct1;
 &ANS(fun_cmp($ans));
 
 $a1_2 = 2*$a1;
-&SOLUTION(EV3(<<'EOT'));
-$SOL $BR
-In general the derivative of \( x^n \) is \( nx^{n-1} \). Using this (and the 
-basic sum and constant multiple rules) we find the derivative of $BR
-\(${a1}x^2 - ${b1}x -$c1 \quad \) is $BR \( ${a1_2}x - $b1 \).$BR $BR
-EOT
 
 BEGIN_TEXT
 Find \( f'( $x1 ) \).
@@ -49,7 +43,11 @@ $ans = $deriv1;
 
 &SOLUTION(EV3(<<'EOT'));
 $SOL $BR
-To find the derivative we just have to evaluate \( f'( x ) \) at 
+In general the derivative of \( x^n \) is \( nx^{n-1} \). Using this (and the 
+basic sum and constant multiple rules) we find the derivative of $BR
+\(${a1}x^2 - ${b1}x -$c1 \quad \) is $BR \( ${a1_2}x - $b1 \).$BR $BR
+
+To find the derivative at \($x1\) we just have to evaluate \( f'( x ) \) at 
 \( x = $x1) \), i.e.  \( ${a1_2}\cdot$x1 - $b1 \) or $ans.
 EOT
 

--- a/courses.dist/modelCourse/templates/setDemo/sample_units_ans.pg
+++ b/courses.dist/modelCourse/templates/setDemo/sample_units_ans.pg
@@ -26,7 +26,9 @@ Two perpendicular sides of a triangle are $fx m and
 $fy m long respectively.  
 What is the length of the third side of the triangle? $BR$BR
 You can answer this in terms of m's, cm's, km's, in's, ft, etc. but you must enter the units. $BR$BR
-Check "Show Hint" and then "Submit Answer" if you don't remember the Pythagorean theorem.
+Click "Hint" below if you don't remember the Pythagorean theorem.
+$BR$BR
+\{ans_rule(40) \}
 END_TEXT
 
 HINT(EV3(<<'EOT'));
@@ -34,8 +36,5 @@ Remembering the Pythagorean theorem \( A^2 +B^2 = C^2 \), you can enter
 sqrt(${fx}${CARET}2 + ${fy}${CARET}2) m or  \{spf($ansxy, "%0.2f" )\} m or  \{spf($anscm, "%0.2f" )\} cm or ...
 EOT
 
-BEGIN_TEXT
-\{ans_rule(40) \}
-END_TEXT
 ANS(num_cmp("$ansxy", units => 'm'));
 ENDDOCUMENT()

--- a/courses.dist/modelCourse/templates/setOrientation/prob02.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob02.pg
@@ -58,7 +58,7 @@ $ITEMSEP
 $ITEM
 ${LQ}MathJax${RQ} mode is the default choice (what $WW uses unless you tell 
 it otherwise). It uses Cascading Style
-Sheets (CSS) with web fonts or SVG, instead of bitmap images or Flash, so equations scale with surrounding text at all zoom levels.  MathJax is compatible with screenreaders & provides zoom for everyone.
+Sheets (CSS) with web fonts or SVG, instead of bitmap images or Flash, so equations scale with surrounding text at all zoom levels.  MathJax is compatible with screenreaders and provides zoom for everyone.
 
 \{EndParList("UL")\}
 $PAR

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -43,11 +43,13 @@ var ToggleNavigation = function () {
 	
 	
 	$(window).resize(function(){
-	    windowwidth = $(window).width();
-	    if(windowwidth < threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-left')) {
-		hideSidebar();
-	    } else if (windowwidth >= threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-right')) {	
-		showSidebar();
+	    if ($(window).width() != windowwidth) {
+		windowwidth = $(window).width();
+		if(windowwidth < threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-left')) {
+		    hideSidebar();
+		} else if (windowwidth >= threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-right')) {	
+		    showSidebar();
+		}
 	    }
 	}); 
     }

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -811,28 +811,28 @@ sub links {
 				    print CGI::start_ul();
 				    if ($ce->{showeditors}->{problemsetdetail1}) {
 					print CGI::start_li(); # $setID
-					print &$makelink("${pfx}ProblemSetDetail", text=>"-$prettySetID", urlpath_args=>{%args,setID=>$setID}, systemlink_args=>\%systemlink_args);
+					print &$makelink("${pfx}ProblemSetDetail", text=>$r->maketext("[_1] (old editor)", $prettySetID), urlpath_args=>{%args,setID=>$setID}, systemlink_args=>\%systemlink_args);
                      		        print CGI::end_li();
 				    }
 
 				    if ($ce->{showeditors}->{problemsetdetail2}) {
 					print CGI::start_li(); # $setID (2)
-					print &$makelink("${pfx}ProblemSetDetail2", text=>"--$prettySetID", urlpath_args=>{%args,setID=>$setID}, systemlink_args=>\%systemlink_args);
+					print &$makelink("${pfx}ProblemSetDetail2", text=>"$prettySetID", urlpath_args=>{%args,setID=>$setID}, systemlink_args=>\%systemlink_args);
                      		        print CGI::end_li();
 				    }
 
 					if (defined $problemID) {
 					    print CGI::start_li();
 					    print CGI::start_ul();
-					    print CGI::li(&$makelink("${pfx}PGProblemEditor", text=>"$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor1"))
+					    print CGI::li(&$makelink("${pfx}PGProblemEditor", text=>$r->maketext("[_1] (old editor)", $prettyProblemID), urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor1"))
 							if $ce->{showeditors}->{pgproblemeditor1};
-					    print CGI::li(&$makelink("${pfx}PGProblemEditor2", text=>"--$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor2"))
+					    print CGI::li(&$makelink("${pfx}PGProblemEditor2", text=>"$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor2"))
 							if $ce->{showeditors}->{pgproblemeditor2};;
 					    
-					    print CGI::li(&$makelink("${pfx}PGProblemEditor3", text=>"----$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor3"))
+					    print CGI::li(&$makelink("${pfx}PGProblemEditor3", text=>"--$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor3"))
 						if $ce->{showeditors}->{pgproblemeditor3};;
 	
-					    print CGI::li(&$makelink("${pfx}SimplePGEditor", text=>"----$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"Simple_Editor"))
+					    print CGI::li(&$makelink("${pfx}SimplePGEditor", text=>"$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"Simple_Editor"))
 						if $ce->{showeditors}->{simplepgeditor};;
 					    print CGI::end_ul();
 					    print CGI::end_li();

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -2805,7 +2805,7 @@ sub add_location_handler {
 
 	# a check to be sure that the location addresses don't already
 	#    exist
-	my $badLocAddr;
+	my $badLocAddr = '';
 	if ( ! $badAddr && $locationID ) {
 		if ( $db->countLocationAddresses( $locationID ) ) {
 			my @allLocAddr = $db->listLocationAddresses($locationID);

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -96,10 +96,15 @@ sub can_showCorrectAnswers {
 #    any individual problem.  to deal with this, we make 
 #    can_showCorrectAnswers give the least restrictive view of hiding, and 
 #    then filter scores for the problems themselves later
-	my $canShowScores = ( $Set->hide_score eq 'N' ||
-			      $Set->hide_score_by_problem eq 'Y' ||
-			      ( $Set->hide_score eq 'BeforeAnswerDate' &&
-				after($tmplSet->answer_date) ) );
+
+#    showing correcrt answers but not showing scores doesn't make sense
+#    so we should hide the correct answers if we aren not showing
+#    scores GG.
+
+	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	  ( $Set->hide_score eq 'N' ||
+	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
+	      after($tmplSet->answer_date) ) );
 
 	return ( ( ( after( $Set->answer_date ) || 
 		     ( $attemptsUsed >= $maxAttempts && 
@@ -138,10 +143,14 @@ sub can_showSolutions {
 #    any individual problem.  to deal with this, we make can_showSolutions 
 #    give the least restrictive view of hiding, and then filter scores for 
 #    the problems themselves later
-	my $canShowScores = ( $Set->hide_score eq 'N' ||
-			      $Set->hide_score_by_problem eq 'Y' ||
-			      ( $Set->hide_score eq 'BeforeAnswerDate' &&
-				after($tmplSet->answer_date) ) );
+#    showing correcrt answers but not showing scores doesn't make sense
+#    so we should hide the correct answers if we aren not showing
+#    scores GG.
+
+	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	  ( $Set->hide_score eq 'N' ||
+	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
+	      after($tmplSet->answer_date) ) );
 
 	return ( ( ( after( $Set->answer_date ) || 
 		     ( $attemptsUsed >= $attempts_per_version &&
@@ -1708,8 +1717,9 @@ sub body {
 
 	# some convenient output variables
 	my $canShowProblemScores = $can{showScore} && 
-	    ($set->hide_score eq 'N' || $set->hide_score_by_problem eq 'N' ||
+	    ($set->hide_score_by_problem eq 'N' ||
 	     $authz->hasPermissions($user, "view_hidden_work"));
+
 	my $canShowWork = $authz->hasPermissions($user, "view_hidden_work") || ($set->hide_work eq 'N' || ($set->hide_work eq 'BeforeAnswerDate' && $timeNow>$tmplSet->answer_date));
 
 	# for nicer answer checking on multi-page tests, we want to keep 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2133,7 +2133,7 @@ sub body {
 				my $curr_prefix = 'Q' . sprintf("%04d", $probOrder[$i]+1) . '_';
 				my @curr_fields = grep /^$curr_prefix/, keys %{$self->{formFields}};
 				foreach my $curr_field ( @curr_fields ) {
- 					foreach ( split(/\0/, $self->{formFields}->{$curr_field}) ) {
+ 					foreach ( split(/\0/, $self->{formFields}->{$curr_field} // '') ) {
  						print CGI::hidden({-name=>$curr_field, 
  							   	   -value=>$_});
  					}

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -259,10 +259,14 @@ sub can_checkAnswers {
 	#    be shown, but not show the score on any individual problem.  
 	#    to deal with this, we use the least restrictive view of hiding 
 	#    here, and then filter for the problems themselves later
-	my $canShowScores = ( $Set->hide_score eq 'N' ||
-			      $Set->hide_score_by_problem eq 'Y' ||
-			      ( $Set->hide_score eq 'BeforeAnswerDate' &&
-				after($tmplSet->answer_date) ) );
+	#    showing correcrt answers but not showing scores doesn't make sense
+	#    so we should hide the correct answers if we aren not showing
+	#    scores GG.
+
+	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	  ( $Set->hide_score eq 'N' ||
+	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
+	      after($tmplSet->answer_date) ) );
 
 	if (before($Set->open_date, $submitTime)) {
 		return $authz->hasPermissions($User->user_id, "check_answers_before_open_date");
@@ -305,7 +309,6 @@ sub can_showScore {
 
 	# address hiding scores by problem
 	my $canShowScores = ( $Set->hide_score eq 'N' ||
-			      $Set->hide_score_by_problem eq 'Y' ||
 			      ( $Set->hide_score eq 'BeforeAnswerDate' &&
 				after($tmplSet->answer_date) ) );
 

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -357,9 +357,18 @@ sub displayStudentStats {
 
 		my @cgi_prob_scores = ();
 
+		my $show_problem_scores = 1;
+
+		if ( defined( $set->hide_score_by_problem ) &&
+		     ! $authz->hasPermissions($r->param("user"), "view_hidden_work")
+		     && $set->hide_score_by_problem eq 'Y' )  {
+		  $show_problem_scores = 0;
+		}
+		
 		for (my $i = 0; $i < $max_problems; $i++) {
-		    my $score = defined($prob_scores[$i]) ? 
-			$prob_scores[$i] :  '&nbsp;';
+		  my $score = (defined($prob_scores[$i]) &&
+		    $show_problem_scores) ? 
+		      $prob_scores[$i] :  '&nbsp;';
 		    my $class = '';
 		    if ($score =~ /100\s*/) {
 			$score = '100&nbsp;';
@@ -368,7 +377,7 @@ sub displayStudentStats {
 			$score = '&nbsp;.&nbsp;&nbsp;';
 			$class = "unattempted";
 		    }
-		    my $att = defined($prob_att[$i]) ?
+		    my $att = defined($prob_att[$i]) && $show_problem_scores ?
 			$prob_att[$i] : '&nbsp;';
 
 		    $cgi_prob_scores[$i] = CGI::td(

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -95,7 +95,14 @@ sub scoring_info {
 	my $delimiter            = ',';
 	my $scoringDirectory    = $ce->{courseDirs}->{scoring};
 
-	return  $r->maketext('There is no additional grade information.  A message about additional grades can go in in ~[TMPL~]/email/[_1]. It is merged with the file ~[Scoring~]/[_2]. These files can be edited using the "Email" link and the "File Manager" link in the left margin.', $message_file, $merge_file) unless (-e "$scoringDirectory/$merge_file" && -e "$filePath");
+	# get out if the files don't exist
+	if (!(-e "$scoringDirectory/$merge_file" && -e "$filePath")) {
+	  if ($r->authz->hasPermissions($userID, "access_instructor_tools")) {
+	    return  $r->maketext('There is no additional grade information.  A message about additional grades can go in in ~[TMPL~]/email/[_1]. It is merged with the file ~[Scoring~]/[_2]. These files can be edited using the "Email" link and the "File Manager" link in the left margin.', $message_file, $merge_file);
+	  } else {
+	    return '';
+	  }
+	}
 	
 	my $rh_merge_data   = $self->read_scoring_file("$merge_file", "$delimiter");
 	my $text;

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -541,7 +541,7 @@ sub addProblemToSet {
 	if (defined($args{value})){$value = $args{value};}  # 0 is a valid value for $args{value}  
 
 	my $maxAttempts = $args{maxAttempts} || $max_attempts_default;
-	my $showMeAnother = $args{showMeAnother} || $showMeAnother_default;
+	my $showMeAnother = $args{showMeAnother} // $showMeAnother_default;
 	my $prPeriod = $prPeriod_default;
 	if (defined($args{prPeriod})){
 		$prPeriod = $args{prPeriod};

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -558,8 +558,12 @@ sub addProblemToSet {
 	    # makes it a new top level problem 
 	    if ($set && $set->assignment_type eq 'jitar') {
 		my @problemIDs = $db->listGlobalProblems($setName);
-		my @seq = jitar_id_to_seq($problemIDs[$#problemIDs]);
-		$problemID = seq_to_jitar_id($seq[0]+1);
+		if (@problemIDs) {
+		  my @seq = jitar_id_to_seq($problemIDs[$#problemIDs]);
+		  $problemID = seq_to_jitar_id($seq[0]+1);
+		} else {
+		  $problemID = seq_to_jitar_id(1);
+		}
 	    } else {
 		$problemID = WeBWorK::Utils::max($db->listGlobalProblems($setName)) + 1;
 	    }

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
@@ -756,7 +756,7 @@ EOF
 				# Check permissions
 				#next if FORM_PERMS()->{$actionID} and not $authz->hasPermissions($user, FORM_PERMS()->{$actionID});
 				my $actionForm = "${actionID}_form";
-				my $newWindow = ($actionID =~ m/^(view|add_problem|save)$/)? 1: 0;
+				my $newWindow = ($actionID =~ m/^(view|save)$/)? 1: 0;
 				my $onChange = "setRadio($i,$newWindow)";
 				my %actionParams = $self->getActionParams($actionID);
 				my $line_contents = $self->$actionForm($onChange, %actionParams);

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
@@ -2043,7 +2043,7 @@ sub save_as_handler {
 			# problems at the end		
 			if ($set->assignment_type eq 'jitar') {
 				my @problemIDs = $self->r->db->listGlobalProblems($setName);
-				@problemIDs = sort @problemIDs;
+				@problemIDs = sort { $a <=> $b } @problemIDs;
 				my @seq = jitar_id_to_seq($problemIDs[$#problemIDs]);
 				$targetProblemNumber = seq_to_jitar_id($seq[0]+1);
 			} else {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -288,9 +288,9 @@ use constant FIELD_PROPERTIES => {
 	'hide_score:hide_score_by_problem' => {
 		name      => "Show Scores on Finished Assignments?",
 		type      => "choose",
-		choices   => [ qw( N: Y:N BeforeAnswerDate:N Y:Y BeforeAnswerDate:Y ) ],
+		choices   => [ qw( N:N Y:Y BeforeAnswerDate:N N:Y BeforeAnswerDate:Y ) ],
 		override  => "any",
-		labels    => { 'N:' => 'Yes', 'Y:N' => 'No', 'BeforeAnswerDate:N' => 'Only after set answer date', 'Y:Y' => 'Totals only (not problem scores)', 'BeforeAnswerDate:Y' => 'Totals only, only after answer date' },
+		labels    => { 'N:N' => 'Yes', 'Y:Y' => 'No', 'BeforeAnswerDate:N' => 'Only after set answer date', 'N:Y' => 'Totals only (not problem scores)', 'BeforeAnswerDate:Y' => 'Totals only, only after answer date' },
 	},
 	hide_work         => {
 		name      => "Show Problems on Finished Tests",

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -2585,6 +2585,7 @@ sub output_JS {
 	.changed {background-color: #ffffcc}
     </style>!,"\n";
 
+	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/vendor/jquery/modules/jquery.ui.touch-punch.js"}), CGI::end_script();
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/DatePicker/jquery-ui-timepicker-addon.js"}), CGI::end_script();
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/DatePicker/datepicker.js"}), CGI::end_script();
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/AddOnLoad/addOnLoadEvent.js"}), CGI::end_script();

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -293,9 +293,9 @@ use constant FIELD_PROPERTIES => {
 	'hide_score:hide_score_by_problem' => {
 		name      => "Show Scores on Finished Assignments?",
 		type      => "choose",
-		choices   => [ qw( N: Y:N BeforeAnswerDate:N Y:Y BeforeAnswerDate:Y ) ],
+		choices   => [ qw( N:N Y:Y BeforeAnswerDate:N N:Y BeforeAnswerDate:Y ) ],
 		override  => "any",
-		labels    => { 'N:' => 'Yes', 'Y:N' => 'No', 'BeforeAnswerDate:N' => 'Only after set answer date', 'Y:Y' => 'Totals only (not problem scores)', 'BeforeAnswerDate:Y' => 'Totals only, only after answer date' },
+		labels    => { 'N:N' => 'Yes', 'Y:Y' => 'No', 'BeforeAnswerDate:N' => 'Only after set answer date', 'N:Y' => 'Totals only (not problem scores)', 'BeforeAnswerDate:Y' => 'Totals only, only after answer date' },
 	},
 	hide_work         => {
 		name      => "Show Problems on Finished Tests",
@@ -1330,7 +1330,7 @@ sub initialize {
 					my @fields = split(/:/, $field);
 					for ( my $i=0; $i<@fields; $i++ ) { 
 						my $f = $fields[$i];
-						$setRecord->$f($values[$i]); 
+						$setRecord->$f($values[$i]);
 					}
 				} else {
 					$setRecord->$field($param);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -1221,7 +1221,7 @@ sub initialize {
 							my @fields = split(/:/, $field);
 							for ( my $i=0; $i<@values; $i++ ) { 
 								my $f=$fields[$i]; 
-								$record->$f($values[$i]); 
+								$record->$f($values[$i]);
 							}
 						} else {
 							$record->$field($param);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1149,6 +1149,7 @@ sub create_handler {
 		$newSetRecord->hardcopy_header("defaultHeader");
 		#Rest of the dates are set according to to course configuration
 		$newSetRecord->open_date($dueDate - 60*$ce->{pg}{assignOpenPriorToDue});
+		$newSetRecord->reduced_scoring_date($dueDate - 60*$ce->{pg}{ansEvalDefaults}{reducedScoringPeriod});
 		$newSetRecord->due_date($dueDate);
 		$newSetRecord->answer_date($dueDate + 60*$ce->{pg}{answersOpenAfterDueDate});
 		$newSetRecord->visible(DEFAULT_VISIBILITY_STATE());	# don't want students to see an empty set

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -750,13 +750,15 @@ sub filter_handler {
                 $result = $r->maketext("showing visible sets");
 		# DBFIXME do filtering in the database, please!
 		my @setRecords = $db->getGlobalSets(@{$self->{allSetIDs}});
-		my @visibleSetIDs = map { $_->visible ? $_->set_id : ""} @setRecords;		
+		my @visibleSetIDs = grep { $_->visible } @setRecords;
+		@visibleSetIDs = map {$_->set_id} @visibleSetIDs;
 		$self->{visibleSetIDs} = \@visibleSetIDs;
 	} elsif ($scope eq "unvisible") {
                 $result = $r->maketext("showing hidden sets");
 		# DBFIXME do filtering in the database, please!
 		my @setRecords = $db->getGlobalSets(@{$self->{allSetIDs}});
-		my @unvisibleSetIDs = map { (not $_->visible) ? $_->set_id : ""} @setRecords;
+		my @unvisibleSetIDs = grep { not $_->visible } @setRecords;
+		@unvisibleSetIDs = map {$_->set_id} @unvisibleSetIDs;
 		$self->{visibleSetIDs} = \@unvisibleSetIDs;
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -653,15 +653,18 @@ sub everything2normal {
 	my ($self, @everything) = @_;
 	my @result = ();
 	my $adjstatus = 0;
+
+	# if its has adjusted status columns we need to include
+	# those as well
+	my $str = $self->r->maketext('ADJ STATUS');
+	if (grep(grep(/$str/, @{$_}),@everything)) {
+	    $adjstatus = 1;
+	}
+		
 	foreach my $row (@everything) {
 		my @row = @$row;
 		my @newRow = ();
 		push @newRow, @row[0..4];
-		# if its has adjusted status columns we need to include
-		# those as well
-		if ($row[6] eq $self->r->maketext("ADJ STATUS")) {
-		  $adjstatus = 1;
-		}
 		if ($adjstatus) {
 		  for (my $i = 5; $i < @row; $i+=4) {
 		    push @newRow, $row[$i];

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -652,12 +652,25 @@ sub everything2info {
 sub everything2normal {
 	my ($self, @everything) = @_;
 	my @result = ();
+	my $adjstatus = 0;
 	foreach my $row (@everything) {
 		my @row = @$row;
 		my @newRow = ();
 		push @newRow, @row[0..4];
-		for (my $i = 5; $i < @row; $i+=3) {
-			push @newRow, $row[$i];
+		# if its has adjusted status columns we need to include
+		# those as well
+		if ($row[6] eq $self->r->maketext("ADJ STATUS")) {
+		  $adjstatus = 1;
+		}
+		if ($adjstatus) {
+		  for (my $i = 5; $i < @row; $i+=4) {
+		    push @newRow, $row[$i];
+		    push @newRow, $row[$i+1];
+		  }
+		} else {
+		  for (my $i = 5; $i < @row; $i+=3) {
+		    push @newRow, $row[$i];
+		  }
 		}
 		#push @newRow, $row[$#row];
 		push @result, [@newRow];
@@ -695,16 +708,6 @@ sub appendColumns {
 # Reads a CSV file and returns an array of arrayrefs, each containing a
 # row of data:
 # (["c1r1", "c1r2", "c1r3"], ["c2r1", "c2r2", "c2r3"])
-sub readCSV {
-	my ($self, $fileName) = @_;
-	my @result = ();
-	my @rows = split m/\n/, readFile($fileName);
-	foreach my $row (@rows) {
-		push @result, [split m/\s*,\s*/, $row];
-	}
-	return @result;
-}
-
 # Write a CSV file from an array in the same format that readCSV produces
 sub writeCSV {
 	my ($self, $filename, @csv) = @_;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
@@ -264,15 +264,13 @@ sub add_selected {
 	my @selected = @past_problems;
 	my (@path, $file, $selected, $freeProblemID);
 	# DBFIXME count would work just as well
-	$freeProblemID = max($db->listGlobalProblems($setName)) + 1;
 	my $addedcount=0;
 
 	for $selected (@selected) {
 		if($selected->[1] & ADDED) {
 			$file = $selected->[0];
 			my $problemRecord = $self->addProblemToSet(setName => $setName,
-				sourceFile => $file, problemID => $freeProblemID);
-			$freeProblemID++;
+				sourceFile => $file);
 			$self->assignProblemToAllSetUsers($problemRecord);
 			$selected->[1] |= SUCCESS;
 			$addedcount++;
@@ -794,7 +792,7 @@ sub make_top_row {
 
 	print CGI::Tr(CGI::td({-class=>"InfoPanel", -align=>"center"},
 		"Browse ",
-		CGI::submit(-name=>"browse_npl_library", -value=>"National Problem Library", -style=>$these_widths, @dis1),
+		CGI::submit(-name=>"browse_npl_library", -value=>"Open Problem Library", -style=>$these_widths, @dis1),
 		CGI::submit(-name=>"browse_local", -value=>$r->maketext("Local Problems"), -style=>$these_widths, @dis2),
 		CGI::submit(-name=>"browse_mysets", -value=>$r->maketext("From This Course"), -style=>$these_widths, @dis3),
 		CGI::submit(-name=>"browse_setdefs", -value=>$r->maketext("Set Definition Files"), -style=>$these_widths, @dis4),

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -481,9 +481,11 @@ sub body {
 		}
 			
 		my $num_ans = $#scores;
-		
+	
 		if ($record{time} - $previousTime > $ce->{sessionKeyTimeout}) {
 		  $rowOptions->{'class'} = 'table-rule';
+		} else {
+		  $rowOptions->{'class'} = '';
 		}
 
 		@row = (CGI::td({width=>10}),CGI::td({style=>"color:#808080"},CGI::small($time)));

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -190,29 +190,6 @@ sub body {
 	my %prettyFieldNames = map { $_ => $_ } 
 		$userTemplate->FIELDS();
 	
-# 	@prettyFieldNames{qw(
-# 		#user_id
-# 		first_name
-# 		last_name
-# 		email_address
-# 		student_id
-# 		status
-# 		section
-# 		recitation
-# 		comment
-# 		permission
-# 	)} = (
-# 		#"Login Name",
-# 		"First Name",
-# 		"Last Name",
-# 		"Email",
-# 		"Student ID",
-# 		"Status",
-# 		"Section",
-# 		"Recitation",
-# 		"Comment",
-# 		"Permission Level",
-# 	);
 	
 	my @dateFields         = @{DATE_FIELDS_ORDER()};
 	my $rh_dateFieldLabels =  DATE_FIELDS();
@@ -243,69 +220,6 @@ sub body {
 
 	print CGI::h4({align=>'center'},"Edit ",CGI::a({href=>$basicInfoUrl},'class list data')," for  $userName ($editForUserID) who has been assigned $setCount sets.");
 	
-	#print CGI::h4("User Data");
-# 	print CGI::start_table({ align=>'center', border=>1,cellpadding=>5});
-# 	print CGI::Tr(
-# 		CGI::th(CGI::checkbox({ type => 'checkbox',
-# 								name => "edit.basic.info",
-# 								label => '',
-#                         		checked => 0
-#         }),"Edit class list data for $editForUserID"),
-#         CGI::th(CGI::checkbox({ type => 'checkbox',
-# 								name => "change.password",
-# 								label => '',
-#                         		checked => 0
-#         }),"Change Password for $editForUserID"));
-#         
-# 	print "<tr><td rowspan=\"2\">";
-# 	########################################
-# 	# Basic student data
-# 	########################################
-# 	print CGI::start_table();
-# 	foreach ($userTemplate->FIELDS()) {
-# 		next if $_ eq 'user_id';   # don't print login name
-# 		print CGI::Tr(
-# 			CGI::td([
-# 		        	$prettyFieldNames{$_}, 
-# 				CGI::input({ -value => $UserRecord->$_, -size => 25 })
-# 			])
-# 		);
-# 	}
-# 	foreach ($permissionLevelTemplate->FIELDS()) {
-# 		print CGI::Tr(
-# 			CGI::td([
-# 		        	$prettyFieldNames{$_}, 
-# 				CGI::input({ -value => $PermissionRecord->$_, -size => 25 })
-# 			])
-# 		);
-# 	}
-# 	print CGI::end_table();
-# 	
-# 	#print CGI::br();
-# 	print "</td><td valign=\"top\">";
-# 	########################################
-# 	# Change password section
-# 	########################################
-# 	my $profRecord = $db->getUser($userID);
-# 	my $profName = $profRecord->first_name . " " . $profRecord->last_name;
-# 	my $poss = "'s ";
-# 	my $pass = " password ";
-# 	
-# 	print CGI::start_table();
-# 	print CGI::Tr(CGI::td(["<b>$profName</b>$poss$pass", CGI::input({ -type => "password", -name => "$userID.password"})]));
-# 	print CGI::Tr(CGI::td(["<b>$userName</b>$poss new $pass", CGI::input({ -type => "password", -name => "$editForUserID.password.1"})]));
-# 	print CGI::Tr(CGI::td(["Confirm <b>$userName</b>$poss new $pass", CGI::input({ -type => "password", -name => "$editForUserID.password.2"})]));
-# 	print CGI::end_table();
-# 	print "</td></tr>";
-# 	print CGI::Tr(CGI::th(  #FIXME  enable this once it can be handled
-# # 		CGI::checkbox({ type => 'checkbox',
-# # 								name => "change.login",
-# # 								label => '',
-# #                         		checked => 0
-# #         }),
-#         "Change login name $editForUserID to ", CGI::input({-name=>'new_login', -value=>''  ,-size=>25})
-# 	));
-# 	print CGI::end_table();
 	
 	print CGI::br();
 
@@ -387,31 +301,29 @@ sub body {
 	# get a list of sets to show
 	# DBFIXME already have this data
 	my @setsToShow = sortByName( undef, $db->listGlobalSets() );
-	# insert any set versions that we have
-	my $i = $#setsToShow;
-	if ( defined( $UserSetVersionRecords{$setsToShow[$i]} ) ) {
-		push( @setsToShow, map{ $_->set_id . ",v" . $_->version_id }
-			@{$UserSetVersionRecords{$setsToShow[$i]}} );
-	}
-	$i--;
-	my $numit = 0;
-	while ( $i>=0 ) {
-		if ( defined( $UserSetVersionRecords{$setsToShow[$i]} ) ) {
-			splice( @setsToShow, $i+1, 0,
-				map{ $_->set_id . ",v" . $_->version_id }
-				@{$UserSetVersionRecords{$setsToShow[$i]}} );
-		}
-		$i--;
-		$numit++;
-		# just to be safe
-		last if $numit >= 150;
-	}
-	warn("Truncated display of sets at 150 in UserDetail.pm.  This is a " .
-	     "brake to avoid spiraling into the abyss.  If you really have " .
-	     "more than 150 sets in your course, reset the limit at about line " .
-	     "370 in webwork/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm.")
-		if ( $numit == 150 );
 
+	# insert any set versions that we have
+	if (@setsToShow) {
+	  my $i = $#setsToShow;
+	  if ( defined( $UserSetVersionRecords{$setsToShow[$i]} ) ) {
+	    push( @setsToShow, map{ $_->set_id . ",v" . $_->version_id }
+		  @{$UserSetVersionRecords{$setsToShow[$i]}} );
+	  }
+	  $i--;
+	  my $numit = 0;
+	  while ( $i>=0 ) {
+	    if ( defined( $UserSetVersionRecords{$setsToShow[$i]} ) ) {
+	      splice( @setsToShow, $i+1, 0,
+		      map{ $_->set_id . ",v" . $_->version_id }
+		      @{$UserSetVersionRecords{$setsToShow[$i]}} );
+	    }
+	    $i--;
+	    $numit++;
+	    # just to be safe
+		last if $numit >= 150;
+	  }
+	  warn("Truncated display of sets at 150 in UserDetail.pm.  This is a brake to avoid spiraling into the abyss.  If you really have more than 150 sets in your course, reset the limit at about line 370 in webwork/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm.") if ( $numit == 150 );
+	}
 
 	foreach my $setID ( @setsToShow ) {
 		# catch the versioned sets that we just added
@@ -467,32 +379,6 @@ sub body {
 	);
 
 
-#	print CGI::start_table();
-#	print CGI::Tr(
-#		CGI::th({ -align => "center"},[
-#			"Assigned",
-#			"Set Name",
-#			"Opens",
-#			"Answers Due",
-#			"Answers Available",
-#		])
-#	);
-				
-#	foreach my $setID (sortByName(undef, @UserSetIDs)) {
-#		my $MergedSetRecord = $MergedSetRecords{$setID};
-#		print CGI::Tr(
-#			CGI::td({ -align => "center" }, [
-#				CGI::checkbox({checked => (defined $MergedSetRecord)}),
-#				$setID,
-#				CGI::checkbox() .
-#				CGI::input({ -value => $self->formatDateTime($MergedSetRecord->open_date), -size => 25}),
-#				CGI::checkbox() .
-#				CGI::input({ -value => $self->formatDateTime($MergedSetRecord->due_date), -size => 25}),
-#				CGI::checkbox() .
-#				CGI::input({ -value => $self->formatDateTime($MergedSetRecord->answer_date), -size => 25}),
-#			])
-#		);
-#	}
 	return '';
 }
 

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -186,7 +186,7 @@ sub body {
 	# generating module.
 	my $authen_error = MP2 ? $r->notes->get("authen_error") : $r->notes("authen_error");
 	if ($authen_error) {
-		print CGI::div({class=>"ResultsWithError"},
+		print CGI::div({class=>"ResultsWithError", tabindex=>'0'},
 			CGI::p($authen_error)
 		);
 	}

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -123,9 +123,10 @@ sub title {
 	my $r = $self->r;
 	my $eUserID = $r->param("effectiveUser");
 	# using the url arguments won't break if the set/problem are invalid
-	my $setID = WeBWorK::ContentGenerator::underscore2nbsp($self->r->urlpath->arg("setID"));
+	my $prettySetID = WeBWorK::ContentGenerator::underscore2nbsp($r->urlpath->arg("setID"));
+	my $setID = $r->urlpath->arg("setID");
 	
-	my $title = $setID;
+	my $title = $prettySetID;
 	#put either due date or reduced scoring date in the title. 
 	my $set = $r->db->getMergedSet($eUserID, $setID);
 	if (defined($set) && between($set->open_date, $set->due_date)) {

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -600,7 +600,6 @@ sub setListRow {
 	    $startTime = localtime($set->version_creation_time() || 0); #fixes error message for undefined creation_time
 	    
 	    if ( $authz->hasPermissions($user, "view_hidden_work") || 
-		 $set->hide_score_by_problem eq 'Y' ||
 		 $set->hide_score() eq 'N' || 
 		 ( $set->hide_score eq 'BeforeAnswerDate' && time > $tmplSet->answer_date() ) ) {
 	      # find score

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -33,6 +33,37 @@ use WeBWorK::Utils qw(after readFile sortByName path_is_subdir is_restricted wwR
 use WeBWorK::Localize;
 # what do we consider a "recent" problem set?
 use constant RECENT => 2*7*24*60*60 ; # Two-Weeks in seconds
+# the "default" data in the course_info.txt file
+use constant DEFAULT_COURSE_INFO_TXT => "Put information about your course here.  Click the edit button above to add your own message.\n";
+
+
+sub if_can {
+  my ($self, $arg) = @_;
+
+  if ($arg ne 'info') {
+    return $self->can($arg) ? 1 : 0;
+  } else {
+    my $r = $self->r;
+    my $ce = $r->ce;
+    my $urlpath = $r->urlpath;
+    my $authz = $r->authz;
+    my $user = $r->param("user");
+
+    # we only print the info box if the viewer has permission
+    # to edit it or if its not the standard template box.
+    
+    my $course_info_path = $ce->{courseDirs}->{templates} . "/"
+      . $ce->{courseFiles}->{course_info};
+    my $text;
+
+    if (-f $course_info_path) { #check that it's a plain  file
+      $text = eval { readFile($course_info_path) };
+    }
+    return $authz->hasPermissions($user, "access_instructor_tools") ||
+	  $text ne DEFAULT_COURSE_INFO_TXT;
+    
+  }
+}
 
 sub info {
 	my ($self) = @_;
@@ -50,9 +81,6 @@ sub info {
 	if (defined $course_info and $course_info) {
 		my $course_info_path = $ce->{courseDirs}->{templates} . "/$course_info";
 			
-		#print CGI::start_div({-class=>"info-wrapper"});
-		#print CGI::start_div({class=>"info-box", id=>"InfoPanel"});
-		
 		# deal with instructor crap
 		my $editorURL;
 		if ($authz->hasPermissions($user, "access_instructor_tools")) {
@@ -84,9 +112,6 @@ sub info {
 			}
 		}
 
-		#print CGI::end_div();
-		#print CGI::end_div();
-		
 		return "";
 	}
 }
@@ -690,7 +715,7 @@ sub restricted_progression_msg {
   if ($open) {
     $status .= $r->maketext("if you score at least [_1]% on", sprintf("%.0f",$restriction));
   } else {
-    $status .= $r->maketext("but you must score at least [_1]% on", sprintf("%.0f",$restriction));
+    $status .= $r->maketext("but to access it you must score at least [_1]% on", sprintf("%.0f",$restriction));
   }
   
   $status .= ' ';

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -426,7 +426,7 @@ our %pathTypes = (
 	},
 	instructor_set_detail => {
 		name    => 'Set Detail for set $setID',
-		parent  => 'instructor_set_list',
+		parent  => 'instructor_set_list2',
 		kids    => [ qw/instructor_users_assigned_to_set/ ],
 		match   => qr|^([^/]+)/|,
 		capture => [ qw/setID/ ],

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -891,6 +891,13 @@ sub unarchiveCourse {
 	if (-e $old_dump_file) {
 		unlink $old_dump_file or carp "Failed to unlink course database dump file '$old_dump_file: $_\n";
 	}
+
+	# Create the html_temp folder (since it isn't included in the
+	# tarball
+	my $tmpDir = $ce2->{courseDirs}->{html_temp};
+	if (! -e $tmpDir) {
+	  mkdir $tmpDir or warn "Failed to create html_temp directory '$tmpDir': $!. You will have to create this directory manually.\n";
+	}
 	
 	##### step 6: rename course #####
 	

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -340,7 +340,8 @@ sub getAllDBchapters {
 	my $subject = $r->param('library_subjects');
 	return () unless($subject);
 	my $dbh = getDB($r->ce);
-	my $query = "SELECT DISTINCT c.name FROM `$tables{dbchapter}` c, 
+	my $query = "SELECT DISTINCT c.name, c.DBchapter_id 
+                                FROM `$tables{dbchapter}` c, 
 				`$tables{dbsubject}` t
                  WHERE c.DBsubject_id = t.DBsubject_id AND
                  t.name = \"$subject\" ORDER BY c.DBchapter_id";
@@ -365,7 +366,8 @@ sub getAllDBsections {
 	my $chapter = $r->param('library_chapters');
 	return () unless($chapter);
 	my $dbh = getDB($r->ce);
-	my $query = "SELECT DISTINCT s.name FROM `$tables{dbsection}` s,
+	my $query = "SELECT DISTINCT s.name, s.DBsection_id 
+                 FROM `$tables{dbsection}` s,
                  `$tables{dbchapter}` c, `$tables{dbsubject}` t
                  WHERE s.DBchapter_id = c.DBchapter_id AND
                  c.DBsubject_id = t.DBsubject_id AND

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -313,13 +313,14 @@ sub getAllDBsubjects {
 	my $r = shift;
 	my %tables = getTables($r->ce);
 	my @results=();
-	my $row;
-	my $query = "SELECT DISTINCT name FROM `$tables{dbsubject}` ORDER BY DBsubject_id";
+	my @row;
+	my $query = "SELECT DISTINCT name, DBsubject_id FROM `$tables{dbsubject}` ORDER BY DBsubject_id";
 	my $dbh = getDB($r->ce);
 	my $sth = $dbh->prepare($query);
 	$sth->execute();
-	while ($row = $sth->fetchrow_array()) {
-		push @results, $row;
+
+	while (@row = $sth->fetchrow_array()) {
+		push @results, $row[0];
 	}
 	# @results = sortByName(undef, @results);
 	return @results;


### PR DESCRIPTION
This is a pull of assorted bugfixes for release 2.12.  

-  [x] OPL-update:  I increased the size of various fields (space is cheap) and added a check to make sure that edition is a number.  
  -  To test: Run `OPL-update`.  On Ubuntu 16.04 it should fail pre patch.  It should work post patch on any machine. 
-  [x] Show Me Another Default:  I added a config page field for the Show Me Another Default value.  
  -  To test:  Check that the field for the default value appears. 
- [x] Orientation:  I removed a & from a setOrientation file that was preventing hardcopies from generating. 
  -  To test:  Get the new setOrientation and make a hardcopy. 
-  [x] Course Info Box:  I replaced the text in the course info box with something friendlier.  I also added code so that if the text is the "default" then the box isn't shown to students at all. 
  -  To test:  Make a new course with the new course_info.txt file.  Check the text in the box.  Check that students don't see the box if the text is unchanged.  Check that if you change it then students can see the box. 
-  [x] Grades Message:  I fixed a bug where the "additional grades" message could appear to students. 
  -  To test:  Check that the "additional grades" message appears to instructors and not students. 
- [x] Unarchiving:  I fixed a bug where unarchiving a course did  not create the html_temp directory. 
  -  To test:  Archive, Delete, then Unarchive a course.  Check that the course has a file in `webwork/htdocs/tmp`. 
-  [ ] MySQL:  In Ubuntu 16.04 mysql has a flag set which prevents searches that use ORDER BY on a field that is not also being SELECTed.  I changed some queries in ListingsDB so that they work in 16.04. 
  -  To test:  Make sure that the Library Browser works, including selecting subjects, chapters and sections.  Bonus points for testing on a server that has the mysql flag `ONLY_FULL_GROUP_BY` set. 
- [x] Show Totals Only:  I fixed some issue with the show totals only feature of Gateways.  Before it would show students their problem grades on the Grades page and allow them to check and show correct answers.  Now if totals only is used it only shows their totals on the Grades page and disables check and show correct answers. 
  -  To test:  Choose "Totals Only" or "Totals only after answer date" for a gateway and check that you can see your total grade on the Grades page, the Problem Set Page and the actual gateway page, but that you cant see problem scores or check correct answers or show solutions. 
  -  Also check that the other options for Show Scores (Yes, No, After Due Date) all work as expected.  I.E.  The scores are either hidden or not. 
- [x] Just In Time Individual Set Scoring:  Fixed a bug where the scr csv when scoring an individual homework set was malformed. 
  -  To test:  Grade a just in time set and select the "Record Scores for Single Sets" option.  Before the patch the scr file won't have the correct headings or data. After the patch it should have "STATUS" and "ADJ STATUS" for all problems, with the correct data. 
- [x] Set Maker No JS: Fixed an issue where problems could not be added to just in time sets from the set maker no js browser. 
  -  To test:  Add a problem to a just in time set from the setmakernojs library browser.
- [x] SimplePG:  Removed SimplePGEditor config variables from the course config page since we dont use them in ww2.  Nothing to test,  just mark this off if the change is acceptable.   
- [x]  Changed the navigation bar to be a little cleaner.  (removed a bunch of the dashes)
  -  To test:  Edit a problem and look at the navigation bar and make sure it looks ok.  
- [x] Reduced Scoring: Fixed bug where creating a set didn't set the reduced_scoring_date
  -  To test:  Create a set.  Before the patch the reduced scoring date will be at unix time zero, after the patch it should follow the default config setting. 
- [x]  Drag and Drop: Added ability to drag and reorder problems using phones. 
  -  To test:  Use the problem set detail 2 page on a phone.  You should be able to reorder problems after the patch.  
- [x]  Phone Scroll: Fixed an issue where scrolling on chrome mobile would trigger resize event. 
  -  To test:  On a mobile device using chrome, hide the sidebar and then scroll down a long page.  Before the patch the sidebar will pop back open and after it should stay closed.  
- [x]  Scaffolding:  Made scaffold headings tab selectable and respond to pressing enter. 
   -  To test:  Open a problem which uses the scaffolding macro.  Before the patch you cannot select the headers using tab selection and so you cant open closed tabs without a mouse.  After the patch you should be able to navigate scaffolds without a mouse.  