### PR TITLE
Add template statements for overriding permission levels for PG info …

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -428,4 +428,14 @@ $showeditors{simplepgeditor}   = 0;
 $options{setDefSearchDepth}=4; #search down 4 levels
 $options{useOPLdefFiles}=1;
 
+################################################################################
+# Permission overrides (e.g. "admin", "professor", "ta", "student", "guest"
+################################################################################
+
+# $permissionLevels{show_resource_info} 				= "admin";
+# $permissionLevels{show_pg_info_checkbox}            = "admin";
+# $permissionLevels{show_answer_hash_info_checkbox}	= "admin";
+# $permissionLevels{show_answer_group_info_checkbox}	= "admin";
+
+# $permissionLevels{modify_tags} = "undef";
 1; #final line of the file to reassure perl that it was read properly.


### PR DESCRIPTION
…buttons and for library tags.

It turns out the version numbers were already updated. 

This replaces the pull request for reorganizing the client directory.  
It turns out that I had updated sendXMLRPC.pl in more than one branch on my computer
and these updates need to be combined and reconciled before I can commit. I don't want to do that 
just before a release.  I'll save this feature and reorganizing the client directory for 2.14 -- it is not urgently needed by most people. 