### PR TITLE
Limit the length of the author KEY in the author table. 

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -159,7 +159,7 @@ if($libraryVersion eq '2.5') {
 	lastname varchar (255) NOT NULL,
 	firstname varchar (255) NOT NULL,
 	email varchar (255),
-	KEY author (lastname, firstname),
+	KEY author (lastname(100), firstname(100)),
 	PRIMARY KEY (author_id)
 '],
 [$tables{path}, '


### PR DESCRIPTION

Limit the length of the author KEY in the author table. 

This will become more important as more people use utf8 in databases but
it doesn't interfere with any of the current databases that use only the latin1 encodings.