### PR TITLE
Multi library support - beta version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ applets
 tmp
 logs
 courses.dist
-library-directory-tree.json
-library-subject-tree.json
-textbook-tree.json
+*library-directory-tree.json
+*library-subject-tree.json
+*textbook-tree.json
 development.yml
 *~
 !tmp/README

--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -22,6 +22,9 @@ use Cwd;
 use DBI;
 
 
+my $myLib = "OPL" ; # default value
+
+
  #(maximum varchar length is 255 for mysql version < 5.0.3.  
  #You can increase path length to  4096 for mysql > 5.0.3)
 
@@ -96,9 +99,9 @@ my $dbh = DBI->connect(
         },
 );
 
-my $libraryRoot = $ce->{problemLibrary}->{root};
+my $libraryRoot = $ce->{problemLibrary}->{$myLib}->{root};
 $libraryRoot =~ s|/+$||;
-my $libraryVersion = $ce->{problemLibrary}->{version};
+my $libraryVersion = $ce->{problemLibrary}->{$myLib}->{version};
 my $db_storage_engine = $ce->{problemLibrary_db}->{storage_engine};
 
 my $verbose = 0;
@@ -431,7 +434,7 @@ if(open(IN, "$libraryRoot/Textbooks")) {
 	close(IN);
 } else {
 	print "Textbooks file was not found in library $libraryRoot. If the path to the problem library doesn't seem
-	correct, make modifications in webwork2/conf/site.conf (\$problemLibrary{root}).  If that is correct then
+	correct, make modifications in webwork2/conf/localOverrides.conf (\$problemLibrary{OPL}{root}).  If that is correct then
 	updating from git should download the Textbooks file.\n";
 }
 #### End of textbooks
@@ -453,7 +456,7 @@ if(open(IN, "$libraryRoot/Taxonomy2")) {
 	$canopenfile = 1;
 } else {
 	print "Taxonomy file was not found in library $libraryRoot. If the path to the problem library doesn't seem
-	correct, make modifications in webwork2/conf/site.conf (\$problemLibrary{root}).  If that is correct then
+	correct, make modifications in webwork2/conf/localOverrides.conf (\$problemLibrary{OPL}{root}).  If that is correct then
 	updating from git should download the Taxonomy file.\n";
 } 
 
@@ -514,7 +517,12 @@ if($canopenfile) {
 
 #### Save the official taxonomy in json format
 my $webwork_htdocs = $ce->{webwork_dir}."/htdocs";
-my $file = "$webwork_htdocs/DATA/tagging-taxonomy.json";
+
+# Get the filename for the taxo_file which is set for THIS library via the
+# settings in conf/defaults.config and/or conf/localOverrides.conf
+my $taxo_file = $ce->{problemLibrary}->{$myLib}->{taxo};
+
+my $file = "$webwork_htdocs/DATA/${taxo_file}";
 open(OUTF, ">$file") or die "Cannot open $file";
 print OUTF to_json($tagtaxo,{pretty=>1}) or die "Cannot write to $file";
 close(OUTF);
@@ -886,7 +894,7 @@ for my $chap (@{$dbchaps}) {
 }
 
 # Now run the script build-library-tree
-# This is used to create the file library-tree.json which can be used to 
+# This is used to create the file ${myLib}-library-tree.json which can be used to
 # load in subject-chapter-section information for the OPL
 
 use strict;
@@ -960,16 +968,20 @@ foreach my $i (0..$#subjects){
 	push (@subject_tree, $clone);
 }
 
-build_library_directory_tree($ce);
-build_library_subject_tree($ce,$dbh);
-build_library_textbook_tree($ce,$dbh);
+build_library_directory_tree($myLib,$ce);
+build_library_subject_tree($myLib,$ce,$dbh);
+build_library_textbook_tree($myLib,$ce,$dbh);
 
 $dbh->disconnect;
 
-if ($ce->{problemLibrary}{showLibraryLocalStats} ||
-    $ce->{problemLibrary}{showLibraryGlobalStats}) {
-  print "\nUpdating Library Statistics.\n";
-  do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics';
+if ( $myLib eq "OPL" ) {
+    # Only the "real" OPL has Library statistics
+
+    if ($ce->{problemLibrary}{$myLib}{showLibraryLocalStats} ||
+	$ce->{problemLibrary}{$myLib}{showLibraryGlobalStats}) {
+	print "\nUpdating Library Statistics.\n";
+	do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics';
+    }
 }
 
 

--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -21,8 +21,31 @@ use File::Basename;
 use Cwd;
 use DBI;
 
+# Command line arguments
+# for some reason the first command line argument is disappearing before it gets here
 
 my $myLib = "OPL" ; # default value
+my $clearAll = 1  ; # default value - drop ALL old tables
+
+if ( ( 0 + @ARGV ) > 0 ) {
+
+  #print join("  ,  ", @ARGV );
+
+  $myLib = shift;
+
+  print "myLib = $myLib \n";
+
+  my $nextArg = "none";
+  if ( @ARGV ) {
+    $nextArg = shift ;
+    if ( $nextArg eq "noDrop" ) {
+      $clearAll = 0 ;
+      print "Received the noDrop setting.\n";
+    }
+
+  }
+}
+
 
 
  #(maximum varchar length is 255 for mysql version < 5.0.3.  
@@ -79,6 +102,26 @@ my %NPLtables = (
  pgfile_problem => 'NPL-pgfile-problem',
 );
 
+# Which tables to ALWAYS drop and recreate and which can remain
+# 1 = always drop, 0 = conditional on command-line arguments
+my %AlwayDropTables = (
+ dbsubject => 0,
+ dbchapter => 0,
+ dbsection => 0,
+ author    => 0,
+ path      => 0,
+ keyword   => 0,
+ textbook  => 0,
+ chapter   => 0,
+ section   => 0,
+ problem   => 0,
+ morelt    => 0,
+ pgfile         => 1,
+ pgfile_keyword => 1,
+ pgfile_problem => 1,
+);
+
+
 
 # Get database connection
 
@@ -133,14 +176,30 @@ if($libraryVersion eq '2.5') {
 	print "Library version is $libraryVersion; NPLtables! \n";
 }
 
+
+# Modify table names for per-library tables
+my @special_tables = qw( pgfile pgfile_keyword pgfile_problem );
+my $tmp1; my $tblName;
+foreach $tmp1 ( @special_tables ) {
+    $tblName = $tables{$tmp1};
+    #print "old table name $tblName\n";
+    if ( $libraryVersion eq '2.5') {
+	$tblName =~ s/OPL/${myLib}/;
+    } else {
+	$tblName =~ s/NPL/${myLib}/;
+    }
+    #print "new table name $tblName\n";
+    $tables{$tmp1} = $tblName;
+}
+
 @create_tables = (
-[$tables{dbsubject}, '
+["dbsubject",$tables{dbsubject}, '
 	DBsubject_id int(15) NOT NULL auto_increment,
 	name varchar(255) NOT NULL,
 	KEY DBsubject (name),
 	PRIMARY KEY (DBsubject_id)
 '],
-[$tables{dbchapter}, '
+["dbchapter",$tables{dbchapter}, '
 	DBchapter_id int(15) NOT NULL auto_increment,
 	name varchar(255) NOT NULL,
 	DBsubject_id int(15) DEFAULT 0 NOT NULL,
@@ -148,7 +207,7 @@ if($libraryVersion eq '2.5') {
 	KEY (DBsubject_id),
 	PRIMARY KEY (DBchapter_id)
 '],
-[$tables{dbsection}, '
+["dbsection",$tables{dbsection}, '
 	DBsection_id int(15) NOT NULL auto_increment,
 	name varchar(255) NOT NULL,
 	DBchapter_id int(15) DEFAULT 0 NOT NULL,
@@ -156,7 +215,7 @@ if($libraryVersion eq '2.5') {
 	KEY (DBchapter_id),
 	PRIMARY KEY (DBsection_id)
 '],
-[$tables{author}, '
+["author",$tables{author}, '
 	author_id int (15) NOT NULL auto_increment,
 	institution tinyblob,
 	lastname varchar (255) NOT NULL,
@@ -165,7 +224,7 @@ if($libraryVersion eq '2.5') {
 	KEY author (lastname(100), firstname(100)),
 	PRIMARY KEY (author_id)
 '],
-[$tables{path}, '
+["path",$tables{path}, '
 	path_id int(15) NOT NULL auto_increment,
 	path varchar(255) NOT NULL,
 	machine varchar(255),
@@ -173,7 +232,7 @@ if($libraryVersion eq '2.5') {
 	KEY (path),
 	PRIMARY KEY (path_id)
 '],
-[$tables{pgfile}, '
+["pgfile",$tables{pgfile}, '
 	pgfile_id int(15) NOT NULL auto_increment,
 	DBsection_id int(15) NOT NULL,
 	author_id int(15),
@@ -187,19 +246,19 @@ if($libraryVersion eq '2.5') {
 	MO TINYINT,
 	PRIMARY KEY (pgfile_id)
 '],
-[$tables{keyword}, '
+["keyword",$tables{keyword}, '
 	keyword_id int(15) NOT NULL auto_increment,
 	keyword varchar(256) NOT NULL,
 	KEY (keyword),
 	PRIMARY KEY (keyword_id)
 '],
-[$tables{pgfile_keyword}, '
+["pgfile_keyword",$tables{pgfile_keyword}, '
 	pgfile_id int(15) DEFAULT 0 NOT NULL,
 	keyword_id int(15) DEFAULT 0 NOT NULL,
 	KEY pgfile_keyword (keyword_id, pgfile_id),
 	KEY pgfile (pgfile_id)
 '],
-[$tables{textbook}, '
+["textbook",$tables{textbook}, '
 	textbook_id int (15) NOT NULL auto_increment,
 	title varchar (255) NOT NULL,
 	edition int (15) DEFAULT 0 NOT NULL,
@@ -209,7 +268,7 @@ if($libraryVersion eq '2.5') {
 	pubdate varchar (255),
 	PRIMARY KEY (textbook_id)
 '],
-[$tables{chapter}, '
+["chapter",$tables{chapter}, '
 	chapter_id int (15) NOT NULL auto_increment,
 	textbook_id int (15),
 	number int(3),
@@ -219,7 +278,7 @@ if($libraryVersion eq '2.5') {
 	KEY (number),
 	PRIMARY KEY (chapter_id)
 '],
-[$tables{section}, '
+["section",$tables{section}, '
 	section_id int(15) NOT NULL auto_increment,
 	chapter_id int (15),
 	number int(3),
@@ -229,7 +288,7 @@ if($libraryVersion eq '2.5') {
 	KEY (number),
 	PRIMARY KEY section (section_id)
 '],
-[$tables{problem}, '
+["problem",$tables{problem}, '
 	problem_id int(15) NOT NULL auto_increment,
 	section_id int(15),
 	number int(4) NOT NULL,
@@ -238,7 +297,7 @@ if($libraryVersion eq '2.5') {
 	KEY (section_id),
 	PRIMARY KEY (problem_id)
 '],
-[$tables{morelt}, '
+["morelt",$tables{morelt}, '
 	morelt_id int(15) NOT NULL auto_increment,
 	name varchar(255) NOT NULL,
 	DBsection_id int(15),
@@ -246,7 +305,7 @@ if($libraryVersion eq '2.5') {
 	KEY (name),
 	PRIMARY KEY (morelt_id)
 '],
-[$tables{pgfile_problem}, '
+["pgfile_problem",$tables{pgfile_problem}, '
 	pgfile_id int(15) DEFAULT 0 NOT NULL,
 	problem_id int(15) DEFAULT 0 NOT NULL,
 	PRIMARY KEY (pgfile_id, problem_id)
@@ -261,8 +320,19 @@ $dbh->do("DROP TABLE IF EXISTS `NPL-institution`");
 $dbh->do("DROP TABLE IF EXISTS `NPL-pgfile-institution`");
 
 for my $tableinfo (@create_tables) {
-	my $tabname = $tableinfo->[0];
-	my $tabinit = $tableinfo->[1];
+ 	my $tabCnm  = $tableinfo->[0];
+	my $tabname = $tableinfo->[1];
+        my $tabinit = $tableinfo->[2];
+
+# FIXME some tables should NOT be dropped on special libraries
+	if ( $clearAll == 0 ) {
+	  # Do not drop and recreate some tables
+	  if ( $AlwayDropTables{$tabCnm} == 0 ) {
+	    print "Not dropping/re-creating $tabname$tabname\n";
+	    next;
+	  }
+	}
+
 	my $query = "DROP TABLE IF EXISTS `$tabname`";
 	$dbh->do($query);
 	$query = "CREATE TABLE `$tabname` ( $tabinit ) ENGINE=$db_storage_engine";
@@ -868,29 +938,33 @@ sub pgfiles {
 
 print "\n\n";
 
-# Now prune away DBsection, etc, which do not appear in any files
-#%my $query = "SELECT chapter_id FROM `$tables{chapter}` WHERE textbook_id = \"$bookid\" AND number = \"$1\"";
-#%my $chapid = $dbh->selectrow_array($query);
+# When allowing multiple libraries, only the FIRST library should do pruning.
+if ( $clearAll == 1 ) {
 
-#select dbs.DBsection_id from OPL_DBsection dbs;
-#select COUNT(*) from OPL_pgfile where DBsection_id=857;
+    # Now prune away DBsection, etc, which do not appear in any files
+    #%my $query = "SELECT chapter_id FROM `$tables{chapter}` WHERE textbook_id = \"$bookid\" AND number = \"$1\"";
+    #%my $chapid = $dbh->selectrow_array($query);
 
-my $dbsects = $dbh->selectall_arrayref("SELECT DBsection_id from `$tables{dbsection}`");
-for my $sect (@{$dbsects}) {
+    #select dbs.DBsection_id from OPL_DBsection dbs;
+    #select COUNT(*) from OPL_pgfile where DBsection_id=857;
+
+    my $dbsects = $dbh->selectall_arrayref("SELECT DBsection_id from `$tables{dbsection}`");
+    for my $sect (@{$dbsects}) {
 	$sect = $sect->[0];
 	my $srar = $dbh->selectall_arrayref("SELECT * FROM `$tables{pgfile}` WHERE DBsection_id=$sect");
 	if(scalar(@{$srar})==0) {
 		$dbh->do("DELETE FROM `$tables{dbsection}` WHERE DBsection_id=$sect");
 	}
-}
+    }
 
-my $dbchaps = $dbh->selectall_arrayref("SELECT DBchapter_id from `$tables{dbchapter}`");
-for my $chap (@{$dbchaps}) {
+    my $dbchaps = $dbh->selectall_arrayref("SELECT DBchapter_id from `$tables{dbchapter}`");
+    for my $chap (@{$dbchaps}) {
 	$chap = $chap->[0];
 	my $srar = $dbh->selectall_arrayref("SELECT * FROM `$tables{dbsection}` WHERE DBchapter_id=$chap");
 	if(scalar(@{$srar})==0) {
 		$dbh->do("DELETE FROM `$tables{dbchapter}` WHERE DBchapter_id=$chap");
 	}
+    }
 }
 
 # Now run the script build-library-tree

--- a/bin/OPLUtils.pm
+++ b/bin/OPLUtils.pm
@@ -166,6 +166,20 @@ sub build_library_subject_tree {
 
 	my %tables = ($libraryVersion eq '2.5')? %OPLtables : %NPLtables;
 
+	# Modify table names for per-library tables
+	my @special_tables = qw( pgfile pgfile_keyword pgfile_problem );
+	my $tmp1; my $tblName;
+	foreach $tmp1 ( @special_tables ) {
+	  $tblName = $tables{$tmp1};
+	  #print "old table name $tblName\n";
+	  if ( $libraryVersion eq '2.5') {
+	    $tblName =~ s/OPL/$myLib/;
+	  } else {
+	    $tblName =~ s/NPL/$myLib/;
+	  }
+	  #print "new table name $tblName\n";
+	  $tables{$tmp1} = $tblName;
+	}
 
 	my $selectClause = "select subj.name, ch.name, sect.name, path.path,pg.filename from `$tables{dbsection}` AS sect "
 		."JOIN `$tables{dbchapter}` AS ch ON ch.DBchapter_id = sect.DBchapter_id "
@@ -319,6 +333,20 @@ sub build_library_textbook_tree {
 
 	my %tables = ($libraryVersion eq '2.5')? %OPLtables : %NPLtables;
 
+	# Modify table names for per-library tables
+	my @special_tables = qw( pgfile pgfile_keyword pgfile_problem );
+	my $tmp1; my $tblName;
+	foreach $tmp1 ( @special_tables ) {
+	  $tblName = $tables{$tmp1};
+	  #print "old table name $tblName\n";
+	  if ( $libraryVersion eq '2.5') {
+	    $tblName =~ s/OPL/$myLib/;
+	  } else {
+	    $tblName =~ s/NPL/$myLib/;
+	  }
+	  #print "new table name $tblName\n";
+	  $tables{$tmp1} = $tblName;
+	}
 
 	my $selectClause = "SELECT pg.pgfile_id from `$tables{path}` as path "
 		."LEFT JOIN `$tables{pgfile}` AS pg ON pg.path_id=path.path_id "

--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -72,7 +72,7 @@ system("chmod g+w ".$ce->{pg_dir}."/lib/chromatic");
 
 # The server should not be able to write to the OPL (for most sites)
 
-my $libroot = $ce->{problemLibrary}->{root};
+my $libroot = $ce->{problemLibrary}->{OPL}->{root};
 
 system("chown -R $me $libroot");
 system("chmod -R 755 $libroot");

--- a/bin/update-OPL-statistics
+++ b/bin/update-OPL-statistics
@@ -182,7 +182,8 @@ $dbh->commit();
 
 # check to see if the global statistics file exists and if it does, upload it.
 
-my $global_sql_file = $ce->{problemLibrary}{root}.'/OPL_global_statistics.sql';
+# FIXME - currently hardwired for OPL
+my $global_sql_file = $ce->{problemLibrary}{OPL}{root}.'/OPL_global_statistics.sql';
 
 if (-e $global_sql_file) {
 
@@ -201,6 +202,9 @@ DROP TABLE IF EXISTS OPL_global_statistics;
 EOS
   $dbh->commit();
 
+  # Added NSW
+  $dbh->disconnect();
+
   $dbuser = shell_quote($dbuser);
   $dbpass = shell_quote($dbpass);
   $db = shell_quote($db);
@@ -209,6 +213,8 @@ EOS
 
   `$mysql_command --host=$host --port=$port --user=$dbuser --password=$dbpass $db < $global_sql_file`;
 
+} else {
+  $dbh->disconnect();
 }
 
 1;

--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -280,7 +280,9 @@ BEGIN {
 
 }
 
-################################################################################
+
+use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
+use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
 
 use Carp;
 #use Crypt::SSLeay;  # needed for https
@@ -294,8 +296,56 @@ use File::Path;
 use File::Temp qw/tempdir/;
 use String::ShellQuote;
 use Cwd 'abs_path';
+use WebworkClient;
+use FormatRenderedProblem;
+#use Proc::ProcessTable; # use in standalonePGproblemRenderer
 
+use 5.10.0;
+$Carp::Verbose = 1;
 
+#############################################
+# CONFIGURE
+#
+# Configure displays for local operating system
+# This section will differ from on operating system to another
+# The default code is for the macOS and  applications commonly available on macOS.
+#############################################
+
+  
+#Default display commands.
+use constant  HTML_DISPLAY_COMMAND  => "open -a 'Google Chrome' "; # (MacOS command)
+use constant  HASH_DISPLAY_COMMAND => "";   # display tempoutputfile to STDOUT
+
+### Path to a temporary file for storing the output of sendXMLRPC.pl
+ use constant  TEMPOUTPUTDIR   => "$ENV{WEBWORK_ROOT}/DATA/"; 
+ die "You must make the directory ".TEMPOUTPUTDIR().
+     " writeable " unless -w TEMPOUTPUTDIR();
+ use constant TEMPOUTPUTFILE  => TEMPOUTPUTDIR()."temporary_output.html";
+    
+### Default path to a temporary file for storing the output 
+### of sendXMLRPC.pl
+use constant LOG_FILE => "$ENV{WEBWORK_ROOT}/DATA/xmlrpc_results.log";
+
+### Command for editing the pg source file in the browswer
+use constant EDIT_COMMAND =>"bbedit";   # for Mac BBedit editor (used as `EDIT_COMMAND() . " $file_path")
+
+### Command for editing and viewing the tex output of the pg question.
+use constant TEX_DISPLAY_COMMAND =>"open -a 'TeXShop'";
+
+### Command for editing and viewing the tex output of the pg question.
+use constant PDF_DISPLAY_COMMAND =>"open -a 'Preview'";
+
+### set display mode
+use constant DISPLAYMODE   => 'MathJax'; 
+use constant PROBLEMSEED   => '987654321'; 
+
+### verbose output when UNIT_TESTS_ON =1;
+ our $UNIT_TESTS_ON             = 0;
+
+############################################################
+# End configure displays for local operating system
+############################################################
+ 
 ############################################################
 # Read command line options
 ############################################################
@@ -321,12 +371,6 @@ my $print_resource_hash;
 my $print_help_message;
 my $read_list_from_this_file;
 my $path_to_log_file;
-
-our %credentials;
-our @path_list;
-my $credentials_string;
-
-
 GetOptions(
 	'a' 			=> \$display_ans_output1,
 	'A' 			=> \$display_ans_output2,
@@ -351,18 +395,12 @@ GetOptions(
 	'log=s'         => \$path_to_log_file,
 );
 
+
 print_help_message() if $print_help_message;
 
 ############################################################
 # End Read command line options
 ############################################################
-
-################################################################################
-
-# Move up the reading of credential files to here in order to get
-# WEBWORK_URL defined before it is needed. (For Docker installs when
-# called from outside Docker, it may not be in the environment variables.)
-
 
 ####################################################
 # get credentials
@@ -371,10 +409,9 @@ print_help_message() if $print_help_message;
 # credentials are needed
 # credentials file location -- search for one of these files 
 
+our @path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
 
-BEGIN {
-    @path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
-    $credentials_string = <<EOF;
+my $credentials_string = <<EOF;
 The credentials file should contain something like this:
 
   %credentials = (
@@ -425,113 +462,57 @@ The credentials file should contain something like this:
   
 EOF
 
-    if (defined $credentials_path and (-r $credentials_path) ) {
-	# we're all set
-    } elsif(defined $credentials_path) { #can't find credentials
-	die "Can't find credentials file $credentials_path searching\n";
-    }
+if (defined $credentials_path and (-r $credentials_path) ) {
+		# we're all set
+} elsif(defined $credentials_path) { #can't find credentials
+		die "Can't find credentials file $credentials_path searching\n";
+}
 
-    # if credentials_path not set explicitly go look for a credentials file.
-    unless (defined $credentials_path) {
+# if credentials_path not set explicitly go look for a credentials file.
+unless (defined $credentials_path) {
 	foreach my $path ( @path_list) { 
-	    print "looking for credentials file: $path. -- ".((-r $path)?'found!':'(not found)')."\n" if $verbose;
-	    next unless defined $path;
-	    if (-r $path ) {
-		$credentials_path = $path;
-		last;
-	    }
+		print "looking for credentials file: $path. -- ".((-r $path)?'found!':'(not found)')."\n" if $verbose;
+		next unless defined $path;
+		if (-r $path ) {
+			$credentials_path = $path;
+			last;
+		}
 	}
-    }
+}
 
-    # verify that a credentials file has been found
-    if  ( $credentials_path ) {
+# verify that a credentials file has been found
+if  ( $credentials_path ) { 
 	print "Credentials taken from file $credentials_path\n" if $verbose;
-    } else {  #failed to find credentials file
+} else {  #failed to find credentials file
 	die <<EOF;
 Can not find path for credentials. Looked in @path_list.
 $credentials_string
 ---------------------------------------------------------
 EOF
-    }
+}  
 
-    eval{require $credentials_path};
-    if ($@  or not  %credentials) {
+our %credentials;
+eval{require $credentials_path};
+if ($@  or not  %credentials) {
 	print STDERR $credentials_string;
 	die;
-    }
-
-    foreach my $key (sort qw(site_url webwork_url form_action_url site_password userID courseID course_password )) {
-	print STDERR "$key is missing from ".
-	    "\%credentials at $credentials_path\n" unless $credentials{$key};
-    }
-
-    # When used in the docker environment ENV{WEBWORK_URL} needs to be set
-    # since that environment variable is called in site.conf
-
-
-    $ENV{WEBWORK_URL}=$ENV{WEBWORK_URL}//$credentials{webwork_url};
-
-    if ($verbose) {
-	foreach (sort keys %credentials){print "$_ =>$credentials{$_} \n";}
-    }
 }
 
+foreach my $key (sort qw(site_url webwork_url form_action_url site_password userID courseID course_password )) {
+	print STDERR "$key is missing from ".
+				 "\%credentials at $credentials_path\n" unless $credentials{$key};
+}
 
-################################################################################
-
-
-use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
-use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
-
-use WebworkClient;
-use FormatRenderedProblem;
-#use Proc::ProcessTable; # use in standalonePGproblemRenderer
-
-use 5.10.0;
-$Carp::Verbose = 1;
-
-#############################################
-# CONFIGURE
-#
-# Configure displays for local operating system
-# This section will differ from on operating system to another
-# The default code is for the macOS and  applications commonly available on macOS.
-#############################################
+# When used in the docker environment ENV{WEBWORK_URL} needs to be set
+# since that environment variable is called in site.conf
 
 
-#Default display commands.
-use constant  HTML_DISPLAY_COMMAND  => "open -a 'Google Chrome' "; # (MacOS command)
-use constant  HASH_DISPLAY_COMMAND => "";   # display tempoutputfile to STDOUT
+	$ENV{WEBWORK_URL}=$ENV{WEBWORK_URL}//$credentials{webwork_url};
 
-### Path to a temporary file for storing the output of sendXMLRPC.pl
- use constant  TEMPOUTPUTDIR   => "$ENV{WEBWORK_ROOT}/DATA/";
- die "You must make the directory ".TEMPOUTPUTDIR().
-     " writeable " unless -w TEMPOUTPUTDIR();
- use constant TEMPOUTPUTFILE  => TEMPOUTPUTDIR()."temporary_output.html";
- 
-### Default path to a temporary file for storing the output
-### of sendXMLRPC.pl
-use constant LOG_FILE => "$ENV{WEBWORK_ROOT}/DATA/xmlrpc_results.log";
 
-### Command for editing the pg source file in the browswer
-use constant EDIT_COMMAND =>"bbedit";   # for Mac BBedit editor (used as `EDIT_COMMAND() . " $file_path")
-
-### Command for editing and viewing the tex output of the pg question.
-use constant TEX_DISPLAY_COMMAND =>"open -a 'TeXShop'";
-
-### Command for editing and viewing the tex output of the pg question.
-use constant PDF_DISPLAY_COMMAND =>"open -a 'Preview'";
-
-### set display mode
-use constant DISPLAYMODE   => 'MathJax';
-use constant PROBLEMSEED   => '987654321';
-
-### verbose output when UNIT_TESTS_ON =1;
-our $UNIT_TESTS_ON             = 0;
-
-############################################################
-# End configure displays for local operating system
-############################################################
+if ($verbose) {
+	foreach (sort keys %credentials){print "$_ =>$credentials{$_} \n";} 
+}
 
 #allow credentials to overrride the default displayMode 
 #and the browser display
@@ -809,10 +790,10 @@ sub process_problem {
 	my $xmlrpc_client = new WebworkClient (
 		url                    => $credentials{site_url},
 		form_action_url        => $credentials{form_action_url},
-		site_password          => $credentials{site_password}//'',
-		courseID               => $credentials{courseID},
-		userID                 => $credentials{userID},
-		session_key            => $credentials{session_key}//'',
+		site_password          =>  $credentials{site_password}//'',
+		courseID               =>  $credentials{courseID},
+		userID                 =>  $credentials{userID},
+		session_key            =>  $credentials{session_key}//'',
 		sourceFilePath         => $adj_file_path,
 	);
 	

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -572,6 +572,10 @@ $maxCourseIdLength = 40;
 # 
 # The problemLibrary configuration data should now be set in localOverrides.conf
 
+# 2018 - in order to support multiple installed libraries, there are changes to
+# the structure of the configuration settings.
+# the "{OPL}" was added to the path to the records for the main OPL settings.
+
 # For configuration instructions, see:
 # http://webwork.maa.org/wiki/National_Problem_Library
 # The directory containing the natinal problem library files. 
@@ -582,8 +586,8 @@ $maxCourseIdLength = 40;
 
 #RE-CONFIGURE problemLibrary values in localOverrides.conf  
 #################################################
-$problemLibrary{root}        ="/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
-$problemLibrary{version}     ="2.5"; # 2.0 for NPL, 2.5 for OPL
+$problemLibrary{OPL}{root}        ="/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
+$problemLibrary{OPL}{version}     ="2.5"; # 2.0 for NPL, 2.5 for OPL
 ###########################################################
 
 # Problem Library SQL database connection information
@@ -594,14 +598,16 @@ $problemLibrary_db = {
         storage_engine => 'MYISAM',
 };
 
-$problemLibrary{tree} = 'library-directory-tree.json';
+$problemLibrary{OPL}{tree} = 'OPL-library-directory-tree.json';
+$problemLibrary{OPL}{taxo} = 'OPL-tagging-taxonomy.json';
+
 
 # These flags control if statistics on opl problems are shown in the library
 # browser.  If you want to include local statistics you will need to
 # run webwork2/bin/update-OPL-statistics on a regular basis.  
-$problemLibrary{showLibraryLocalStats} = 1;
-# This flag controls whether global statistics will0be displayed
-$problemLibrary{showLibraryGlobalStats} = 1;
+$problemLibrary{OPL}{showLibraryLocalStats} = 1;
+# This flag controls whether global statistics will be displayed
+$problemLibrary{OPL}{showLibraryGlobalStats} = 1;
 
 ################################################################################
 # Logs

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -121,26 +121,130 @@ $webworkFiles{screenSnippets}{setHeader}         = "$webworkDirs{conf}/snippets/
 # NationalProblemLibrary -- OpenProblemLibrary
 ################################################################################
 
+# 2018 - in order to support multiple installed libraries, there are changes to
+# the structure of the configuration settings.
+# the "{OPL}" was added to the path to the records for the main OPL settings.
+
+$problemLibrary{OPL} = { }; # Create an empty hash for the OPL library records
 
 # For configuration instructions, see:
 # http://webwork.maa.org/wiki/National_Problem_Library
 # The directory containing the natinal problem library files. Set to "" if no problem
 # library is installed.
 # NationalProblemLibrary (NPL) has been renamed to OpenProblemLibrary (OPL)
-#$problemLibrary{root}        = "/opt/webwork/libraries/NationalProblemLibrary";
-#$problemLibrary{version}     = "2";
-# uncomment these lines below and comment out the line above if using OPL instead of NPL
+#$problemLibrary{OPL}{root}        = "/opt/webwork/libraries/NationalProblemLibrary";
+#$problemLibrary{OPL}{version}     = "2";
+# uncomment the 2 lines above and comment the 2 below if using NPL instead of OPL
 
-$problemLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
-$contribLibrary{root}       = "/opt/webwork/libraries/webwork-open-problem-library/Contrib";
-$problemLibrary{version}    = "2.5";  
+$problemLibrary{OPL}{root}       = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
+$contribLibrary{OPL}{root}       = "/opt/webwork/libraries/webwork-open-problem-library/Contrib";
+$problemLibrary{OPL}{version}    = "2.5";
+
+# What is the "displayed" name of this library
+$problemLibrary{OPL}{name}    = "Open Problem Library";
+
+
+# What is the name of the symbolic link from inside course template directories
+# to this library. For the main OPL the value "Library" should be used. Some
+# PG files which load other files have that value hard-coded in.
+$problemLibrary{OPL}{linkname}    = "Library"; # Do NOT change this for the OPL
+
+# Used to get internal short name from the "linkname":
+$problemLibrary{LookupTable}{Library}    = "OPL";
+
+# JSON files for this library
+$problemLibrary{OPL}{tree} = 'OPL-library-directory-tree.json';
+$problemLibrary{OPL}{taxo} = 'OPL-tagging-taxonomy.json';
+$problemLibrary{OPL}{subj} = 'OPL-library-subject-tree.json';
+$problemLibrary{OPL}{text} = 'OPL-textbook-tree.json';
 
 # These flags control if statistics on opl problems are shown in the library
 # browser.  If you want to include local statistics you will need to
 # run webwork2/bin/update-OPL-statistics on a regular basis.  
-$problemLibrary{showLibraryLocalStats} = 1;
+$problemLibrary{OPL}{showLibraryLocalStats} = 1;
 # This flag controls whether global statistics will be displayed
-$problemLibrary{showLibraryGlobalStats} = 1;
+$problemLibrary{OPL}{showLibraryGlobalStats} = 1;
+
+# ======================================================
+
+# Sample records for an additional SEARCHABLE library
+
+#$problemLibrary{TSTL1} = { }; # Empty hash for the TSTL1 library records
+
+# Where is the library root directory on the server
+#$problemLibrary{TSTL1}{root}       = "/opt/webwork/libraries/tl-01";
+
+# What table version should we use. Should match that of the OTHER libraries
+#    so we use the value set for the primary libraries
+#$problemLibrary{TSTL1}{version} = "$problemLibrary{OPL}{version}";
+
+# What is the "displayed" name of this library
+#$problemLibrary{TSTL1}{name}    = "Test Library 1";
+
+# What is the name of the symbolic link from inside course template directories
+# to this library.
+# Warning: Do NOT use the value "Library" for anything except the main OPL.
+# Some PG files in the OPL reference/load other problems under the
+# assumption that the OPL is under "Library" so we should NOT put something else there.
+#$problemLibrary{TSTL1}{linkname}    = "TestLibrary1"; # Do not call this "Library" that should be reserved for the main OPL only, as linked PG problems in the OPL expect that specific value
+
+# Set the LookupTable values used to get internal short name from the "linkname":
+#$problemLibrary{LookupTable}{TestLibrary1}    = "TSTL1";
+
+# JSON files for this library
+#$problemLibrary{TSTL1}{tree} = 'TSTL1-library-directory-tree.json';
+#$problemLibrary{TSTL1}{taxo} = 'TSTL1-tagging-taxonomy.json';
+#$problemLibrary{TSTL1}{subj} = 'TSTL1-library-subject-tree.json';
+#$problemLibrary{TSTL1}{text} = 'TSTL1-textbook-tree.json';
+
+# A present it is assumed that additional libraries will NOT have stats supports,
+# so we disable the following settings.
+#$problemLibrary{TSTL1}{showLibraryLocalStats}  = 0;
+#$problemLibrary{TSTL1}{showLibraryGlobalStats} = 0;
+
+# End of sample records for an additional SEARCHABLE library
+
+# ======================================================
+
+# Sample records for an additional SEARCHABLE library
+
+#$problemLibrary{TSTL2} = { }; # Empty hash for the TSTL1 library records
+
+# Where is the library root directory on the server
+#$problemLibrary{TSTL2}{root}       = "/opt/webwork/libraries/tl-02";
+
+# What table version should we use. Should match that of the OTHER libraries
+#    so we use the value set for the primary libraries
+#$problemLibrary{TSTL2}{version} = "$problemLibrary{OPL}{version}";
+
+# What is the "displayed" name of this library
+#$problemLibrary{TSTL2}{name}    = "Test Library 2";
+
+# What is the name of the symbolic link from inside course template directories
+# to this library.
+# Warning: Do NOT use the value "Library" for anything except the main OPL.
+# Some PG files in the OPL reference/load other problems under the
+# assumption that the OPL is under "Library" so we should NOT put something else there.
+#$problemLibrary{TSTL2}{linkname}    = "TestLibrary2"; # Do not call this "Library" that should be reserved for the main OPL only, as linked PG problems in the OPL expect that specific value
+
+# Set the LookupTable values used to get internal short name from the "linkname":
+#$problemLibrary{LookupTable}{TestLibrary2}    = "TSTL2";
+
+# JSON files for this library
+#$problemLibrary{TSTL2}{tree} = 'TSTL2-library-directory-tree.json';
+#$problemLibrary{TSTL2}{taxo} = 'TSTL2-tagging-taxonomy.json';
+#$problemLibrary{TSTL2}{subj} = 'TSTL2-library-subject-tree.json';
+#$problemLibrary{TSTL2}{text} = 'TSTL2-textbook-tree.json';
+
+# A present it is assumed that additional libraries will NOT have stats supports,
+# so we disable the following settings.
+#$problemLibrary{TSTL2}{showLibraryLocalStats}  = 0;
+#$problemLibrary{TSTL2}{showLibraryGlobalStats} = 0;
+
+# End of sample records for an additional SEARCHABLE library
+
+# ======================================================
+
 
 # Additional library buttons can be added to the Library Browser (SetMaker.pm)
 # by adding the libraries you want to the following line.  For each key=>value
@@ -322,12 +426,12 @@ $pg{options}{periodicRandomizationPeriod} = 5;
 ################################################################################
 
  $pg{specialPGEnvironmentVars}{DragMath} = 0;
- $pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools/",
- $pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools/",
- $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/CAPA_Graphics/",
- push @{$pg{directories}{macrosPath}},  
-   "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools",
-   "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools";
+ #$pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools/",
+ #$pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools/",
+ #$pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/CAPA_Graphics/",
+ #push @{$pg{directories}{macrosPath}},  
+ #  "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools",
+ #  "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools";
 
  # The link Contrib in the course templates directory should point to ../webwork-open-problem-library/Contrib 
 

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -250,6 +250,9 @@ $mail{tls_allowed} = 0;
 #
 # The problemLibrary configuration data should now be set in localOverrides.conf
 
+# 2018 - in order to support multiple installed libraries, there are changes to
+# the structure of the configuration settings.
+
 # For configuration instructions, see:
 # http://webwork.maa.org/wiki/National_Problem_Library
 # The directory containing the Open Problem Library files.
@@ -260,7 +263,7 @@ $mail{tls_allowed} = 0;
 
 #CONFIGURE problemLibrary values in this file. These settings override defaults in default.config
 #################################################
-$problemLibrary{root}        ="/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
+$problemLibrary{OPL}{root}        ="/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
 ###########################################################
 
 ################################################################################

--- a/htdocs/js/apps/SetMaker/setmaker.js
+++ b/htdocs/js/apps/SetMaker/setmaker.js
@@ -94,10 +94,12 @@ function init_webservice(command) {
 }
 
 function lib_update(who, what) {
-  var child = { subjects : 'chapters', chapters : 'sections', sections : 'count'};
+  var child = { myLibrary : 'subjects', subjects : 'chapters', chapters : 'sections', sections : 'count'};
 
   nomsg();
   var all = 'All ' + capFirstLetter(who);
+
+  if(who=='myLibrary')  { all = 'All Libraries'; }
 
   var mydefaultRequestObject = init_webservice('searchLib');
   if(mydefaultRequestObject == null) {
@@ -105,9 +107,11 @@ function lib_update(who, what) {
     // console.log("Could not get webservice request object");
     return false;
   }
+  var myLb = $('[name="library_name"]     option:selected').val();
   var subj = $('[name="library_subjects"] option:selected').val();
   var chap = $('[name="library_chapters"] option:selected').val();
   var sect = $('[name="library_sections"] option:selected').val();
+  if(myLb == 'All Libraries'){ myLb = '';};
   if(subj == 'All Subjects') { subj = '';};
   if(chap == 'All Chapters') { chap = '';};
   if(sect == 'All Sections') { sect = '';};
@@ -117,12 +121,16 @@ function lib_update(who, what) {
   if(lib_text == 'All Textbooks') { lib_text = '';};
   if(lib_textchap == 'All Chapters') { lib_textchap = '';};
   if(lib_textsect == 'All Sections') { lib_textsect = '';};
+
+  mydefaultRequestObject.library_name     = myLb;
+
   mydefaultRequestObject.library_subjects = subj;
   mydefaultRequestObject.library_chapters = chap;
   mydefaultRequestObject.library_sections = sect;
   mydefaultRequestObject.library_textbooks = lib_text;
   mydefaultRequestObject.library_textchapter = lib_textchap;
   mydefaultRequestObject.library_textsection = lib_textsect;
+
   if(who == 'count') {
     mydefaultRequestObject.command = 'countDBListings';
     // console.log(mydefaultRequestObject);
@@ -131,6 +139,7 @@ function lib_update(who, what) {
 		   data: mydefaultRequestObject,
 		   timeout: 10000, //milliseconds
 		   success: function (data) {
+
 		       if (data.match(/WeBWorK error/)) {
 			   reportWWerror(data);		   
 		       }
@@ -139,11 +148,21 @@ function lib_update(who, what) {
 		       // console.log(response);
 		       var arr = response.result_data;
 		       arr = arr[0];
-		       var line = "There are "+ arr +" matching WeBWorK problems"
-		       if(arr == "1") {
-			   line = "There is 1 matching WeBWorK problem"
+
+		       if(myLb == ''){ myLb = 'All Libraries';};
+
+
+		       var line = "There are "+ arr +" matching WeBWorK problems in " + myLb
+		       if (arr == "1") {
+			   line = "There is 1 matching WeBWorK problem in " + myLb
+		       } else if (arr == "0") {
+			   line = "There are no matching WeBWorK problem in " + myLb
+
 		       }
 		       $('#library_count_line').html(line);
+
+		       if(myLb == 'All Libraries'){ myLb = '';};
+	
 		       return true;
 		   },
 		  error: function (data) {
@@ -157,9 +176,18 @@ function lib_update(who, what) {
     setselect('library_'+who, [all]);
     return lib_update(child[who], 'clear');
   }
+  if(who=='subjects' && myLb=='') { return lib_update(who, 'clear'); }
   if(who=='chapters' && subj=='') { return lib_update(who, 'clear'); }
   if(who=='sections' && chap=='') { return lib_update(who, 'clear'); }
+
+//  if(who=='myLibrary'){ subcommand = "getAllLibraries";}
+
+  if(who=='myLibrary'){ subcommand = "getAllLibraries";}
+  if(who=='subjects') { subcommand = "getAllDBsubjects";}
+  if(who=='chapters') { subcommand = "getAllDBchapters";}
+
   if(who=='sections') { subcommand = "getSectionListings";}
+
   mydefaultRequestObject.command = subcommand;
   // console.log(mydefaultRequestObject);
     return $.ajax({type:'post',

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -3384,8 +3384,8 @@ sub upgrade_notification {
 	} 
     } 
 
-    die "Couldn't find ".$ce->{problemLibrary}{root}.'.  Are you sure $problemLibrary{root} is set correctly in localOverrides.conf?' unless
-	chdir($ce->{problemLibrary}{root}); 
+    die "Couldn't find ".$ce->{problemLibrary}{OPL}{root}.'.  Are you sure $problemLibrary{OPL}{root} is set correctly in localOverrides.conf?' unless
+	chdir($ce->{problemLibrary}{OPL}{root});
     
     if ($LibraryRemote && $LibraryBranch) {
 	# Check if there is an updated version of the OPL available
@@ -3421,11 +3421,11 @@ sub upgrade_notification {
     # Check to see if the OPL_update script has been run more recently
     # than the last pull of the library. 
     # this json file is (re)-created every time OPL-update is run. 
-    my $jsonfile = $ce->{webworkDirs}{htdocs}.'/DATA/'.$ce->{problemLibrary}{tree};
+    my $jsonfile = $ce->{webworkDirs}{htdocs}.'/DATA/'.$ce->{problemLibrary}{OPL}{tree};
     # If no json file then the OPL script needs to be run
     unless (-e $jsonfile) {
 	$upgradesAvailable = 1;
-	$upgradeMessage .= CGI::Tr(CGI::td($r->maketext('There is no library tree file for the library, you will need to run OPL-update.')));
+	$upgradeMessage .= CGI::Tr(CGI::td($r->maketext('There is no library tree file for the OPL library, you will need to run OPL-update (on the main OPL).')));
     # otherwise we need to check to see if the date on the tree file
     # is after the date on the last commit in the library
     } else {
@@ -3435,7 +3435,7 @@ sub upgrade_notification {
 	    my $lastcommit = `git log -1 --pretty=format:%at`;
 	    if ($lastcommit > $opldate) {
 		$upgradesAvailable = 1;
-		$upgradeMessage .= CGI::Tr(CGI::td($r->maketext('The library index is older than the library, you need to run OPL-update.')));
+		$upgradeMessage .= CGI::Tr(CGI::td($r->maketext('The OPL library index is older than the OPL library, you need to run OPL-update(on the main OPL).')));
 	    }
 	}
     } 

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
@@ -539,11 +539,12 @@ sub browse_library_panel {
 	my $ce = $r->ce;
 
 	# See if the problem library is installed
-	my $libraryRoot = $r->{ce}->{problemLibrary}->{root};
+	# FIXME NSW
+	my $libraryRoot = $r->{ce}->{problemLibrary}->{OPL}->{root};
 
 	unless($libraryRoot) {
 		print CGI::div({class=>'ResultsWithError', align=>"center"}, 
-			"The problem library has not been installed.");
+			"The OPL problem library has not been installed.");
 		return;
 	}
 	# Test if the Library directory link exists.  If not, try to make it
@@ -551,8 +552,8 @@ sub browse_library_panel {
 		unless(symlink($libraryRoot, "$ce->{courseDirs}->{templates}/Library")) {
 			my $msg =	 <<"HERE";
 You are missing the directory <code>templates/Library</code>, which is needed
-for the Problem Library to function.	It should be a link pointing to
-<code>$libraryRoot</code>, which you set in <code>conf/site.conf</code>.
+for the Open Problem Library to function.	It should be a link pointing to
+<code>$libraryRoot</code>, which you set in <code>conf/localOverrides.conf</code>.
 I tried to make the link for you, but that failed.	Check the permissions
 in your <code>templates</code> directory.
 HERE
@@ -561,7 +562,7 @@ HERE
 	}
 
 	# Now check what version we are supposed to use
-	my $libraryVersion = $r->{ce}->{problemLibrary}->{version} || 1;
+	my $libraryVersion = $r->{ce}->{problemLibrary}->{OPL}->{version} || 1;
 	if($libraryVersion == 1) {
 		return $self->browse_library_panel1;
 	} elsif($libraryVersion >= 2) {

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2183,14 +2183,18 @@ sub output_JS{
 
 	# This is for tagging menus (if allowed)
 	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {
-		if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/tagging-taxonomy.json') ) {
+		# Determine the proper taxonomy file to use
+		my $tagging_from = "OPL"; # FIXME, should come from settings
+		my $taxofile = $ce->{problemLibrary}->{$tagging_from}->{taxo};
+
+		if (open(TAXONOMY,  $ce->{webworkDirs}{root}.'/htdocs/DATA/${taxofile}') ) {
 			my $taxo = '[]';
 			$taxo = join("", <TAXONOMY>);
 			close TAXONOMY;
 			print qq!\n<script>var taxo = $taxo ;</script>!;
 		} else {
 			print qq!\n<script>var taxo = [] ;</script>!;
-			print qq!\n<script>alert('Could not load the OPL taxonomy from the server.');</script>!;
+			print qq!\n<script>alert('Could not load the ${tagging_from} taxonomy from the server.');</script>!;
 		}
 		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/TagWidget/tagwidget.js"}), CGI::end_script();
 	}

--- a/lib/WeBWorK/Utils/LibraryStats.pm
+++ b/lib/WeBWorK/Utils/LibraryStats.pm
@@ -66,7 +66,12 @@ sub getLocalStats {
 
     unless ($selectstm->execute($source_file)) {
       if ($selectstm->errstr =~ /Table .* doesn't exist/) {
-	warn "Couldn't find the OPL local statistics table.  Did you download the latest OPL and run update-OPL-statistics?"
+	warn "Couldn't find the OPL local statistics table.  Did you download the latest OPL and run update-OPL-statistics?";
+
+	# NSW hack - to avoid crash when no statistics
+	return {source_file => $source_file};
+	# END NSW hack
+
       }
       die $selectstm->errstr;
     }
@@ -92,7 +97,12 @@ sub getGlobalStats {
 
     unless ($selectstm->execute($source_file)) {
       if ($selectstm->errstr =~ /Table .* doesn't exist/) {
-	warn "Couldn't find the OPL global statistics table.  Did you download the latest OPL and run update-OPL-statistics?"
+	warn "Couldn't find the OPL global statistics table.  Did you download the latest OPL and run update-OPL-statistics?";
+
+	# NSW hack - to avoid crash when no statistics
+	return {source_file => $source_file};
+	# END NSW hack
+
       }
       die $selectstm->errstr;
     }

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -99,6 +99,23 @@ sub getTables {
 	} else {
 		%tables = %OPLtables;
 	}
+
+	# Modify table names for per-library tables
+	my @special_tables = qw( pgfile pgfile_keyword pgfile_problem );
+	my $tmp1; my $tblName;
+	foreach $tmp1 ( @special_tables ) {
+	    next if ( $myLib eq "" ); # Skip this
+	    $tblName = $tables{$tmp1};
+	    #print "old table name $tblName\n";
+	    if ( $ce->{problemLibrary}->{$myLib}->{version} eq "2" ) {
+	        $tblName =~ s/NPL/${myLib}/;
+	    } else {
+	        $tblName =~ s/OPL/${myLib}/;
+	    }
+	    #print "new table name $tblName\n";
+	    $tables{$tmp1} = $tblName;
+	}
+
 	return %tables;
 }
 


### PR DESCRIPTION
This is a beta version of multi-library support for the library search tools (`SetMaker.pm`). 

The configuration is more complicated, and samples are in `conf/localOverrides.conf.dist` as each library requires several settings. Several files which read library settings were modified to use the new library config structure.

Sample test libraries are available at https://github.com/taniwallach/ww-test-libs

The modified OPL-update script expects the library "code name" as in the config settings, and the second library and on should set the `noDrop` option (to prevent deletion of the database tables shared by all the libraries).

Ex:

```
/opt/webwork/webwork2/bin/OPL-update local OPL
/opt/webwork/webwork2/bin/OPL-update local TSTL1 noDrop
/opt/webwork/webwork2/bin/OPL-update local TSTL2 noDrop
```
