### PR TITLE
Minor modifications to config files

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -464,20 +464,16 @@ $uneditableCourseFiles = ['simple.conf',
 # 
 # would add two buttons, one for the Rochester library and one for the ASU
 # library, provided templates/rochester and templates/asu exists either as 
-# subdirectories or links to other directories. The "NPL Directory" button
+# subdirectories or links to other directories. The "OPL Directory" button
 # activated below gives access to all the directories in the National 
 # Problem Library.
 # 
 $courseFiles{problibs}    = {
 	Library          => "OPL Directory",
-# 	rochesterLibrary => "Rochester",
-# 	unionLibrary     =>"Union",
-# 	asuLibrary       => "Arizona State",
-# 	dcdsLibrary      => "Detroit CDS",
-# 	dartmouthLibrary => "Dartmouth",
-# 	indianaLibrary   => "Indiana",
-# 	osuLibrary       => "Ohio State",	
-#   capaLibrary      => "CAPA",   # remember to create link from capaLibrary to CAPA in contrib
+	Contrib          => "Contrib", # remember to create link from Contrib to Contrib 
+	                               # library directory
+	capaLibrary      => "CAPA",    # remember to create link from capaLibrary to CAPA
+	                               # in contrib
 };
 
 ################################################################################

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -152,6 +152,10 @@ $problemLibrary{showLibraryGlobalStats} = 1;
  
 $courseFiles{problibs}    = {
 	Library          => "OPL Directory",
+    capaLibrary      => "CAPA",
+    Contrib          => "Contrib",
+# the following are not really needed but you can 
+# create links to your own private libraries this way. 
 # 	rochesterLibrary => "Rochester",
 # 	unionLibrary     => "Union",
 # 	asuLibrary       => "Arizona State",
@@ -159,7 +163,7 @@ $courseFiles{problibs}    = {
 # 	dartmouthLibrary => "Dartmouth",
 # 	indianaLibrary   => "Indiana",
 # 	osuLibrary       => "Ohio State",	
-#       capaLibrary      => "CAPA",
+
 };
 
 
@@ -382,6 +386,9 @@ $showeditors{simplepgeditor}   = 0;
 # this to work.  See http://webwork.maa.org/wiki/R_in_WeBWorK for more info.
 
 # $pg{specialPGEnvironmentVars}{Rserve} = {host => "localhost"};
+
+# use this setting when running in a docker container.
+# $pg{specialPGEnvironmentVars}{Rserve} = {host => "r"};
 
 ################################################################################
 # Authentication Methods

--- a/courses.dist/modelCourse/templates/CAPA
+++ b/courses.dist/modelCourse/templates/CAPA
@@ -1,0 +1,1 @@
+Library/Contrib/CAPA

--- a/courses.dist/modelCourse/templates/Contrib
+++ b/courses.dist/modelCourse/templates/Contrib
@@ -1,0 +1,1 @@
+Library/Contrib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: webwork
     depends_on:
       - db
+      - r
     volumes:
       - ".:/opt/webwork/webwork2"
       - "./.data/courses:/opt/webwork/courses"


### PR DESCRIPTION
These modifications make it easier (or at least more obvious) how to set up buttons in the library browser that directly access the directory trees -- e.g. "Contrib" in addition to "OPL directory"
and "CAPA".  Direct links to local libraries can be added in this way. 