### PR TITLE
Renumber Bug

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail2/problemsetdetail2.js
+++ b/htdocs/js/apps/ProblemSetDetail2/problemsetdetail2.js
@@ -1,8 +1,13 @@
 $(function() {
 
+
     //Problem set detail 2 
     $('#problemset_detail_list').addClass('container-fluid');
 
+    //This sets ajax coos to be synchronous so as to not overwhelm the server
+    $.ajax({async : false});
+
+    
     //This uses the nextedSortable jquery-ui module to drive the 
     // problem list, if its enabled
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -396,9 +396,9 @@ sub authenticate {
       debug("OAuth verification Failed ");
       
       $self->{error} .= $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
-      $self->{log_error} .= "OAuth verification failed.  Check the Consumer Secret.";
+      $self->{log_error} .= "OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.";
       if ( $ce->{debug_lti_parameters} ) {
-	warn("OAuth verification failed.  Check the Consumer Secret.");
+	warn("OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.");
       }
       return 0;
     } else {

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -360,10 +360,13 @@ sub authenticate {
 
   # We need to provide the request URL when verifying the OAuth request.
   # We use the url request by default, but also allow it to be overriden
-  my $path = $ce->{server_root_url}.$ce->{webwork_url}.$r->urlpath()->path;
+  my $path = $ce->{server_root_url}.$ce->{webwork_url};
   $path = $ce->{LTIBasicToThisSiteURL} ? 
     $ce->{LTIBasicToThisSiteURL} : $path;
 
+  # append the path the the server url
+  $path = $path.$r->urlpath()->path;
+  
   # We also try a version without the trailing / in case that was not
   # included when the LMS user created the LMS link 
   my $altpath = $path;

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -398,7 +398,7 @@ sub authenticate {
       $self->{error} .= $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
       $self->{log_error} .= "OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.";
       if ( $ce->{debug_lti_parameters} ) {
-	warn("OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.");
+	warn("OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL as defined in site.conf. E.G. Check that if you have https in the LMS url then you have https in \$server_root_url in site.conf");
       }
       return 0;
     } else {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -2308,7 +2308,7 @@ sub body {
 	# Display problem information
 	#####################################################################
 
-	my @problemIDList = $db->listGlobalProblems($setID);
+        my @problemIDList = sort {$a <=> $b} $db->listGlobalProblems($setID);
 	
 	# DBFIXME use iterators instead of getting all at once
 	

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -1714,7 +1714,6 @@ sub initialize {
 		##################################################################
 
 		my %newProblemNumbers = ();
-		my $consecutive = $r->param('force_renumber') || 0;
 		my $prevNum = 0;
 		my @prevSeq = (0);
 
@@ -1733,36 +1732,63 @@ sub initialize {
 			    unshift @idSeq, $r->param('prob_num_'.$id);
 			}
 
-			if ($consecutive) {
-			    # we dont really care about the content of idSeq
-			    # in this case, just the length
-			    my $depth = $#idSeq;
-			    
-			    if ($depth <= $#prevSeq) {
-				@prevSeq = @prevSeq[ 0 .. $depth ];
-				$prevSeq[$#prevSeq]++;
-			    } else {
-				$prevSeq[$#prevSeq+1] = 1;
-			    }
-			    
-			    $newProblemNumbers{$jj} = seq_to_jitar_id(@prevSeq);
-			    
-			} else {
-			    $newProblemNumbers{$jj} = seq_to_jitar_id(@idSeq);
-			}
-			
+			$newProblemNumbers{$jj} = seq_to_jitar_id(@idSeq);
+						
 		    } else {
-			if ($consecutive) {
-			    $prevNum++;
-			    $newProblemNumbers{$jj} = $prevNum;
-			} else {
-			    $newProblemNumbers{$jj} = $r->param('prob_num_' . $jj);
-			} 
+		      $newProblemNumbers{$jj} = $r->param('prob_num_' . $jj);
 		    }
-		}
+		  }
 		
 		handle_problem_numbers($self,\%newProblemNumbers, $db, $setID) unless defined $r->param('undo_changes');
+
 		
+		#####################################################################
+		# Make problem numbers consecutive if required
+		#####################################################################
+
+
+		if ($r->param('force_renumber')) {
+
+		  my %newProblemNumbers = ();
+		  my $prevNum = 0;
+		  my @prevSeq = (0);
+		
+		  for my $jj (sort { $a <=> $b } $db->listGlobalProblems($setID)) {
+		    
+		    if ($setRecord->assignment_type eq 'jitar') {
+		      my @idSeq;
+		      my $id = $jj;
+		      
+		      next unless $r->param('prob_num_'.$id);
+		      
+		      unshift @idSeq, $r->param('prob_num_'.$id);
+		      while (defined $r->param('prob_parent_id_'.$id)) {
+			$id = $r->param('prob_parent_id_'.$id);
+			unshift @idSeq, $r->param('prob_num_'.$id);
+		      }
+		      
+		      # we dont really care about the content of idSeq
+		      # in this case, just the length
+		      my $depth = $#idSeq;
+		      
+		      if ($depth <= $#prevSeq) {
+			@prevSeq = @prevSeq[ 0 .. $depth ];
+			$prevSeq[$#prevSeq]++;
+		      } else {
+			$prevSeq[$#prevSeq+1] = 1;
+		      }
+		      
+		      $newProblemNumbers{$jj} = seq_to_jitar_id(@prevSeq);
+						
+		    } else {
+		      $prevNum++;
+		      $newProblemNumbers{$jj} = $prevNum;
+		    }
+		  }
+		
+		  handle_problem_numbers($self,\%newProblemNumbers, $db, $setID) unless defined $r->param('undo_changes');
+
+		}
 
 		#####################################################################
 		# Add blank problem if needed


### PR DESCRIPTION
This fixes a bug where using the "Force Renumber" option on the Problem Set Detail 2 page would stop any renumbering you had done to be ignored.  To test:
-  Go to the problem set detail page and reorder problems in a set. 
-  Check the "Force problems to be numbered consecutively option" and submit. 
-  After the patch the reordering should be present (and before the patch it will be reverted). 
-  Also check other functionality about renumbering and forcing problems to be ordered consecutively.  