### PR TITLE
Fix spelling of maketext in achievements assignment module

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
@@ -56,7 +56,7 @@ sub initialize {
 		$self->addmessage(CGI::div({class=>'ResultsWithoutError'}, $r->maketext("Achievement has been unassigned to all students.")));
 		$doAssignToSelected = 1;
 	} elsif (defined $r->param('assignToSelected')) {
-	   	$self->addmessage(CGI::div({class=>'ResultsWithoutError'}, $r->maktext("Achievement has been assigned to selected users.")));
+	   	$self->addmessage(CGI::div({class=>'ResultsWithoutError'}, $r->maketext("Achievement has been assigned to selected users.")));
 		$doAssignToSelected = 1;
 	} elsif (defined $r->param("unassignFromAll")) {
 	   # no action taken


### PR DESCRIPTION
Fixed the spelling of maketext (was maktext) in file.  This bug was blocking the ability to update the achievements for an individual student. 

To test:  

before patch trying to unassign an achievement for a single student gave an error message that maktext was not defined. 
(I believe assigning a single student would give the same message.) 

after the patch the achievement is assigned or unassigned properly.
