### PR TITLE
show number of active students in Statistics

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -680,7 +680,7 @@ print  CGI::p($r->maketext('The percentage of active students with correct answe
 			]
 			)),
 		CGI::Tr(CGI::td(
-			[ $r->maketext('number of active students'), map {($number_of_students_attempting_problem{$_})
+			[ $r->maketext('&#35; of active students'), map {($number_of_students_attempting_problem{$_})
 			                      ? $number_of_students_attempting_problem{$_}
 			                      : '-'}
 			                       @problemIDs

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -680,7 +680,7 @@ print  CGI::p($r->maketext('The percentage of active students with correct answe
 			]
 			)),
 		CGI::Tr(CGI::td(
-			[ $r->maketext('&#35; of active students'), map {($number_of_students_attempting_problem{$_})
+			[ $r->maketext('# of active students'), map {($number_of_students_attempting_problem{$_})
 			                      ? $number_of_students_attempting_problem{$_}
 			                      : '-'}
 			                       @problemIDs

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -678,6 +678,13 @@ print  CGI::p($r->maketext('The percentage of active students with correct answe
 			                      : '-'}			                   
 			                       @problemIDs 
 			]
+			)),
+		CGI::Tr(CGI::td(
+			[ $r->maketext('number of active students'), map {($number_of_students_attempting_problem{$_})
+			                      ? $number_of_students_attempting_problem{$_}
+			                      : '-'}
+			                       @problemIDs
+			]
 			));
 
 	#show a grading link if necc


### PR DESCRIPTION
Show the number of active students for each problem on the Statistics page. As far as I am aware this number this not easily available elsewhere.