### PR TITLE
Hardwire taxo

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -186,7 +186,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{keyword}, '
 	keyword_id int(15) NOT NULL auto_increment,
-	keyword varchar(255) NOT NULL,
+	keyword varchar(256) NOT NULL,
 	KEY (keyword),
 	PRIMARY KEY (keyword_id)
 '],

--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -13,13 +13,14 @@ var basicRequestObject = {
 };
 
 function readfromtaxo(who, valarray) {
+  var mytaxo = taxo;
   if(who == 'subjects') {
-	return(taxo.map(function(z) {return(z['name']);} ));
+	return(mytaxo.map(function(z) {return(z['name']);} ));
   }
   var failed = true;
-  for(var i=0; i<taxo.length; i++) {
-    if(taxo[i]['name'] == valarray[0]) {
-	  taxo = taxo[i]['subfields'];
+  for(var i=0; i<mytaxo.length; i++) {
+    if(mytaxo[i]['name'] == valarray[0]) {
+	  mytaxo = mytaxo[i]['subfields'];
 	  failed=false;
 	  break;
 	}
@@ -29,12 +30,12 @@ function readfromtaxo(who, valarray) {
 	return([]);
   }
   if(who == 'chapters') {
-	return(taxo.map(function(z) {return(z['name']);} ));
+	return(mytaxo.map(function(z) {return(z['name']);} ));
   }
   failed = true;
-  for(var i=0; i<taxo.length; i++) {
-    if(taxo[i]['name'] == valarray[1]) {
-	  taxo = taxo[i]['subfields'];
+  for(var i=0; i<mytaxo.length; i++) {
+    if(mytaxo[i]['name'] == valarray[1]) {
+	  mytaxo = mytaxo[i]['subfields'];
 	  failed=false;
 	  break;
 	}
@@ -44,7 +45,7 @@ function readfromtaxo(who, valarray) {
 	return([]);
   }
   if(who == 'sections') {
-	return(taxo.map(function(z) {return(z['name']);} ));
+	return(mytaxo.map(function(z) {return(z['name']);} ));
   }
   return([]); // Should not get here
 }

--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -12,38 +12,14 @@ var basicRequestObject = {
     "command":"searchLib"
 };
 
-// Get the taxonomy
-
-var taxo=[];  // Global variable to hold it
-var loadtaxo = $.ajax({
-  dataType: "json",
-  url: "/webwork2_files/DATA/tagging-taxonomy.json", 
-  success: function(data) {
-    taxo = data;
-  },
-  error: function() {
-    alert("Failed to load OPL taxonomy from server.");
-  }
-});
-
-// If needed, wait until asynchronous load is done
-function fetch_taxo() {
-  if(taxo.length>0) {
-    return(taxo);
-  } else {
-    loadtaxo.done(fetch_taxo());
-  }
-}
-
 function readfromtaxo(who, valarray) {
-  var mytaxo = fetch_taxo();
   if(who == 'subjects') {
-	return(mytaxo.map(function(z) {return(z['name']);} ));
+	return(taxo.map(function(z) {return(z['name']);} ));
   }
   var failed = true;
-  for(var i=0; i<mytaxo.length; i++) {
-    if(mytaxo[i]['name'] == valarray[0]) {
-	  mytaxo = mytaxo[i]['subfields'];
+  for(var i=0; i<taxo.length; i++) {
+    if(taxo[i]['name'] == valarray[0]) {
+	  taxo = taxo[i]['subfields'];
 	  failed=false;
 	  break;
 	}
@@ -53,12 +29,12 @@ function readfromtaxo(who, valarray) {
 	return([]);
   }
   if(who == 'chapters') {
-	return(mytaxo.map(function(z) {return(z['name']);} ));
+	return(taxo.map(function(z) {return(z['name']);} ));
   }
   failed = true;
-  for(var i=0; i<mytaxo.length; i++) {
-    if(mytaxo[i]['name'] == valarray[1]) {
-	  mytaxo = mytaxo[i]['subfields'];
+  for(var i=0; i<taxo.length; i++) {
+    if(taxo[i]['name'] == valarray[1]) {
+	  taxo = taxo[i]['subfields'];
 	  failed=false;
 	  break;
 	}
@@ -68,7 +44,7 @@ function readfromtaxo(who, valarray) {
 	return([]);
   }
   if(who == 'sections') {
-	return(mytaxo.map(function(z) {return(z['name']);} ));
+	return(taxo.map(function(z) {return(z['name']);} ));
   }
   return([]); // Should not get here
 }

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1760,6 +1760,15 @@ sub output_JS {
   if ($self->r->authz->hasPermissions(scalar($self->r->param('user')), "modify_tags")) {
 	my $site_url = $ce->{webworkURLs}->{htdocs};
 	print qq!<script src="$site_url/js/apps/TagWidget/tagwidget.js"></script>!;
+	if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/tagging-taxonomy.json') ) {
+		my $taxo = '[]';
+		$taxo = join("", <TAXONOMY>); 
+		close TAXONOMY;
+		print qq!\n<script>var taxo = $taxo ;</script>!;
+	} else {
+		print qq!\n<script>var taxo = [] ;</script>!;
+		print qq!\n<script>alert('Could not load the OPL taxonomy from the server.');</script>!;
+	}
   }
   return '';
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2171,6 +2171,15 @@ sub output_JS{
 
 	# This is for any page specific js.  Right now its just used for achievement popups
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Problem/problem.js"}), CGI::end_script();
+	if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/tagging-taxonomy.json') ) {
+		my $taxo = '[]';
+		$taxo = join("", <TAXONOMY>);
+		close TAXONOMY;
+		print qq!\n<script>var taxo = $taxo ;</script>!;
+	} else {
+		print qq!\n<script>var taxo = [] ;</script>!;
+		print qq!\n<script>alert('Could not load the OPL taxonomy from the server.');</script>!;
+	}
 
 	return "";
 }

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2166,20 +2166,20 @@ sub output_JS{
 
 	# This is for tagging menus (if allowed)
 	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {
+		if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/tagging-taxonomy.json') ) {
+			my $taxo = '[]';
+			$taxo = join("", <TAXONOMY>);
+			close TAXONOMY;
+			print qq!\n<script>var taxo = $taxo ;</script>!;
+		} else {
+			print qq!\n<script>var taxo = [] ;</script>!;
+			print qq!\n<script>alert('Could not load the OPL taxonomy from the server.');</script>!;
+		}
 		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}), CGI::end_script();
 	}
 
 	# This is for any page specific js.  Right now its just used for achievement popups
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Problem/problem.js"}), CGI::end_script();
-	if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/tagging-taxonomy.json') ) {
-		my $taxo = '[]';
-		$taxo = join("", <TAXONOMY>);
-		close TAXONOMY;
-		print qq!\n<script>var taxo = $taxo ;</script>!;
-	} else {
-		print qq!\n<script>var taxo = [] ;</script>!;
-		print qq!\n<script>alert('Could not load the OPL taxonomy from the server.');</script>!;
-	}
 
 	return "";
 }


### PR DESCRIPTION


This solves the following problem with the tagging widget (used to set OPL tags for a problem). In the library browser, there are many problems, so many instances of the widget, and they all need the taxonomy. We had been trying to load it asynchronously, but in some browsers, particular on windows computers, it would fail. There was a timing issue/problem with making the ajax call since the widget needs the taxonomy before it initializes.

This fixes it by just putting the taxonomy directly in the web page (in a script variable). Ultimately, the same amount of data gets sent to the browser.

In both versions (old and new), we relied on the json file with the taxonomy, generated by OPL-update. We now do a javascript alert if we cannot read that file.

This affects to places - the library browser and the display of an individual problem, but only when the user authorization to modify tags.
