### PR TITLE
Set specific charset on new OPL tables

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -262,7 +262,7 @@ for my $tableinfo (@create_tables) {
 	my $tabinit = $tableinfo->[1];
 	my $query = "DROP TABLE IF EXISTS `$tabname`";
 	$dbh->do($query);
-	$query = "CREATE TABLE `$tabname` ( $tabinit ) ENGINE=$db_storage_engine";
+	$query = "CREATE TABLE `$tabname` ( $tabinit ) ENGINE=$db_storage_engine CHARACTER SET latin1";
 	$dbh->do($query);
 	if($lib eq 'OPL') {
 		$old_tabname = $tabname;


### PR DESCRIPTION
If our database defaults to the utf8 character set and we run OPL-update, it
will fail creating tables.  It fails because the primary key of the new tables
is too large.  This is because the primary key includes several VARCHAR
columns, which are 3x in size if they are utf8.

This commit changes the table creating queries to force the latin1 character
set instead of using the database default.  This allows the tables to be
created and the OPL indexes loaded into the database.
