### PR TITLE
Adjust warning for testing grade passback to the LMS.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -6,10 +6,10 @@
 # To enable this file, uncomment the appropriate lines in localOverrides.conf
 #############################################################################
 
-# set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
+# Set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
 # debugging.  This is useful when setting things up for the first time because
 # different LMS systems have different parameters
-$debug_lti_parameters = 0; 
+$debug_lti_parameters = 1; 
 
 # To get more information on passing grades back to the LMS enmass set debug_lti_grade_passback
 # to one.  And set the LTIMassUpdateInterval to 60 (seconds).
@@ -48,8 +48,9 @@ $authen{user_module} = [
 # Basic_TheLastOption, then WeBWorK::Login
 # will display a screen directing the user
 # back to an external authentication system.
+# This prevents you from attempting to login in to WeBWorK directly.
 
-$external_auth=1;
+#$external_auth=1;
 
 # NOTE:  If external authentication is disabled
 # then you should probably also prevent students

--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -6,10 +6,28 @@
 # To enable this file, uncomment the appropriate lines in localOverrides.conf
 #############################################################################
 
-# set this to 1 to have LTI calling parameters printed to HTML page for
+# set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
 # debugging.  This is useful when setting things up for the first time because
 # different LMS systems have different parameters
 $debug_lti_parameters = 0; 
+
+# To get more information on passing grades back to the LMS enmass set debug_lti_grade_passback
+# to one.  And set the LTIMassUpdateInterval to 60 (seconds).
+$debug_lti_grade_passback = 0;
+
+# This will print into the apache log the success or failure of updating each user/set.
+# If the set has "no lis_source_did" then that set hasn't been assigned, or the user is an instructor
+# and not a student.
+
+# Setting both debug_lti_parameters and debug_lti_grade_passback will cause the full request and 
+# response between the LMS and WW to be printed into apache error log file for each
+# user/set  update of the grade.
+
+# The switches above can be set in course.conf to enable debugging for just one course.
+
+# If you want even more information enable the debug facility for SubmitGrade.pm in 
+# the WeBWorK::Constants file.  
+# This will print extensive debug messages for all courses.
 
 # This first section enables LTI authentication.
 # Failover to Basic_TheLastOption is necessary to authenticate with

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -1,8 +1,7 @@
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/conf/localOverrides.conf.dist,v 1.225 2010/05/18 18:03:31 apizer Exp $
+# Copyright  2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -49,6 +48,12 @@ $mail{feedbackRecipients}    = [
 	#'prof2@yourserver.yourdomain.edu',
 ];
 
+### additional mail overrides
+# Use this to customize the text of the feedback button.
+$feedback_button_name = "Email WeBWorK TA";
+
+
+
 ################################################################################
 # Repository Information
 ###############################################################################
@@ -91,7 +96,7 @@ $language = "en";
 
 # This is the site_info file.  You should consider changing this to point
 # to a file which is not tracked by git
-$webworkFiles{site_info} = "$webworkDirs{htdocs}/site_info.txt";
+$webworkFiles{site_info} = "$webworkDirs{htdocs}/our_site_info.txt";
 
 
 # The setHeader preceeds each set in hardcopy output. It is a PG file.
@@ -205,7 +210,7 @@ $permissionLevels{dont_log_past_answers} = undef;   #controls logging of the res
 ################################################################################
 
 # This sets if the PG editor should use a js based "codemirror" editor or
-# just a textarea		
+# just a textarea
 $options{PGCodeMirror} = 1;
 
 # This sets if mathview is available on the PG editor for use as a minimal latex equation editor
@@ -390,15 +395,45 @@ $showeditors{simplepgeditor}   = 0;
 # Extra modules have been created to allow WeBWorK to use certain external
 # methods of authentication.
 
+################################################################################
 # IMS LTI Authentication
+################################################################################
+
 # Uncomment the following line to enable authentication via IMS LTI.
 # You will have to copy the file authen_LTI.conf.dist to authen_LTI.conf,
 # and then edit that file to fill in the settings for your installation.
 
 #include("conf/authen_LTI.conf");
+# default settings
+#$debug_lti_parameters = 0; 
+#$debug_lti_grade_passback = 0;
+
+# Set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
+# debugging.  This is useful when setting things up for the first time because
+# different LMS systems have different parameters
+
+# To get more information on passing grades back to the LMS enmass set debug_lti_grade_passback
+# to one.  And set the LTIMassUpdateInterval to 60 (seconds).
+
+# This will print into the apache log the success or failure of updating each user/set.
+# If the set has "no lis_source_did" then that set hasn't been assigned, or the user is an instructor
+# and not a student.
+
+# Setting both debug_lti_parameters and debug_lti_grade_passback will cause the full request and 
+# response between the LMS and WW to be printed into apache error log file for each
+# user/set  update of the grade.
+
+# The switches above can be set in course.conf to enable debugging for just one course.
+
+# If you want even more information enable the debug facility for SubmitGrade.pm in 
+# the WeBWorK::Constants file.  
+# This will print extensive debug messages for all courses.
 
 
+
+################################################################################
 # LDAP Authentication
+################################################################################
 # Uncomment the following line to enable authentication via an LDAP server.
 # You will have to copy the file authen_ldap.conf.dist to authen_ldap.conf,
 # and then edit that file to fill in the settings for your installation.

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -96,7 +96,8 @@ $language = "en";
 
 # This is the site_info file.  You should consider changing this to point
 # to a file which is not tracked by git
-$webworkFiles{site_info} = "$webworkDirs{htdocs}/our_site_info.txt";
+$webworkFiles{site_info} = "$webworkDirs{htdocs}/site_info.txt";
+#$webworkFiles{site_info} = "$webworkDirs{htdocs}/our_site_info.txt";
 
 
 # The setHeader preceeds each set in hardcopy output. It is a PG file.

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -291,7 +291,7 @@ EOS
 		  timestamp => time(),
 		  body_hash => $bodyhash
 							 );
-	debug("created grade request "). $gradeRequest;
+	debug("created grade request ". $gradeRequest);
   $gradeRequest->sign();
 	debug("signed grade request"); 
   my $HTTPRequest = HTTP::Request->new(

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -27,10 +27,12 @@ use strict;
 use warnings;
 use WeBWorK::Debug;
 use WeBWorK::CGI;
+use Carp;
 use WeBWorK::Utils qw(grade_set grade_gateway grade_all_sets wwRound);
 use Net::OAuth;
 use HTTP::Request;
 use LWP::UserAgent;
+
 use Digest::SHA qw(sha1_base64);
 
 # This package contains utilities for submitting grades to the LMS
@@ -40,6 +42,15 @@ sub new {
   my $self = {
 	      r => $r,
 	     };
+  # sanity check
+  my $ce = $r->{ce};
+  my $db = $self->{r}->{db};
+  unless (ref($ce//'') and ref($db)//'') {
+  	warn("course environment is not defined") unless ref($ce//'');
+  	warn("database reference is not defined") unless ref($db//'');
+  	croak("Could not create WeBWorK::Authen::LTIAdvanced::SubmitGrade object, missing items from request");
+  }
+ 
   bless $self, $class;
   return $self;
 }
@@ -57,7 +68,8 @@ sub update_sourcedid {
   # These parameters are used to build the passback request
   # warn if no outcome service url
   if (!defined($r->param('lis_outcome_service_url'))) {
-    warn "No LIS Outcome Service URL.  Unable to report grades to the LMS. Are external grades enabled in the LMS?" if $ce->{debug_lti_parameters};
+    carp "The parameter lis_outcome_service_url is not defined.  Unable to report grades to the LMS.".
+    " Are external grades enabled in the LMS?" if $ce->{debug_lti_grade_passback};
   } else {
     # otherwise keep it up to date
     my $lis_outcome_service_url = $db->getSettingValue('lis_outcome_service_url');
@@ -88,12 +100,12 @@ sub update_sourcedid {
   # depending on the request and the mode we are in.  
   my $sourcedid = $r->param('lis_result_sourcedid');
   if (!defined($sourcedid)) {
-    warn "No LISSourceDID! Some LMS's do not give grades to instructors, but this could also be a sign that external grades are not enabled in your LMS." if $ce->{debug_lti_parameters};
+    warn "No LISSourceID! Some LMS's do not give grades to instructors, but this".  
+     "could also be a sign that external grades are not enabled in your LMS." if $ce->{debug_lti_grade_passback};
   } elsif ($ce->{LTIGradeMode} eq 'course') {
     # Update the SourceDID for the user if we are in course mode
     my $User = $db->getUser($userID);
-    if (!defined($User->lis_source_did) ||
-	$User->lis_source_did ne $sourcedid) {
+    if (!defined($User->lis_source_did) || $User->lis_source_did ne $sourcedid) {
       $User->lis_source_did($sourcedid);
       $db->putUser($User);
     }
@@ -101,22 +113,23 @@ sub update_sourcedid {
     my $urlpath = $r->urlpath;
     my $setID = $urlpath->arg("setID");
     if (!defined($setID)) {
-      warn "Not a link to a Problem Set and in homework grade mode. Links to WeBWorK should point to specific problem sets." if $ce->{debug_lti_parameters};
+      warn "Not a link to a Problem Set and in homework grade mode.".
+        " Links to WeBWorK should point to specific problem sets.";
     } else {
       my $set = $db->getUserSet($userID,$setID);
       # if set is not defined and we are going to a page with
       # is set dependent then there are problems that will be caught
       # later
       if (defined($set) &&
-	  (!defined($set->lis_source_did) ||
+	   (!defined($set->lis_source_did) ||
 	   $set->lis_source_did ne $sourcedid)) {
-	$set->lis_source_did($sourcedid);
-	$db->putUserSet($set);
+		$set->lis_source_did($sourcedid);
+		$db->putUserSet($set);
 	
       }
     }
   }
-}
+} # end update_sourcedid
 
 # computes and submits the course grade for userID to the LMS
 # the course grade is the average of all sets assigned to the user.  
@@ -131,7 +144,8 @@ sub submit_course_grade {
   my $user = $db->getUser($userID);
 
   die("$userID does not exist") unless $user;
-
+  warn "submitting all grades for user: $userID  \n" if $ce->{debug_lti_grade_passback};
+  warn "lis_source_did is not available for user: $userID \n" if !($user->lis_source_did) and $ce->{debug_lti_grade_passback};
   return $self->submit_grade($user->lis_source_did,$score);
   
 }
@@ -158,9 +172,28 @@ sub submit_set_grade {
   } else {
     $score = grade_set($db,$userSet,$userSet->set_id,$userID,0);
   }
-
+  # make debug prettier
+  my $message_string = '';
+  $message_string .= "\nmass_update: " if $self->{post_processing_mode};
+  $message_string .= "submitting grade for user: $userID set $setID ";
+  $message_string .= "-- lis_source_did is not available " unless ($userSet->lis_source_did);
+  warn($message_string."\n") if $ce->{debug_lti_grade_passback};
   return $self->submit_grade($userSet->lis_source_did,$score);
+}
 
+# error in reporting michael.gage@rochester.edu, Demo, Global $r object is not available. Set:
+# 	PerlOptions +GlobalRequest
+# in httpd.conf at /opt/rh/perl516/root/usr/local/share/perl5/CGI.pm line 346, <IN> line 76.
+# so we don't use CGI::escapeHTML in post processing mode but use this local version instead.
+
+sub local_escape_html {  # a local version of escapeHTML that works for post processing
+	my $self = shift;   # a grading object
+	my @message = @_;
+	if ($self->{post_processing_mode}) {		
+		return join('', @message);    # this goes to log files in post processing to escapeHTML is not essential
+	} else {
+		return CGI::escapeHTML(@message);  #FIXME -- why won't this work in post_processing_mode (missing $r ??)
+	}
 }
 
 # submits a score of $score to the lms with $sourcedid as the
@@ -178,7 +211,9 @@ sub submit_grade {
   # We have to fail gracefully here because some users, like instructors,
   # may not actually have a sourcedid
   if (!$sourcedid) {
-    warn("No sourcedid for this user/assignment.  Some LMS's do not provide sourcedid for instructors so this may not be a problem, or it might mean your settings are not correct.") if $ce->{debug_lti_parameters};
+#     carp("No sourcedid for this user/assignment.  Some LMS's do not provide ".
+#      "sourcedid for instructors so this may not be a problem, or it might ".
+#      "mean your settings are not correct.") if $ce->{debug_lti_grade_passback};
     return 0;
   }
   
@@ -218,32 +253,34 @@ EOS
   while (length($bodyhash) % 4) {
     $bodyhash .= '=';
   }
-
-  warn("Submitting grade using sourcedid: $sourcedid and score: $score") if
-    $ce->{debug_lti_parameters};
+  my $message2='';
+  $message2 .= "mass_update: " if $self->{post_processing_mode};
+  $message2 .= "Submitting grade using sourcedid: $sourcedid and score: $score\n";
+  warn($message2) if $ce->{debug_lti_grade_passback};
   
   my $request_url = $db->getSettingValue('lis_outcome_service_url');
-  if (!defined($request_url)) {
-    warn("Cannot submit grades to LMS, no lis_outcome_service_url");
+  
+  unless ($request_url//'' ) {
+    warn("Cannot submit grades to LMS, no request_url obtained from 'lis_outcome_service_url' ");
     return 0;
   }
 
   my $consumer_key = $db->getSettingValue('consumer_key');
-  if (!defined($consumer_key)) {
+  unless ($consumer_key//'') {
     warn("Cannot submit grades to LMS, no consumer_key");
     return 0;
   }
   
   my $signature_method = $db->getSettingValue('signature_method');
-  if (!defined($signature_method)) {
+  unless ($signature_method//'') {
     warn("Cannot submit grades to LMS, no signature_method");
     return 0;
   }
-
+  debug("found data required for submitting grades to LMS");
   my $requestGen = Net::OAuth->request("consumer");
-  
+  debug( "obtained requestGen $requestGen");
   $requestGen->add_required_message_params('body_hash');
-  
+  debug("add required message params"); 
   my $gradeRequest = $requestGen->new(
 		  request_url => $request_url,
 		  request_method => "POST",
@@ -254,8 +291,9 @@ EOS
 		  timestamp => time(),
 		  body_hash => $bodyhash
 							 );
+	debug("created grade request "). $gradeRequest;
   $gradeRequest->sign();
-	  
+	debug("signed grade request"); 
   my $HTTPRequest = HTTP::Request->new(
 	       $gradeRequest->request_method,
 	       $gradeRequest->request_url,
@@ -264,26 +302,45 @@ EOS
 		  'Content-Type'  => 'application/xml',
 	       ],
 	       $replaceResultXML,
-				      );
+		);
+    debug ("posting grade request: $HTTPRequest");
+ 
+my $response = eval {   
+   LWP::UserAgent->new->request($HTTPRequest);
+ };
+ if ($@) {
+  	warn "error sending HTTP request to LMS, $@";
+  }
 
-  my $response = LWP::UserAgent->new->request($HTTPRequest);
+# debug section
 
+
+	if ($ce->{debug_lti_grade_passback} and $ce->{debug_lti_parameters}){
+	  warn "The response is:\n ". ($self->local_escape_html(join(" ", %$response )));  
+	  warn "The request was:\n ". ($self->local_escape_html(join(" ",%$HTTPRequest))); 
+	}
+
+
+# end debug section 
   if ($response->is_success) {
     $response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
     my $message = $1;
+    warn ("result is: $message\n") if $ce->{debug_lti_grade_passback};
     if ($message ne 'success') {
-      warn("Unable to update LMS grade. Error: ".$message);
-      debug(CGI::escapeHTML($response->content));
+      debug("Unable to update LMS grade $sourcedid . LMS responded with message: ". $message) ;
       return 0;
     } else {
       # if we got here we got successes from both the post and the lms
-      return 1;
+      debug("Successfully updated LMS grade $sourcedid. LMS responded with message: ".$message );
     }
   } else {
-    warn("Unable to update LMS grade. Error: ".$response->message);
-    debug(CGI::escapeHTML($response->content));
+    debug("Unable to update LMS grade $sourcedid. Error: ".($response->message) );
+    debug(local_escape_html($response->content)); 
     return 0;
   }
+   debug("Success submitting grade using sourcedid: $sourcedid and score: $score\n") ;
+ 
+   return 1; # success
 }
 
 # does a mass update of all grades.  This is all user grades for
@@ -293,9 +350,15 @@ sub mass_update {
   my $r = $self->{r};
   my $ce = $r->{ce};
   my $db = $self->{r}->{db};
+  $self->{post_processing_mode}=1;
+  
+  # sanity check
+  warn("course environment is not defined") unless ref($ce//'');
+  warn("database reference is not defined") unless ref($db//'');
+  warn "\nperforming mass_update via LTI"  if $ce->{debug_lti_grade_passback};
     
   my $lastUpdate = $db->getSettingValue('LTILastUpdate') // 0;
-  my $updateInterval = $ce->{LTIMassUpdateInterval} // -1;
+  my $updateInterval = $ce->{LTIMassUpdateInterval} // -1; # -1 suppresses update
 
   if ($updateInterval != -1 &&
       time - $lastUpdate > $updateInterval) {
@@ -306,23 +369,29 @@ sub mass_update {
       my @users = $db->listUsers();
 
       foreach my $user (@users) {
-	$self->submit_course_grade($user);
+		$self->submit_course_grade($user);
       }
       
     } elsif ($ce->{LTIGradeMode} eq 'homework') {
       my @users = $db->listUsers();
       
       foreach my $user (@users) {
-	my @sets = $db->listUserSets($user);
-	foreach my $set (@sets) {
-
-	  $self->submit_set_grade($user,$set);
-
-	}
+		my @sets = $db->listUserSets($user);
+		warn "\nmass_update: all sets assigned to user $user :\n".join(" ",  @sets)."\n" if $ce->{debug_lti_grade_passback};
+		foreach my $set (@sets) {
+		    eval {
+		    	#$self->update_sourcedid($user);  #CHECK is this the right user id -- this doesn't update properly
+	  			$self->submit_set_grade($user,$set);
+	  		};
+	  		if ($@) {
+	  			warn "error in reporting $user, $set, $@" if $ce->{debug_lti_grade_passback};
+	  		}
+	  	
+		}
       }
     }
   }
-
+  $self->{post_processing_mode}=0; 
 }
 
 1;


### PR DESCRIPTION
This is a parallel PR to #856. This provides an improved messaging system for determining whether grades are being updated. This is particularly tricky in the post processing mass update phase where all of the sets in a course are checked against the grades recorded by the LMS. It is easy for the mass update process to fail silently.