### PR TITLE
Gateway and Grade Bugfix

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -29,7 +29,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(readDirectory list2hash max jitar_id_to_seq jitar_problem_adjusted_status wwRound);
+use WeBWorK::Utils qw(readDirectory list2hash max jitar_id_to_seq jitar_problem_adjusted_status wwRound after);
 use WeBWorK::Localize;
 sub initialize {
 	my ($self) = @_;
@@ -424,7 +424,6 @@ sub displayStudentStats {
 		    # If its the last version then add the max to the course
 		    # totals and reset variables;
 		  if ($currentVersion == $numGatewayVersions) {
-		  } else {
 		      if (after($set->open_date())) {
 			  $courseTotal += $total;
 			  $courseTotalRight += $bestGatewayScore;

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -424,13 +424,18 @@ sub displayStudentStats {
 		    # If its the last version then add the max to the course
 		    # totals and reset variables;
 		  if ($currentVersion == $numGatewayVersions) {
-		    $courseTotal += $total;
-		    $courseTotalRight += $bestGatewayScore;
-		    $bestGatewayScore = 0;
+		  } else {
+		      if (after($set->open_date())) {
+			  $courseTotal += $total;
+			  $courseTotalRight += $bestGatewayScore;
+		      }
+		      $bestGatewayScore = 0;
 		  }
 		} else {		
-		  $courseTotal += $total;
-		  $courseTotalRight += $totalRight;
+		    if (after($set->open_date())) {
+			$courseTotal += $total;
+			$courseTotalRight += $totalRight;
+		    }
 		}
 		
 		push @rows, CGI::Tr({},

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1713,7 +1713,7 @@ sub importSetsFromDef {
 
 		debug("$set_definition_file: reading set definition file");
 		# read data in set definition file
-		my ($setName, $paperHeaderFile, $screenHeaderFile, $openDate, $dueDate, $answerDate, $ra_problemData, $assignmentType, $enableReducedScoring, $reducedScoringDate, $attemptsPerVersion, $timeInterval, $versionsPerInterval, $versionTimeLimit, $problemRandOrder, $problemsPerPage, $hideScore, $hideWork,$timeCap,$restrictIP,$restrictLoc,$relaxRestrictIP,$description,$emailInstructor,$restrictProbProgression) = $self->readSetDef($set_definition_file);
+		my ($setName, $paperHeaderFile, $screenHeaderFile, $openDate, $dueDate, $answerDate, $ra_problemData, $assignmentType, $enableReducedScoring, $reducedScoringDate, $attemptsPerVersion, $timeInterval, $versionsPerInterval, $versionTimeLimit, $problemRandOrder, $problemsPerPage, $hideScore, $hideScoreByProblem, $hideWork,$timeCap,$restrictIP,$restrictLoc,$relaxRestrictIP,$description,$emailInstructor,$restrictProbProgression) = $self->readSetDef($set_definition_file);
 		my @problemList = @{$ra_problemData};
 
 		# Use the original name if form doesn't specify a new one.
@@ -1761,6 +1761,7 @@ sub importSetsFromDef {
 		$newSetRecord->problem_randorder($problemRandOrder);
 		$newSetRecord->problems_per_page($problemsPerPage);
 		$newSetRecord->hide_score($hideScore);
+		$newSetRecord->hide_score_by_problem($hideScoreByProblem);
 		$newSetRecord->hide_work($hideWork);
 		$newSetRecord->time_limit_cap($timeCap);
 		$newSetRecord->restrict_ip($restrictIP);
@@ -1888,7 +1889,7 @@ sub readSetDef {
 		 ('')x16;  # initialize these to ''
 	my ( $timeCap, $restrictIP, $relaxRestrictIP ) = ( 0, 'No', 'No');
 # additional fields currently used only by gateways; later, the world?
-	my ( $hideScore, $hideWork, ) = ( 'N', 'N' );
+	my ( $hideScore, $hideScoreByProblem, $hideWork, ) = ( 'N', 'N', 'N' );
 
 	my %setInfo;
 	if ( open (SETFILENAME, "$filePath") )    {
@@ -1943,6 +1944,8 @@ sub readSetDef {
 				$problemsPerPage = $value;
 			} elsif ($item eq 'hideScore') {
 				$hideScore = ( $value ) ? $value : 'N';
+			} elsif ($item eq 'hideScoreByProblem') {
+				$hideScoreByProblem = ( $value ) ? $value : 'N';
 			} elsif ($item eq 'hideWork') {
 				$hideWork = ( $value ) ? $value : 'N';
 			} elsif ($item eq 'capTimeLimit') {
@@ -2016,6 +2019,11 @@ sub readSetDef {
 		     $hideScore ne 'BeforeAnswerDate' ) {
 			warn($r->maketext("The value [_1] for the hideScore option is not valid; it will be replaced with 'N'.", $hideScore)."\n");
 			$hideScore = 'N';
+		}
+		if ( $hideScoreByProblem ne 'N' && $hideScoreByProblem ne 'Y' && 
+		     $hideScoreByProblem ne 'BeforeAnswerDate' ) {
+			warn($r->maketext("The value [_1] for the hideScore option is not valid; it will be replaced with 'N'.", $hideScoreByProblem)."\n");
+			$hideScoreByProblem = 'N';
 		}
 		if ( $hideWork ne 'N' && $hideWork ne 'Y' && 
 		     $hideWork ne 'BeforeAnswerDate' ) {
@@ -2225,6 +2233,7 @@ sub readSetDef {
 		 $versionsPerInterval, $versionTimeLimit, $problemRandOrder,
 		 $problemsPerPage, 
 		 $hideScore,
+		 $hideScoreByProblem,
 		 $hideWork,
 		 $timeCap,
 		 $restrictIP,
@@ -2348,6 +2357,7 @@ SET:	foreach my $set (keys %filenames) {
 		    my $probRandom   = $setRecord->problem_randorder;
 		    my $probPerPage  = $setRecord->problems_per_page;
 		    my $hideScore    = $setRecord->hide_score;
+		    my $hideScoreByProblem  = $setRecord->hide_score_by_problem;
 		    my $hideWork     = $setRecord->hide_work;
 		    my $timeCap      = $setRecord->time_limit_cap;
 		    $gwFields =<<EOG;
@@ -2359,6 +2369,7 @@ versionTimeLimit    = $vTimeLimit
 problemRandOrder    = $probRandom
 problemsPerPage     = $probPerPage
 hideScore           = $hideScore
+hideScoreByProblem  = $hideScoreByProblem
 hideWork            = $hideWork
 capTimeLimit        = $timeCap
 EOG

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1274,6 +1274,7 @@ sub grade_all_sets {
   my $courseTotalRight = 0;
 
   foreach my $userSet (@userSets) {
+    next unless (after ($userSet->open_date()));
     if ($userSet->assignment_type() =~ /gateway/) {
 
       my ($totalRight,$total) = grade_gateway($db,$userSet,$userSet->set_id,$studentName);


### PR DESCRIPTION
This pull request contains a couple of bug fixes. 

1.  The Hmwk Sets Editor now properly processes the "hide_score_by_problem" parameter for gateways.  To test: 
  - [ ] Import a Gateway set and check in the database that the hide_score_by_problem column is not null for the set
  - [ ] Export and Import a Gateway set and make sure that the hide_score_by_problem field is being exported and imported correctly. 
  - [ ] Check that students are shown scores on problems when they should be. 

2.  The Course Total percentage in the Grades page (and for the LTI course total grade) has been changed so that it no longer includes grades from sets that are not yet open. To test: 
  - [ ] Make a set that is not open and check that it does not change the course totals on the Grades page. 
  - [ ] Make a set that is not open and check that it does not change the course total for the LTI grade passback feature. 
