### PR TITLE
CodeMirror Bug

### DIFF
--- a/htdocs/js/apps/PGProblemEditor2/pgproblemeditor2.js
+++ b/htdocs/js/apps/PGProblemEditor2/pgproblemeditor2.js
@@ -1,6 +1,17 @@
 $(function () {
 
-    if (CodeMirror) {
+    var codeMirrorDefined = true;
+
+    try { CodeMirror; }
+
+    catch (e) {
+
+	if (e.name == "ReferenceError") {
+	    codeMirrorDefined = false;
+	}
+    }
+    
+    if (codeMirrorDefined) {
 	cm = CodeMirror.fromTextArea(
 	    $("#problemContents")[0],
 	    {mode: "PG",

--- a/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
+++ b/htdocs/js/apps/PGProblemEditor3/pgproblemeditor3.js
@@ -16,7 +16,18 @@ $(function(){
 	    .addClass('hidden');
     });
 
-    if (CodeMirror) {
+    var codeMirrorDefined = true;
+
+    try { CodeMirror; }
+
+    catch (e) {
+
+	if (e.name == "ReferenceError") {
+	    codeMirrorDefined = false;
+	}
+    }
+    
+    if (codeMirrorDefined) {
 	cm = CodeMirror.fromTextArea(
 	    $("#problemContents")[0],
 	    {mode: "PG",


### PR DESCRIPTION
Fixes issue #742.  Test by setting `$options{PGCodeMirror} = 0;`  Both PGProblemEditor2 and PGProblemEditor3 should be properly formatted.  