### PR TITLE
PreTeXt support

### DIFF
--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -36,6 +36,7 @@ use constant DISPLAY_MODES => {
 	plainText     => "HTML",
 	images        => "HTML_dpng",
 	MathJax	      => "HTML_MathJax",
+	PTX           => "PTX",
 };
 
 sub new {

--- a/lib/WebworkClient/ptx_format.pl
+++ b/lib/WebworkClient/ptx_format.pl
@@ -1,0 +1,10 @@
+$ptx_static_format = <<'ENDPROBLEMTEMPLATE';
+<!--$XML_URL WeBWorK Editor using host: $XML_URL, course: $courseID format: ptx -->
+<!--BEGIN PROBLEM-->
+<webwork>
+$problemText
+</webwork>
+<!--END PROBLEM-->
+ENDPROBLEMTEMPLATE
+
+$ptx_static_format;

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -87,13 +87,15 @@ use constant DISPLAY_MODES => {
 	plainText     => "HTML",
 	images        => "HTML_dpng",
 	MathJax	      => "HTML_MathJax",
+	PTX           => "PTX",
 };
 
 use constant DISPLAY_MODE_FAILOVER => {
 		TeX            => [],
 		HTML           => [],
 		HTML_dpng      => [ "HTML", ],
-		HTML_MathJax    => [ "HTML_dpng", "HTML", ],
+		HTML_MathJax   => [ "HTML_dpng", "HTML", ],
+		PTX            => [ "HTML" ],
 		# legacy modes -- these are not supported, but some problems might try to
 		# set the display mode to one of these values manually and some macros may
 		# provide rendered versions for these modes but not the one we want.


### PR DESCRIPTION
This is the companion PR for [a PR to pg](https://github.com/openwebwork/pg/pull/327). That PR has a full description. 

Beyond what is there, here we introduce a "ptx" format for an XMLRPC call. PreTeXt would use this simplified format to easily access WeBWorK-generated PTX code.