### PR TITLE
fix bug with boolen dropdown lists when languages other than English are used

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -203,11 +203,12 @@ sub display_value {
 
 sub save_string {
 	my ($self, $oldval, $newvalsource) = @_;
+	my $r = $self->{Module}->r;
 	my $varname = $self->{var};
 	my $newval = $self->convert_newval_source($newvalsource);
 	my $displayoldval = $self->comparison_value($oldval);
 	return '' if($displayoldval eq $newval);
-	return('$'. $varname . " = " . ($newval eq 'True' ? 1 : 0) .";\n");
+	return('$'. $varname . " = " . ($newval eq $r->maketext("True") ? 1 : 0) .";\n");
 }
 
 sub entry_widget {


### PR DESCRIPTION
The problem was that localized values of "True" and "False" appeared in the dropdown boxes, but they were compared against "True" when saving changes. Therefore saving these values when "True" translated to something else than "True" did not work.