### PR TITLE
add dir="auto" attribute to <td>

### DIFF
--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -284,7 +284,7 @@ sub formatAnswerRow {
 
 	my $row = join('',
 			  ($self->showAnswerNumbers) ? CGI::td({},$answerNumber):'',
-			  ($self->showAttemptAnswers) ? CGI::td({},$self->nbsp($answerString)):'' ,   # student original answer
+			  ($self->showAttemptAnswers) ? CGI::td({dir=>"auto"},$self->nbsp($answerString)):'' ,   # student original answer
 			  ($self->showAttemptPreviews)?  $self->formatToolTip($answerString, $answerPreview):"" ,
 			  ($self->showAttemptResults)?   $attemptResults : '' ,
 			  ($self->showCorrectAnswers)?  $self->formatToolTip($correctAnswer,$correctAnswerPreview):"" ,


### PR DESCRIPTION
This adds the attribute dir="auto" to the `<td>` element that displays the
students original answer. This is useful in a global dir="rtl" setting.
For mathematical formulas consisting of ASCII characters this should
imply an LTR setting, while it should imply an RTL setting when the text
entered is written in a language that is written from right to left.

This is related to the PG PR https://github.com/openwebwork/pg/pull/323, where a corresponding modification was made to an `<input>` element.