### PR TITLE
add UniSiegen to macros

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1083,6 +1083,7 @@ $pg{directories}{macrosPath} = [
    "$courseDirs{templates}/Library/macros/UBC",
    "$courseDirs{templates}/Library/macros/Hope",
    "$courseDirs{templates}/Library/macros/MC",
+   "$courseDirs{templates}/Library/macros/UniSiegen",
 ];
 
 # The applet search path. If a full URL is given, it is used unmodified. If an


### PR DESCRIPTION
I added UniSiegen to the macros path to insure that the `logicMacros.pl` file is found, which I added in the pull request

https://github.com/openwebwork/webwork-open-problem-library/pull/335 

and that I introduced into several problems in the pull request

https://github.com/openwebwork/webwork-open-problem-library/pull/336

So this should probably be pulled together with the latter pull request. I am creating this PR to the master branch to avoid that the affected problems break, because `logicMacros.pl` is not found.