### PR TITLE
Sanitize ScoringDownload  getFile parameter.  Fixes bug #3793

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
@@ -40,6 +40,8 @@ sub pre_header_initialize {
 	if ($authz->hasPermissions($user, "score_sets")) {
 		if ($file =~ m!/!) {  #
 			$self->addbadmessage("Your file name may not contain a path component");
+		} elsif (($file =~ m!~!)){
+			$self->addbadmessage("Your file name may not contain a tilde. ");
 		} else {
 			$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); 
 			# 0==don't delete file after downloading

--- a/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
@@ -34,9 +34,16 @@ sub pre_header_initialize {
 	my $scoringDir = $ce->{courseDirs}->{scoring};
 	my $file       = $r->param('getFile');
 	my $user       = $r->param('user');
-	
+ 
+# the parameter 'getFile" needs to be sanitized. (see bug #3793 )
+# See checkName in FileManager.pm for a more complete sanitization.
 	if ($authz->hasPermissions($user, "score_sets")) {
-		$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); # 0==don't delete file after downloading
+		if ($file =~ m!/!) {  #
+			$self->addbadmessage("Your file name may not contain a path component");
+		} else {
+			$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); 
+			# 0==don't delete file after downloading
+		}
 	} else {
 		$self->addbadmessage("You do not have permission to access scoring data.");
 	}


### PR DESCRIPTION
This fixes at least part of bug #3793.  Now the file name cannot contain / which prevents the exploit described in #3793

