### PR TITLE
Fix spelling error   change peroid to period

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -367,7 +367,7 @@ sub body {
 		my $beginReducedScoringPeriod =  $self->formatDateTime($reduced_scoring_date);
 		
 		if (before($reduced_scoring_date)) {
-		  print CGI::div({class=>"ResultsAlert"}, $r->maketext("After the reduced scoring peroid begins all work counts for [_1]% of its value.", $reducedScoringPerCent));
+		  print CGI::div({class=>"ResultsAlert"}, $r->maketext("After the reduced scoring period begins all work counts for [_1]% of its value.", $reducedScoringPerCent));
 		  
 		} elsif (between($reduced_scoring_date,$set->due_date())) {
 		  print CGI::div({class=>"ResultsAlert"},$r->maketext("This set is in its reduced scoring period.  All work counts for [_1]% of its value.",$reducedScoringPerCent));

--- a/lib/WeBWorK/Localize/en.po
+++ b/lib/WeBWorK/Localize/en.po
@@ -674,7 +674,7 @@ msgstr ""
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/en_us.po
+++ b/lib/WeBWorK/Localize/en_us.po
@@ -676,7 +676,7 @@ msgstr ""
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/es.po
+++ b/lib/WeBWorK/Localize/es.po
@@ -801,7 +801,7 @@ msgstr "tr: Answer Date"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/fr.po
+++ b/lib/WeBWorK/Localize/fr.po
@@ -820,7 +820,7 @@ msgstr "Date de disponibilité des réponses"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/heb.po
+++ b/lib/WeBWorK/Localize/heb.po
@@ -797,7 +797,7 @@ msgstr "tr: Answer Date"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/ko.po
+++ b/lib/WeBWorK/Localize/ko.po
@@ -734,7 +734,7 @@ msgstr "대답한 날짜"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/ru_RU.po
+++ b/lib/WeBWorK/Localize/ru_RU.po
@@ -799,7 +799,7 @@ msgstr "Дата ответа"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/tr.po
+++ b/lib/WeBWorK/Localize/tr.po
@@ -798,7 +798,7 @@ msgstr "Cevap tarihi"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/webwork2.pot
+++ b/lib/WeBWorK/Localize/webwork2.pot
@@ -549,7 +549,7 @@ msgstr ""
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
-msgid "After the reduced scoring peroid begins all work counts for %1% of its value."
+msgid "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/zh_CN.po
+++ b/lib/WeBWorK/Localize/zh_CN.po
@@ -733,7 +733,7 @@ msgstr "答案日期"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715

--- a/lib/WeBWorK/Localize/zh_hk.po
+++ b/lib/WeBWorK/Localize/zh_hk.po
@@ -799,7 +799,7 @@ msgstr "答案日期"
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
-"After the reduced scoring peroid begins all work counts for %1% of its value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715


### PR DESCRIPTION
The word period was misspelled as peroid.  This fixes the misspelling in the original file and in several translating files that translate the original message. 