### PR TITLE
XSS Fixes

### DIFF
--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -30,6 +30,7 @@ details.
 
 use strict;
 use warnings;
+use Apache2::Const qw(:common);
 use HTML::Entities;
 use HTML::Scrubber;
 use Date::Format;
@@ -130,11 +131,14 @@ sub handler($) {
 			$r->send_http_header unless MP2; # not needed for Apache2
 			$htmlMessage = "<html><body>$htmlMessage</body></html>";
 		}
-		print $htmlMessage;
 		
 		# log the error to the apache error log
 		my $textMessage = textMessage($r, $warnings, $exception, @backtrace);
 		$log->error($textMessage);
+
+		$r->custom_response(FORBIDDEN,$htmlMessage);
+
+		$result = FORBIDDEN;
 	}
 	
 	return $result;

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -38,6 +38,7 @@ C<WeBWorK::ContentGenerator> to call.
 use strict;
 use warnings;
 use Time::HiRes qw/time/;
+use HTML::Entities qw/encode_entities/;
 use WeBWorK::Localize;
 # load WeBWorK::Constants before anything else
 # this sets package variables in several packages
@@ -155,8 +156,9 @@ sub dispatch($) {
 	my %displayArgs = $urlPath->args;
 	
 	unless ($displayModule) {
-		debug("The display module is empty, so we can DECLINE here.\n");
-		die "No display module found for path '$path'.";
+	    debug("The display module is empty, so we can DECLINE here.\n");
+	    $path = encode_entities($path);
+	    die "No display module found for path '$path'.";
 	}
 	
 	debug("The display module for this path is: $displayModule\n");

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -103,6 +103,7 @@ use WeBWorK::DB::Utils qw/make_vsetID grok_vsetID grok_setID_from_vsetID_sql
 	grok_versionID_from_vsetID_sql/;
 use WeBWorK::Debug;
 use WeBWorK::Utils qw(runtime_use);
+use HTML::Entities qw( encode_entities );
 
 =for comment
 
@@ -2317,20 +2318,20 @@ sub validateKeyfieldValue {
     my ($keyfield,$value,$versioned) = @_;
 
     if ($keyfield eq "problem_id" || $keyfield eq 'problemID') {
-	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [0-9])"
+	croak "invalid characters in '".encode_entities($keyfield)." field: '".encode_entities($value)."' (valid characters are [0-9])"
 	    unless $value =~ m/^[0-9]*$/;
     } elsif ($versioned and $keyfield eq "set_id" || $keyfield eq 'setID') {
-	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [-a-zA-Z0-9_.,])"
+	croak "invalid characters in '".encode_entities($keyfield)." field: '".encode_entities($value)."' (valid characters are [0-9])"
 	    unless $value =~ m/^[-a-zA-Z0-9_.,]*$/;
 	# } elsif ($versioned and $keyfield eq "user_id") { 
     } elsif ($keyfield eq "user_id" || $keyfield eq 'userID') { 
 	check_user_id($value); #  (valid characters are [-a-zA-Z0-9_.,]) see above.
     } elsif ($keyfield eq "ip_mask") {
-	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [-a-fA-F0-9_.:/])"
+	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [-a-zA-Z0-9_.,])"
 	    unless $value =~ m/^[-a-fA-F0-9_.:\/]*$/;
 	
     } else {
-	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [-a-zA-Z0-9_.])"
+	croak "invalid characters in '".encode_entities($keyfield)." field: '".encode_entities($value)."' (valid characters are [0-9])"
 	    unless $value =~ m/^[-a-zA-Z0-9_.]*$/;
     }
     


### PR DESCRIPTION
This fixes some XSS stuff.  At the request of a security person I also changed the response code from 200 (OK) to 403 (FORBIDDEN) when `Apache/WeBWorK.pm` throws an error.  Note, the response code is still 200 (OK) if `ContentGenerator.pm` is the module that throws the error. 

To test
1.  Try the following URLS and check that the `<script>` tag is encoded (i.e. visible)
 - `http://yourserver.edu/webwork2/<script>`
 - `http://yourserver.edu/webwork2/admin/<script>`
2.  Visit the above links with a webpage inspector open to the Network tab and check that the error response is 403 and not 200.   