### PR TITLE
Hot fix sendmail notification bug

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -412,7 +412,7 @@ $showeditors{simplepgeditor}   = 0;
 ## Key database, see the   Session Managment section
 ## of defaults.config.dist
 
-## For session management using the key databasse table, uncomment the following line,
+## For session management using the key database table, uncomment the following line,
 ## which will override the setting  $session_management_via = "session_cookie"
 ## set in defaults.config.
 

--- a/courses.dist/modelCourse/course.conf
+++ b/courses.dist/modelCourse/course.conf
@@ -83,5 +83,10 @@ $dbLayoutName = 'sql_single';
 # controls if the Tagging features are displayed.  This is mainly used by library editors
 # $permissionLevels{modify_tags} = "professor";
 
+# Settings to connect this course to Canvas via  LTI.
+# $LTIGradeOnSubmit = 1;
+# $debug_lti_parameters = 1;
+# $LTIBasicConsumerSecret = "xxxxxxxxx";
+# $LTIGradeMode = "homework";
 
 1;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -910,13 +910,15 @@ sub email_notification {
 
 	my $mailing_errors = "";
 
-	my $transport = Email::Sender::Transport::SMTP->new({
-		host => $ce->{mail}->{smtpServer},
-		ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
-		timeout => $ce->{mail}->{smtpTimeout}
-	});
-
-	$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort}; 
+# 	my $transport = Email::Sender::Transport::SMTP->new({
+# 		host => $ce->{mail}->{smtpServer},
+# 		ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
+# 		timeout => $ce->{mail}->{smtpTimeout}
+# 	});
+# 
+# 	$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort}; 
+#           createEmailSenderTransportSMTP is defined in ContentGenerator
+	my $transport = $self->createEmailSenderTransportSMTP();
 
 	my $email = Email::Simple->create(
 		header => [


### PR DESCRIPTION
This fixes a bug in which the notification that emails were successfully sent to a class was not properly sent to the instructor. 

Test by going the "Email" page and mail a message to yourself. Assuming you are an instructor you should receive two email messages:  the first is the message that you sent, and a second email saying that all of the emails had been successfully sent.