### PR TITLE
Improve file name check for scoring download exploit bug.  

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -122,8 +122,8 @@ sub initialize {
 		if (!$scoringFileNameOK) { # fileName is not properly formed
 			$self->addbadmessage($r->maketext("Your file name is not valid! "));
 		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
-				 "directory path component and only the characters ~[-_.a-zA-Z0-9 ~]  are allowed.")
-			); # ~ is needed to escape [ and ] within maketext
+				 "directory path component and only the characters -_.a-zA-Z0-9 and space  are allowed.")
+			); 
 		}
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -29,6 +29,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::Utils qw(readFile seq_to_jitar_id jitar_id_to_seq jitar_problem_adjusted_status wwRound x);
+use WeBWorK::ContentGenerator::Instructor::FileManager;
 
 our @userInfoColumnHeadings = (x("STUDENT ID"), x("login ID"), x("LAST NAME"), x("FIRST NAME"), x("SECTION"), x("RECITATION"));
 our @userInfoFields = ("student_id", "user_id","last_name", "first_name", "section", "recitation");
@@ -52,11 +53,14 @@ sub initialize {
 	my $scoreSelected = $r->param('scoreSelected');
 	my $scoringFileName = $r->param('scoringFileName') || "${courseName}_totals";
 	$scoringFileName =~ s/\.csv\s*$//; $scoringFileName .='.csv';  # must end in .csv
+	my $scoringFileNameOK = (
+		$scoringFileName eq  WeBWorK::ContentGenerator::Instructor::FileManager::checkName($scoringFileName)
+	);
 	$self->{scoringFileName}=$scoringFileName;
 	
 	$self->{padFields}  = defined($r->param('padFields') ) ? 1 : 0; 
 	
-	if (defined $scoreSelected && @selected) {
+	if (defined $scoreSelected && @selected && $scoringFileNameOK) {
 
 		my @totals                 = ();
 		my $recordSingleSetScores  = $r->param('recordSingleSetScores');
@@ -111,9 +115,17 @@ sub initialize {
 		$self->appendColumns( \@totals,\@sum_scores);
 		$self->writeCSV("$scoringDir/$scoringFileName", @totals);
 
-	} elsif (defined $scoreSelected) {
-		$self->addbadmessage($r->maketext("You must select one or more sets for scoring"));
-	} 
+	} else {
+		if (!@selected) {  # nothing selected for scoring
+			$self->addbadmessage($r->maketext("You must select one or more sets for scoring!"));
+		}
+		if (!$scoringFileNameOK) { # fileName is not properly formed
+			$self->addbadmessage($r->maketext("Your file name is not valid! ")).
+		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
+				 "directory path component and only the characters ~[^-_.a-zA-Z0-9 ~]  are allowed.")
+			); # ~ is needed to escape [ and ] within maketext
+		}
+	}
 	
 	# Obtaining list of sets:
 	my @setNames =  $db->listGlobalSets();

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -122,7 +122,7 @@ sub initialize {
 		if (!$scoringFileNameOK) { # fileName is not properly formed
 			$self->addbadmessage($r->maketext("Your file name is not valid! ")).
 		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
-				 "directory path component and only the characters ~[^-_.a-zA-Z0-9 ~]  are allowed.")
+				 "directory path component and only the characters ~[-_.a-zA-Z0-9 ~]  are allowed.")
 			); # ~ is needed to escape [ and ] within maketext
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -120,7 +120,7 @@ sub initialize {
 			$self->addbadmessage($r->maketext("You must select one or more sets for scoring!"));
 		}
 		if (!$scoringFileNameOK) { # fileName is not properly formed
-			$self->addbadmessage($r->maketext("Your file name is not valid! ")).
+			$self->addbadmessage($r->maketext("Your file name is not valid! "));
 		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
 				 "directory path component and only the characters ~[-_.a-zA-Z0-9 ~]  are allowed.")
 			); # ~ is needed to escape [ and ] within maketext

--- a/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
@@ -41,10 +41,10 @@ sub pre_header_initialize {
  # See checkName in FileManager.pm for a more complete sanitization.
   	if ($authz->hasPermissions($user, "score_sets")) {
  		unless ( $file eq  WeBWorK::ContentGenerator::Instructor::FileManager::checkName($file) ) {  #
- 			$self->addbadmessage("Your file name is not valid. ".
- 			 "A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
- 			 "directory path component and only the characters [^-_.a-zA-Z0-9 ]  are allowed."
- 			 );
+			$self->addbadmessage($r->maketext("Your file name is not valid! "));
+		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
+				 "directory path component and only the characters -_.a-zA-Z0-9 and space are allowed.")
+			); 
  		} else {
  			$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); 
  			# 0==don't delete file after downloading

--- a/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
@@ -16,6 +16,7 @@
 
 package WeBWorK::ContentGenerator::Instructor::ScoringDownload;
 use base qw(WeBWorK::ContentGenerator::Instructor);
+use WeBWorK::ContentGenerator::Instructor::FileManager;
 
 =head1 NAME
  
@@ -34,19 +35,21 @@ sub pre_header_initialize {
 	my $scoringDir = $ce->{courseDirs}->{scoring};
 	my $file       = $r->param('getFile');
 	my $user       = $r->param('user');
- 
-# the parameter 'getFile" needs to be sanitized. (see bug #3793 )
-# See checkName in FileManager.pm for a more complete sanitization.
-	if ($authz->hasPermissions($user, "score_sets")) {
-		if ($file =~ m!/!) {  #
-			$self->addbadmessage("Your file name may not contain a path component");
-		} elsif (($file =~ m!~!)){
-			$self->addbadmessage("Your file name may not contain a tilde. ");
-		} else {
-			$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); 
-			# 0==don't delete file after downloading
-		}
-	} else {
+	
+
+ # the parameter 'getFile" needs to be sanitized. (see bug #3793 )
+ # See checkName in FileManager.pm for a more complete sanitization.
+  	if ($authz->hasPermissions($user, "score_sets")) {
+ 		unless ( $file eq  WeBWorK::ContentGenerator::Instructor::FileManager::checkName($file) ) {  #
+ 			$self->addbadmessage("Your file name is not valid. ".
+ 			 "A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
+ 			 "directory path component and only the characters [^-_.a-zA-Z0-9 ]  are allowed."
+ 			 );
+ 		} else {
+ 			$self->reply_with_file("text/comma-separated-values", "$scoringDir/$file", $file, 0); 
+ 			# 0==don't delete file after downloading
+ 		}	
+ 	} else {
 		$self->addbadmessage("You do not have permission to access scoring data.");
 	}
 }


### PR DESCRIPTION


A more robust check of the fileName using the FileManager checkName function. This insures
that the fileName for the scoring file conforms precisely to the same rules used by the FileManager for files.

This pull request is not quite ready yet. I have to implement a similar check on the scoring tools page so that you cannot enter an incorrect file name there. I'll do that shortly.

Sorry to put you through the extra work -- I caught this problem this morning around 8 and I thought I had closed the pull request, but I guess I didn't push "commit and close" on the github web page.