### PR TITLE
Automatically set HTML lang attribute in math4 templates based on course language, set dir="rtl" for Hebrew and Arabic

### DIFF
--- a/htdocs/themes/math4-ar/math4.css
+++ b/htdocs/themes/math4-ar/math4.css
@@ -12,7 +12,14 @@
  * FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
  * Artistic License for more details.
  */
+
+/* CodeMirror overrides */
  
+.CodeMirror-code {
+  outline: none;
+  direction: ltr !important;
+}
+
 /* Bootstrap overrides */
 a:focus {
     outline-style:solid;

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
 <head>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/htdocs/themes/math4/lbtwo.template
+++ b/htdocs/themes/math4/lbtwo.template
@@ -21,7 +21,7 @@
 -->
 
 
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<html xmlns="http://www.w3.org/1999/xhtml" <!--#output_course_lang_and_dir-->>
 <head>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -12,7 +12,14 @@
  * FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
  * Artistic License for more details.
  */
+
+/* CodeMirror overrides */
  
+.CodeMirror-code {
+  outline: none;
+  direction: ltr !important;
+}
+
 /* Bootstrap overrides */
 a:focus {
     outline-style:solid;

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
 <head>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
 <head>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -514,6 +514,53 @@ HTTP header is sent but before any content is sent.
 
 #sub initialize {  }
 
+=item output_course_lang_and_dir()
+
+Defined in this package.
+
+Sets the LANG attribute and when needed the DIR attribute based
+on the language set in the course configuration.
+
+The intended use is to set these tags in the main HTML tag of the generated
+web page when the template files calls this function.
+
+It selects the language based on the setting in the course configuration
+file (when it is set) and otherwise defaults back to
+	lang="en-US"
+which was the old hard-coded setting.
+
+When the language chosen is a known right to left language, it will also set
+the DIR attribute to "rtl". Currently, only Hebrew ("heb" or "he") and
+Arabic ("ar") trigger the RTL direction setting.
+
+=cut
+
+sub output_course_lang_and_dir{
+        my $self = shift;
+        my $master_lang_setting = "lang=\"en-US\""; # default setting
+        my $master_dir_setting  = "";               # default is NOT set
+
+        my $ce_lang = $self->r->ce->{language};
+
+        if ( $ce_lang eq "en" ) {
+          $master_lang_setting = "lang=\"en-US\""; # as in default
+        } elsif ( $ce_lang =~ /^he/i ) { # supports also the current "heb" option
+          # Hebrew - requires RTL direction
+          $master_lang_setting = "lang=\"he\""; # Hebrew
+          $master_dir_setting  = "dir=\"rtl\""; # RTL
+        } elsif ( $ce_lang =~ /^ar/i ) {
+          # Hebrew - requires RTL direction
+          $master_lang_setting = "lang=\"ar\""; # Arabic
+          $master_dir_setting  = "dir=\"rtl\""; # RTL
+        } else {
+          # use the language setting of the course, with NO direction setting
+          $master_lang_setting = "lang=\"${ce_lang}\"";
+        }
+
+        print "$master_lang_setting $master_dir_setting";
+        return "";
+}
+
 =item content()
 
 Defined in this package.


### PR DESCRIPTION
Modified the math4 template files to set the LANG attribute for the main HTML tag based on the course language, and defaulting to the prior setting of	lang="en-US"	when that fails.

When the course language is Hebrew or Arabic, it will also add the DIR attribute set to RTL (right to left) to the main HTML tag.

Setting the HTML language attribute properly is important for screen-readers / accessibility standards. 

This is a small change to support localization which should be independent of the other work being done to support UTF8.

In a sense, this request is intended to remove the need for the math4-ar theme added in pull request # 802 [https://github.com/openwebwork/webwork2/pull/802].