### PR TITLE
Remove unneccessary escaping of apostrophes in Library Browser

### DIFF
--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -462,19 +462,19 @@ sub getDBListings {
 	my $extrawhere = '';
 	my @select_parameters=();
 	if($subj) {
-		$subj =~ s/'/\\'/g;
+#		$subj =~ s/'/\\'/g;
 #		$extrawhere .= " AND dbsj.name=\"$subj\" ";
 		$extrawhere .= " AND dbsj.name= ? ";
 		push @select_parameters, $subj;
 	}
 	if($chap) {
-		$chap =~ s/'/\\'/g;
+#		$chap =~ s/'/\\'/g;
 #		$extrawhere .= " AND dbc.name=\"$chap\" ";
 		$extrawhere .= " AND dbc.name= ? ";
 		push @select_parameters, $chap;
 	}
 	if($sec) {
-		$sec =~ s/'/\\'/g;
+#		$sec =~ s/'/\\'/g;
 #		$extrawhere .= " AND dbsc.name=\"$sec\" ";
 		$extrawhere .= " AND dbsc.name= ? ";
 		push @select_parameters, $sec;


### PR DESCRIPTION
This is a fix to #832.  It should probably be back ported to 2.13, since several people have reported this issue on the forums.
On a separate note, someone should clean up this file and remove all of the commented out code.