### PR TITLE
Comment out a pretty print of $self  which was causing a segmentation…

### DIFF
--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -267,7 +267,7 @@ sub formatAnswerRow {
 		# push @correct_ids,   $name if $answerScore == 1;
 	} elsif (($rh_answer->{type}//'') eq 'essay') {
 		$resultString =  $self->maketext("Ungraded"); 
-		# $self->{essayFlag} = 1;
+		$self->{essayFlag} = 1;
 	} elsif ( defined($answerScore) and $answerScore == 0) { # MEG: I think $answerScore ==0 is clearer than "not $answerScore"
 		# push @incorrect_ids, $name if $answerScore < 1;
 		$resultStringClass = "ResultsWithError";
@@ -318,7 +318,7 @@ sub answerTemplate {
     	push @tableRows, CGI::Tr($self->formatAnswerRow($rh_answers->{$ans_id}, $ans_id, $answerNumber++));
     	push @correct_ids,   $ans_id if ($rh_answers->{$ans_id}->{score}//0) >= 1;
     	push @incorrect_ids,   $ans_id if ($rh_answers->{$ans_id}->{score}//0) < 1;
-    	$self->{essayFlag} = 1;
+    	#$self->{essayFlag} = 1;
     }
 	my $answerTemplate = CGI::h3($self->maketext("Results for this submission")) .
     	CGI::table({class=>"attemptResults"},@tableRows);

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -834,7 +834,7 @@ EOS
 	$localStorageMessages.= CGI::p('Your overall score for this problem is'.'&nbsp;'.CGI::span({id=>'problem-overall-score'},''));
 	$localStorageMessages .= CGI::end_div();
 		
-	my $pretty_print_self  = pretty_print($self);
+#	my $pretty_print_self  = pretty_print($self);
 ######################################################
 # Return interpolated problem template
 ######################################################


### PR DESCRIPTION
… fault when WebClient's formatting routine was called.


As far as I can tell this variable is never used so commenting it out should not have any effect.
If pretty print is called (i.e. it's not commented out) then when using clients/sendXMLPRC.pl or the standalonePGrenderer or the opaque_server (see my repo on standalone renderer and the openwebwork repo on opaque_server) a segment 11 fault is generated as the WebworkClient is used to format output.