### PR TITLE
Hardwire the url for the WeBWorK and PG branches being used.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:16.04
 
+
+ENV WEBWORK_BRANCH WeBWorK-2.14
+ENV PG_BRANCH rel-PG-2.14
 ENV WEBWORK_URL /webwork2
-ENV WEBWORK_ROOT_URL http://localhost
+ENV WEBWORK_ROOT_URL http://localhost:8080
 ENV WEBWORK_DB_HOST db
 ENV WEBWORK_DB_PORT 3306
 ENV WEBWORK_DB_NAME webwork
@@ -80,11 +83,11 @@ RUN mkdir -p $APP_ROOT/courses $APP_ROOT/libraries $APP_ROOT/webwork2
 
 COPY VERSION /tmp
 
-RUN WEBWORK_VERSION=`cat /tmp/VERSION|sed -n 's/.*\(develop\)'\'';/\1/p' && cat /tmp/VERSION|sed -n 's/.*\([0-9]\.[0-9]*\)'\'';/PG\-\1/p'` \
-    && curl -fSL https://github.com/openwebwork/pg/archive/${WEBWORK_VERSION}.tar.gz -o /tmp/${WEBWORK_VERSION}.tar.gz \
-    && tar xzf /tmp/${WEBWORK_VERSION}.tar.gz \
-    && mv pg-${WEBWORK_VERSION} $APP_ROOT/pg \
-    && rm /tmp/${WEBWORK_VERSION}.tar.gz \
+    
+RUN curl -fSL https://github.com/openwebwork/pg/archive/${PG_BRANCH}.tar.gz -o /tmp/${PG_BRANCH}.tar.gz \
+    && tar xzf /tmp/${PG_BRANCH}.tar.gz \
+    && mv pg-${PG_BRANCH} $APP_ROOT/pg \
+    && rm /tmp/${PG_BRANCH}.tar.gz \
     && curl -fSL https://github.com/openwebwork/webwork-open-problem-library/archive/master.tar.gz -o /tmp/opl.tar.gz \
     && tar xzf /tmp/opl.tar.gz \
     && mv webwork-open-problem-library-master $APP_ROOT/libraries/webwork-open-problem-library \
@@ -92,12 +95,8 @@ RUN WEBWORK_VERSION=`cat /tmp/VERSION|sed -n 's/.*\(develop\)'\'';/\1/p' && cat 
     && curl -fSL https://github.com/mathjax/MathJax/archive/master.tar.gz -o /tmp/mathjax.tar.gz \
     && tar xzf /tmp/mathjax.tar.gz \
     && mv MathJax-master $APP_ROOT/MathJax \
-    && rm /tmp/mathjax.tar.gz \
-    && rm /tmp/VERSION
-    #curl -fSL https://github.com/openwebwork/webwork2/archive/WeBWorK-${WEBWORK_VERSION}.tar.gz -o /tmp/WeBWorK-${WEBWORK_VERSION}.tar.gz \
-    #&& tar xzf /tmp/WeBWorK-${WEBWORK_VERSION}.tar.gz \
-    #&& mv webwork2-WeBWorK-${WEBWORK_VERSION} $APP_ROOT/webwork2 \
-    #&& rm /tmp/WeBWorK-${WEBWORK_VERSION}.tar.gz \
+    && rm /tmp/mathjax.tar.gz 
+
 
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc
 
@@ -105,8 +104,10 @@ COPY . $APP_ROOT/webwork2
 
 RUN cd $APP_ROOT/webwork2/courses.dist \
     && cp *.lst $APP_ROOT/courses/ \
-    && cp -R modelCourse $APP_ROOT/courses/ \
-    && cd $APP_ROOT/pg/lib/chromatic \
+    && cp -R modelCourse $APP_ROOT/courses/ 
+    
+    
+RUN cd $APP_ROOT/pg/lib/chromatic \
     && gcc color.c -o color
 
 # setup apache

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -311,7 +311,7 @@ $webworkURLs{AuthorHelpURL}           ='http://webwork.maa.org/wiki/Category:Aut
 # <link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/math.css"/>
 
 # Location of MathJax script, used for the MathJax display mode.
-$webworkURLs{MathJax}       = "$webworkURLs{htdocs}/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full";
+$webworkURLs{MathJax}       = "$server_root_url$webworkURLs{htdocs}/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full";
 
 # Location of Tabber script, used to generate tabbed widgets.
 $webworkURLs{tabber}		= "$webworkURLs{htdocs}/js/legacy/vendor/tabber.js";


### PR DESCRIPTION
When calling MathJax include the full site address. (Appears to be needed if the port is 8080 instead of 80). (in defaults.config)

The method of guessing the PG branch from reading the webwork VERSION file is fragile.
Until we establish a firm naming scheme for branches
it is safer to require that the WeBWorK and PG branches
being used are explicitly specified in the docker file. 