### PR TITLE
Fix for Desire2Learn LTI passback

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -580,10 +580,12 @@ sub maybe_update_user {
     # Create a temp user and run it through the create process
     my $tempUser = $db->newUser();
     $tempUser->user_id($userID);
-    $self->{last_name} =~ s/\+/ /g;
-    $tempUser->last_name($self->{last_name});
-    $self->{first_name} =~ s/\+/ /g;
-    $tempUser->first_name($self->{first_name});
+    my $last_name = $self->{last_name} // '';
+    $last_name =~ s/\+/ /g;
+    $tempUser->last_name($last_name);
+    my $first_name = $self->{first_name} // '';
+    $first_name =~ s/\+/ /g;
+    $tempUser->first_name($first_name);
     $tempUser->email_address($self->{email});
     $tempUser->status("C");
     $tempUser-> section($self->{section} // "");

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -365,8 +365,7 @@ sub authenticate {
     $ce->{LTIBasicToThisSiteURL} : $path;
 
   if ( $ce->{debug_lti_parameters} ) {
-      warn("The following path was reconstructed by WeBWorK.  It should 
-match the path in the LMS:");
+      warn("The following path was reconstructed by WeBWorK.  It should match the path in the LMS:");
       warn($path);
   }
   

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -364,6 +364,12 @@ sub authenticate {
   $path = $ce->{LTIBasicToThisSiteURL} ? 
     $ce->{LTIBasicToThisSiteURL} : $path;
 
+  if ( $ce->{debug_lti_parameters} ) {
+      warn("The following path was reconstructed by WeBWorK.  It should 
+match the path in the LMS:");
+      warn($path);
+  }
+  
   # We also try a version without the trailing / in case that was not
   # included when the LMS user created the LMS link 
   my $altpath = $path;

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -210,6 +210,8 @@ sub submit_grade {
 </imsx_POXEnvelopeRequest>
 EOS
 
+  chomp($replaceResultXML);
+  
   my $bodyhash = sha1_base64($replaceResultXML);
 
   # since sha1_base64 doesn't pad we have to do so manually 


### PR DESCRIPTION
This fixes issue #725 as suggested.  Danny has tested this with Desire2Learn and Moodle.  I have tested this with Blackboard and Canvas.  Grade passback works as expected in all cases.  

To Test:  Check that LTI grade passback works with your LMS set up.  

P.S.  I also added a more complete error message for troubleshooting the LTI authentication process.  This is already in master, but you can the code change in the diff for #727.  