### PR TITLE
Prefer whitelisting over blacklisting to prevent XSS

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -536,7 +536,7 @@ sub content {
 	
 	my $themesDir = $ce->{webworkDirs}{themes};
 	my $theme = $r->param("theme") || $ce->{defaultTheme};
-	$theme = $ce->{defaultTheme} unless $theme =~ m!^[a-zA-Z0-9_.-]+$!;
+	$theme = $ce->{defaultTheme} if $theme =~ m!(?:^|/)\.\.(?:/|$)!;
 	#$ce->{webworkURLs}->{stylesheet} = ($ce->{webworkURLs}->{htdocs})."/css/$theme.css";   # reset the style sheet
 	# the line above is clever -- but I think it is better to link directly to the style sheet from the system.template
 	# then the link between template and css is made in .template file instead of hard coded as above
@@ -546,11 +546,13 @@ sub content {
 	unless (-r $templateFile) {  #hack to prevent disaster when missing theme directory
 	   if (-r "$themesDir/math4/$template.template") {
 	   		$templateFile = "$themesDir/math4/$template.template";
+			$theme = HTML::Entities::encode_entities($theme);
 	   		warn "Theme $theme is not one of the available themes. ".
 	   		"Please check the theme configuration ".
 	   		"in the files localOverrides.conf, course.conf and ".
 	   		"simple.conf and on the course configuration page.\n"
 	   	} else {
+			$theme = HTML::Entities::encode_entities($theme);
 	   		die "Neither the theme $theme nor the defaultTheme math4 are available.  ".  
 	   		"Please notify your site administrator that the structure of the ".
 	   		"themes directory needs attention.";

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -536,7 +536,7 @@ sub content {
 	
 	my $themesDir = $ce->{webworkDirs}{themes};
 	my $theme = $r->param("theme") || $ce->{defaultTheme};
-	$theme = $ce->{defaultTheme} if $theme =~ m!(?:^|/)\.\.(?:/|$)!;
+	$theme = $ce->{defaultTheme} unless $theme =~ m![a-zA-Z0-9_.-]+!;
 	#$ce->{webworkURLs}->{stylesheet} = ($ce->{webworkURLs}->{htdocs})."/css/$theme.css";   # reset the style sheet
 	# the line above is clever -- but I think it is better to link directly to the style sheet from the system.template
 	# then the link between template and css is made in .template file instead of hard coded as above

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -536,7 +536,7 @@ sub content {
 	
 	my $themesDir = $ce->{webworkDirs}{themes};
 	my $theme = $r->param("theme") || $ce->{defaultTheme};
-	$theme = $ce->{defaultTheme} unless $theme =~ m![a-zA-Z0-9_.-]+!;
+	$theme = $ce->{defaultTheme} unless $theme =~ m!^[a-zA-Z0-9_.-]+$!;
 	#$ce->{webworkURLs}->{stylesheet} = ($ce->{webworkURLs}->{htdocs})."/css/$theme.css";   # reset the style sheet
 	# the line above is clever -- but I think it is better to link directly to the style sheet from the system.template
 	# then the link between template and css is made in .template file instead of hard coded as above


### PR DESCRIPTION
Warning: I haven't I actually tested this (I don't have a deployment of my own & I am looking for a non-production environment)

Anyway this PR prevents the below XSS by preferring a whitelisting approach for theme selection over a blacklisting approach for data validation of the 'theme' querystring parameter.

https://[site]/webwork2/?user=&effectiveUser=&key=&theme=1%3Cimg+src=xyz+onerror=alert(150)%3E%3Cxss_/%3E
