### PR TITLE
Change statements to students with regard to reduced scoring.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -133,9 +133,11 @@ sub title {
 	  my $enable_reduced_scoring =  $r->{ce}->{pg}{ansEvalDefaults}{enableReducedScoring} && $set->enable_reduced_scoring && $set->reduced_scoring_date &&$set->reduced_scoring_date != $set->due_date;
 	  if ($enable_reduced_scoring && 
 	      before($set->reduced_scoring_date)) {
-	    $title .= ' - '.$r->maketext("Reduced Scoring Starts [_1]", 
+	    $title .= ' - '.$r->maketext("Due [_1], after which reduced scoring is available until [_2]", 
 	         $self->formatDateTime($set->reduced_scoring_date,undef,
-				       $r->ce->{studentDateDisplayFormat}));
+				       $r->ce->{studentDateDisplayFormat}),
+			 $self->formatDateTime($set->due_date, undef, 
+			           $r->ce->{studentDateDisplayFormat}));
 	  } elsif ($set->due_date) {
 	    $title .= ' - '.$r->maketext("Closes [_1]", 
 	         $self->formatDateTime($set->due_date,undef,

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -686,7 +686,7 @@ sub set_due_msg {
   if ($enable_reduced_scoring &&
       $t < $reduced_scoring_date) {
     
-    $status .= $r->maketext("Open, reduced scoring starts on [_1].", $beginReducedScoringPeriod);
+    $status .= $r->maketext("Open, due [_1], afterward reduced credit can be earned until [_2].", $beginReducedScoringPeriod, $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
   } else {
     if ($gwversion) {
       $status = $r->maketext("Open, complete by [_1].",  $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
@@ -696,8 +696,7 @@ sub set_due_msg {
 
     if ($enable_reduced_scoring && $reduced_scoring_date &&
 	$t > $reduced_scoring_date) {
-      $status .= ' ';
-      $status .= CGI::div({-class=>"ResultsAlert"}, $r->maketext("Reduced scoring started on [_1].", $beginReducedScoringPeriod));
+      $status = $r->maketext("Due date [_1] has passed, reduced credit can still be earned until [_2].", $beginReducedScoringPeriod, $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
     }
   }
 


### PR DESCRIPTION
This changes messages students see when reduced scoring is in effect.  It refers to the start of reduced scoring as the due date.  This is because students found the original way confusing -- they felt cheated for getting reduced credit when they submitted their work before the due date, in spite of messages in webwork.