### PR TITLE
OPL Statistics Port Bug

### DIFF
--- a/bin/update-OPL-statistics
+++ b/bin/update-OPL-statistics
@@ -186,9 +186,11 @@ my $global_sql_file = $ce->{problemLibrary}{root}.'/OPL_global_statistics.sql';
 
 if (-e $global_sql_file) {
 
-  my ($dbi,$dbtype,$db,$host) = split(':',$ce->{database_dsn});
+  my ($dbi,$dbtype,$db,$host,$port) = split(':',$ce->{database_dsn});
   
   $host = 'localhost' unless $host;
+
+  $port = 3306 unless $port;
   
   my $dbuser = $ce->{database_username};
   my $dbpass = $ce->{database_password};
@@ -204,8 +206,8 @@ EOS
   $db = shell_quote($db);
   
   my $mysql_command = $ce->{externalPrograms}->{mysql};  
-  
-  `$mysql_command -h $host -u $dbuser -p$dbpass $db < $global_sql_file`;
+
+  `$mysql_command --host=$host --port=$port --user=$dbuser --password=$dbpass $db < $global_sql_file`;
 
 }
 

--- a/bin/upload-OPL-statistics
+++ b/bin/upload-OPL-statistics
@@ -30,9 +30,11 @@ use String::ShellQuote;
 my $ce = new WeBWorK::CourseEnvironment({
 					 webwork_dir => $ENV{WEBWORK_ROOT},});
 
-my ($dbi,$dbtype,$db,$host) = split(':',$ce->{database_dsn});
+my ($dbi,$dbtype,$db,$host,$port) = split(':',$ce->{database_dsn});
 
 $host = 'localhost' unless $host;
+
+$port = 3306 unless $port;
 
 my $dbuser = $ce->{database_username};
 my $dbpass = $ce->{database_password};
@@ -49,7 +51,7 @@ $db = shell_quote($db);
 
 my $mysqldump_command = $ce->{externalPrograms}->{mysqldump};  
 
-`$mysqldump_command --host=$host --user=$dbuser --password=$dbpass $db OPL_local_statistics > $output_file`;
+`$mysqldump_command --host=$host --port=$port --user=$dbuser --password=$dbpass $db OPL_local_statistics > $output_file`;
 
 print "Database File Created\n";
 


### PR DESCRIPTION
This addresses #722.  Now the port of the server can be specified using the format described in site.conf.  If its not specified the default port of 3306 is used.  

To test:  -  Make sure that you can update and upload OPL statistics.  (You just have to run the upload, but you don't have to upload the files.)  
-  Add a port to your dsn and make sure it is used.  Note:  If your using localhost then mysql will ignore the port.  