### PR TITLE
Gateway Answer Bug

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -101,7 +101,8 @@ sub can_showCorrectAnswers {
 #    so we should hide the correct answers if we aren not showing
 #    scores GG.
 
-	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	my $canShowScores = ($Set->hide_score_by_problem eq 'N' ||
+			     !$Set->hide_score_by_problem) &&
 	  ( $Set->hide_score eq 'N' ||
 	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
 	      after($tmplSet->answer_date) ) );
@@ -146,7 +147,8 @@ sub can_showSolutions {
 #    so we should hide the correct answers if we aren not showing
 #    scores GG.
 
-	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	my $canShowScores = ($Set->hide_score_by_problem eq 'N' ||
+			     !$Set->hide_score_by_problem) &&
 	  ( $Set->hide_score eq 'N' ||
 	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
 	      after($tmplSet->answer_date) ) );
@@ -260,8 +262,8 @@ sub can_checkAnswers {
 	#    showing correcrt answers but not showing scores doesn't make sense
 	#    so we should hide the correct answers if we aren not showing
 	#    scores GG.
-
-	my $canShowScores = $Set->hide_score_by_problem eq 'N' &&
+	my $canShowScores = ($Set->hide_score_by_problem eq 'N' ||
+			     !$Set->hide_score_by_problem) &&
 	  ( $Set->hide_score eq 'N' ||
 	    ( $Set->hide_score eq 'BeforeAnswerDate' &&
 	      after($tmplSet->answer_date) ) );

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -108,8 +108,7 @@ sub can_showCorrectAnswers {
 
 	return ( ( ( after( $Set->answer_date ) || 
 		     ( $attemptsUsed >= $maxAttempts && 
-		       $maxAttempts != 0 &&
-		       $Set->due_date() == $Set->answer_date() ) ) ||
+		       $maxAttempts != 0 ) ) ||
 		   $authz->hasPermissions($User->user_id, 
 				"show_correct_answers_before_answer_date") ) &&
 		 ( $authz->hasPermissions($User->user_id, "view_hidden_work") ||
@@ -154,8 +153,7 @@ sub can_showSolutions {
 
 	return ( ( ( after( $Set->answer_date ) || 
 		     ( $attemptsUsed >= $attempts_per_version &&
-		       $attempts_per_version != 0 &&
-		       $Set->due_date() == $Set->answer_date() ) ) ||
+		       $attempts_per_version != 0 ) ) ||
 		   $authz->hasPermissions($User->user_id, 
 				"show_correct_answers_before_answer_date") ) &&
 		 ( $authz->hasPermissions($User->user_id, "view_hidden_work") ||


### PR DESCRIPTION
This fixes a couple of bugs.  The first is that sometimes the "hide_score_by_problem" variable for old sets which has been imported is undefined.  So we want to assume that that is a "N" if its not there.  

The second issue is that on gateways where the answer date differed from the due date, solutions and correct answers weren't shown even if the student had run out of attempts.  This was intentionally added by someone but doesn't make sense to me.  If someone has a reason why it should be this way let me know.  To test: 
-  Create a gateway with a different close and answer date, a test time limit of 50 min, and only 1 attempt. 
-  Take the gateway.  Before the patch you won't have access to the solutions and after you should be able to see solutions and correct answers.  
