### PR TITLE
Hot fix to prevent  webwork from crashing when landing on the homepag…

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -45,7 +45,7 @@ sub new {
   # sanity check
   my $ce = $r->{ce};
   my $db = $self->{r}->{db};
-  unless (ref($ce//'') and ref($db)//'') {
+  unless (ref($ce//'') and ref($db//'')) {
   	warn("course environment is not defined") unless ref($ce//'');
   	warn("database reference is not defined") unless ref($db//'');
   	croak("Could not create WeBWorK::Authen::LTIAdvanced::SubmitGrade object, missing items from request");

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -169,7 +169,7 @@ sub go {
 	# If grades are begin passed back to the lti then we peroidically
 	# update all of the grades because things can get out of sync if
 	# instructors add or modify sets.
-	if ($ce->{LTIGradeMode}) {
+	if ($ce->{LTIGradeMode} and ref($r->{db}//'')  ) {
 
 	  my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($r);
 	  


### PR DESCRIPTION
checks to prevent webwork from crashing while accessing the homepage when LTI is enabled at the site level.

The homepage does not provide a course or a database since no course has been selected yet. 