### PR TITLE
Change Mail::Sender to Email::Sender in remaining locations

### DIFF
--- a/lib/WeBWorK/Utils/DelayedMailer.pm
+++ b/lib/WeBWorK/Utils/DelayedMailer.pm
@@ -52,7 +52,7 @@ sub new {
 # %msg format:
 #   $msg{to}      = either a single address or an arrayref containing multiple addresses
 #   $msg{subject} = string subject
-#   $msg{msg}     = string body of email (this is what Mail::Sender::MailMsg uses)
+#   $msg{msg}     = string body of email (this is what Email::Sender::MailMsg uses)
 sub add_message {
 	my ($self, %msg) = @_;
 	

--- a/lib/WeBWorK/Utils/RestrictedMailer.pm
+++ b/lib/WeBWorK/Utils/RestrictedMailer.pm
@@ -15,14 +15,14 @@
 ################################################################################
 
 package WeBWorK::Utils::RestrictedMailer;
-use base "Mail::Sender";
+use base "Email::Sender";
 
 =for comment
 
 PLEASE NOTE
 
 This class does not impose any restrictions on its own, it simply provides
-restricted versions of Mail::Sender's Open, OpenMultipart, MailMsg, and
+restricted versions of Email::Sender's Open, OpenMultipart, MailMsg, and
 MailFile methods.
 
 The restricted methods prevent the caller from overriding parameters that
@@ -129,14 +129,14 @@ sub new {
 	$params = munge_params("new", @$params) if ref $params eq "ARRAY";
 	
 	# make a deep copy of the params that will be passed to new
-	# Mail::Sender might delete some elements, and we need the whole thing for later comparison
+	# Email::Sender might delete some elements, and we need the whole thing for later comparison
 	my $initial_params = dclone $params;
 	
 	# create the object, passing the params in
 	my $self = $invocant->SUPER::new($params);
 	
 	# handle errors
-	die $Mail::Sender::Error unless ref $self;
+	die $Email::Sender::Error unless ref $self;
 	
 	# store the set of initial params for later perusal
 	$self->initial_params = $initial_params;

--- a/lib/WebworkWebservice/CourseActions.pm
+++ b/lib/WebworkWebservice/CourseActions.pm
@@ -699,7 +699,7 @@ sub sendEmail {
 	debug("smtpServer: " . $smtpServer);
 	
 	
-	my $mailer = Mail::Sender->new({
+	my $mailer = Email::Sender->new({
 				tls_allowed => $ce->{tls_allowed}//1, # the default for this for  Mail::Sender is 1
 				from      => $smtpServer,
 				fake_from => "pstaab\@fitchburgstate.edu",


### PR DESCRIPTION
This updates Mail::Sender to Email::Sender in three files that are not currently active.

The function sendMail in Webworkwebservice/CourseActions deserves work.  The functionality
is useful for WW3 if nowhere else.

It is not clear whether RestrictedMailer and RestirctedClosureClass should remain in the webwork2 repos but I'm not ready to pull them yet without comment.

Here are some earlier notes.

-------------------------------------------------------------------


As far as I can tell RestrictedMailer.pm is not being used. This and RestrictedClosureClass.pm were introduced by Sam Hathaway @sh002i with the plan of using it to block some possible security holes still open with the Safe compartment. They were to be used with Safe::Hole which is a CPAN module.

I'll merge this PR now. Soon I'll issue a new PR fixing the Mail::Sender reference in Webworkwebservice/CourseActions.pm. There is note there from Peter Staab @pstaabp indicating that the webservice function sendMail() has not been working for some time. It's main use case at the moment is for WW3.