### PR TITLE
Modernize 'isText' subroutine

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -1274,7 +1274,7 @@ sub showHTML {
 #
 sub isText {
 	my $string = shift;
-	return $string !~ m/[\x00-\x1F\x7F]{2}/;
+	return $text !~ m/(?=[^\r\n\t])[\x00-\x1F\x7F]{2}/;
 }
 
 ##################################################

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -1274,7 +1274,7 @@ sub showHTML {
 #
 sub isText {
 	my $string = shift;
-	return $text !~ m/(?=[^\r\n\t])[\x00-\x1F\x7F]{2}/;
+	return $string !~ m/(?=[^\r\n\t])[\x00-\x1F\x7F]{2}/;
 }
 
 ##################################################

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -1274,7 +1274,7 @@ sub showHTML {
 #
 sub isText {
 	my $string = shift;
-	return $string !~ m/(?=[^\r\n\t])[\x00-\x1F\x7F]{2}/;
+	return $string !~ m/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]{2}/;
 }
 
 ##################################################

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -1274,7 +1274,7 @@ sub showHTML {
 #
 sub isText {
 	my $string = shift;
-	return $string !~ m/[^\s\x20-\x7E]{4}/;
+	return $string !~ m/[\x00-\x1F\x7F]{2}/;
 }
 
 ##################################################

--- a/t/test_fileManager.pl
+++ b/t/test_fileManager.pl
@@ -8,7 +8,7 @@ BEGIN {
         eval "use lib '$WebworkBase::RootWebwork2Dir/lib'"; die $@ if $@;
 }
 
-use Test::More tests => 12;
+use Test::More tests => 14;
 use WeBWorK::ContentGenerator::Instructor::FileManager qw/isText/;
 
 ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
@@ -23,3 +23,5 @@ ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\r\n\r\ndef\r\
 ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("                 "), 'string of all spaces is text';
 ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
 ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\x00\ndef"), 'control character before newline surrounded by ASCII chars is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\n\x00def"), 'newline before control character surrounded by ASCII chars is text';

--- a/t/test_fileManager.pl
+++ b/t/test_fileManager.pl
@@ -7,19 +7,22 @@ BEGIN {
 	eval "use lib '$WebworkBase::RootWebwork2Dir/lib'"; die $@ if $@;
 }
 
-use WeBWorK::ContentGenerator::Instructor::FileManager;
 
 use Test::More tests => 12;
 
-ok isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
-ok isText("abc\ndef"), 'string with newline is text';
-ok isText("abc\r\ndef"), 'string with CRLF (windows style) is text';
-ok !isText("abcdef\x01\x02abcdef"), 'string with 2 consecutive control characters is not text';
-ok !isText("\x01\x1F\x7FHD08U23NV\x00\x08"), 'string with multiple blocks of 2+ control characters is not text';
-ok isText("abcdef\x0Aasdfd"), 'text with 1 control character is still considered text';
-ok isText("\x00abcdef\x1Fghijklm"), 'text with multiple instances of single isolated control characters is still considered text';
-ok isText("abc\n\ndef\n\n\n\nghijklm"), 'text with multiple consecutive newlines is text';
-ok isText("abc\r\n\r\ndef\r\n\r\n\r\n\r\nghijklm"), 'text with multiple consecutive CRLF\'s (windows style) is text';
-ok isText("                 "), 'string of all spaces is text';
-ok isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
-ok isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';
+use WeBWorK::ContentGenerator::Instructor::FileManager;
+
+my $fm = WeBWorK::ContentGenerator::Instructor::FileManager::;
+
+ok $fm->isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
+ok $fm->isText("abc\ndef"), 'string with newline is text';
+ok $fm->isText("abc\r\ndef"), 'string with CRLF (windows style) is text';
+ok !$fm->isText("abcdef\x01\x02abcdef"), 'string with 2 consecutive control characters is not text';
+ok !$fm->isText("\x01\x1F\x7FHD08U23NV\x00\x08"), 'string with multiple blocks of 2+ control characters is not text';
+ok $fm->isText("abcdef\x0Aasdfd"), 'text with 1 control character is still considered text';
+ok $fm->isText("\x00abcdef\x1Fghijklm"), 'text with multiple instances of single isolated control characters is still considered text';
+ok $fm->isText("abc\n\ndef\n\n\n\nghijklm"), 'text with multiple consecutive newlines is text';
+ok $fm->isText("abc\r\n\r\ndef\r\n\r\n\r\n\r\nghijklm"), 'text with multiple consecutive CRLF\'s (windows style) is text';
+ok $fm->isText("                 "), 'string of all spaces is text';
+ok $fm->isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
+ok $fm->isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';

--- a/t/test_fileManager.pl
+++ b/t/test_fileManager.pl
@@ -1,28 +1,25 @@
+#!/Volumes/WW_test/opt/local/bin/perl -w
 use 5.010;
 use warnings;
 
 BEGIN {
-	require "./grab_course_environment.pl";
-	eval "use lib '$WebworkBase::RootPGDir/lib'"; die $@ if $@;
-	eval "use lib '$WebworkBase::RootWebwork2Dir/lib'"; die $@ if $@;
+        require "./grab_course_environment.pl";
+        eval "use lib '$WebworkBase::RootPGDir/lib'"; die $@ if $@;
+        eval "use lib '$WebworkBase::RootWebwork2Dir/lib'"; die $@ if $@;
 }
 
-
 use Test::More tests => 12;
+use WeBWorK::ContentGenerator::Instructor::FileManager qw/isText/;
 
-use WeBWorK::ContentGenerator::Instructor::FileManager;
-
-my $fm = WeBWorK::ContentGenerator::Instructor::FileManager::;
-
-ok $fm->isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
-ok $fm->isText("abc\ndef"), 'string with newline is text';
-ok $fm->isText("abc\r\ndef"), 'string with CRLF (windows style) is text';
-ok !$fm->isText("abcdef\x01\x02abcdef"), 'string with 2 consecutive control characters is not text';
-ok !$fm->isText("\x01\x1F\x7FHD08U23NV\x00\x08"), 'string with multiple blocks of 2+ control characters is not text';
-ok $fm->isText("abcdef\x0Aasdfd"), 'text with 1 control character is still considered text';
-ok $fm->isText("\x00abcdef\x1Fghijklm"), 'text with multiple instances of single isolated control characters is still considered text';
-ok $fm->isText("abc\n\ndef\n\n\n\nghijklm"), 'text with multiple consecutive newlines is text';
-ok $fm->isText("abc\r\n\r\ndef\r\n\r\n\r\n\r\nghijklm"), 'text with multiple consecutive CRLF\'s (windows style) is text';
-ok $fm->isText("                 "), 'string of all spaces is text';
-ok $fm->isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
-ok $fm->isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\ndef"), 'string with newline is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\r\ndef"), 'string with CRLF (windows style) is text';
+ok !WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdef\x01\x02abcdef"), 'string with 2 consecutive control characters it not text';
+ok !WeBWorK::ContentGenerator::Instructor::FileManager::isText("\x01\x1F\x7FHD08U23NV\x00\x08"), 'string with multiple blocks of 2+ control characters is not text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdef\x0Aasdfd"), 'text with 1 control character is still considered text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("\x00abcdef\x1Fghijklm"), 'text with multiple instances of single isolated control characters is still considered text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\n\ndef\n\n\n\nghijklm"), 'text with multiple consecutive newlines is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abc\r\n\r\ndef\r\n\r\n\r\n\r\nghijklm"), 'text with multiple consecutive CRLF\'s (windows style) is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("                 "), 'string of all spaces is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
+ok WeBWorK::ContentGenerator::Instructor::FileManager::isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';

--- a/t/test_fileManager.pl
+++ b/t/test_fileManager.pl
@@ -1,0 +1,25 @@
+use 5.010;
+use warnings;
+
+BEGIN {
+	require "./grab_course_environment.pl";
+	eval "use lib '$WebworkBase::RootPGDir/lib'"; die $@ if $@;
+	eval "use lib '$WebworkBase::RootWebwork2Dir/lib'"; die $@ if $@;
+}
+
+use WeBWorK::ContentGenerator::Instructor::FileManager;
+
+use Test::More tests => 12;
+
+ok isText("abcdghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"), 'ordinary string is text';
+ok isText("abc\ndef"), 'string with newline is text';
+ok isText("abc\r\ndef"), 'string with CRLF (windows style) is text';
+ok !isText("abcdef\x01\x02abcdef"), 'string with 2 consecutive control characters is not text';
+ok !isText("\x01\x1F\x7FHD08U23NV\x00\x08"), 'string with multiple blocks of 2+ control characters is not text';
+ok isText("abcdef\x0Aasdfd"), 'text with 1 control character is still considered text';
+ok isText("\x00abcdef\x1Fghijklm"), 'text with multiple instances of single isolated control characters is still considered text';
+ok isText("abc\n\ndef\n\n\n\nghijklm"), 'text with multiple consecutive newlines is text';
+ok isText("abc\r\n\r\ndef\r\n\r\n\r\n\r\nghijklm"), 'text with multiple consecutive CRLF\'s (windows style) is text';
+ok isText("                 "), 'string of all spaces is text';
+ok isText("      \r\n\t\r\n\t        "), 'string of all spaces, tabs, CRs and newlines is text';
+ok isText("abcdef\t\t\t\tasdfjka"), 'string with multiple consecutive tabs is text';


### PR DESCRIPTION
Check for control characters instead of non-ASCII characters to determine if a file is a text file or a binary file.