### PR TITLE
Fix fake_problem to work when periodic rerandomization is enabled

### DIFF
--- a/lib/WeBWorK/Utils/Tasks.pm
+++ b/lib/WeBWorK/Utils/Tasks.pm
@@ -147,6 +147,7 @@ sub fake_problem {
 	$problem->last_answer(""); 
 	$problem->num_correct(1000); 
 	$problem->num_incorrect(1000); 
+	$problem->prCount(0);
 
 	#for my $key (keys(%{$problem})){
 	#	my $value = '####UNDEF###';


### PR DESCRIPTION
This fixes the following bug:
When periodic rerandomization is enabled for a course, and the default number of attempts before rerandomizing is not 0 (infinite), then when clicking on "try it" from the Library Browser, one gets a warning message about an undefined quantity, and the problem insists that you request a new version rather than letting you check answers.
I have briefly tested this with periodic rerandomization on and off, and it works for me in both cases.