### PR TITLE
Rel ww2.14 send xmlrpc update

### DIFF
--- a/clients/pr
+++ b/clients/pr
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# inside the docker container
+# this can be called from vim with :w ! ./pr
+
+# it sends the contents of the buffer to /var/www/html/xmlrpc_out.html aka localhost:8080/xmlrpc_output.html
+
+./sendXMLRPC.pl -h - >/var/www/html/xmlrpc_out.html
+
+# process STDIN with sendXMLRPC.p and send it to /var/www/html/xmlrpc_out.html  
+# where it can be read at localhost:8080/xmlrpc_out.html
+
+
+# Not sure how to get rid of the ./
+
+# This can also be called from the command line with   cat t/input.pg |./pr

--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -2,8 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/clients/renderProblem.pl,v 1.4 2010/05/11 15:44:05 gage Exp $
+# Copyright © 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -22,6 +21,14 @@ webwork2/clients/sendXMLRPC.pl
 
 =head1 DESCRIPTION
 
+
+This module provides functions for rendering html from files outside the normal
+context of providing a webwork homework set user  an existing problem set.
+
+It can be used to create a live version of a single problem, one that is not
+part of any set, and can facilitate editing these problems outside of the 
+context of WeBWorK2. 
+
 This script will take a list of files or directories
 and send it to a WeBWorK daemon webservice
 to have it rendered.  For directories each .pg file under that 
@@ -36,7 +43,23 @@ The capital letter switches, -B, -H, and -C render the question twice.  The firs
 time returns an answer hash which contains the correct answers. The question is
 then resubmitted to the renderer with the correct answers filled in and displayed.  
 
-IMPORTANT: Create a valid credentials file.
+IMPORTANT: Create a valid credentials file (a sample file ww_credentials.dist is provided).
+	(See below.)
+	Locations where this file can be located:
+		"$ENV{HOME}/.ww_credentials"
+		"$ENV{HOME}/ww_session_credentials"
+		'ww_credentials'
+		'ww_credentials.dist'
+	The file sets the remove server and the local display/edit commands.
+
+IMPORTANT: Remember to configure:
+	1. the local output file (near the top of this script)
+	2. the display commands (in the ww_credentials file)
+	3. the remote server to contact (in the ww_credentials file)
+   Things will NOT work until the configuration is done.
+
+This script is similar to standalonePGproblemRenderer.pl. It does not require a local WeBWorK site
+on the same computer but does require an internet connection to a remote WeBWorK site.
 
 =cut
 
@@ -53,20 +76,59 @@ IMPORTANT: Create a valid credentials file.
     
     Place a credential file containing the following information at one of the locations above 
     or create a file with this information and specify it with the --credentials option.
+
+  # Cut here - top =============================================
+
+  # The sample settings below should be customized for your server and local system
+
+  %credentials = (
+    # Set the URLs of the remote site and the site password
+
+	# Test settings for the demo.webwork.rochester.edu site
+        site_url        => 'https://demo.webwork.rochester.edu',
+	form_action_url => 'https://demo.webwork.rochester.edu/webwork2/html2xml',
+        site_password   => 'xmlrpc',
+
+	# Settings for use with a local webwork system (ex. via Docker)
+	# site_url        => 'http://localhost:80',
+	# form_action_url => 'http://localhost:80/webwork2/html2xml',
+	# site_password   => 'xmlrpc',
+
+    # Set the identification credential used by the "daemon_course" on the remote site
+        courseID        => "daemon_course",
+        userID          => "daemon",
+        course_password => "daemon",
+    # Set the display mode to use
+        ww_display_mode   => "MathJax",
+    # Set the path to the LOCAL log file (make sure to create an empty file)
+	# when commented out - no file is needed
+	# path_to_log_file =>"",
+    # Set the display commands which work on the machine on which you are
+    # running sendXMLRPC.pl
+	# Sample settings for Mac:
+
+        # html_display_command   => "open -a 'Google Chrome' ", # A web browser
+	# html_display_command   => "open -a Firefox ",
+	# tex_display_command    => "open -a 'TeXShop'",	# Editor or TeX editor
+	# pdf_display_command    => "open -a 'Preview'",	# PDF viewer
+	# hash_display_command   => "cat ", 			# to diplay file to STDOUT
+
+	# ==============================
+
+	# Sample settings for Linux:
+
+	# html_display_command => "firefox", 			# A web browser
+	# html_display_command => "google-chrome",
+	# tex_display_command  => "vim",				# Editor or TeX editor
+	# tex_display_command  => "emacs",
+	# pdf_display_command  => "xpdf",				# PDF viewer
+	# pdf_display_command  => "evince",
+	# pdf_display_command  => "acroread",			# PDF viewer
+	# hash_display_command => "cat ",			# to diplay file to STDOUT
+  );
+
+  # Cut here - bottom =============================================
     
-    	%credentials = (
-    			userID                 => "my login name for the webwork course",
-    			course_password        => "my password ",
-    			courseID               => "the name of the webwork course",
-                site_url	           => "url of rendering site
-                site_password          => "site password" # preliminary access to site
-                form_action_url        =>  'http://localhost:80/webwork2/html2xml'; #action url for form
-                ww_display_mode        =>  'MathJax', # optional 
-                                          # --  'MathJax' and 'images' are the possible values           
-                html_display_command   =>  "open -a 'Google Chrome' "  # optional
-                                                      # for Mac: have Chrome read html output file
-                                                      # modify this for other platforms or browsers  
-    	);
 
 =cut
 
@@ -128,13 +190,23 @@ IMPORTANT: Create a valid credentials file.
     which are (will be)  submitted to the question.
     
 =item   -e
+
 	Open the source file in an editor. 
+	
+=item   --tex
+
+	Process question in TeX mode and output to the command line
+
+=item   --pdf 
+
+	Process question in TeX mode, convert to PDF and display.
 	
 =item   
 
 	The single letter options can be "bundled" e.g.  -vcCbB
 	
 =item  --list   pg_list
+
 	Read and process a list of .pg files contained in the file C<pg_list>.  C<pg_list>
 	consists of a sequence of lines each of which contains the full path to a pg
 	file that should be processed. (For example this might be the output from an
@@ -158,6 +230,11 @@ IMPORTANT: Create a valid credentials file.
     the PG_debug output which follows the question content.  Use in conjunction with -b or -B.
     This contains more information than printing the answer hash. (perhaps too much). 
 
+=item   --resource
+
+	Prints the resources used by the question. The information appears in 
+    the PG_debug output which follows the question content.  Use in conjunction with -b or -B.
+
 =item	--credentials=s
 
  	Specifies a file s where the  credential information can be found.
@@ -167,7 +244,14 @@ IMPORTANT: Create a valid credentials file.
        Prints help information. 
        
 =item  --log 
+
        Sets path to log file
+
+=item  --seed=s     
+                 
+       Sets problemSeed to the number contained in string s
+
+
 
 =back
 =cut
@@ -179,6 +263,17 @@ use warnings;
 #######################################################
 # Find the webwork2 root directory
 #######################################################
+BEGIN {
+	use File::Basename;
+	$main::dirname = dirname(__FILE__);
+}
+$ENV{MOD_PERL_API_VERSION} = 2;
+use lib "$main::dirname";
+#use lib "."; # is this needed?
+
+# some files such as FormatRenderedProblem.pm may need to be in the same directory
+
+
 BEGIN {
         die "WEBWORK_ROOT not found in environment. \n
              WEBWORK_ROOT can be defined in your .cshrc or .bashrc file\n
@@ -193,47 +288,25 @@ BEGIN {
 	unless (-r $WeBWorK::Constants::PG_DIRECTORY ) {
 		die "Cannot read webwork pg directory at $WeBWorK::Constants::PG_DIRECTORY";
 	}
+
 }
 
-use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
-use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
-use Crypt::SSLeay;  # needed for https
-use WebworkClient;
+################################################################################
+
+use Carp;
+#use Crypt::SSLeay;  # needed for https
+use LWP::Protocol::https;
 use Time::HiRes qw/time/;
 use MIME::Base64 qw( encode_base64 decode_base64);
 use Getopt::Long qw[:config no_ignore_case bundling];
 use File::Find;
 use FileHandle;
+use File::Path;
+use File::Temp qw/tempdir/;
+use String::ShellQuote;
 use Cwd 'abs_path';
 
-#############################################
-# Configure displays for local operating system
-#############################################
 
-### verbose output when UNIT_TESTS_ON =1;
- our $UNIT_TESTS_ON             = 0;
-  
-#Default display commands.
-use constant  HTML_DISPLAY_COMMAND  => "open -a 'Google Chrome' "; # (MacOS command)
-#use constant  HASH_DISPLAY_COMMAND => "";   # display tempoutputfile to STDOUT
-
-### Path to a temporary file for storing the output of renderProblem.pl
- use constant  TEMPOUTPUTDIR   => "$ENV{WEBWORK_ROOT}/DATA/"; 
- die "You must make the directory ".TEMPOUTPUTDIR().
-     " writeable " unless -w TEMPOUTPUTDIR();
- use constant TEMPOUTPUTFILE  => TEMPOUTPUTDIR()."temporary_output.html";
-    
-### Default path to a temporary file for storing the output of sendXMLRPC.pl
-use constant LOG_FILE => "$ENV{WEBWORK_ROOT}/DATA/xmlrpc_results.log";
-
-### set display mode
-use constant DISPLAYMODE   => 'MathJax'; 
-use constant PROBLEMSEED   => '987654321'; 
-
-############################################################
-# End configure
-############################################################
- 
 ############################################################
 # Read command line options
 ############################################################
@@ -250,100 +323,246 @@ my $verbose = '';
 my $credentials_path;
 my $format = 'standard';
 my $edit_source_file = '';
+my $display_tex_output='';
+my $display_pdf_output='';
 my $print_answer_hash;
 my $print_answer_group;
 my $print_pg_hash;
+my $print_resource_hash;
 my $print_help_message;
 my $read_list_from_this_file;
 my $path_to_log_file;
+my $problemSeed;
+
+our %credentials;
+our @path_list;
+my $credentials_string;
+
+
 GetOptions(
-	'a' => \$display_ans_output1,
-	'A' => \$display_ans_output2,
-	'b' => \$display_html_output1,
-	'B' => \$display_html_output2,
-	'h' => \$display_hash_output1,
-	'H' => \$display_hash_output2,
-	'c' => \$record_ok1, # record_problem_ok1 needs to be written
-	'C' => \$record_ok2,
-	'v' => \$verbose,
-	'e' => \$edit_source_file, 
-	'list=s' =>\$read_list_from_this_file,   # read file containing list of full file paths
+	'a' 			=> \$display_ans_output1,
+	'A' 			=> \$display_ans_output2,
+	'b' 			=> \$display_html_output1,
+	'B' 			=> \$display_html_output2,
+	'h' 			=> \$display_hash_output1,
+	'H' 			=> \$display_hash_output2,
+	'c' 			=> \$record_ok1, # record_problem_ok1 needs to be written
+	'C' 			=> \$record_ok2,
+	'v' 			=> \$verbose,
+	'e' 			=> \$edit_source_file, 
+	'tex' 			=> \$display_tex_output,
+	'pdf' 			=> \$display_pdf_output,
+	'list=s' 		=>\$read_list_from_this_file,   # read file containing list of full file paths
 	'pg' 			=> \$print_pg_hash,
 	'anshash' 		=> \$print_answer_hash,
 	'ansgrp'  		=> \$print_answer_group,
+	'resource'      => \$print_resource_hash,
 	'f=s' 			=> \$format,
 	'credentials=s' => \$credentials_path,
 	'help'          => \$print_help_message,
 	'log=s'         => \$path_to_log_file,
+	'seed=s'        => \$problemSeed,   
 );
 
-
 print_help_message() if $print_help_message;
+
+############################################################
+# End Read command line options
+############################################################
+
+################################################################################
+
+# Move up the reading of credential files to here in order to get
+# WEBWORK_URL defined before it is needed. (For Docker installs when
+# called from outside Docker, it may not be in the environment variables.)
 
 
 ####################################################
 # get credentials
 ####################################################
 
+# credentials are needed
 # credentials file location -- search for one of these files 
 
-our @path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
 
-my $credentials_string = <<EOF;
-The credentials file should contain this:
-	%credentials = (
-			userID              => "my login name for the webwork course",
-			course_password     => "my password ",
-			courseID            => "the name of the webwork course",
-            site_url	        => "url of rendering site",
-            site_password       => "site password", # preliminary access to site
-            form_action_url     =>  'http://localhost:80/webwork2/html2xml', #action url for form
-            ww_display_mode       =>  'MathJax', # optional 
-                                               # --  'MathJax' and 'images' are the possible values
-            html_display_command  =>  "open -a 'Google Chrome' "  # optional
-                                                      # for Mac: have Chrome read html output file
-                                                      # modify this for other platforms or browsers
-	);
-1;
+
+@path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
+$credentials_string = <<EOF;
+The credentials file should contain something like this:
+
+  %credentials = (
+    # Set the URLs of the remote site and the site password
+
+	# Test settings for the demo.webwork.rochester.edu site
+        site_url        => 'https://demo.webwork.rochester.edu',
+	form_action_url => 'https://demo.webwork.rochester.edu/webwork2/html2xml',
+        site_password   => 'xmlrpc',
+
+	# Settings for use with a local webwork system (ex. via Docker)
+	# site_url        => 'http://localhost:80',
+	# form_action_url => 'http://localhost:80/webwork2/html2xml',
+	# site_password   => 'xmlrpc',
+
+    # Set the identification credential used by the "daemon_course" on the remote site
+        courseID        => "daemon_course",
+        userID          => "daemon",
+        course_password => "daemon",
+    # Set the display mode to use
+        ww_display_mode   => "MathJax",
+    # Set the path to the LOCAL log file (make sure to create an empty file)
+	# when commented out - no file is needed
+	# path_to_log_file =>"",
+    # Set the display commands which work on the machine on which you are
+    # running sendXMLRPC.pl
+	# Sample settings for Mac:
+
+    # html_display_command   => "open -a 'Google Chrome' ", # A web browser
+	# html_display_command   => "open -a Firefox ",
+	# tex_display_command    => "open -a 'TeXShop'",	# Editor or TeX editor
+	# pdf_display_command    => "open -a 'Preview'",	# PDF viewer
+	# hash_display_command   => "cat ", 			# to diplay file to STDOUT
+
+	# ==============================
+
+	# Sample settings for Linux:
+
+	# html_display_command => "firefox", 			# A web browser
+	# html_display_command => "google-chrome",
+	# tex_display_command  => "vim",				# Editor or TeX editor
+	# tex_display_command  => "emacs",
+	# pdf_display_command  => "xpdf",				# PDF viewer
+	# pdf_display_command  => "evince",
+	# pdf_display_command  => "acroread",			# PDF viewer
+	# hash_display_command => "cat ",			# to diplay file to STDOUT
+  );
+  
 EOF
+if (defined $credentials_path and (-r $credentials_path) ) {
+# we're all set
+} elsif(defined $credentials_path) { #can't find credentials
+die  "Can't find credentials file $credentials_path searching\n";
+}
 
-foreach my $path ($credentials_path, @path_list) { # look in specified credentials first
-	next unless defined $path;
-	if (-r $path ) {
-		$credentials_path = $path;
-		last;
+# if credentials_path not set explicitly go look for a credentials file.
+unless (defined $credentials_path) {
+	foreach my $path ( @path_list) { 
+	    print STDERR "looking for credentials file: $path. -- ".((-r $path)?'found!':'(not found)')."\n" if $verbose;
+	    next unless defined $path;
+	    if (-r $path ) {
+			$credentials_path = $path;
+			last;
+	    }
 	}
 }
-if  ( $credentials_path ) { 
-	print "Credentials taken from file $credentials_path\n" if $verbose;
-} else {
+
+# verify that a credentials file has been found
+if  ( $credentials_path ) {
+	print STDERR "Credentials taken from file $credentials_path\n" if $verbose;
+} else {  #failed to find credentials file
 	die <<EOF;
-Can't find path for credentials. Looked in @path_list.
+Can not find path for credentials. Looked in @path_list.
 $credentials_string
 ---------------------------------------------------------
 EOF
-}  
+}
 
-our %credentials;
 eval{require $credentials_path};
 if ($@  or not  %credentials) {
-	foreach my $key (qw(userID courseID course_password XML_URL XML_PASSWORD FORM_ACTION_URL)) {
-		print STDERR "$key is missing from ".
-		             "\%credentials at $credentials_path\n" unless $credentials{$key};
-	}
 	print STDERR $credentials_string;
 	die;
 }
 
-if ($verbose) {
-	foreach (keys %credentials){print "$_ =>$credentials{$_} \n";} 
+foreach my $key (sort qw(site_url webwork_url form_action_url site_password userID courseID course_password )) {
+	print STDERR "$key is missing from ".
+	"\%credentials at $credentials_path\n" unless $credentials{$key};
 }
 
-#allow credentials to overrride the default displayMode and the browser display
-our $HTML_DISPLAY_COMMAND = $credentials{html_display_command}//HTML_DISPLAY_COMMAND();
-#our $HASH_DISPLAY_COMMAND = $credentials{hashdisplayCommand}//HASH_DISPLAY_COMMAND();
+# When used in the docker environment ENV{WEBWORK_URL} needs to be set
+# since that environment variable is called in site.conf
 
+
+$ENV{WEBWORK_URL}=$ENV{WEBWORK_URL}//$credentials{webwork_url};
+
+if ($verbose) {
+	foreach (sort keys %credentials){print STDERR "$_ =>$credentials{$_} \n";}
+}
+
+
+
+################################################################################
+
+
+use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
+use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
+
+use WebworkClient;
+use FormatRenderedProblem;
+#use Proc::ProcessTable; # use in standalonePGproblemRenderer
+
+use 5.10.0;
+$Carp::Verbose = 1;
+
+#############################################
+# CONFIGURE
+#
+# Configure displays for local operating system
+# This section will differ from on operating system to another
+# The default code is for the macOS and  applications commonly available on macOS.
+#############################################
+
+
+#Default display commands.
+use constant  HTML_DISPLAY_COMMAND  => "open -a 'Google Chrome' "; # (MacOS command)
+use constant  HASH_DISPLAY_COMMAND => "";   # display tempoutputfile to STDOUT
+
+### Path to a temporary file for storing the output of sendXMLRPC.pl
+ use constant  TEMPOUTPUTDIR   => "$ENV{WEBWORK_ROOT}/DATA/";
+ die "You must make the directory ".TEMPOUTPUTDIR().
+     " writeable " unless -w TEMPOUTPUTDIR();
+ use constant TEMPOUTPUTFILE  => TEMPOUTPUTDIR()."temporary_output.html";
+ 
+### Default path to a temporary file for storing the output
+### of sendXMLRPC.pl
+use constant LOG_FILE => "$ENV{WEBWORK_ROOT}/DATA/xmlrpc_results.log";
+
+### Command for editing the pg source file in the browswer
+use constant EDIT_COMMAND =>"bbedit";   # for Mac BBedit editor (used as `EDIT_COMMAND() . " $file_path")
+
+### Command for editing and viewing the tex output of the pg question.
+use constant TEX_DISPLAY_COMMAND =>"open -a 'TeXShop'";
+
+### Command for editing and viewing the tex output of the pg question.
+use constant PDF_DISPLAY_COMMAND =>"open -a 'Preview'";
+
+### set display mode
+use constant DISPLAYMODE   => 'MathJax';
+use constant PROBLEMSEED   => '987654321';
+
+### verbose output when UNIT_TESTS_ON =1;
+our $UNIT_TESTS_ON             = 0;
+
+############################################################
+# End configure displays for local operating system
+############################################################
+
+#allow credentials to overrride the default displayMode 
+#and the browser display
+our $HTML_DISPLAY_COMMAND = $credentials{html_display_command}//HTML_DISPLAY_COMMAND();
+our $HASH_DISPLAY_COMMAND = $credentials{hash_display_command}//HASH_DISPLAY_COMMAND();
 our $DISPLAYMODE          = $credentials{ww_display_mode}//DISPLAYMODE();
+our $TEX_DISPLAY_COMMAND  = $credentials{tex_display_command}//TEX_DISPLAY_COMMAND();
+our $PDF_DISPLAY_COMMAND  = $credentials{pdf_display_command}//PDF_DISPLAY_COMMAND();
+
+##################################################
+#  END gathering credentials for client
+##################################################
+
+##################################################
+# create course environment and create log files
+##################################################
+
+# course environment is provided by caller and credentials for sendXMLRPC
+
 $path_to_log_file         = $path_to_log_file //$credentials{path_to_log_file}//LOG_FILE();  #set log file path.
 
 eval { # attempt to create log file
@@ -351,11 +570,12 @@ eval { # attempt to create log file
 	open(FH, '>>',$path_to_log_file) or die "Can't open file $path_to_log_file for writing";
 	close(FH);	
 };
+
 die "You must first create an output file at $path_to_log_file
      with permissions 777 " unless -w $path_to_log_file;
 
 ##################################################
-#  END gathering credentials for client
+#  set default inputs for the problem
 ##################################################
 
 ############################################
@@ -372,7 +592,8 @@ my $default_input = {
 
 my $default_form_data = { 
 		displayMode				=> $DISPLAYMODE,
-		outputformat 			=> $format,
+		outputformat 			=> $format//'standard',
+		problemSeed             => $problemSeed//PROBLEMSEED(),
 };
 
 ##################################################
@@ -382,6 +603,7 @@ my $default_form_data = {
 ##################################################
 #  MAIN SECTION gather and process problem template files
 ##################################################
+my $cg_start = time; # this is Time::HiRes's time, which gives floating point values
 
 our @files_and_directories = @ARGV;
 # print "files ", join("|", @files_and_directories), "\n";
@@ -410,11 +632,13 @@ if ($read_list_from_this_file) {
 		if (-d $item) {  # if the item is a directory traverse the tree
 			my $dir = abs_path($item);
 			find(\&wanted, ($dir));
+		} elsif ($item eq "-") {
+			process_pg_file($item);              # process STDIN
 		} elsif (-f $item) { # if the item is a file process it.
 			my $file_path = abs_path($item);
-			next unless $file_path =~ /\.pg$/;
-			next if $file_path =~ /\-text\.pg$/;
-			next if $file_path =~ /header/i;
+			next unless $file_path =~ /\.pg$/;   # only process pg files
+			next if $file_path =~ /\-text\.pg$/; # don't process auxiliary include files
+			next if $file_path =~ /header/i;     # don't process header files
 			process_pg_file($file_path);
 		} else {
 			print "$item cannot be found or read\n";
@@ -432,6 +656,11 @@ sub wanted {
 }
 
 
+
+##########################################################
+#  Subroutines
+##########################################################
+
 #######################################################################
 # Process the pg file
 #######################################################################
@@ -440,19 +669,38 @@ sub process_pg_file {
 	my $file_path = shift;
 	my $NO_ERRORS = "";
 	my $ALL_CORRECT = "";
-	my $problemSeed1 = 1112;
 	my $form_data1 = { %$default_form_data,
-					  problemSeed => $problemSeed1};
+					  };
 
-	my ($error_flag, $xmlrpc_client, $error_string) = 
+	if ($display_tex_output or $display_pdf_output) {
+		my $form_data2 = {
+			%$form_data1,
+			displayMode  =>'tex',
+			outputformat => 'tex',
+		};
+		print "process tex files\n" if $UNIT_TESTS_ON;
+		my ($error_flag, $formatter, $error_string) = 
+	    	process_problem($file_path, $default_input, $form_data2);
+	    	
+	    # create tex file for both and tex and pdf output
+	    my $tex_file_name = create_tex_output($file_path, $formatter);
+	    # display tex file if --tex option is set 
+	    if ($display_tex_output) {	    
+	    	system($TEX_DISPLAY_COMMAND." ".TEMPOUTPUTDIR().$tex_file_name);
+	    } elsif($display_pdf_output) { # process tex file to create pdf file and display if --pdf option
+	    	my $pdf_path = create_pdf_output($tex_file_name); 
+	    	system($PDF_DISPLAY_COMMAND." ".$pdf_path);	    
+	    }
+	}
+	my ($error_flag, $formatter, $error_string) = 
 	    process_problem($file_path, $default_input, $form_data1);
 	# extract and display result
 		#print "display $file_path\n";
 		edit_source_file($file_path) if $edit_source_file;
-		display_html_output($file_path, $xmlrpc_client->formatRenderedProblem) if $display_html_output1;
-		display_hash_output($file_path, $xmlrpc_client->return_object) if $display_hash_output1;
-		display_ans_output($file_path, $xmlrpc_client->return_object) if $display_ans_output1;
-		$NO_ERRORS = record_problem_ok1($error_flag, $xmlrpc_client, $file_path) if $record_ok1;      
+		display_html_output($file_path, $formatter) if $display_html_output1;
+		display_hash_output($file_path, $formatter) if $display_hash_output1;
+		display_ans_output($file_path, $formatter) if $display_ans_output1;
+		$NO_ERRORS = record_problem_ok1($error_flag, $formatter, $file_path) if $record_ok1;      
 		
 		unless ($display_html_output2 or $display_hash_output2 or $display_ans_output2 or $record_ok2) {
 			print "DONE -- $NO_ERRORS -- \n"if $verbose;
@@ -464,12 +712,13 @@ sub process_pg_file {
 
 	my %correct_answers = (); 
 	my $some_correct_answers_not_specified = 0;
-	foreach my $ans_id (keys %{$xmlrpc_client->return_object->{answers}} ) {
-		my $ans_obj = $xmlrpc_client->return_object->{answers}->{$ans_id};
-		my $answergroup = $xmlrpc_client->return_object->{PG_ANSWERS_HASH}->{$ans_id};
+	foreach my $ans_id (keys %{$formatter->return_object->{answers}} ) {
+		my $ans_obj = $formatter->return_object->{answers}->{$ans_id};
+		# the answergrps are in PG_ANSWERS_HASH
+		my $answergroup = $formatter->return_object->{PG_ANSWERS_HASH}->{$ans_id};
 		my @response_order = @{$answergroup->{response}->{response_order}};
 		#print scalar(@response_order), " first response $response_order[0] $ans_id\n";
-		$ans_obj->{type} = $ans_obj->{type}//'';
+		$ans_obj->{type} = $ans_obj->{type}//'';  #make sure it's defined.
 		if ($ans_obj->{type} eq 'MultiAnswer') { 
 		    # singleResponse multianswer type
 		    # an outrageous hack
@@ -502,15 +751,16 @@ sub process_pg_file {
 				#print "responding to matrix answer with several ans_blanks\n";
 				#print "responses", join(" ", %{$answergroup->{response}->{responses}}),"\n";
 				#print "correct answer ", $ans_obj->{correct_value}, "\n";
-				my $ans_str = ($ans_obj->{correct_ans})//($ans_obj->{correct_value});
-				$ans_str =~ s/\[//g;
+                my $ans_str = ($ans_obj->{correct_value})//($ans_obj->{correct_ans}); #(correct_ans can have html formatting -- not good)				$ans_str =~ s/\[//g;
 				$ans_str =~ s/\]//g;
 				my @ans_array = split(/\s*,\s*/, $ans_str);
 				foreach my $response_id (@response_order) {
 					$correct_answers{$response_id} = shift @ans_array;
 				}
 			} else {
-				warn "responding to an answer evaluator of type |".$ans_obj->{type}. "|  with ".scalar(@response_order)." ans_blanks: ", join(" ",@response_order),"\n";
+				warn "responding to an answer evaluator of type |".$ans_obj->{type}. 
+				  "|  with ".scalar(@response_order)." ans_blanks: ", 
+				   join(" ",@response_order),"\n" if $UNIT_TESTS_ON;
 				$correct_answers{$ans_id}=($ans_obj->{correct_ans})//($ans_obj->{correct_value})//'';
 			}
 		}
@@ -526,19 +776,25 @@ sub process_pg_file {
 	} #end loop collecting correct answers. 
 	# adjust input and reinitialize form_data
 	my $form_data2 = { %$default_form_data,
-				   problemSeed => $problemSeed1,
 				   answersSubmitted => 1,
 				   WWsubmit         => 1, # grade answers
 				   WWcorrectAns          => 1, # show correct answers
 				   %correct_answers
 				};
-	($error_flag, $xmlrpc_client, $error_string)=();
-	($error_flag, $xmlrpc_client, $error_string) = 
+
+	my $pg_start = time; # this is Time::HiRes's time, which gives floating point values
+
+	($error_flag, $formatter, $error_string)=();
+	($error_flag, $formatter, $error_string) = 
 			process_problem($file_path, $default_input, $form_data2);
-	display_html_output($file_path, $xmlrpc_client->formatRenderedProblem) if $display_html_output2;
-	display_hash_output($file_path, $xmlrpc_client->return_object) if $display_hash_output2;
-	display_ans_output($file_path, $xmlrpc_client->return_object) if $display_ans_output2;
-	$ALL_CORRECT = record_problem_ok2($error_flag, $xmlrpc_client, $file_path, $some_correct_answers_not_specified) if $record_ok2;      
+	my $pg_stop = time;
+	my $pg_duration = $pg_stop-$pg_start;
+
+	display_html_output($file_path, $formatter) if $display_html_output2;
+	display_hash_output($file_path, $formatter) if $display_hash_output2;
+	display_ans_output($file_path, $formatter) if $display_ans_output2;
+	$ALL_CORRECT = record_problem_ok2($error_flag, $formatter, $file_path, $some_correct_answers_not_specified, $pg_duration) if $record_ok2;      
+	#print "display the correct answers here";
 	display_inputs(%correct_answers) if $verbose;  # choice of correct answers submitted 
 	# should this information on what answers are being submitted have an option switch?
 
@@ -549,25 +805,358 @@ sub process_pg_file {
 # Auxiliary subroutines
 #######################################################################
 
+sub process_problem {
+	my $file_path = shift;
+	my $input    = shift;
+	my $form_data  = shift;
+	# %credentials is global
 
-sub display_inputs {
-	my %correct_answers = @_;
-	foreach my $key (sort keys %correct_answers) {
-		print "$key => $correct_answers{$key}\n";
+	### get source and correct file_path name so that it is relative to templates directory
+
+	my ($adj_file_path, $source) = get_source($file_path);
+	#print "find file at $adj_file_path ", length($source), "\n";
+
+
+	### build client
+	my $xmlrpc_client = new WebworkClient (
+		url                    => $credentials{site_url},
+		form_action_url        => $credentials{form_action_url},
+		site_password          => $credentials{site_password}//'',
+		courseID               => $credentials{courseID},
+		userID                 => $credentials{userID},
+		session_key            => $credentials{session_key}//'',
+		sourceFilePath         => $adj_file_path,
+	);
+	
+	### update client
+	$xmlrpc_client->encodeSource($source);
+	$xmlrpc_client->form_data( $form_data	);
+	
+	### update inputs
+	my $problemSeed = $form_data->{problemSeed};
+	die "problem seed not defined in sendXMLRPC::process_problem" unless $problemSeed;
+
+	my $updated_input = {%$input, 
+					  envir => $xmlrpc_client->environment(
+							   fileName       => $adj_file_path,
+							   sourceFilePath => $adj_file_path,
+							   problemSeed    => $problemSeed,),
+	};
+
+	$form_data->{showAnsGroupInfo} 		= $print_answer_group;
+	$form_data->{showAnsHashInfo}       = $print_answer_hash;
+	$form_data->{showPGInfo}	        = $print_pg_hash;
+	$form_data->{showResourceInfo}	    = $print_resource_hash;
+	
+
+
+	##################################################
+	# Process the pg file
+	##################################################
+	### store the time before we invoke the content generator
+	my $cg_start = time; # this is Time::HiRes's time, which gives floating point values
+
+	############################################
+	# Call server via xmlrpc_client to render problem
+	############################################
+	
+	our($return_object, $error_flag, $error_string);
+	$error_flag=0; $error_string=''; 
+	
+	
+	
+	
+	   
+	$return_object = $xmlrpc_client->xmlrpcCall('renderProblem', $updated_input);
+	
+	#######################################################################
+	# Handle errors
+	#######################################################################
+	
+	unless ( $xmlrpc_client->fault  )    {
+		print "\n\n Result of renderProblem \n\n" if $UNIT_TESTS_ON;
+		print pretty_print_rh($return_object) if $UNIT_TESTS_ON;
+	    if (not defined $return_object) {  #FIXME make sure this is the right error message if site is unavailable
+	    	$error_string = "0\t Could not connect to rendering site ". $xmlrpc_client->{url}."\n";
+	    } elsif (defined($return_object->{flags}->{error_flag}) and $return_object->{flags}->{error_flag} ) {
+			$error_string = "0\t $file_path has errors\n";
+		} elsif (defined($return_object->{errors}) and $return_object->{errors} ){
+			$error_string = "0\t $file_path has syntax errors\n";
+		}
+		$error_flag=1 if $return_object->{errors};
+	} else {
+		$error_flag=1;
+		$error_string = $xmlrpc_client->return_object;  # error report		
+	}	
+	
+##################################################
+# Create FormatRenderedProblems object	-- not needed for sendXMLRPC
+##################################################
+
+	##################################################
+	# log elapsed time
+	##################################################
+	my $scriptName = 'sendXMLRPC';
+	my $cg_end = time;
+	my $cg_duration = $cg_end - $cg_start;
+	WebworkClient::writeRenderLogEntry("", 
+	"{script:$scriptName; file:$file_path; ". 
+	sprintf("duration: %.3f sec;", $cg_duration).
+	" url: $credentials{site_url}; }",'');
+	
+	#######################################################################
+	# End processing of the pg file
+	#######################################################################
+	my $formatter = $xmlrpc_client; ## for compatibility with standalonePGproblemRenderer
+	return $error_flag, $formatter, $error_string;
+}
+
+
+
+sub create_pdf_output {
+	my $tex_file_name = shift;
+	my @errors=();   
+	print "pdf mode\n" if $UNIT_TESTS_ON;
+	my $pdf_file_name = $tex_file_name;
+	$pdf_file_name =~ s/\.\w+$/\.pdf/;    # replace extension with pdf
+	
+	##########################################
+	# create working directory
+	##########################################
+	
+	# create a randomly-named working directory in the TEMPOUTPUTDIR() directory
+	my $working_dir_path = eval { tempdir("work.XXXXXXXX", DIR => TEMPOUTPUTDIR()) };
+	if ($@) {
+		push @errors, "Couldn't create temporary working directory: $@";
+	}
+	# make sure the directory can be read by other daemons e.g. lighttpd
+	chmod 0755, $working_dir_path;
+
+	# do some error checking
+	unless (-e $working_dir_path) {
+		push @errors, "Temporary directory ".$working_dir_path
+			." does not exist, but creation didn't fail. This shouldn't happen.";
+	}
+	unless (-w $working_dir_path) {
+		push @errors, "Temporary directory ".$working_dir_path
+			." is not writeable.";
+
+	}
+	
+	# catch errors if directory is not made (should be global, outside subroutine)
+	if (@errors) {
+		print "There were errors in creating the working directory for processing tex to pdf. \n".
+	      join("\n", @errors);
+	    delete_temp_dir($working_dir_path);
+	    return 0; # FAIL if no working directory
+	}
+	
+	
+	########################################
+	# try to mv the tex file into the working directory
+	########################################
+
+	my $src_path = TEMPOUTPUTDIR().$tex_file_name;
+	my $dest_path = "$working_dir_path/$tex_file_name";
+	my $mv_cmd = "2>&1 mv ". shell_quote("$src_path", "$dest_path");
+	my $mv_out = readpipe $mv_cmd;
+	if ($?) {
+		push @errors, "Failed to rename $src_path  to "
+			."$dest_path in directory \n"
+			."$mv_out";
+		print join("\n",@errors);
+	}
+
+	##########################################
+	# process tex file to pdf  (if working directory was created)
+	##########################################
+	@errors =();  # reset errors
+	
+	my $tex_file_path = $dest_path;
+	my $pdf_path = "$working_dir_path/$pdf_file_name";
+	print "pdflatex $tex_file_path\n" if $UNIT_TESTS_ON;
+	
+	# call pdflatex - we don't want to chdir in the mod_perl process, as
+	# that might step on the feet of other things (esp. in Apache 2.0)
+	my $pdflatex_cmd = "cd " . shell_quote($working_dir_path) . " && "
+		. "pdflatex"
+		. " $tex_file_name >pdflatex.stdout 2>pdflatex.stderr hardcopy";
+	if (my $rawexit = system $pdflatex_cmd) {
+		my $exit = $rawexit >> 8;
+		my $signal = $rawexit & 127;
+		my $core = $rawexit & 128;
+		push @errors, "Failed to convert TeX to PDF with command $pdflatex_cmd))"
+			." (exit=$exit signal=$signal core=$core).";
+		
+		# read hardcopy.log and report first error
+		my $hardcopy_log = "$working_dir_path/$tex_file_name";
+		$hardcopy_log =~ s/\.tex$/\.log/;   # replace extension
+		if (-e $hardcopy_log) {
+			if (open my $LOG, "<", $hardcopy_log) {
+				my $line;
+				while ($line = <$LOG>) {
+					last if $line =~ /^!\s+/;
+				}
+				my $first_error = $line;
+				while ($line = <$LOG>) {
+					last if $line =~ /^!\s+/;
+					$first_error .= $line;
+				}
+				close $LOG;
+				if (defined $first_error) {
+					push @errors, "First error in TeX log is: $first_error";
+				} else {
+					push @errors, "No errors encoundered in TeX log.";
+				}
+			} else {
+				push @errors, "Could not read TeX log: $!";
+			}
+		} else {
+			push @errors, "No TeX log was found.";
+		}
+	}
+	
+	########################################
+	# try to rename the pdf file
+	########################################
+
+	my $src_path1 = $pdf_path;
+	my $final_pdf_path = TEMPOUTPUTDIR().$pdf_file_name;
+	my $mv_cmd1 = "2>&1 mv ". shell_quote("$src_path1", "$final_pdf_path");
+	my $mv_out1 = readpipe $mv_cmd1;
+	if ($?) {
+		push @errors, "Failed to rename $src_path  to "
+			."$final_pdf_path in directory \n"
+			."$mv_out1";
+	}
+	
+
+	##################################################	
+	# remove the temp directory if there are no errors
+	##################################################
+	if (@errors) {
+		print "Errors in converting the tex file to pdf: ".join("\n", @errors);
+		return 0;
+	}
+	
+	unless (@errors or $UNIT_TESTS_ON) {
+		delete_temp_dir($working_dir_path);
+	} 
+	
+ 
+	
+	
+	# return path to pdf file
+	print "pdflatex to $final_pdf_path DONE\n" if $UNIT_TESTS_ON;
+	# this is doable but will require changing directories
+	# look at the solution done using hardcopy
+	return $final_pdf_path;}
+
+# helper function to remove temp dirs
+sub delete_temp_dir {
+	my ($temp_dir_path) = @_;
+	
+	my $rm_cmd = "2>&1 rm -rf " . shell_quote($temp_dir_path);  #can use perl command for this??
+	my $rm_out = readpipe $rm_cmd;
+	if ($?) {
+		print "Failed to remove temporary directory '".$temp_dir_path."':\n$rm_out\n";
+		return 0;
+	} else {
+		return 1;
 	}
 }
-sub edit_source_file {
+
+
+sub create_tex_output {
 	my $file_path = shift;
-	system("bbedit $file_path");
+	my $formatter = shift;
+	my $output_text = $formatter->formatRenderedProblem;
+	$file_path =~s|/$||;   # remove final /
+	$file_path =~ m|/?([^/]+)$|;
+	my $file_name = $1;
+	$file_name =~ s/\.\w+$/\.tex/;    # replace extension with tex
+	my $output_file = TEMPOUTPUTDIR().$file_name;
+	local(*FH);
+	open(FH, '>', $output_file) or die "Can't open file $output_file for writing";
+	print FH $output_text;
+	close(FH);
+	print "tex result sent to $output_file\n" if $UNIT_TESTS_ON;
+#	sleep 5;   #wait 5 seconds
+#	unlink($output_file);
+	return $file_name;
 }
+
+sub	display_html_output {  #display the problem in a browser
+	my $file_path = shift;
+	my $formatter = shift;
+	my $output_text = $formatter->formatRenderedProblem;
+	$file_path =~s|/$||;   # remove final /
+	$file_path =~ m|/?([^/]+)$|;
+	my $file_name = $1;
+	$file_name =~ s/\.\w+$/\.html/;    # replace extension with html
+	my $output_file = TEMPOUTPUTDIR().$file_name;
+	local(*FH);
+	open(FH, '>', $output_file) or die "Can't open file $output_file for writing";
+	print FH $output_text;
+	close(FH);
+
+	system($HTML_DISPLAY_COMMAND." ".$output_file);
+	sleep 5;   #wait 1 seconds
+	unlink($output_file);
+}
+
+sub display_hash_output {   # print the entire hash output to the command line
+	my $file_path = shift;
+	my $formatter = shift;
+	my $output_text = $formatter->formatRenderedProblem;
+	$file_path =~s|/$||;   # remove final /
+	$file_path =~ m|/?([^/]+)$|;
+	my $file_name = $1;
+	$file_name =~ s/\.\w+$/\.txt/;    # replace extension with html
+	my $output_file = TEMPOUTPUTDIR().$file_name;
+	my $output_text2 = pretty_print_rh($output_text);
+	print STDOUT $output_text2;
+
+# 	local(*FH);
+# 	open(FH, '>', $output_file) or die "Can't open file $output_file writing";
+# 	print FH $output_text2;
+# 	close(FH);
+# 
+# 	system($HASH_DISPLAY_COMMAND().$output_file."; rm $output_file;");
+	#sleep 1; #wait 1 seconds
+	#unlink($output_file);
+}
+
+sub display_ans_output {  # print the collection of answer hashes to the command line
+	my $file_path = shift;
+	my $formatter = shift;
+	my $return_object = $formatter->return_object;	
+	$file_path =~s|/$||;   # remove final /
+	$file_path =~ m|/?([^/]+)$|;
+	my $file_name = $1;
+	$file_name =~ s/\.\w+$/\.txt/;    # replace extension with html
+	my $output_file = TEMPOUTPUTDIR().$file_name;
+	my $output_text = pretty_print_rh($return_object->{answers});
+	print STDOUT $output_text;
+# 	local(*FH);
+# 	open(FH, '>', $output_file) or die "Can't open file $output_file writing";
+# 	print FH $output_text;
+# 	close(FH);
+# 
+# 	system($HASH_DISPLAY_COMMAND().$output_file."; rm $output_file;");
+# 	sleep 1; #wait 1 seconds
+# 	unlink($output_file);
+}
+
+
 sub record_problem_ok1 {
 	my $error_flag = shift//'';
-	my $xmlrpc_client = shift;
+	my $formatter = shift;  # for formatting
 	my $file_path = shift;
-	my $return_string = shift;
-	my $result = $xmlrpc_client->return_object;
-	if (defined($result->{flags}->{DEBUG_messages}) ) {
-		my @debug_messages = @{$result->{flags}->{DEBUG_messages}};
+	my $return_string = '';
+	my $return_object = $formatter->return_object;
+	if (defined($return_object->{flags}->{DEBUG_messages}) ) {
+		my @debug_messages = @{$return_object->{flags}->{DEBUG_messages}};
 		$return_string .= (pop @debug_messages ) ||'' ; #avoid error if array was empty
 		if (@debug_messages) {
 			$return_string .= join(" ", @debug_messages);
@@ -575,11 +1164,11 @@ sub record_problem_ok1 {
 					$return_string = "";
 		}
 	}
-	if (defined($result->{errors}) ) {
-		$return_string= $result->{errors};
+	if (defined($return_object->{errors}) ) {
+		$return_string= $return_object->{errors};
 	}
-	if (defined($result->{flags}->{WARNING_messages}) ) {
-		my @warning_messages = @{$result->{flags}->{WARNING_messages}};
+	if (defined($return_object->{flags}->{WARNING_messages}) ) {
+		my @warning_messages = @{$return_object->{flags}->{WARNING_messages}};
 		$return_string .= (pop @warning_messages)||''; #avoid error if array was empty
 			$@=undef;
 		if (@warning_messages) {
@@ -603,15 +1192,17 @@ sub record_problem_ok1 {
 }
 sub record_problem_ok2 {
 	my $error_flag = shift//'';
-	my $xmlrpc_client = shift;
+	my $formatter = shift;
 	my $file_path = shift;
 	my $some_correct_answers_not_specified = shift;
+	my $pg_duration = shift;  #processing time
+	my $return_object = $formatter->return_object;
 	my %scores = ();
 	my $ALL_CORRECT= 0;
 	my $all_correct = ($error_flag)?0:1;
-		foreach my $ans (keys %{$xmlrpc_client->return_object->{answers}} ) {
+		foreach my $ans (keys %{$return_object->{answers}} ) {
 			$scores{$ans} = 
-			      $xmlrpc_client->return_object->{answers}->{$ans}->{score};
+			      $return_object->{answers}->{$ans}->{score};
 			$all_correct =$all_correct && $scores{$ans};
 		}
 	$all_correct = ".5" if $some_correct_answers_not_specified;
@@ -622,143 +1213,28 @@ sub record_problem_ok2 {
 	close(FH);
 	return $ALL_CORRECT;
 }
-sub process_problem {
-	my $file_path = shift;
-	my $input    = shift;
-	my $form_data  = shift;
-	# %credentials is global
-	my $problemSeed = $form_data->{problemSeed};
-	die "problem seed not defined in sendXMLRPC::process_problem" unless $problemSeed;
-	
-	### get source and correct file_path name so that it is relative to templates directory
-	my ($adj_file_path, $source) = get_source($file_path);
-	#print "find file at $adj_file_path ", length($source), "\n";
-	### build client
-	my $xmlrpc_client = new WebworkClient (
-		url                    => $credentials{site_url},
-		form_action_url        => $credentials{form_action_url},
-		site_password          =>  $credentials{site_password}//'',
-		courseID               =>  $credentials{courseID},
-		userID                 =>  $credentials{userID},
-		session_key            =>  $credentials{session_key}//'',
-		sourceFilePath         => $adj_file_path,
-	);
-	
-	### update client
-	$xmlrpc_client->encodeSource($source);
-	$form_data->{showAnsGroupInfo} 		= $print_answer_group;
-	$form_data->{showAnsHashInfo}       = $print_answer_hash;
-	$form_data->{showPGInfo}	        = $print_pg_hash;
-	$xmlrpc_client->form_data( $form_data	);
-	
-	### update inputs
-	my $updated_input = {%$input, 
-					  envir => $xmlrpc_client->environment(
-							   fileName       => $adj_file_path,
-							   sourceFilePath => $adj_file_path,
-							   problemSeed    => $problemSeed,),
-	};
-	
-	##################################################
-	# input section
-	##################################################
-	### store the time before we invoke the content generator
-	my $cg_start = time; # this is Time::HiRes's time, which gives floating point values
+
+###########################################
+# standalonePGproblemRenderer  -- not needed for sendXMLRPC
+###########################################
 
 
-	############################################
-	# Call server via xmlrpc_client
-	############################################
-	our($output, $return_string, $result, $error_flag, $error_string);
-	$error_flag=0; $error_string='';    
-	$result = $xmlrpc_client->xmlrpcCall('renderProblem', $updated_input);
-	unless ( $xmlrpc_client->fault  )    {
-		print "\n\n Result of renderProblem \n\n" if $UNIT_TESTS_ON;
-		print pretty_print_rh($result) if $UNIT_TESTS_ON;
-	    if (not defined $result) {  #FIXME make sure this is the right error message if site is unavailable
-	    	$error_string = "0\t Could not connect to rendering site ". $xmlrpc_client->{url}."\n";
-	    } elsif (defined($result->{flags}->{error_flag}) and $output->{flags}->{error_flag} ) {
-			$error_string = "0\t $file_path has errors\n";
-		} elsif (defined($result->{errors}) and $output->{errors} ){
-			$error_string = "0\t $file_path has syntax errors\n";
-		}
-		$error_flag=1 if $result->{errors};
-	} else {
-		$error_flag=1;
-		$error_string = $xmlrpc_client->return_object;  # error report		
-	}	
-	##################################################
-	# log elapsed time
-	##################################################
-	my $scriptName = 'sendXMLRPC';
-	my $cg_end = time;
-	my $cg_duration = $cg_end - $cg_start;
-	WebworkClient::writeRenderLogEntry("", "{script:$scriptName; file:$file_path; ". sprintf("duration: %.3f sec;", $cg_duration)." url: $credentials{site_url}; }",'');
-	return $error_flag, $xmlrpc_client, $error_string;
-}
 
 ##################################################
-# print the output (or the error message)  and display
-#FIXME -- possibly refactor these two into display_output()??
+# utilities
 ##################################################
 
-sub	display_html_output {  #display the problem in a browser
+sub display_inputs {
+	my %correct_answers = @_;
+	foreach my $key (sort keys %correct_answers) {
+		print "$key => $correct_answers{$key}\n";
+	}
+}
+sub edit_source_file {
 	my $file_path = shift;
-	my $output_text = shift;
-	$file_path =~s|/$||;   # remove final /
-	$file_path =~ m|/?([^/]+)$|;
-	my $file_name = $1;
-	$file_name =~ s/\.\w+$/\.html/;    # replace extension with html
-	my $output_file = TEMPOUTPUTDIR().$file_name;
-	local(*FH);
-	open(FH, '>', $output_file) or die "Can't open file $output_file for writing";
-	print FH $output_text;
-	close(FH);
-
-	system($HTML_DISPLAY_COMMAND." ".$output_file);
-	sleep 1;   #wait 1 seconds
-	unlink($output_file);
+	system(EDIT_COMMAND()." $file_path");
 }
 
-sub display_hash_output {   # print the entire hash output to the command line
-	my $file_path = shift;
-	my $output_text = shift;	
-	$file_path =~s|/$||;   # remove final /
-	$file_path =~ m|/?([^/]+)$|;
-	my $file_name = $1;
-	$file_name =~ s/\.\w+$/\.txt/;    # replace extension with html
-	my $output_file = TEMPOUTPUTDIR().$file_name;
-	my $output_text2 = pretty_print_rh($output_text);
-	print STDOUT $output_text2;
-# 	local(*FH);
-# 	open(FH, '>', $output_file) or die "Can't open file $output_file writing";
-# 	print FH $output_text2;
-# 	close(FH);
-# 
-# 	system(HASH_DISPLAY_COMMAND().$output_file."; rm $output_file;");
-	#sleep 1; #wait 1 seconds
-	#unlink($output_file);
-}
-
-sub display_ans_output {  # print the collection of answer hashes to the command line
-	my $file_path = shift;
-	my $return_object = shift;	
-	$file_path =~s|/$||;   # remove final /
-	$file_path =~ m|/?([^/]+)$|;
-	my $file_name = $1;
-	$file_name =~ s/\.\w+$/\.txt/;    # replace extension with html
-	my $output_file = TEMPOUTPUTDIR().$file_name;
-	my $output_text = pretty_print_rh($return_object->{answers});
-	print STDOUT $output_text;
-# 	local(*FH);
-# 	open(FH, '>', $output_file) or die "Can't open file $output_file writing";
-# 	print FH $output_text;
-# 	close(FH);
-# 
-# 	system(HASH_DISPLAY_COMMAND().$output_file."; rm $output_file;");
-# 	sleep 1; #wait 1 seconds
-# 	unlink($output_file);
-}
 
 ##################################################
 # Get problem template source and adjust file_path name
@@ -767,12 +1243,16 @@ sub display_ans_output {  # print the collection of answer hashes to the command
 sub get_source {
 	my $file_path = shift;
 	my $source;	
-	die "Unable to read file $file_path \n" unless -r $file_path;
+	die "Unable to read file $file_path \n" unless $file_path eq '-' or -r $file_path;
 	eval {  #File::Slurp would be faster (see perl monks)
 		 local $/=undef;
-  		open(FH, '<',$file_path) or die "Couldn't open file $file_path: $!";
-		$source   = <FH>; #slurp  input
-  		close FH;
+		if ($file_path eq '-') {
+			$source = <STDIN>;
+		} else {
+			open(FH, '<',$file_path) or die "Couldn't open file $file_path: $!";
+			$source   = <FH>; #slurp  input
+			close FH;
+		}
 	};
 	die "Something is wrong with the contents of $file_path\n" if $@;
 	### adjust file_path so that it is relative to the rendering course directory
@@ -829,53 +1309,13 @@ sub pretty_print_rh {
 	return $out." ";
 }
 
+############################################
+# Help message
+############################################
 
 sub print_help_message {
 print <<'EOT';
-NAME
-    webwork2/clients/sendXMLRPC.pl
-
-DESCRIPTION
-    This script will take a list of files or directories and send it to a
-    WeBWorK daemon webservice to have it rendered. For directories each .pg
-    file under that directory is rendered.
-
-    The results can be displayed in a browser (use -b or -B switches) as was
-    done with renderProblem.pl, on the command line (Use -h or -H switches)
-    as was done with renderProblem_rawoutput.pl or summary information about
-    whether the problem was correctly rendered can be sent to a log file
-    (use -c or C switches).
-
-    The capital letter switches, -B, -H, and -C render the question twice.
-    The first time returns an answer hash which contains the correct
-    answers. The question is then resubmitted to the renderer with the
-    correct answers filled in and displayed.
-
-    IMPORTANT: Remember to configure the local output file and display
-    command near the top of this script. !!!!!!!!
-
-    IMPORTANT: Create a valid credentials file.
-
-SYNOPSIS
-            sendXMLRPC -vcCbB input.pg
-
-DETAILS
-  credentials file
-        These locations are searched, in order,  for the credentials file.
-        ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
-
-        Place a credential file containing the following information at one of the locations above 
-        or create a file with this information and specify it with the --credentials option.
-    
-            %credentials = (
-                            userID                 => "my login name for the webwork course",
-                            course_password        => "my password ",
-                            courseID               => "the name of the webwork course",
-                  XML_URL                  => "url of rendering site
-                  XML_PASSWORD          => "site password" # preliminary access to site
-                  $FORM_ACTION_URL      =  'http://localhost:80/webwork2/html2xml'; #action url for form
-            );
-
+ 
   Options
     -a
                 Displays the answer hashes returned by the question on the command line.
@@ -913,24 +1353,27 @@ DETAILS
                  simple
 
     -v
-                Verbose output. Used mostly for debugging. 
-                 In particular it displays explicitly the correct answers which are (will be)  submitted to the question.
+                 Verbose output. Used mostly for debugging. 
+                 In particular it displays explicitly the correct answers which are (will be)  
+                 submitted to the question and it specifies which credential file is used.
 
     -e
-				Open the source file in an editor. 
-
-                The single letter options can be "bundled" e.g.  -vcCbB
-                
-	--list   pg_list
-				Read and process a list of .pg files contained in the file C<pg_list>.  C<pg_list>
-				consists of a sequence of lines each of which contains the full path to a pg
-				file that should be processed. (For example this might be the output from an
-				earlier run of sendXMLRPC using the -c flag. )
-
+                 Open the source file in an editor. 
+                 The single letter options can be "bundled" e.g.  -vcCbB
+    --tex    
+                 Process question in TeX mode and output to the command line
+    --pdf          
+                 Process question in TeX mode, then by pdflatex and output 
+                 to the command line
+ 
+    --list   pg_list
+                 Read and process a list of .pg files contained in the file C<pg_list>.  C<pg_list>
+                 consists of a sequence of lines each of which contains the full path to a pg
+                 file that should be processed. (For example this might be the output from an
+                 earlier run of sendXMLRPC using the -c flag. )
     --pg
                 Triggers the printing of the all of the variables available to the PG question. 
                 The table appears within the question content. Use in conjunction with -b or -B.
-
     --anshash
                 Prints the answer hash for each answer in the PG_debug output which appears below
                 the question content. Use in conjunction with -b or -B. 
@@ -941,15 +1384,22 @@ DETAILS
                 Prints the PGanswergroup for each answer evaluator. The information appears in 
                 the PG_debug output which follows the question content.  Use in conjunction with -b or -B.
                 This contains more information than printing the answer hash. (perhaps too much).
+    --resource
+
+                 Prints the resources used by the question. The information appears in 
+                 the PG_debug output which follows the question content.  Use in conjunction with -b or -B.
 
     --credentials=s
-                Specifies a file s where the  credential information can be found.
+                 Specifies a file s where the  credential information can be found.
 
-	--help
-		   Prints help information. 
-	   
-	--log 
-		   Sets path to log file
+    --help
+                 Prints help information. 
+
+    --log 
+                 Sets path to log file
+    
+    --seed=s     
+                 Sets problemSeed to the number contained in string s
 
 
 EOT

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -1,0 +1,263 @@
+#!/usr/bin/perl -w
+
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/lib/WebworkClient.pm,v 1.1 2010/06/08 11:46:38 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+FormatRenderedProblem.pm
+
+=cut
+
+package FormatRenderedProblem;
+
+use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
+use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
+use MIME::Base64 qw( encode_base64 decode_base64);
+use WeBWorK::Utils::AttemptsTable;
+use WeBWorK::PG::ImageGenerator;
+use WeBWorK::Utils qw( wwRound);   # required for score summary
+our $UNIT_TESTS_ON  = 0; 
+#####################
+# error formatting
+sub format_hash_ref {
+	my $hash = shift;
+	warn "Use a hash reference" unless ref($hash) =~/HASH/;
+	return join(" ", map {$_="--" unless defined($_);$_ } %$hash),"\n";
+}
+
+sub new {
+    my $invocant = shift;
+    my $class = ref $invocant || $invocant;
+	$self = {
+		return_object => {},
+		encoded_source => {},
+		sourceFilePath => '',
+		url            => 'https://hosted2.webwork.rochester.edu',
+		form_action_url =>'',
+		maketext   	   => sub {return @_}, 
+		courseID       => 'daemon_course',  # optional?
+		userID         => 'daemon',  # optional?
+		course_password => 'daemon',
+		inputs_ref      => {},	  
+		@_,
+	};
+	bless $self, $class;
+}
+sub return_object {   # out
+	my $self = shift;
+	my $object = shift;
+	$self->{return_object} = $object if defined $object and ref($object); # source is non-empty
+	$self->{return_object};
+}
+sub encoded_source {
+	my $self = shift;
+	my $source = shift;
+	$self->{encoded_source} =$source if defined $source and $source =~/\S/; # source is non-empty
+	$self->{encoded_source};
+}
+sub url {
+	my $self = shift;
+	my $new_url = shift;
+	$self->{url} = $new_url if defined($new_url) and $new_url =~ /\S/;
+	$self->{url};
+}
+sub formatRenderedProblem {
+	my $self 			  = shift;
+	my $problemText       ='';
+	my $rh_result         = $self->return_object() || {};  # wrap problem in formats
+	$problemText          = "No output from rendered Problem" unless $rh_result ;
+	print "\nformatRenderedProblem return_object $rh_result = ",join(" ", sort keys %$rh_result),"\n" if $UNIT_TESTS_ON;
+	if (ref($rh_result) and $rh_result->{text} ) {  ##text vs body_text
+		$problemText       =  $rh_result->{text};
+	} else {
+		$problemText       .= "Unable to decode problem text<br/>\n".
+		$self->{error_string}."\n".
+		format_hash_ref($rh_result);
+	}
+	my $problemHeadText   = $rh_result->{header_text}//'';  ##head_text vs header_text
+	my $rh_answers        = $rh_result->{answers}//{};
+	print"\n return_object answers ", join(" ",  %{$rh_result->{PG_ANSWERS_HASH}} ) if $UNIT_TESTS_ON;
+	my $answerOrder       = $rh_result->{flags}->{ANSWER_ENTRY_ORDER}; #[sort keys %{ $rh_result->{answers} }];
+	my $encoded_source    = $self->encoded_source//'';
+	my $sourceFilePath    = $self->{sourceFilePath}//'';
+	my $warnings          = '';
+	
+	#################################################
+	# regular Perl warning messages generated with warn
+	#################################################
+
+	if ( defined ($rh_result->{WARNINGS}) and $rh_result->{WARNINGS} ){
+		$warnings = "<div style=\"background-color:pink\">
+		             <p >WARNINGS</p><p>".decode_base64($rh_result->{WARNINGS})."</p></div>";
+	}
+	#warn "keys: ", join(" | ", sort keys %{$rh_result });
+	
+	#################################################	
+	# PG debug messages generated with DEBUG_message();
+	#################################################
+	
+	my $debug_messages = $rh_result->{debug_messages} ||     [];
+    $debug_messages = join("<br/>\n", @{  $debug_messages }    );
+    
+	#################################################    
+	# PG warning messages generated with WARN_message();
+	#################################################
+
+    my $PG_warning_messages =  $rh_result->{warning_messages} ||     [];
+    $PG_warning_messages = join("<br/>\n", @{  $PG_warning_messages }    );
+    
+	#################################################
+	# internal debug messages generated within PG_core
+	# these are sometimes needed if the PG_core warning message system
+	# isn't properly set up before the bug occurs.
+	# In general don't use these unless necessary.
+	#################################################
+
+    my $internal_debug_messages = $rh_result->{internal_debug_messages} || [];
+    $internal_debug_messages = join("<br/>\n", @{ $internal_debug_messages  } );
+    
+    my $fileName = $self->{input}->{envir}->{fileName} || "";
+
+
+    #################################################
+
+
+	$self->{outputformats}={};
+	my $XML_URL      	 =  $self->url//'';
+	my $FORM_ACTION_URL  =  $self->{form_action_url}//'';
+	my $courseID         =  $self->{courseID}//'';
+	my $userID           =  $self->{userID}//'';
+	my $course_password  =  $self->{course_password}//'';
+	my $problemSeed      =  $self->{inputs_ref}->{problemSeed}//6666;
+	my $session_key      =  $rh_result->{session_key}//'';
+	my $displayMode      =  $self->{inputs_ref}->{displayMode}//'foobar';
+	
+	my $previewMode      =  defined($self->{inputs_ref}->{preview})||0;
+	my $checkMode        =  defined($self->{inputs_ref}->{WWcheck})||0;
+	my $submitMode       =  defined($self->{inputs_ref}->{WWsubmit})||0;
+	my $showCorrectMode  =  defined($self->{inputs_ref}->{WWcorrectAns})||0;
+        # problemIdentifierPrefix can be added to the request as a parameter.  
+        # It adds a prefix to the 
+        # identifier used by the  format so that several different problems
+        # can appear on the same page.   
+	my $problemIdentifierPrefix = $self->{inputs_ref}->{problemIdentifierPrefix} //'';
+    my $problemResult    =  $rh_result->{problem_result}//'';
+    my $problemState     =  $rh_result->{problem_state}//'';
+    my $showSummary      = ($self->{inputs_ref}->{showSummary})//1; #default to show summary for the moment
+	my $formLanguage     = ($self->{inputs_ref}->{language})//'en';
+
+	my $scoreSummary     =  '';
+
+
+	my $tbl = WeBWorK::Utils::AttemptsTable->new(
+		$rh_answers,
+		answersSubmitted       => $self->{inputs_ref}->{answersSubmitted}//0,
+		answerOrder            => $answerOrder//[],
+		displayMode            => $self->{inputs_ref}->{displayMode},
+		imgGen                 => $imgGen,
+		ce                     => '',	#used only to build the imgGen
+		showAttemptPreviews    => ($previewMode or $submitMode or $showCorrectMode),
+		showAttemptResults     => ($submitMode or $showCorrectMode),
+		showCorrectAnswers     => ($showCorrectMode),
+		showMessages           => ($previewMode or $submitMode or $showCorrectMode),
+		showSummary            => ( ($showSummary and ($submitMode or $showCorrectMode) )//0 )?1:0,  
+		maketext               => WeBWorK::Localize::getLoc($formLanguage//'en'),
+		summary                => $problemResult->{summary} //'', # can be set by problem grader???
+	);
+
+
+	my $answerTemplate = $tbl->answerTemplate;
+	my $color_input_blanks_script = $tbl->color_answer_blanks;
+	$tbl->imgGen->render(refresh => 1) if $tbl->displayMode eq 'images';
+
+
+	# FIXME -- can we avoid using imgGenerator here?
+	# warn "imgGen is ", $tbl->imgGen;
+	#warn "answerOrder ", $tbl->answerOrder;
+	#warn "answersSubmitted ", $tbl->answersSubmitted;
+	# render equation images
+
+
+
+	if ($submitMode && $problemResult) {
+		$scoreSummary = CGI::p('Your score on this attempt is '.wwRound(0, $problemResult->{score} * 100).'%');
+		if ($problemResult->{msg}) {
+			 $scoreSummary .= CGI::p($problemResult->{msg});
+		}
+
+		$scoreSummary .= CGI::p('Your score on this problem has not been recorded.');
+		$scoreSummary .= CGI::hidden({id=>'problem-result-score', name=>'problem-result-score',value=>$problemResult->{score}});
+	}
+
+	# This stuff is put here because eventually we will add locale support so the 
+	# text will have to be done server side. 
+	my $localStorageMessages = CGI::start_div({id=>'local-storage-messages'});
+	$localStorageMessages.= CGI::p('Your overall score for this problem is'.'&nbsp;'.CGI::span({id=>'problem-overall-score'},''));
+	$localStorageMessages .= CGI::end_div();
+		
+	#my $pretty_print_self  = pretty_print($self);
+######################################################
+# Return interpolated problem template
+######################################################
+
+	my $format_name = $self->{inputs_ref}->{outputformat}//'standard';
+	# find the appropriate template in WebworkClient folder
+	my $template = do("WebworkClient/${format_name}_format.pl");
+	die "Unknown format name $format_name" unless $template;
+	# interpolate values into template
+	$template =~ s/(\$\w+)/$1/gee;  
+	return $template;
+}
+
+sub pretty_print {    # provides html output -- NOT a method
+    my $r_input = shift;
+    my $level = shift;
+    $level = 4 unless defined($level);
+    $level--;
+    return '' unless $level > 0;  # only print three levels of hashes (safety feature)
+    my $out = '';
+    if ( not ref($r_input) ) {
+    	$out = $r_input if defined $r_input;    # not a reference
+    	$out =~ s/</&lt;/g  ;  # protect for HTML output
+    } elsif ("$r_input" =~/hash/i) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_iput).
+	    local($^W) = 0;
+	    
+		$out .= "$r_input " ."<TABLE border = \"2\" cellpadding = \"3\" BGCOLOR = \"#FFFFFF\">";
+		
+		
+		foreach my $key ( sort ( keys %$r_input )) {
+			$out .= "<tr><TD> $key</TD><TD>=&gt;</td><td>&nbsp;".pretty_print($r_input->{$key}) . "</td></tr>";
+		}
+		$out .="</table>";
+	} elsif (ref($r_input) eq 'ARRAY' ) {
+		my @array = @$r_input;
+		$out .= "( " ;
+		while (@array) {
+			$out .= pretty_print(shift @array, $level) . " , ";
+		}
+		$out .= " )";
+	} elsif (ref($r_input) eq 'CODE') {
+		$out = "$r_input";
+	} else {
+		$out = $r_input;
+		$out =~ s/</&lt;/g; # protect for HTML output
+	}
+	
+	return $out." ";
+}
+
+1;


### PR DESCRIPTION
Fixes a problem with -v (verbose) and adds two features.
1. You can specify the problemSeed using  the option -seed=s  where s is a number
2. You can take input from STDIN  using   sendXMLRPC.pl -h -    (- stands for STDIN)

To test:  in the directory  `webwork2/clients`
1.

sendXMLRPC.pl -v      (before patch this will do nothing)
                                      after patch this will print out information telling you which credential file is being used.

2. 
sendXMLRPC.pl --seed=123 -b t/input.pg     
inspect the line at the top of the problem to make sure that the problemSeed printed there agrees with the seed you entered.

3. cat t/input.pg |sendXMLRPC --seed=432 -b -
should work the same as the command above (except the problemSeed is different)

4. If you have this set up in a docker box and have vim installed in the docker box you can try
vim t/input.pg
inside vim type
:w ! ./pr
This should send an html version of the vim buffer to /var/www/html/xmlrpc_out.html
Using the browser view the rendered version at http://localhost:8080/xmlrpc_out.html
-----------
By editing the script pr you could also use this to print the vim buffer outside the docker environment -- just direct the output of sendXMLRPC.pl to the appropriate location or application

