### PR TITLE
Path to Rserve.pm in defaults.config

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1219,7 +1219,7 @@ ${pg}{modules} = [
 	[qw(Locale::Maketext)],
 	[qw(WeBWorK::Localize)],
 	[qw(JSON)],
-        [qw(Rserve Class::Tiny IO::Handle)],
+        [qw(Statistics::R::IO::Rserve Class::Tiny IO::Handle)],
 ];
 
 ##### Problem creation defaults


### PR DESCRIPTION
This eliminated some "Failed to evaluate module" errors that appeared in every problem whether it used R or not. I'll be happy to open another PR to the `develop` branch if that's appropriate.