### PR TITLE
Remove symlinks (see discussion at issue #835)

### DIFF
--- a/htdocs/css/union.css
+++ b/htdocs/css/union.css
@@ -1,1 +1,0 @@
-../../conf/templates/union/union.css

--- a/htdocs/css/ur.css
+++ b/htdocs/css/ur.css
@@ -1,1 +1,0 @@
-../../conf/templates/ur/ur.css


### PR DESCRIPTION
The presence of these links interferes with Docker setup, see the discussion at #835. The symlink at `webwork2/htdocs/mathjax` is still used.