### PR TITLE
Fix bug by initializing variable text

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -54,7 +54,7 @@ sub if_can {
     
     my $course_info_path = $ce->{courseDirs}->{templates} . "/"
       . $ce->{courseFiles}->{course_info};
-    my $text;
+    my $text = DEFAULT_COURSE_INFO_TXT;
 
     if (-f $course_info_path) { #check that it's a plain  file
       $text = eval { readFile($course_info_path) };


### PR DESCRIPTION
One line fix to the mentioned bug.  Without this, the variable $text might be tested without initializing it.