### PR TITLE
Allow student_id to be retrieved from a (configurable) LTI parameter

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -86,6 +86,18 @@ $preferred_source_of_username = "lis_person_contact_email_primary";
 #$strip_address_from_email = 1;
 
 ################################################################################
+# LTI Preferred source of Student Id
+################################################################################
+
+# If preferred_source_of_student_id is not set, WeBWorK will look in the LTI
+# parameter 'custom_student_id.' If preferred_source_of_student_id is set, then
+# WeBWorK will look in the LTI parameter specified below. This parameter may be
+# dependendent on the LMS. E.G., In D2L, student_id is stored in OrgDefinedId and
+# the corresponding LTI parameter is called ext_d2l_orgdefinedid.
+
+#$preferred_source_of_student_id = "ext_d2l_orgdefinedid";
+
+################################################################################
 # LTI Basic Authentication Parameters 
 ################################################################################
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -213,7 +213,7 @@ sub get_credentials {
 	warn "=========== summary ============";
 	warn "User id is |$self->{user_id}|\n";
 	warn "User mail address is |$self->{email}|\n";
-	warn "Student id is |$self->{student_id}|\n";
+	warn "Student id is |", $self->{student_id}//'undefined',"|\n";
 	warn "preferred_source_of_username is |", $ce->{preferred_source_of_username}//'undefined',"|\n";
 	warn "preferred_source_of_student_id is |", $ce->{preferred_source_of_student_id}//'undefined',"|\n";
 	warn "================================\n";

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -167,6 +167,7 @@ sub get_credentials {
 	 ['oauth_timestamp', 'oauth_timestamp'],
 	 ['section', 'custom_section'],
 	 ['recitation', 'custom_recitation'],
+	 ['student_id', 'custom_student_id'],
 	);
 
       # Some LMS's misspell the lis_person_sourcedid parameter name
@@ -199,6 +200,12 @@ sub get_credentials {
 	$self->{user_id} =~ s/@.*$// if
 	  $ce->{strip_address_from_email};
       }
+
+     if (!defined($self->{student_id})
+         and defined($ce->{preferred_source_of_student_id})) {
+       my $user_id_lti_param_name = $ce->{preferred_source_of_student_id};
+       $self->{student_id} = $r->param($user_id_lti_param_name);
+     }
       
       # For setting up its helpful to print out what the system think the
       # User id and address is at this point 
@@ -206,7 +213,9 @@ sub get_credentials {
 	warn "=========== summary ============";
 	warn "User id is |$self->{user_id}|\n";
 	warn "User mail address is |$self->{email}|\n";
+	warn "Student id is |$self->{student_id}|\n";
 	warn "preferred_source_of_username is |", $ce->{preferred_source_of_username}//'undefined',"|\n";
+	warn "preferred_source_of_student_id is |", $ce->{preferred_source_of_student_id}//'undefined',"|\n";
 	warn "================================\n";
       }
       if (!defined($self->{user_id})) {
@@ -518,6 +527,7 @@ sub create_user {
   $newUser-> section($self->{section} // "");
   $newUser->recitation($self->{recitation} // "");
   $newUser->comment(formatDateTime(time, "local"));
+  $newUser->student_id($self->{student_id} // "");
 
   # Allow sites to customize the user
   if (defined($ce->{LTI_modify_user})) {
@@ -593,6 +603,7 @@ sub maybe_update_user {
     $tempUser->status("C");
     $tempUser-> section($self->{section} // "");
     $tempUser->recitation($self->{recitation} // "");
+    $tempUser->student_id($self->{student_id} // "");
     
     # Allow sites to customize the temp user
     if (defined($ce->{LTI_modify_user})) {
@@ -601,7 +612,7 @@ sub maybe_update_user {
 
     my @elements = qw(last_name first_name 
 		      email_address status 
-		      section recitation);
+		      section recitation student_id);
 
     my $change_made = 0;
 


### PR DESCRIPTION
The default LTI parameter is custom_student_id, otherwise it can be set in authen_LTI.conf.