### PR TITLE
Develop june1 fix

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -43,7 +43,7 @@ my @modulesList = qw(
 	Carp
 	CGI
 	Class::Accessor
-	Crypt::SSLeay
+	#Crypt::SSLeay
 	Dancer
 	Dancer::Plugin::Database
 	Data::Dump

--- a/htdocs/themes/math4-ar/math4.js
+++ b/htdocs/themes/math4-ar/math4.js
@@ -85,8 +85,10 @@ $(function(){
     $('img[src$="question_mark.png"]').replaceWith('<span class="icon icon-question-sign" data-alt="help" style="font-size:16px; margin-right:5px"></span>');
 
     // Turn summaries and help boxes into popovers
-    $('a.table-summary').popover().click(function (event) {
-	event.preventDefault();
+    // Not sure there are any table-summary classes
+    // Also not sure why it didn't work before I added  {trigger : 'click'}
+    $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
     });
     $('a.help-popup').popover({trigger : 'click'}).click(function (event) {
 	event.preventDefault();

--- a/htdocs/themes/math4-ar/math4.js
+++ b/htdocs/themes/math4-ar/math4.js
@@ -86,14 +86,17 @@ $(function(){
 
     // Turn summaries and help boxes into popovers
     // Not sure there are any table-summary classes
-    // Also not sure why it didn't work before I added  {trigger : 'click'}
-    $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+    // loading Sage interacts removes the popover function 
+    //(loads older version of bootstrap?)
+    // so we'll work around that for now
+    if ($.fn.popover) {
+    	$('a.table-summary').popover({trigger : 'click'}).click(function (event) {
 		event.preventDefault();
-    });
-    $('a.help-popup').popover({trigger : 'click'}).click(function (event) {
-	event.preventDefault();
-    }).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
-
+		});
+		$('a.help-popup').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
+		}).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
+    }
     // Sets login form input to bigger size
     $('#login_form input').addClass('input-large');    
     
@@ -125,19 +128,25 @@ $(function(){
     $('.answerComments').addClass('well');
     $('#SMA_button').addClass('btn btn-primary');
     
-    $("table.attemptResults td[onmouseover*='Tip']").each(function () {
-	var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);
-	if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
-	//on the presentation of a matrix  and then causes errors throughout the rest of the script
-	$(this).attr('onmouseover','');
-	if (data) {
-	    $(this).wrapInner('<div class="results-popover" />');
 
-	    var popdiv = $('div', this);
-	    popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
-	} 
+    // this finds the wztooltips object entries and adds
+    // bootstrap styling using popover to them
+    // check first that popover is defined 
+    // (work around for sage interacts which remove popover for some reason)
+	$("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
+		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);	
+		if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
+		//on the presentation of a matrix  and then causes errors throughout the rest of the script
+		if ($.fn.popover) { 
+			$(this).attr('onmouseover','');
+			if (data) {
+				$(this).wrapInner('<div class="results-popover" />');
+				var popdiv = $('div', this);
+				popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
+			}
+		} 
 	    
-    });
+	});
 
     // sets up problems to rescale the image accoring to attr height width
     // and not native height width.  

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -85,8 +85,9 @@ $(function(){
     $('img[src$="question_mark.png"]').replaceWith('<span class="icon icon-question-sign" data-alt="help" style="font-size:16px; margin-right:5px"></span>');
 
     // Turn summaries and help boxes into popovers
-    $('a.table-summary').popover().click(function (event) {
-	event.preventDefault();
+    // Not sure there are any table-summary classes
+    $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
     });
     $('a.help-popup').popover({trigger : 'click'}).click(function (event) {
 	event.preventDefault();

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -86,12 +86,13 @@ $(function(){
 
     // Turn summaries and help boxes into popovers
     // Not sure there are any table-summary classes
-    $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
-		event.preventDefault();
-    });
-    $('a.help-popup').popover({trigger : 'click'}).click(function (event) {
-	event.preventDefault();
-    }).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
+    // Also not sure why it didn't work before I added  {trigger : 'click'}
+    // $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+	//	event.preventDefault();
+    //});
+    //$('a.help-popup').popover({trigger : 'click'}).click(function (event) {
+	//event.preventDefault();
+    //}).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
 
     // Sets login form input to bigger size
     $('#login_form input').addClass('input-large');    
@@ -124,17 +125,29 @@ $(function(){
     $('.answerComments').addClass('well');
     $('#SMA_button').addClass('btn btn-primary');
     
-    $("table.attemptResults td[onmouseover*='Tip']").each(function () {
-	var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);
-	if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
-	//on the presentation of a matrix  and then causes errors throughout the rest of the script
-	$(this).attr('onmouseover','');
-	if (data) {
-	    $(this).wrapInner('<div class="results-popover" />');
-
-	    var popdiv = $('div', this);
-	    popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
-	} 
+    console.log("hi there");
+    // this finds the wztooltips object entries
+    $("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
+    //$("table.attemptResults td[onmouseover]").each(function(index, elem) {
+		console.log("index: "+index+" element: "+elem);
+		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);
+		console.log("data: "+ data);
+ 	
+// 	if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
+// 	//on the presentation of a matrix  and then causes errors throughout the rest of the script
+// 	$(this).attr('onmouseover','');
+// 	console.log("data1 "+data);
+ 	if (data) {
+ 	    $(this).wrapInner(function() {
+ 	    console.log("wrappInner: ",this)
+ 	    return '<div class="results-popover" />'});
+        console.log("children:",$(this).children('div'));
+ 	    var popdiv = $(this).children('div'); // find the first div under 'this'
+ 	    console.log('this: ', this);
+ 	    console.log("popdiv: ", popdiv);
+ 	    console.log("can callpopover: " ,  $.isFunction(popdiv.popover));
+// 	    popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
+ 	} 
 	    
     });
 

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -86,14 +86,17 @@ $(function(){
 
     // Turn summaries and help boxes into popovers
     // Not sure there are any table-summary classes
-    // Also not sure why it didn't work before I added  {trigger : 'click'}
-    // $('a.table-summary').popover({trigger : 'click'}).click(function (event) {
-	//	event.preventDefault();
-    //});
-    //$('a.help-popup').popover({trigger : 'click'}).click(function (event) {
-	//event.preventDefault();
-    //}).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
-
+    // loading Sage interacts removes the popover function 
+    //(loads older version of bootstrap?)
+    // so we'll work around that for now
+    if ($.fn.popover) {
+    	$('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
+		});
+		$('a.help-popup').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
+		}).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
+    }
     // Sets login form input to bigger size
     $('#login_form input').addClass('input-large');    
     
@@ -125,31 +128,25 @@ $(function(){
     $('.answerComments').addClass('well');
     $('#SMA_button').addClass('btn btn-primary');
     
-    console.log("hi there");
-    // this finds the wztooltips object entries
-    $("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
-    //$("table.attemptResults td[onmouseover]").each(function(index, elem) {
-		console.log("index: "+index+" element: "+elem);
-		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);
-		console.log("data: "+ data);
- 	
-// 	if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
-// 	//on the presentation of a matrix  and then causes errors throughout the rest of the script
-// 	$(this).attr('onmouseover','');
-// 	console.log("data1 "+data);
- 	if (data) {
- 	    $(this).wrapInner(function() {
- 	    console.log("wrappInner: ",this)
- 	    return '<div class="results-popover" />'});
-        console.log("children:",$(this).children('div'));
- 	    var popdiv = $(this).children('div'); // find the first div under 'this'
- 	    console.log('this: ', this);
- 	    console.log("popdiv: ", popdiv);
- 	    console.log("can callpopover: " ,  $.isFunction(popdiv.popover));
-// 	    popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
- 	} 
+
+    // this finds the wztooltips object entries and adds
+    // bootstrap styling using popover to them
+    // check first that popover is defined 
+    // (work around for sage interacts which remove popover for some reason)
+	$("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
+		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);	
+		if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
+		//on the presentation of a matrix  and then causes errors throughout the rest of the script
+		if ($.fn.popover) { 
+			$(this).attr('onmouseover','');
+			if (data) {
+				$(this).wrapInner('<div class="results-popover" />');
+				var popdiv = $('div', this);
+				popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
+			}
+		} 
 	    
-    });
+	});
 
     // sets up problems to rescale the image accoring to attr height width
     // and not native height width.  

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -422,63 +422,63 @@ sub output_JS{
 
 # prints out summary information for the problem pages.
 
-sub output_summary{
-
-	my $self = shift;
-
-	my $editMode = $self->{editMode};
-	my $problem = $self->{problem};
-	my $pg = $self->{pg};
-	my $submitAnswers = $self->{submitAnswers};
-	my %will = %{ $self->{will} };
-	my $checkAnswers = $self->{checkAnswers};
-	my $previewAnswers = $self->{previewAnswers};
-
-	my $r = $self->r;
-
-	my $authz = $r->authz;
-	my $user = $r->param('user');
-
-	# custom message for editor
-	if ($authz->hasPermissions($user, "modify_problem_sets") and defined $editMode) {
-		if ($editMode eq "temporaryFile") {
-			print CGI::p(CGI::div({class=>'temporaryFile'}, "Viewing temporary file: ", $problem->source_file));
-		} elsif ($editMode eq "savedFile") {
-			# taken care of in the initialization phase
-		}
-	}
-	print CGI::start_div({class=>"problemHeader"});
-
-
-	# attempt summary
-	#FIXME -- the following is a kludge:  if showPartialCorrectAnswers is negative don't show anything.
-	# until after the due date
-	# do I need to check $will{showCorrectAnswers} to make preflight work??
-	if (($pg->{flags}->{showPartialCorrectAnswers} >= 0 and $submitAnswers) ) {
-		# print this if user submitted answers OR requested correct answers
-
-		print $self->attemptResults($pg, 1,
-			$will{showCorrectAnswers},
-			$pg->{flags}->{showPartialCorrectAnswers}, 1, 1);
-	} elsif ($checkAnswers) {
-		# print this if user previewed answers
-		print CGI::div({class=>'ResultsWithError'},"ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"), CGI::br();
-		print $self->attemptResults($pg, 1, $will{showCorrectAnswers}, 1, 1, 1);
-			# show attempt answers
-			# show correct answers if asked
-			# show attempt results (correctness)
-			# show attempt previews
-	} elsif ($previewAnswers) {
-		# print this if user previewed answers
-		print CGI::div({class=>'ResultsWithError'},"PREVIEW ONLY -- ANSWERS NOT RECORDED"),CGI::br(),$self->attemptResults($pg, 1, 0, 0, 0, 1);
-			# show attempt answers
-			# don't show correct answers
-			# don't show attempt results (correctness)
-			# show attempt previews
-	}
-
-	print CGI::end_div();
-}
+# sub output_summary{
+# 
+# 	my $self = shift;
+# 
+# 	my $editMode = $self->{editMode};
+# 	my $problem = $self->{problem};
+# 	my $pg = $self->{pg};
+# 	my $submitAnswers = $self->{submitAnswers};
+# 	my %will = %{ $self->{will} };
+# 	my $checkAnswers = $self->{checkAnswers};
+# 	my $previewAnswers = $self->{previewAnswers};
+# 
+# 	my $r = $self->r;
+# 
+# 	my $authz = $r->authz;
+# 	my $user = $r->param('user');
+# 
+# 	# custom message for editor
+# 	if ($authz->hasPermissions($user, "modify_problem_sets") and defined $editMode) {
+# 		if ($editMode eq "temporaryFile") {
+# 			print CGI::p(CGI::div({class=>'temporaryFile'}, "Viewing temporary file: ", $problem->source_file));
+# 		} elsif ($editMode eq "savedFile") {
+# 			# taken care of in the initialization phase
+# 		}
+# 	}
+# 	print CGI::start_div({class=>"problemHeader"});
+# 
+# 
+# 	# attempt summary
+# 	#FIXME -- the following is a kludge:  if showPartialCorrectAnswers is negative don't show anything.
+# 	# until after the due date
+# 	# do I need to check $will{showCorrectAnswers} to make preflight work??
+# 	if (($pg->{flags}->{showPartialCorrectAnswers} >= 0 and $submitAnswers) ) {
+# 		# print this if user submitted answers OR requested correct answers
+# 
+# 		print $self->attemptResults($pg, 1,
+# 			$will{showCorrectAnswers},
+# 			$pg->{flags}->{showPartialCorrectAnswers}, 1, 1);
+# 	} elsif ($checkAnswers) {
+# 		# print this if user previewed answers
+# 		print CGI::div({class=>'ResultsWithError'},"ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"), CGI::br();
+# 		print $self->attemptResults($pg, 1, $will{showCorrectAnswers}, 1, 1, 1);
+# 			# show attempt answers
+# 			# show correct answers if asked
+# 			# show attempt results (correctness)
+# 			# show attempt previews
+# 	} elsif ($previewAnswers) {
+# 		# print this if user previewed answers
+# 		print CGI::div({class=>'ResultsWithError'},"PREVIEW ONLY -- ANSWERS NOT RECORDED"),CGI::br(),$self->attemptResults($pg, 1, 0, 0, 0, 1);
+# 			# show attempt answers
+# 			# don't show correct answers
+# 			# don't show attempt results (correctness)
+# 			# show attempt previews
+# 	}
+# 
+# 	print CGI::end_div();
+# }
 
 # output_CSS subroutine
 


### PR DESCRIPTION
The sage interact seems to reload an old version of bootstrap.js or in some other way interferes with the bootstrap function calls.
In particular the functions $.fn.popover and $.fn.modal are not available.

A companion PR to pg (pg#329) modifies math4.js  so that these functions are used only if they are defined on the page. This means that tooltips for the attemptResults table work, but have the old styling before we started using bootstrap styling.