### PR TITLE
Develop config hotfix

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1088,6 +1088,7 @@ $pg{directories}{macrosPath} = [
    "$courseDirs{templates}/Library/macros/UBC",
    "$courseDirs{templates}/Library/macros/Hope",
    "$courseDirs{templates}/Library/macros/MC",
+   "$courseDirs{templates}/Library/macros/UniSiegen",
 ];
 
 # The applet search path. If a full URL is given, it is used unmodified. If an


### PR DESCRIPTION
A hotfix for adding UniSiegen to macro file search list in default.config. 

This parallels the hotfix #801 submitted to the master branch (rel2.13)

May also add a hot fix for sendmail notifications that didn't make it into develop previously?