### PR TITLE
Translation file updates for release 2.14

### DIFF
--- a/lib/WeBWorK/Localize/en.po
+++ b/lib/WeBWorK/Localize/en.po
@@ -1,93 +1,98 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: WeBWorK Online Homework System\n"
+"Project-Id-Version: webwork2\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: \n"
-"Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: Webwork language team <gage@math.rochester.edu>\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: English (United States) (http://www.transifex.com/webwork/"
+"webwork2/language/en_US/)\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
 msgid "#corr"
-msgstr ""
+msgstr "#corr"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "#incorr"
-msgstr ""
+msgstr "#incorr"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
 msgid "% correct"
-msgstr ""
+msgstr "% correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
 msgid "% correct with review"
-msgstr ""
+msgstr "% correct with review"
 
+# Percent students
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
 msgid "% students"
-msgstr ""
+msgstr "% students"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
 msgid "%1 (old editor)"
-msgstr ""
+msgstr "%1 (old editor)"
 
+# Gateway (test 3)
 #. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
 msgid "%1 (test %2)"
-msgstr ""
+msgstr "%1 (test %2)"
 
-#
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
-#, fuzzy
 msgid "%1 Points:"
-msgstr "Problem List"
+msgstr "%1 Points:"
 
-#
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
-#, fuzzy
 msgid "%1 Problems:"
-msgstr "Problem List"
+msgstr "%1 Problems:"
 
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr ""
+msgstr "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
 
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
-msgstr ""
+msgstr "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
 
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
 msgid "%1 students out of %2"
-msgstr ""
+msgstr "%1 students out of %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
-msgstr ""
+msgstr "%1 title and institution changed from %2 to %3 and from %4 to %5"
 
 #. (scalar @userIDsToExport, $dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
 msgid "%1 users exported to file %2/%3"
-msgstr ""
+msgstr "%1 users exported to file %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
+"%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
@@ -97,57 +102,62 @@ msgid ""
 "Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
 "again."
 msgstr ""
+"%1 uses an external authentication system (e.g., Oncourse,  CAS,  "
+"Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
+"again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:97
 msgid ""
 "%1 uses an external authentication system.  You've authenticated through "
 "that system, but aren't allowed to log in to this course."
 msgstr ""
+"%1 uses an external authentication system.  You've authenticated through "
+"that system, but aren't allowed to log in to this course."
 
 #. ($levelpercentage)
 #. ($percentage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
 msgid "%1% Complete"
-msgstr ""
+msgstr "%1% Complete"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
 msgid "%1% correct"
-msgstr ""
+msgstr "%1% correct"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
 msgid "%1's Current Address"
-msgstr ""
+msgstr "%1's Current Address"
 
 #. ($user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
 msgid "%1's Current Password"
-msgstr ""
+msgstr "%1's Current Password"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
 msgid "%1's New Address"
-msgstr ""
+msgstr "%1's New Address"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
 msgid "%1's New Password"
-msgstr ""
+msgstr "%1's New Password"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
 msgid "%1's new password cannot be blank."
-msgstr ""
+msgstr "%1's new password cannot be blank."
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
 msgid "%1's password has been changed."
-msgstr ""
+msgstr "%1's password has been changed."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
@@ -158,46 +168,47 @@ msgstr "%1: Problem %2"
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
 msgid "%1: Problem %2 Show Me Another"
-msgstr ""
+msgstr "%1: Problem %2 Show Me Another"
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
 msgid "%1: The directory for the course not found."
-msgstr ""
+msgstr "%1: The directory for the course not found."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
 msgid "%quant(%1,course was, courses were) successfully unhidden."
-msgstr ""
+msgstr "%quant(%1,course was, courses were) successfully unhidden."
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:297
 msgid "%quant(%1,error) occured while generating hardcopy:"
-msgstr ""
+msgstr "%quant(%1,error) occured while generating hardcopy:"
 
 #. ($n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:802
 msgid "%quant(%1,file) unpacked successfully"
-msgstr ""
+msgstr "%quant(%1,file) unpacked successfully"
 
 #. ($numBlanks)
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
+"%quant(%1,of the questions remains,of the questions remain) unanswered."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
 msgid "%quant_1( course was, courses were) successfully hidden."
-msgstr ""
+msgstr "%quant_1( course was, courses were) successfully hidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "%score"
-msgstr ""
+msgstr "%score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
 msgid "(Any unsaved changes will be lost.)"
-msgstr ""
+msgstr "(Any unsaved changes will be lost.)"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
@@ -205,46 +216,51 @@ msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
+"(Instructor hint preview: show the student hint after the following number "
+"of attempts:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
 msgid "(This problem will not count towards your grade.)"
-msgstr ""
+msgstr "(This problem will not count towards your grade.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
+"(This test is overtime because it was not submitted in the allowed time.)"
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr ""
+msgstr "(Your score on this %1 is not available until %2.)"
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
 msgid "(Your score on this %1 is not available.)"
-msgstr ""
+msgstr "(Your score on this %1 is not available.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
 msgid "(correct)"
-msgstr ""
+msgstr "(correct)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
 msgid "(gw/quiz) After version answer date"
-msgstr ""
+msgstr "(gw/quiz) After version answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
 msgid "(incorrect)"
-msgstr ""
+msgstr "(incorrect)"
 
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
 msgid "(score %1)"
-msgstr ""
+msgstr "(score %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
 msgid "1 student"
-msgstr ""
+msgstr "1 student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
 msgid ""
@@ -260,7 +276,19 @@ msgid ""
 "std_problem_grader (the all or nothing grader). It will work with custom "
 "graders if they are written appropriately.</p>"
 msgstr ""
+"<p>After the Reduced Scoring Date all additional work done by the student "
+"counts at a reduced rate. Here is where you set the reduced rate which must "
+"be a percentage. For example if this value is 50% and a student views a "
+"problem during the Reduced Scoring Period, they will see the message \"You "
+"are in the Reduced Scoring Period: All additional work done counts 50% of "
+"the original.\" </p><p>To use this, you also have to enable Reduced Scoring "
+"and set the Reduced Scoring Date for individual assignments by editing the "
+"set data using the Hmwk Sets Editor.</p><p>This works with the "
+"avg_problem_grader (which is the the default grader) and the "
+"std_problem_grader (the all or nothing grader). It will work with custom "
+"graders if they are written appropriately.</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
@@ -274,7 +302,18 @@ msgid ""
 "least one display mode. If you select only one, then the options box will "
 "not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
+"<p>When viewing a problem, users may choose different methods of rendering "
+"formulas via an options box in the left panel. Here, you can adjust what "
+"display modes are listed.</p><p>Some display modes require other software to "
+"be installed on the server. Be sure to check that all display modes selected "
+"here work from your server.</p><p>The display modes are <ul><li> plainText: "
+"shows the raw LaTeX srings for formulas.<li> images: produces images using "
+"the external programs LaTeX and dvipng.<li> MathJax: a successor to jsMath, "
+"uses javascript to place render mathematics.</ul></p></p>You must use at "
+"least one display mode. If you select only one, then the options box will "
+"not give a choice of modes (since there will only be one active).</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
 msgid ""
 "<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
@@ -289,13 +328,24 @@ msgid ""
 "unless you check at least one of these options - the students would simply "
 "see a new version that they can not attempt or learn from.</p>"
 msgstr ""
+"<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
+"new problem</i> when Show Me Another is clicked</li> "
+"<li><b>SMAshowSolutions</b>: shows walk-through solution <i>for the new "
+"problem</i> when Show Me Another is clicked; a check is done first to make "
+"sure that a solution exists </li><li><b>SMAshowCorrect</b>: correct answers "
+"<i>for the new problem</i> can be viewed when Show Me Another is clicked; "
+"note that <b>SMAcheckAnswers</b> needs to be enabled at the same time</"
+"li><li><b>SMAshowHints</b>: show hints <i>for the new problem</i> (assuming "
+"they exist)</li></ul>Note: there is very little point enabling the button "
+"unless you check at least one of these options - the students would simply "
+"see a new version that they can not attempt or learn from.</p>"
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
 msgid "A course with ID %1 already exists."
-msgstr ""
+msgstr "A course with ID %1 already exists."
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
@@ -303,11 +353,13 @@ msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
+"A directory already exists with the name %1. You must first delete this "
+"existing course before you can unarchive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
 msgid "A file with that name already exists"
-msgstr ""
+msgstr "A file with that name already exists"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
@@ -315,6 +367,9 @@ msgid ""
 "check that no problems are missing and that they are all legible. If not, "
 "please inform your instructor."
 msgstr ""
+"A hardcopy file was generated, but it may not be complete or correct. Please "
+"check that no problems are missing and that they are all legible. If not, "
+"please inform your instructor."
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
@@ -322,6 +377,8 @@ msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
+"A location with the name %1 already exists in the database.  Did you mean to "
+"edit that location instead?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
@@ -329,11 +386,13 @@ msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
+"A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
+"in the class %3.  There were %4 message(s) that could not be sent."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
 msgid "A new file has been created at '%1'"
-msgstr ""
+msgstr "A new file has been created at '%1'"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
@@ -342,6 +401,8 @@ msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
 msgstr ""
+"A new file has been created at '%1' with the contents below.  No changes "
+"have been made to set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -349,7 +410,11 @@ msgid ""
 "to 100 indicates the grade earned. The number on the second line gives the "
 "number of incorrect attempts."
 msgstr ""
+"A period (.) indicates a problem has not been attempted, and a number from 0 "
+"to 100 indicates the grade earned. The number on the second line gives the "
+"number of incorrect attempts."
 
+# Leave symbol codes in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
 msgid ""
 "A switch to govern the use of a Progress Bar for the student; this also "
@@ -357,6 +422,10 @@ msgid ""
 "and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
 "(&#x2717;), or unattempted (no symbol)."
 msgstr ""
+"A switch to govern the use of a Progress Bar for the student; this also "
+"enables/disables the highlighting of the current problem in the side bar, "
+"and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
+"(&#x2717;), or unattempted (no symbol)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:101
 msgid ""
@@ -373,27 +442,40 @@ msgid ""
 "Clicking the links in the entries in the assigned sets columns will take you "
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
+"A table showing all the current users along with several fields of user "
+"information. The fields from left to right are: Login Name, Login Status, "
+"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
+"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
+"the links in the column headers will sort the table by the field it "
+"corresponds to. The Login Name fields contain checkboxes for selecting the "
+"user.  Clicking the link of the name itself will allow you to act as the "
+"selected user.  There will also be an image link following the name which "
+"will take you to a page where you can edit the selected user's information.  "
+"Clicking the emails will allow you to email the corresponding user.  "
+"Clicking the links in the entries in the assigned sets columns will take you "
+"to a page where you can view and reassign the sets for the selected user."
 
+# Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
 msgid "ADJ STATUS"
-msgstr ""
+msgstr "ADJ STATUS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
 msgid "ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "ANSWERS NOT RECORDED"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
 msgid "ANSWERS NOT RECORDED --"
-msgstr ""
+msgstr "ANSWERS NOT RECORDED --"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
 msgid "ANSWERS ONLY CHECKED -- "
-msgstr ""
+msgstr "ANSWERS ONLY CHECKED -- "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
@@ -402,106 +484,108 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
 msgid "Abandon changes"
-msgstr ""
+msgstr "Abandon changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
-msgstr ""
+msgstr "Abandon export"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
 msgid "Achievement"
-msgstr ""
+msgstr "Achievement"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
 msgid "Achievement %1 created with evaluator '%2'."
-msgstr ""
+msgstr "Achievement %1 created with evaluator '%2'."
 
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
 msgid "Achievement %1 exists.  No achievement created"
-msgstr ""
+msgstr "Achievement %1 exists.  No achievement created"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
 msgid "Achievement Editor"
-msgstr ""
+msgstr "Achievement Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:726
 msgid "Achievement Evaluator Editor"
-msgstr ""
+msgstr "Achievement Evaluator Editor"
 
 #. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:173
 msgid "Achievement Evaluator for achievement %1"
-msgstr ""
+msgstr "Achievement Evaluator for achievement %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 msgid "Achievement ID"
-msgstr ""
+msgstr "Achievement ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
-msgstr ""
+msgstr "Achievement ID exists!  No new achievement created.  File not saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:202
 msgid "Achievement Points Per Problem"
-msgstr ""
+msgstr "Achievement Points Per Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:736
 msgid "Achievement User Editor"
-msgstr ""
+msgstr "Achievement User Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
 msgid "Achievement has been assigned to all users."
-msgstr ""
+msgstr "Achievement has been assigned to all users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
-msgstr ""
+msgstr "Achievement has been unassigned to all students."
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
 msgid "Achievement scores saved to %1"
-msgstr ""
+msgstr "Achievement scores saved to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
 msgid "Achievements"
-msgstr ""
+msgstr "Achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "Act as"
-msgstr ""
+msgstr "Act as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:161
 msgid "Act as:"
-msgstr ""
+msgstr "Act as:"
 
 #. (HTML::Entities::encode_entities($eUserID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Acting as %1."
-msgstr ""
+msgstr "Acting as %1."
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
 msgid "Action %1 not found"
-msgstr ""
+msgstr "Action %1 not found"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Active"
-msgstr ""
+msgstr "Active"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:198
 msgid ""
 "Activiating this will enable Mathchievements for webwork.  Mathchievements "
 "can be managed by using the Achievement Editor link."
 msgstr ""
+"Activiating this will enable Mathchievements for webwork.  Mathchievements "
+"can be managed by using the Achievement Editor link."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:208
 msgid ""
@@ -509,61 +593,64 @@ msgid ""
 "students who earn achievements with items that allow them to affect their "
 "homework in a limited way."
 msgstr ""
+"Activiating this will enable achievement items. This features rewards "
+"students who earn achievements with items that allow them to affect their "
+"homework in a limited way."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
-msgstr ""
+msgstr "Add"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:942
 msgid "Add All"
-msgstr ""
+msgstr "Add All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
 msgid "Add Course"
-msgstr ""
+msgstr "Add Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
 msgid "Add Students"
-msgstr ""
+msgstr "Add Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
 msgid "Add Users"
-msgstr ""
+msgstr "Add Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid "Add WeBWorK administrators to new course"
-msgstr ""
+msgstr "Add WeBWorK administrators to new course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1384
 msgid "Add a new test for which Gateway?"
-msgstr ""
+msgstr "Add a new test for which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add as what filetype?"
-msgstr ""
+msgstr "Add as what filetype?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
 msgid "Add how many students?"
-msgstr ""
+msgstr "Add how many students?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
 msgid "Add problems to"
-msgstr ""
+msgstr "Add problems to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
 msgid "Add to what set?"
-msgstr ""
+msgstr "Add to what set?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
 msgid "Add which new users?"
-msgstr ""
+msgstr "Add which new users?"
 
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
@@ -575,28 +662,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
 msgid "Added %1 to %2 as problem %3"
-msgstr ""
+msgstr "Added %1 to %2 as problem %3"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
 msgid "Added '%1' to %2 as new hardcopy header"
-msgstr ""
+msgstr "Added '%1' to %2 as new hardcopy header"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
 msgid "Added '%1' to %2 as new set header"
-msgstr ""
+msgstr "Added '%1' to %2 as new set header"
 
 #. (join(', ', @toAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
 msgid "Added addresses %1 to location %2."
-msgstr ""
+msgstr "Added addresses %1 to location %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:409
 msgid "Additional addresses for receiving feedback e-mail."
-msgstr ""
+msgstr "Additional addresses for receiving feedback e-mail."
 
 #. ($badLocAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
@@ -604,6 +691,8 @@ msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
+"Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
+"Please double check the integrity of the WeBWorK database before continuing."
 
 #. (join(', ', @noAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
@@ -611,6 +700,8 @@ msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
+"Address(es) %1 in the add list is(are) already in the location %2, and so "
+"were skipped."
 
 #. (join(', ', @noDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
@@ -618,6 +709,8 @@ msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
+"Address(es) %1 in the delete list is(are) not in the location %2, and so "
+"were skipped."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
@@ -625,6 +718,8 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and resubmit."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
@@ -632,10 +727,12 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 msgid "Addresses"
-msgstr ""
+msgstr "Addresses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
 msgid ""
@@ -643,6 +740,9 @@ msgid ""
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"Addresses for new location.  Enter one per line, as single IP addresses e."
+"g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
+"g., 192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid ""
@@ -650,154 +750,158 @@ msgid ""
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
 "ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"Addresses to add to the location.  Enter one per line, as single IP "
+"addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
+"ranges (e.g., 192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:190
 msgid "Adds 24 hours to the close date of a homework."
-msgstr ""
+msgstr "Adds 24 hours to the close date of a homework."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:273
 msgid "Adds 48 hours to the close date of a homework."
-msgstr ""
+msgstr "Adds 48 hours to the close date of a homework."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 msgid "Adjusted Status"
-msgstr ""
+msgstr "Adjusted Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:595
 msgid "Advanced Search"
-msgstr ""
+msgstr "Advanced Search"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
 msgid "After set answer date"
-msgstr ""
+msgstr "After set answer date"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
+"After the reduced scoring period begins all work counts for %1% of its value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715
 msgid "All Selected Constraints Joined by \"And\""
-msgstr ""
+msgstr "All Selected Constraints Joined by \"And\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:52
 msgid "All assignments were made successfully."
-msgstr ""
+msgstr "All assignments were made successfully."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
 msgid "All of the answers above are correct."
-msgstr ""
+msgstr "All of the answers above are correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
 msgid "All of the gradeable answers above are correct."
-msgstr ""
+msgstr "All of the gradeable answers above are correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "All of these files will also be made available for mail merge."
-msgstr ""
+msgstr "All of these files will also be made available for mail merge."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
 msgid "All selected sets hidden from all students"
-msgstr ""
+msgstr "All selected sets hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
 msgid "All selected sets made visible for all students"
-msgstr ""
+msgstr "All selected sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
 msgid "All sets hidden from all students"
-msgstr ""
+msgstr "All sets hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
 msgid "All sets made visible for all students"
-msgstr ""
+msgstr "All sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "All students in course"
-msgstr ""
+msgstr "All students in course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:57
 msgid "All unassignments were made successfully."
-msgstr ""
+msgstr "All unassignments were made successfully."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
 msgid "All visible hidden from all students"
-msgstr ""
+msgstr "All visible hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
 msgid "All visible sets made visible for all students"
-msgstr ""
+msgstr "All visible sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
 msgid "Allow unassign"
-msgstr ""
+msgstr "Allow unassign"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
 msgid "Allowed error, as a percentage, for numerical comparisons"
-msgstr ""
+msgstr "Allowed error, as a percentage, for numerical comparisons"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
 msgid "Allowed to <em>act as</em> another user"
-msgstr ""
+msgstr "Allowed to <em>act as</em> another user"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
 msgid "Allowed to change their e-mail address"
-msgstr ""
+msgstr "Allowed to change their e-mail address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
 msgid "Allowed to change their password"
-msgstr ""
+msgstr "Allowed to change their password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
 msgid "Allowed to login to the course"
-msgstr ""
+msgstr "Allowed to login to the course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
 msgid "Allowed to see solutions before the answer date"
-msgstr ""
+msgstr "Allowed to see solutions before the answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:324
 msgid "Allowed to see the correct answers before the answer date"
-msgstr ""
+msgstr "Allowed to see the correct answers before the answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
 msgid "Allowed to view past answers"
-msgstr ""
+msgstr "Allowed to view past answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
 msgid "Allowed to view problems in sets which are not open yet"
-msgstr ""
+msgstr "Allowed to view problems in sets which are not open yet"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1441
 msgid "Amulet of Extension"
-msgstr ""
+msgstr "Amulet of Extension"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
 msgid "An error occured while archiving the course %1:"
-msgstr ""
+msgstr "An error occured while archiving the course %1:"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
 msgid "An error occured while changing the title of the course %1."
-msgstr ""
+msgstr "An error occured while changing the title of the course %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
 msgid "An error occured while deleting the course %1:"
-msgstr ""
+msgstr "An error occured while deleting the course %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
 msgid "An error occured while renaming the course %1 to %2:"
-msgstr ""
+msgstr "An error occured while renaming the course %1 to %2:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
@@ -807,57 +911,59 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:805
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:828
 msgid "Answer Date"
-msgstr ""
+msgstr "Answer Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
 msgid "Answer Log"
-msgstr ""
+msgstr "Answer Log"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Answer Preview"
-msgstr ""
+msgstr "Answer Preview"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1268
 msgid "Answer(s) submitted:"
-msgstr ""
+msgstr "Answer(s) submitted:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
 msgid "Answer:"
-msgstr ""
+msgstr "Answer:"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
 msgid "AnswerGroupInfo"
-msgstr ""
+msgstr "AnswerGroupInfo"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
 msgid "AnswerHashInfo"
-msgstr ""
+msgstr "AnswerHashInfo"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
 msgid "Answers"
-msgstr ""
+msgstr "Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
 msgid "Answers Available"
-msgstr ""
+msgstr "Answers Available"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
 msgid "Answers cannot be due until on or after the open date!"
-msgstr ""
+msgstr "Answers cannot be due until on or after the open date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1050
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1123
 msgid "Answers cannot be made available until on or after the close date!"
-msgstr ""
+msgstr "Answers cannot be made available until on or after the close date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
-msgstr ""
+msgstr "Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
@@ -865,6 +971,8 @@ msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
 msgstr ""
+"Any changes made below will be reflected in the set for ONLY the student(s) "
+"listed above."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -872,59 +980,62 @@ msgid ""
 "be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
+"Any time problem numbers are intentionally changed, the problems will always "
+"be renumbered consecutively, starting from one.  When deleting problems, "
+"gaps will be left in the numbering unless the box above is checked."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
 msgid "Append"
-msgstr ""
+msgstr "Append"
 
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
-msgstr ""
+msgstr "Append to end of %1 set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
 msgid "Archive"
-msgstr ""
+msgstr "Archive"
 
 #. ($archive, $n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
 msgid "Archive '%1' created successfully (%quant( %2, file))"
-msgstr ""
+msgstr "Archive '%1' created successfully (%quant( %2, file))"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:938
 msgid "Archive '%1' deleted"
-msgstr ""
+msgstr "Archive '%1' deleted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Archive Course"
-msgstr ""
+msgstr "Archive Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
 msgid "Archive Courses"
-msgstr ""
+msgstr "Archive Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
 msgid "Archive next course"
-msgstr ""
+msgstr "Archive next course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
 msgid "Archive this Course"
-msgstr ""
+msgstr "Archive this Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
 msgid "Archived Courses"
-msgstr ""
+msgstr "Archived Courses"
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
 msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
-msgstr ""
+msgstr "Archiving course as %1.tar.gz. Reload FileManager to see it."
 
 #. (CGI::b($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
@@ -932,6 +1043,8 @@ msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
+"Are you sure that you want to delete the course %1 after archiving? This "
+"cannot be undone!"
 
 #. (CGI::b($delete_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
@@ -939,67 +1052,70 @@ msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
+"Are you sure you want to delete the course %1? All course files and data "
+"will be destroyed. There is no undo available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
-msgstr ""
+msgstr "Assign"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
-msgstr ""
+msgstr "Assign All Sets to Current User"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
 msgid "Assign selected sets to selected users"
-msgstr ""
+msgstr "Assign selected sets to selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
-msgstr ""
+msgstr "Assign this set to which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "Assign to All Current Users"
-msgstr ""
+msgstr "Assign to All Current Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Assigned"
-msgstr ""
+msgstr "Assigned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
 msgid "Assigned Sets"
-msgstr ""
+msgstr "Assigned Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
 msgid "Assigned achievements to users"
-msgstr ""
+msgstr "Assigned achievements to users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
 msgid "Assigned to"
-msgstr ""
+msgstr "Assigned to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
 msgid "Assignment type"
-msgstr ""
+msgstr "Assignment type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
 msgid "At least one of the answers above is NOT correct."
-msgstr ""
+msgstr "At least one of the answers above is NOT correct."
 
+# Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
 msgid "Att. to Open Children"
-msgstr ""
+msgstr "Att. to Open Children"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
 msgid "Attempt to upgrade directories"
-msgstr ""
+msgstr "Attempt to upgrade directories"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
 msgid "Attempted"
-msgstr ""
+msgstr "Attempted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
@@ -1007,55 +1123,55 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
 msgid "Attempts"
-msgstr ""
+msgstr "Attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Audit"
-msgstr ""
+msgstr "Audit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
 msgid "Authentication failed.  Please speak to your instructor."
-msgstr ""
+msgstr "Authentication failed.  Please speak to your instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
 msgid "Author Info"
-msgstr ""
+msgstr "Author Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Automatic"
-msgstr ""
+msgstr "Automatic"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
 msgid "Automatically render problems on page load"
-msgstr ""
+msgstr "Automatically render problems on page load"
 
 #. ($emailDirectory,$old_default_msg_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
 msgid "Backup file <code>%1/%2</code> created."
-msgstr ""
+msgstr "Backup file <code>%1/%2</code> created."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:745
 msgid "Basic Search"
-msgstr ""
+msgstr "Basic Search"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Binary"
-msgstr ""
+msgstr "Binary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1163
 msgid "Box of Transmogrification"
-msgstr ""
+msgstr "Box of Transmogrification"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:885
 msgid "Browse"
-msgstr ""
+msgstr "Browse"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:455
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:812
 msgid "Browse from:"
-msgstr ""
+msgstr "Browse from:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
 msgid ""
@@ -1064,6 +1180,10 @@ msgid ""
 "have the same section as the user initiating the feedback.  I.E.  Feedback "
 "will only be sent to section leaders."
 msgstr ""
+"By default, feeback is always sent to all users specified to recieve "
+"feedback.  This variable sets the system to only email feedback to users who "
+"have the same section as the user initiating the feedback.  I.E.  Feedback "
+"will only be sent to section leaders."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:410
 msgid ""
@@ -1071,108 +1191,111 @@ msgid ""
 "receive feedback. Feedback is also sent to any addresses specified in this "
 "blank. Separate email address entries by commas."
 msgstr ""
+"By default, feeback is sent to all users above who have permission to "
+"receive feedback. Feedback is also sent to any addresses specified in this "
+"blank. Separate email address entries by commas."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
 msgid "CLOSE DATE"
-msgstr ""
+msgstr "CLOSE DATE"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
 msgid "CLOSE TIME"
-msgstr ""
+msgstr "CLOSE TIME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
 msgid "Cake of Enlargment"
-msgstr ""
+msgstr "Cake of Enlargment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
 msgid "Can e-mail instructor"
-msgstr ""
+msgstr "Can e-mail instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
 msgid "Can report bugs"
-msgstr ""
+msgstr "Can report bugs"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
 msgid "Can show old answers"
-msgstr ""
+msgstr "Can show old answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
 msgid "Can submit answers for a student"
-msgstr ""
+msgstr "Can submit answers for a student"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
 msgid "Can't copy file: %1"
-msgstr ""
+msgstr "Can't copy file: %1"
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
 msgid "Can't create archive '%1': command returned %2"
-msgstr ""
+msgstr "Can't create archive '%1': command returned %2"
 
 #. ($courseID,  $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
 msgid "Can't create course environment for %1 because %2"
-msgstr ""
+msgstr "Can't create course environment for %1 because %2"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
 msgid "Can't create directory: %1"
-msgstr ""
+msgstr "Can't create directory: %1"
 
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
 msgid "Can't create file '%1': %2"
-msgstr ""
+msgstr "Can't create file '%1': %2"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
 msgid "Can't create file: %1"
-msgstr ""
+msgstr "Can't create file: %1"
 
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
 msgid "Can't delete archive '%1': %2"
-msgstr ""
+msgstr "Can't delete archive '%1': %2"
 
 #. ($eUserID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
 msgid "Can't get password record for effective user '%1': %2"
-msgstr ""
+msgstr "Can't get password record for effective user '%1': %2"
 
 #. ($userID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
 msgid "Can't get password record for user '%1': %2"
-msgstr ""
+msgstr "Can't get password record for user '%1': %2"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
 msgid "Can't open %1"
-msgstr ""
+msgstr "Can't open %1"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
 msgid "Can't open file %1"
-msgstr ""
+msgstr "Can't open file %1"
 
 #. ($merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
 msgid "Can't read merge file %1. No message sent"
-msgstr ""
+msgstr "Can't read merge file %1. No message sent"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
 msgid "Can't rename file: %1"
-msgstr ""
+msgstr "Can't rename file: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
 msgid "Can't rename to the same name."
-msgstr ""
+msgstr "Can't rename to the same name."
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:805
 msgid "Can't unpack '%1': command returned %2"
-msgstr ""
+msgstr "Can't unpack '%1': command returned %2"
 
 #. ($!)
 #. ($fullPath)
@@ -1180,127 +1303,132 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
 msgid "Can't write to file %1"
-msgstr ""
+msgstr "Can't write to file %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
 msgid "Cancel E-mail"
-msgstr ""
+msgstr "Cancel E-mail"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
 msgid "Cannot open %1"
-msgstr ""
+msgstr "Cannot open %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
 msgid "Cap Test Time at Set Close Date?"
-msgstr ""
+msgstr "Cap Test Time at Set Close Date?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
 msgid "Category"
-msgstr ""
+msgstr "Category"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:451
 msgid ""
 "Cause the selected homework set to count for twice as many points as it "
 "normally would."
 msgstr ""
+"Cause the selected homework set to count for twice as many points as it "
+"normally would."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1164
 msgid ""
 "Causes a homework problem to become a clone of another problem from the same "
 "set."
 msgstr ""
+"Causes a homework problem to become a clone of another problem from the same "
+"set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
 msgid "Causes a single homework problem to be worth twice as much."
-msgstr ""
+msgstr "Causes a single homework problem to be worth twice as much."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
 msgid "Change Course Title to:"
-msgstr ""
+msgstr "Change Course Title to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
 msgid "Change CourseID to:"
-msgstr ""
+msgstr "Change CourseID to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
 msgid "Change Display Settings"
-msgstr ""
+msgstr "Change Display Settings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
 msgid "Change Email Address"
-msgstr ""
+msgstr "Change Email Address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
 msgid "Change Institution to:"
-msgstr ""
+msgstr "Change Institution to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
 msgid "Change Password"
-msgstr ""
+msgstr "Change Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
 msgid "Change User Settings"
-msgstr ""
+msgstr "Change User Settings"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
 msgid "Change course institution from %1 to %2"
-msgstr ""
+msgstr "Change course institution from %1 to %2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
 msgid "Change title from %1 to %2"
-msgstr ""
+msgstr "Change title from %1 to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
 msgid "Changes abandoned"
-msgstr ""
+msgstr "Changes abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
 msgid "Changes in this file have not yet been permanently saved."
-msgstr ""
+msgstr "Changes in this file have not yet been permanently saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
 msgid "Changes saved"
-msgstr ""
+msgstr "Changes saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1354
 msgid ""
 "Changing the problem seed for display, but there are no problems showing."
 msgstr ""
+"Changing the problem seed for display, but there are no problems showing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:598
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:727
 msgid "Chapter:"
-msgstr ""
+msgstr "Chapter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
 msgid "Check Answers"
-msgstr ""
+msgstr "Check Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
 msgid "Check Test"
-msgstr ""
+msgstr "Check Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
 msgid "Check that it's permissions are set correctly."
-msgstr ""
+msgstr "Check that it's permissions are set correctly."
 
 #. ($emailDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
@@ -1308,60 +1436,64 @@ msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
+"Check whether it exists and whether the directory %1 can be read by the "
+"webserver."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
 msgid "Checking additional error messages"
-msgstr ""
+msgstr "Checking additional error messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:477
 msgid "Choose the set which you would like to be worth twice as much."
-msgstr ""
+msgstr "Choose the set which you would like to be worth twice as much."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:386
 msgid "Choose the set which you would like to enable partial credit for."
-msgstr ""
+msgstr "Choose the set which you would like to enable partial credit for."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
 msgid "Choose the set which you would like to ressurect."
-msgstr ""
+msgstr "Choose the set which you would like to ressurect."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
 msgid "Choose the set whose close date you would like to extend."
-msgstr ""
+msgstr "Choose the set whose close date you would like to extend."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
-msgstr ""
+msgstr "Choose visibility of the sets to be affected"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
 msgid "Choose which sets to be affected"
-msgstr ""
+msgstr "Choose which sets to be affected"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:523
 msgid "Class values"
-msgstr ""
+msgstr "Class values"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
 msgid "Classlist Editor"
-msgstr ""
+msgstr "Classlist Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
 msgid "Clear"
-msgstr ""
+msgstr "Clear"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
 msgid "Clear Problem Display"
-msgstr ""
+msgstr "Clear Problem Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
 msgid ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 msgstr ""
+"Click on a student's name to see the student's version of the homework set. "
+"Click heading to sort table."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
@@ -1369,6 +1501,8 @@ msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
+"Click on the login name to edit individual problem set data, (e.g. due "
+"dates) for these students."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
@@ -1378,10 +1512,14 @@ msgid ""
 "associated with the restriction.  Contact your professor to have this "
 "problem resolved."
 msgstr ""
+"Client ip address %1 is not allowed to work this assignment, because the "
+"assignment has ip address restrictions and there are no allowed locations "
+"associated with the restriction.  Contact your professor to have this "
+"problem resolved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
@@ -1392,47 +1530,47 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Close Date"
-msgstr ""
+msgstr "Close Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
 msgid "Closed, answers available."
-msgstr ""
+msgstr "Closed, answers available."
 
 #. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
 msgid "Closed, answers on %1."
-msgstr ""
+msgstr "Closed, answers on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
 msgid "Closed, answers recently available."
-msgstr ""
+msgstr "Closed, answers recently available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
 msgid "Closed."
-msgstr ""
+msgstr "Closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
 msgid "Closes"
-msgstr ""
+msgstr "Closes"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
 msgid "Closes %1"
-msgstr ""
+msgstr "Closes %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
 msgid "Closes:"
-msgstr ""
+msgstr "Closes:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
 msgid "Collapse"
-msgstr ""
+msgstr "Collapse"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
 msgid "Collapse All"
-msgstr ""
+msgstr "Collapse All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
@@ -1451,104 +1589,102 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Comment"
-msgstr ""
+msgstr "Comment"
 
 #. ($self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
 msgid "Completed results for this assignment are not available until %1"
-msgstr ""
+msgstr "Completed results for this assignment are not available until %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Completed results for this assignment are not available."
-msgstr ""
+msgstr "Completed results for this assignment are not available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
 msgid "Completed."
-msgstr ""
+msgstr "Completed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "Confirm"
-msgstr ""
+msgstr "Confirm"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
 msgid "Confirm %1's New Password"
-msgstr ""
+msgstr "Confirm %1's New Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
 msgid "Confirm Password:"
-msgstr ""
+msgstr "Confirm Password:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
 msgid "Congratulations, you earned a new level!"
-msgstr ""
+msgstr "Congratulations, you earned a new level!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
 msgid "Continue"
-msgstr ""
+msgstr "Continue"
 
 #. ($sourceDirectory, $outputDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
 msgid "Copied auxiliary files from %1 to new location at %2"
-msgstr ""
+msgstr "Copied auxiliary files from %1 to new location at %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy"
-msgstr ""
+msgstr "Copy"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy file as:"
-msgstr ""
+msgstr "Copy file as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
 msgid "Copy templates from:"
-msgstr ""
+msgstr "Copy templates from:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
-#, fuzzy
 msgid "Copy this Problem"
-msgstr "Problem List"
+msgstr "Copy this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
-msgstr ""
+msgstr "Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:644
 msgid "Correct Adjusted Status"
-msgstr ""
+msgstr "Correct Adjusted Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Correct Answer"
-msgstr ""
+msgstr "Correct Answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
 msgid "Correct Answers:"
-msgstr ""
+msgstr "Correct Answers:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
 msgid "Correct Status"
-msgstr ""
+msgstr "Correct Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
 msgid "Correct answers"
-msgstr ""
+msgstr "Correct answers"
 
 #. ($total_correct,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
 msgid "Correct: %1/%2"
-msgstr ""
+msgstr "Correct: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
 msgid "CorrectAnswers"
-msgstr ""
+msgstr "CorrectAnswers"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
@@ -1556,104 +1692,105 @@ msgstr ""
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
+"Could not add %1 problems to this set.  The number must be between 1 and %2"
 
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
 msgid "Couldn't change %1's password: %2"
-msgstr ""
+msgstr "Couldn't change %1's password: %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
 msgid "Couldn't change your email address: %1"
-msgstr ""
+msgstr "Couldn't change your email address: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
 msgid "Couldn't find OPL Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find OPL Branch %1 in remote %2"
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
 msgid "Couldn't find PG Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find PG Branch %1 in remote %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find WeBWorK Branch %1 in remote %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
 msgid "Couldn't save your display options: %1"
-msgstr ""
+msgstr "Couldn't save your display options: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
-msgstr ""
+msgstr "Counter"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
 msgid "Counts for Parent"
-msgstr ""
+msgstr "Counts for Parent"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
 msgid "Course %1 database is in order"
-msgstr ""
+msgstr "Course %1 database is in order"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
 msgid "Course %1 databases must be updated before renaming this course."
-msgstr ""
+msgstr "Course %1 databases must be updated before renaming this course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
-msgstr ""
+msgstr "Course Administration"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
 msgid "Course Configuration"
-msgstr ""
+msgstr "Course Configuration"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
-msgstr ""
+msgstr "Course ID may only contain letters, numbers, hyphens, and underscores."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
 msgid "Course ID:"
-msgstr ""
+msgstr "Course ID:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "Course Info"
-msgstr ""
+msgstr "Course Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
 msgid "Course Name:"
-msgstr ""
+msgstr "Course Name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
 msgid "Course Title:"
-msgstr ""
+msgstr "Course Title:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
 msgid "Course archived."
-msgstr ""
+msgstr "Course archived."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
-msgstr ""
+msgstr "Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
@@ -1665,36 +1802,41 @@ msgid ""
 "Course_Name (status :: date/time of most recent login) where status is "
 "\"hidden\" or \"visible\"."
 msgstr ""
+"Courses are listed either alphabetically or in order by the time of most "
+"recent login activity, oldest first. To change the listing order check the "
+"mode you want and click \"Refresh Listing\".  The listing format is: "
+"Course_Name (status :: date/time of most recent login) where status is "
+"\"hidden\" or \"visible\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "Create"
-msgstr ""
+msgstr "Create"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
 msgid "Create CSV"
-msgstr ""
+msgstr "Create CSV"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
 msgid "Create Location:"
-msgstr ""
+msgstr "Create Location:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
-msgstr ""
+msgstr "Create a New Set in This Course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
 msgid "Create a new achievement with ID"
-msgstr ""
+msgstr "Create a new achievement with ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
-msgstr ""
+msgstr "Create as what type of set?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
-msgstr ""
+msgstr "Create unattached problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
 msgid ""
@@ -1704,74 +1846,82 @@ msgid ""
 "is only available for mysql databases. It depends on the mysqldump "
 "application."
 msgstr ""
+"Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
+"directory. Before archiving, the course database is dumped into a "
+"subdirectory of the course's DATA directory. Currently the archive facility "
+"is only available for mysql databases. It depends on the mysqldump "
+"application."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:648
 msgid "Cupcake of Enlargement"
-msgstr ""
+msgstr "Cupcake of Enlargement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 msgid "Current"
-msgstr ""
+msgstr "Current"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
 msgid "Currently defined locations are listed below."
-msgstr ""
+msgstr "Currently defined locations are listed below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
 msgid "Data"
-msgstr ""
+msgstr "Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
 msgid "Database tables are ok"
-msgstr ""
+msgstr "Database tables are ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables need updating."
-msgstr ""
+msgstr "Database tables need updating."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables ok"
-msgstr ""
+msgstr "Database tables ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
 msgid "Database:"
-msgstr ""
+msgstr "Database:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:189
 msgid ""
 "Default Amount of Time (in minutes) after Due Date that Answers are Open"
 msgstr ""
+"Default Amount of Time (in minutes) after Due Date that Answers are Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:183
 msgid ""
 "Default Amount of Time (in minutes) before Due Date that the Assignment is "
 "Open"
 msgstr ""
+"Default Amount of Time (in minutes) before Due Date that the Assignment is "
+"Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:247
 msgid "Default Length of Reduced Scoring Period in minutes"
-msgstr ""
+msgstr "Default Length of Reduced Scoring Period in minutes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:177
 msgid "Default Time that the Assignment is Due"
-msgstr ""
+msgstr "Default Time that the Assignment is Due"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
@@ -1780,7 +1930,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
 msgid "Delete"
-msgstr ""
+msgstr "Delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
@@ -1788,110 +1938,112 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
 msgid "Delete Course"
-msgstr ""
+msgstr "Delete Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
 msgid "Delete all existing addresses"
-msgstr ""
+msgstr "Delete all existing addresses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
 msgid "Delete course after archiving. Caution there is no undo!"
-msgstr ""
+msgstr "Delete course after archiving. Caution there is no undo!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
 msgid "Delete course:"
-msgstr ""
+msgstr "Delete course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
 msgid "Delete how many?"
-msgstr ""
+msgstr "Delete how many?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
 msgid "Delete it?"
-msgstr ""
+msgstr "Delete it?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
 msgid "Delete location:"
-msgstr ""
+msgstr "Delete location:"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
 msgid "Deleted %quant(%1,achievement)"
-msgstr ""
+msgstr "Deleted %quant(%1,achievement)"
 
 #. (join(', ', @delLocations)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Deleted Location(s): %1"
-msgstr ""
+msgstr "Deleted Location(s): %1"
 
 #. (join(', ', @toDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
 msgid "Deleted addresses %1 from location."
-msgstr ""
+msgstr "Deleted addresses %1 from location."
 
 #. ($self->shortPath($self->{tempFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
 msgid "Deleting temp file at %1"
-msgstr ""
+msgstr "Deleting temp file at %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
+"Deletion deletes all location data and related addresses, and is not "
+"undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
 msgid "Deletion destroys all achievement-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all achievement-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
 msgid "Deletion destroys all set-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all set-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
 msgid "Deletion destroys all user-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all user-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
 msgid "Deny From"
-msgstr ""
+msgstr "Deny From"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
 msgid "Didn't recognize action"
-msgstr ""
+msgstr "Didn't recognize action"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
 msgid "Directory"
-msgstr ""
+msgstr "Directory"
 
 #. ($file, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
 msgid "Directory '%1' not removed: %2"
-msgstr ""
+msgstr "Directory '%1' not removed: %2"
 
 #. ($file, $removed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:678
 msgid "Directory '%1' removed (items deleted: %2)"
-msgstr ""
+msgstr "Directory '%1' removed (items deleted: %2)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "Directory permission errors "
-msgstr ""
+msgstr "Directory permission errors "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
 msgid "Directory structure"
-msgstr ""
+msgstr "Directory structure"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
@@ -1901,102 +2053,104 @@ msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
+"Directory structure is missing directories or the webserver lacks sufficient "
+"privileges."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
 msgid "Directory structure is ok"
-msgstr ""
+msgstr "Directory structure is ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
 msgid "Directory structure needs to be repaired manually before archiving."
-msgstr ""
+msgstr "Directory structure needs to be repaired manually before archiving."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
 msgid "Directory structure needs to be repaired manually before renaming."
-msgstr ""
+msgstr "Directory structure needs to be repaired manually before renaming."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
 msgid "Directory structure or permissions need to be repaired. "
-msgstr ""
+msgstr "Directory structure or permissions need to be repaired. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
-msgstr ""
+msgstr "Display Mode:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
-msgstr ""
+msgstr "Display Past Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
-msgstr ""
+msgstr "Display options: Show"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
 msgid "Display the evaluated student answer"
-msgstr ""
+msgstr "Display the evaluated student answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
-msgstr ""
+msgstr "Do not unassign students unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:274
 msgid "Do not uncheck a set unless you know what you are doing."
-msgstr ""
+msgstr "Do not uncheck a set unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
 msgid "Do not uncheck students, unless you know what you are doing."
-msgstr ""
+msgstr "Do not uncheck students, unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Don't Archive"
-msgstr ""
+msgstr "Don't Archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
 msgid "Don't Unarchive"
-msgstr ""
+msgstr "Don't Unarchive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
 msgid "Don't Upgrade"
-msgstr ""
+msgstr "Don't Upgrade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
 msgid "Don't delete"
-msgstr ""
+msgstr "Don't delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
 msgid "Don't make changes"
-msgstr ""
+msgstr "Don't make changes"
 
 #. ($saveMode)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
 msgid "Don't recognize saveMode: |%1|. Unknown error."
-msgstr ""
+msgstr "Don't recognize saveMode: |%1|. Unknown error."
 
 #. ($type)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
 msgid "Don't recognize statistics display type: |%1|"
-msgstr ""
+msgstr "Don't recognize statistics display type: |%1|"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
 msgid "Don't rename"
-msgstr ""
+msgstr "Don't rename"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
 msgid "Don't use in an achievement"
-msgstr ""
+msgstr "Don't use in an achievement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
 msgid "Done"
-msgstr ""
+msgstr "Done"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
@@ -2006,49 +2160,49 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 #. ($set->set_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
 msgid "Download %1"
-msgstr ""
+msgstr "Download %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:267
 msgid "Download Hardcopy"
-msgstr ""
+msgstr "Download Hardcopy"
 
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr ""
+msgstr "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
 msgid "Download PDF or TeX Hardcopy for Current Set"
-msgstr ""
+msgstr "Download PDF or TeX Hardcopy for Current Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
-msgstr ""
+msgstr "Download PDF or TeX Hardcopy for Selected Sets"
 
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
 msgid "Download hardcopy of set %1 for %2?"
-msgstr ""
+msgstr "Download hardcopy of set %1 for %2?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
 msgid "Download:"
-msgstr ""
+msgstr "Download:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
-msgstr ""
+msgstr "Drop"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
-msgstr ""
+msgstr "Duplicate this set and name it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:371
 msgid ""
@@ -2061,36 +2215,46 @@ msgid ""
 "will be used by default, and choosing <i>true</i> means that the old answer "
 "checkers will be used by default."
 msgstr ""
+"During summer 2005, a newer version of the answer checkers was implemented "
+"for answers which are functions and numbers.  The newer checkers allow more "
+"functions in student answers, and behave better in certain cases.  Some "
+"problems are specifically coded to use new (or old) answer checkers.  "
+"However, for the bulk of the problems, you can choose what the default will "
+"be here.  <p>Choosing <i>false</i> here means that the newer answer checkers "
+"will be used by default, and choosing <i>true</i> means that the old answer "
+"checkers will be used by default."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
 msgid "E-Mail"
-msgstr ""
+msgstr "E-Mail"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
 msgid "E-mail Instructor"
-msgstr ""
+msgstr "E-mail Instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:399
 msgid "E-mail addresses which can receive e-mail from a pg problem"
-msgstr ""
+msgstr "E-mail addresses which can receive e-mail from a pg problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:404
 msgid ""
 "E-mail feedback from students automatically sent to this permission level "
 "and higher:"
 msgstr ""
+"E-mail feedback from students automatically sent to this permission level "
+"and higher:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:389
 msgid "E-mail verbosity level"
-msgstr ""
+msgstr "E-mail verbosity level"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
 msgid "E-mail:"
-msgstr ""
+msgstr "E-mail:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Earned"
-msgstr ""
+msgstr "Earned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
@@ -2106,82 +2270,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
 msgid "Edit"
-msgstr ""
+msgstr "Edit"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
 msgid "Edit %1 of set %2."
-msgstr ""
+msgstr "Edit %1 of set %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
-msgstr ""
+msgstr "Edit All Set Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
-msgstr ""
+msgstr "Edit Assigned Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
 msgid "Edit Evaluator"
-msgstr ""
+msgstr "Edit Evaluator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 msgid "Edit Header"
-msgstr ""
+msgstr "Edit Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
 msgid "Edit Location:"
-msgstr ""
+msgstr "Edit Location:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Edit Problem"
-msgstr ""
+msgstr "Edit Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
 msgid "Edit Problems"
-msgstr ""
+msgstr "Edit Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
 msgid "Edit Set"
-msgstr ""
+msgstr "Edit Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
-msgstr ""
+msgstr "Edit Set Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
 msgid "Edit Target Set"
-msgstr ""
+msgstr "Edit Target Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
 msgid "Edit Which Users?"
-msgstr ""
+msgstr "Edit Which Users?"
 
 #. ($user)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:199
 msgid "Edit data for %1"
-msgstr ""
+msgstr "Edit data for %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
 msgid "Edit it"
-msgstr ""
+msgstr "Edit it"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
 msgid "Edit set %1 data for ALL students assigned to this set."
-msgstr ""
+msgstr "Edit set %1 data for ALL students assigned to this set."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "Edit set %1 for this user."
-msgstr ""
+msgstr "Edit set %1 for this user."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
 msgid ""
@@ -2190,63 +2354,66 @@ msgid ""
 "make all of your changes.  Or, click \"Manage Locations\" above to make no "
 "changes and return to the Manage Locations page."
 msgstr ""
+"Edit the current value of the location description, if desired, then add and "
+"select addresses to delete, and then click the \"Take Action\" button to "
+"make all of your changes.  Or, click \"Manage Locations\" above to make no "
+"changes and return to the Manage Locations page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
 msgid "Edit which sets?"
-msgstr ""
+msgstr "Edit which sets?"
 
+# Edit with a number 1 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
 msgid "Edit1"
-msgstr ""
+msgstr "Edit1"
 
+# Edit with a number 2 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
 msgid "Edit2"
-msgstr ""
+msgstr "Edit2"
 
+# Edit with a number 3 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
 msgid "Edit3"
-msgstr ""
+msgstr "Edit3"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
 msgid "Editing %1 in file '%2'"
-msgstr ""
+msgstr "Editing %1 in file '%2'"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
 msgid "Editing achievement in file '%1'"
-msgstr ""
+msgstr "Editing achievement in file '%1'"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
 msgid "Editing location %1"
-msgstr ""
+msgstr "Editing location %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Editing problem set %1 data for these individual students: %2"
-msgstr ""
+msgstr "Editing problem set %1 data for these individual students: %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
-#, fuzzy
 msgid "Editor"
-msgstr "Problem List"
+msgstr "Editor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
-#, fuzzy
 msgid "Editor rows:"
-msgstr "Problem List"
+msgstr "Editor rows:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -2258,29 +2425,29 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
 msgid "Email Address"
-msgstr ""
+msgstr "Email Address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
 msgid "Email Body:"
-msgstr ""
+msgstr "Email Body:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
 msgid "Email Instructor On Failed Attempt"
-msgstr ""
+msgstr "Email Instructor On Failed Attempt"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Email Link"
-msgstr ""
+msgstr "Email Link"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
 msgid "Email address"
-msgstr ""
+msgstr "Email address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
 msgid "Email instructor"
-msgstr ""
+msgstr "Email instructor"
 
 #. (scalar(@{$self->{ra_send_to}})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
@@ -2289,51 +2456,56 @@ msgid ""
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
+"Email is being sent to %quant(%1,recipient). You will be notified by email "
+"when the task is completed.  This may take several minutes if the class is "
+"large."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 msgid "Emails to be sent to the following:"
-msgstr ""
+msgstr "Emails to be sent to the following:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
 msgid "Enable Achievement Items"
-msgstr ""
+msgstr "Enable Achievement Items"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Enable Conditional Release"
-msgstr ""
+msgstr "Enable Conditional Release"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
 msgid "Enable Course Achievements"
-msgstr ""
+msgstr "Enable Course Achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
 msgid "Enable Progress Bar and current problem highlighting"
-msgstr ""
+msgstr "Enable Progress Bar and current problem highlighting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
 msgid "Enable Reduced Scoring"
-msgstr ""
+msgstr "Enable Reduced Scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
 msgid "Enable Show Me Another button"
-msgstr ""
+msgstr "Enable Show Me Another button"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
 msgid "Enable periodic re-randomization of problems"
-msgstr ""
+msgstr "Enable periodic re-randomization of problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:358
 msgid ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
+"Enable reduced scoring for a homework set.  This will allow you to submit "
+"answers for partial credit for 24 hours after the close date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Enabled"
-msgstr ""
+msgstr "Enabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
 msgid ""
@@ -2341,6 +2513,9 @@ msgid ""
 "attempts. Student would have to click Request New Version to obtain new "
 "version of the problem and to continue working on the problem"
 msgstr ""
+"Enables periodic re-randomization of problems after a given number of "
+"attempts. Student would have to click Request New Version to obtain new "
+"version of the problem and to continue working on the problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:213
 msgid ""
@@ -2350,12 +2525,19 @@ msgid ""
 "homework set until they have achieved the minimum score on all of the listed "
 "sets."
 msgstr ""
+"Enables the use of the conditional release system.  To use conditional "
+"release you need to specify a list of set names on the Problem Set Detail "
+"Page, along with a minimum score.  Students will not be able to access that "
+"homework set until they have achieved the minimum score on all of the listed "
+"sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
 msgid ""
 "Enables the use of the date picker on the Homework Sets Editor 2 page and "
 "the Problem Set Detail page"
 msgstr ""
+"Enables the use of the date picker on the Homework Sets Editor 2 page and "
+"the Problem Set Detail page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:253
 msgid ""
@@ -2363,14 +2545,17 @@ msgid ""
 "seeded version of the current problem, complete with solution (if it exists "
 "for that problem)."
 msgstr ""
+"Enables use of the Show Me Another button, which offers the student a newly-"
+"seeded version of the current problem, complete with solution (if it exists "
+"for that problem)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Enrolled"
-msgstr ""
+msgstr "Enrolled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
 msgid "Enrolled, Drop, etc."
-msgstr ""
+msgstr "Enrolled, Drop, etc."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
@@ -2381,40 +2566,42 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "Enrollment Status"
-msgstr ""
+msgstr "Enrollment Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
 msgid "Enter filename below"
-msgstr ""
+msgstr "Enter filename below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
 msgid "Enter filenames below"
-msgstr ""
+msgstr "Enter filenames below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:132
 msgid ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 msgstr ""
+"Enter information below for students you wish to add. Each student's "
+"password will initially be set to their student ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
 msgid "Entered"
-msgstr ""
+msgstr "Entered"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
 msgid "Entered student:"
-msgstr ""
+msgstr "Entered student:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
 msgid "Equation Display"
-msgstr ""
+msgstr "Equation Display"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1442
 msgid "Error adding set-level proctor: %1"
-msgstr ""
+msgstr "Error adding set-level proctor: %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1344
@@ -2423,24 +2610,26 @@ msgid ""
 "Error getting old set-proctor password from the database: %1.  No update to "
 "the password was done."
 msgstr ""
+"Error getting old set-proctor password from the database: %1.  No update to "
+"the password was done."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
 msgid "Error message:"
-msgstr ""
+msgstr "Error message:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
 msgid "Error messages"
-msgstr ""
+msgstr "Error messages"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
 msgid "Error: Answer date must come after close date in set %1"
-msgstr ""
+msgstr "Error: Answer date must come after close date in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1534
 msgid "Error: Close date must come after open date in set %1"
-msgstr ""
+msgstr "Error: Close date must come after open date in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1551
@@ -2448,33 +2637,35 @@ msgid ""
 "Error: Reduced scoring date must come between the open date and close date "
 "in set %1"
 msgstr ""
+"Error: Reduced scoring date must come between the open date and close date "
+"in set %1"
 
 #. ($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
-msgstr ""
+msgstr "Error: The original file %1 cannot be read."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1528
 msgid "Error: answer date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: answer date cannot be more than 10 years from now in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1082
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1526
 msgid "Error: close date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: close date cannot be more than 10 years from now in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
 msgid "Error: open date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: open date cannot be more than 10 years from now in set %1"
 
 #. ($problem_desc, $problem_name, CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1230
@@ -2482,6 +2673,8 @@ msgid ""
 "Errors encountered while processing %1. This %2 has been omitted from the "
 "hardcopy. Error text: %3"
 msgstr ""
+"Errors encountered while processing %1. This %2 has been omitted from the "
+"hardcopy. Error text: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
@@ -2490,6 +2683,9 @@ msgid ""
 "create the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"Errors occured while hiding the courses listed below when attempting to "
+"create the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
@@ -2498,135 +2694,147 @@ msgid ""
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"Errors occured while unhiding the courses listed below when attempting "
+"delete the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 msgid "Evaluator"
-msgstr ""
+msgstr "Evaluator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
 msgid "Evaluator File"
-msgstr ""
+msgstr "Evaluator File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
+"Except for possible errors listed above, all selected courses are already "
+"hidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
+"Except for possible errors listed above, all selected courses are already "
+"unhidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
+"Existing addresses for the location are given in the scrolling list below.  "
+"Select addresses from the list to delete them:"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
 msgid "Existing file %1 could not be backed up and was lost."
-msgstr ""
+msgstr "Existing file %1 could not be backed up and was lost."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
 msgid "Expand"
-msgstr ""
+msgstr "Expand"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
 msgid "Expand All"
-msgstr ""
+msgstr "Expand All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
 msgid "Export"
-msgstr ""
+msgstr "Export"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
 msgid "Export selected achievements."
-msgstr ""
+msgstr "Export selected achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
 msgid "Export selected sets"
-msgstr ""
+msgstr "Export selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
 msgid "Export to what kind of file?"
-msgstr ""
+msgstr "Export to what kind of file?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
 msgid "Export which sets?"
-msgstr ""
+msgstr "Export which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
 msgid "Export which users?"
-msgstr ""
+msgstr "Export which users?"
 
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
 msgid "Exported achievements to %1"
-msgstr ""
+msgstr "Exported achievements to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
 msgid "Extend the close date for which Gateway?"
-msgstr ""
+msgstr "Extend the close date for which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1442
 msgid ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 msgstr ""
+"Extends the close date of a gateway test by 24 hours. Note: The test must "
+"still be open for this to work."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "FIRST NAME"
-msgstr ""
+msgstr "FIRST NAME"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
 msgid "Failed to create new achievement: %1"
-msgstr ""
+msgstr "Failed to create new achievement: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
 msgid "Failed to create new achievement: no achievement ID specified!"
-msgstr ""
+msgstr "Failed to create new achievement: no achievement ID specified!"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
 msgid "Failed to create new set: %1"
-msgstr ""
+msgstr "Failed to create new set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
-msgstr ""
+msgstr "Failed to create new set: no set name specified!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
+"Failed to duplicate achievement: no achievement selected for duplication!"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
 msgid "Failed to duplicate set: %1"
-msgstr ""
+msgstr "Failed to duplicate set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
-msgstr ""
+msgstr "Failed to duplicate set: no set name specified!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
-msgstr ""
+msgstr "Failed to duplicate set: no set selected for duplication!"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr ""
+msgstr "Failed to duplicate set: set %1 already exists!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
 msgid "Failed to enter student:"
-msgstr ""
+msgstr "Failed to enter student:"
 
 #. ($filePath)
 #. ($scoreFilePath)
@@ -2636,56 +2844,56 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
 msgid "Failed to open %1"
-msgstr ""
+msgstr "Failed to open %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
 msgid "Failed to save: %1"
-msgstr ""
+msgstr "Failed to save: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "False"
-msgstr ""
+msgstr "False"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
 msgid "Feature exhausted for this problem"
-msgstr ""
+msgstr "Feature exhausted for this problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
 msgid "Feedback"
-msgstr ""
+msgstr "Feedback"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:414
 msgid "Feedback by Section."
-msgstr ""
+msgstr "Feedback by Section."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
 msgid "FeedbackMessage"
-msgstr ""
+msgstr "FeedbackMessage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Field is ok"
-msgstr ""
+msgstr "Field is ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
 msgid "Field missing in database"
-msgstr ""
+msgstr "Field missing in database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Field missing in schema"
-msgstr ""
+msgstr "Field missing in schema"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
 msgid "File '%1' exists.  File not saved.  No changes have been made."
-msgstr ""
+msgstr "File '%1' exists.  File not saved.  No changes have been made."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
@@ -2694,69 +2902,71 @@ msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
+"File '%1' exists. File not saved. No changes have been made.  You can change "
+"the file path for this problem manually from the 'Hmwk Sets Editor' page"
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
 msgid "File '%1' not removed: %2"
-msgstr ""
+msgstr "File '%1' not removed: %2"
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:681
 msgid "File '%1' successfully removed"
-msgstr ""
+msgstr "File '%1' successfully removed"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:935
 msgid "File '%2' uploaded successfully"
-msgstr ""
+msgstr "File '%2' uploaded successfully"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
-msgstr ""
+msgstr "File <b>%1</b> already exists. Overwrite it, or rename it as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
 msgid "File Compare"
-msgstr ""
+msgstr "File Compare"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
 msgid "File Manager"
-msgstr ""
+msgstr "File Manager"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
 msgid "File saved"
-msgstr ""
+msgstr "File saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
 msgid "File successfully copied"
-msgstr ""
+msgstr "File successfully copied"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:644
 msgid "File successfully renamed"
-msgstr ""
+msgstr "File successfully renamed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
 msgid "Filename"
-msgstr ""
+msgstr "Filename"
 
 #. ($extension,$location)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1168
 msgid "Files with extension '.%1' usually belong in '%2'"
-msgstr ""
+msgstr "Files with extension '.%1' usually belong in '%2'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
 msgid "Filter by what text?"
-msgstr ""
+msgstr "Filter by what text?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
 msgid "Filter:"
-msgstr ""
+msgstr "Filter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
 msgid "First"
-msgstr ""
+msgstr "First"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -2773,11 +2983,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
 msgid "First Name"
-msgstr ""
+msgstr "First Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
 msgid "First name"
-msgstr ""
+msgstr "First name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
 msgid ""
@@ -2786,179 +2996,185 @@ msgid ""
 "Please specify a different file or move the needed file to the email "
 "directory"
 msgstr ""
+"For security reasons, you cannot specify a message file from a directory "
+"higher than the email directory (you can't use ../blah/blah for example). "
+"Please specify a different file or move the needed file to the email "
+"directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
 msgid "Force problems to be numbered consecutively from one"
-msgstr ""
+msgstr "Force problems to be numbered consecutively from one"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2303
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+"Force problems to be numbered consecutively from one (always done when "
+"reordering problems)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
-msgstr ""
+msgstr "Format for the subject line in feedback e-mails"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
-msgstr ""
+msgstr "From This Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
 msgid "From field must contain one valid email address."
-msgstr ""
+msgstr "From field must contain one valid email address."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
 msgid "From:"
-msgstr ""
+msgstr "From:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1075
 msgid "GLOBAL Usage"
-msgstr ""
+msgstr "GLOBAL Usage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
 msgid "Gateway Name "
-msgstr ""
+msgstr "Gateway Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
 msgid "Gateway Quiz %2"
-msgstr ""
+msgstr "Gateway Quiz %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:808
 msgid "Gateway parameters"
-msgstr ""
+msgstr "Gateway parameters"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:120
 msgid "General"
-msgstr ""
+msgstr "General"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
 msgid "General Information"
-msgstr ""
+msgstr "General Information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate Hardcopy"
-msgstr ""
+msgstr "Generate Hardcopy"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate hardcopy for selected sets and selected users"
-msgstr ""
+msgstr "Generate hardcopy for selected sets and selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
 msgid "Get Library Set Problems"
-msgstr ""
+msgstr "Get Library Set Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
 msgid "Get Target Set Problems"
-msgstr ""
+msgstr "Get Target Set Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
 msgid "Give new password to"
-msgstr ""
+msgstr "Give new password to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
 msgid "Give new password to which users?"
-msgstr ""
+msgstr "Give new password to which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:968
 msgid "Gives full credit on a single homework problem."
-msgstr ""
+msgstr "Gives full credit on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1079
 msgid "Gives full credit on every problem in a set."
-msgstr ""
+msgstr "Gives full credit on every problem in a set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:762
 msgid "Gives half credit on a single homework problem."
-msgstr ""
+msgstr "Gives half credit on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:878
 msgid "Gives half credit on every problem in a set."
-msgstr ""
+msgstr "Gives half credit on every problem in a set."
 
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
 msgid "Global problem %1 for set %2 not found."
-msgstr ""
+msgstr "Global problem %1 for set %2 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "Global set data will be shown instead of user specific data"
-msgstr ""
+msgstr "Global set data will be shown instead of user specific data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:155
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 msgid "Grade"
-msgstr ""
+msgstr "Grade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
 msgid "Grade Problem"
-msgstr ""
+msgstr "Grade Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
 msgid "Grade Test"
-msgstr ""
+msgstr "Grade Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
 msgid "Grader"
-msgstr ""
+msgstr "Grader"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
 msgid "Grades"
-msgstr ""
+msgstr "Grades"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:97
 msgid "Grades have been saved for all current users."
-msgstr ""
+msgstr "Grades have been saved for all current users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:229
 msgid "Grading assignment:"
-msgstr ""
+msgstr "Grading assignment:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:967
 msgid "Greater Rod of Revelation"
-msgstr ""
+msgstr "Greater Rod of Revelation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1078
 msgid "Greater Tome of Enlightenment"
-msgstr ""
+msgstr "Greater Tome of Enlightenment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
 msgid "Guest Login"
-msgstr ""
+msgstr "Guest Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
 msgid "HTTP Headers"
-msgstr ""
+msgstr "HTTP Headers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
 msgid "Hardcopy Format:"
-msgstr ""
+msgstr "Hardcopy Format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
 msgid "Hardcopy Generator"
-msgstr ""
+msgstr "Hardcopy Generator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
@@ -2967,100 +3183,103 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:783
 msgid "Hardcopy Header"
-msgstr ""
+msgstr "Hardcopy Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
 msgid "Hardcopy Theme"
-msgstr ""
+msgstr "Hardcopy Theme"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
 msgid "Headers"
-msgstr ""
+msgstr "Headers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
 msgid "Help"
-msgstr ""
+msgstr "Help"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:479
 msgid "Here is a new version of your problem."
-msgstr ""
+msgstr "Here is a new version of your problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
 msgid "Hidden"
-msgstr ""
+msgstr "Hidden"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
 msgid "Hide All"
-msgstr ""
+msgstr "Hide All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
 msgid "Hide Courses"
-msgstr ""
+msgstr "Hide Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
 msgid "Hide Hints"
-msgstr ""
+msgstr "Hide Hints"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
 msgid "Hide Hints from Students"
-msgstr ""
+msgstr "Hide Hints from Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Hide Inactive Courses"
-msgstr ""
+msgstr "Hide Inactive Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
 msgid "Hide all paths"
-msgstr ""
+msgstr "Hide all paths"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
 msgid "Hide path:"
-msgstr ""
+msgstr "Hide path:"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
 msgid "Hint:"
-msgstr ""
+msgstr "Hint:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
 msgid "Hints"
-msgstr ""
+msgstr "Hints"
 
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
 msgid "Hmwk Sets Editor"
-msgstr ""
+msgstr "Hmwk Sets Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
-msgstr ""
+msgstr "Homework Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
 msgid "Homework Totals"
-msgstr ""
+msgstr "Homework Totals"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
-msgstr ""
+msgstr "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
 msgid "Icon"
-msgstr ""
+msgstr "Icon"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
 msgid "Icon File"
-msgstr ""
+msgstr "Icon File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
 msgstr ""
+"If a password field is left blank, the student's current password will be "
+"maintained."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:454
 msgid ""
@@ -3069,6 +3288,10 @@ msgid ""
 "of the problem's status and the weighted average of the status of its child "
 "problems which have this flag enabled."
 msgstr ""
+"If this flag is set then this problem will count towards the grade of its "
+"parent problem.  In general the adjusted status on a problem is the larger "
+"of the problem's status and the weighted average of the status of its child "
+"problems which have this flag enabled."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
 msgid ""
@@ -3076,6 +3299,9 @@ msgid ""
 "emails will be notified whenever a student runs out of attempts on a problem "
 "and its children without receiving an adjusted status of 100%"
 msgstr ""
+"If this is enabled then instructors with the ability to receive feedback "
+"emails will be notified whenever a student runs out of attempts on a problem "
+"and its children without receiving an adjusted status of 100%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
@@ -3083,6 +3309,9 @@ msgid ""
 "they have completed all of the previous problems, and their child problems "
 "if necessary"
 msgstr ""
+"If this is enabled then students will be unable to attempt a problem until "
+"they have completed all of the previous problems, and their child problems "
+"if necessary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
 msgid ""
@@ -3092,91 +3321,97 @@ msgid ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 msgstr ""
+"If you check %1 your login information will be remembered by the browser you "
+"are using, allowing you to visit WeBWorK pages without typing your user name "
+"and password (until your session expires). This feature is not safe for "
+"public workstations, untrusted machines, and machines over which you do not "
+"have direct control."
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
-msgstr ""
+msgstr "Illegal file '%1' specified"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
 msgid "Illegal filename contains '..'"
-msgstr ""
+msgstr "Illegal filename contains '..'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
 msgid "Import"
-msgstr ""
+msgstr "Import"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "Import achievements from"
-msgstr ""
+msgstr "Import achievements from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
-msgstr ""
+msgstr "Import from where?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
 msgid "Import how many sets?"
-msgstr ""
+msgstr "Import how many sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
 msgid "Import sets with names"
-msgstr ""
+msgstr "Import sets with names"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
 msgid "Import users from what file?"
-msgstr ""
+msgstr "Import users from what file?"
 
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
 msgid "Imported %quant(%1,achievement)"
-msgstr ""
+msgstr "Imported %quant(%1,achievement)"
 
 #. ($total_inprogress, $num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "In progress: %1/%2"
-msgstr ""
+msgstr "In progress: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Inactive"
-msgstr ""
+msgstr "Inactive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:141
 msgid "Inactivity time before a user is required to login again"
-msgstr ""
+msgstr "Inactivity time before a user is required to login again"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
 msgid "Include Success Index"
-msgstr ""
+msgstr "Include Success Index"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
-msgstr ""
+msgstr "Incorrect"
 
 #. ($total_incorrect,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
 msgid "Incorrect: %1/%2"
-msgstr ""
+msgstr "Incorrect: %1/%2"
 
+# Short for Initial
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
 msgid "Init"
-msgstr ""
+msgstr "Init"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
 msgid "Institution:"
-msgstr ""
+msgstr "Institution:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
 msgid "Instructor Tools"
-msgstr ""
+msgstr "Instructor Tools"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
 msgid "Instructor solution preview: show the student solution after due date."
-msgstr ""
+msgstr "Instructor solution preview: show the student solution after due date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "Invalid Reply-to address."
-msgstr ""
+msgstr "Invalid Reply-to address."
 
 #. ($output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
@@ -3185,65 +3420,70 @@ msgid ""
 "All email file names must end in the extension \".msg\" choose a file name "
 "with a \".msg\" extension. The message was not saved."
 msgstr ""
+"Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
+"All email file names must end in the extension \".msg\" choose a file name "
+"with a \".msg\" extension. The message was not saved."
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
 msgid "Invalid headerType %1"
-msgstr ""
+msgstr "Invalid headerType %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
 msgid "Invalid user ID or password."
-msgstr ""
+msgstr "Invalid user ID or password."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2306
 msgid ""
 "It is before the open date.  You probably want to renumber the problems if "
 "you are deleting some from the middle."
 msgstr ""
+"It is before the open date.  You probably want to renumber the problems if "
+"you are deleting some from the middle."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
-msgstr ""
+msgstr "Items"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
 msgid "Jump to Page:"
-msgstr ""
+msgstr "Jump to Page:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
 msgid "Jump to Problem:"
-msgstr ""
+msgstr "Jump to Problem:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
 msgid "Just-In-Time parameters"
-msgstr ""
+msgstr "Just-In-Time parameters"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:772
 msgid "Keywords:"
-msgstr ""
+msgstr "Keywords:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "LAST NAME"
-msgstr ""
+msgstr "LAST NAME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1089
 msgid "LOCAL Usage"
-msgstr ""
+msgstr "LOCAL Usage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:135
 msgid "Language (refresh page after saving changes to reveal new language.)"
-msgstr ""
+msgstr "Language (refresh page after saving changes to reveal new language.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
 msgid "Last"
-msgstr ""
+msgstr "Last"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
 msgid "Last Answer"
-msgstr ""
+msgstr "Last Answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -3260,19 +3500,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
 msgid "Last Name"
-msgstr ""
+msgstr "Last Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "Last column of merge file"
-msgstr ""
+msgstr "Last column of merge file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
 msgid "Last name"
-msgstr ""
+msgstr "Last name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Latest Answers"
-msgstr ""
+msgstr "Latest Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
 msgid ""
@@ -3280,42 +3520,45 @@ msgid ""
 "to login again.<p> This value should be entered as a number, so as 3600 "
 "instead of 60*60 for one hour"
 msgstr ""
+"Length of time, in seconds, a user has to be inactive before he is required "
+"to login again.<p> This value should be entered as a number, so as 3600 "
+"instead of 60*60 for one hour"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:761
 msgid "Lesser Rod of Revelation"
-msgstr ""
+msgstr "Lesser Rod of Revelation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:877
 msgid "Lesser Tome of Enlightenment"
-msgstr ""
+msgstr "Lesser Tome of Enlightenment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:768
 msgid "Level:"
-msgstr ""
+msgstr "Level:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
-msgstr ""
+msgstr "Library Browser"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
-msgstr ""
+msgstr "Library Browser 2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
-msgstr ""
+msgstr "Library Browser 3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
 msgid "Library Browser no js"
-msgstr ""
+msgstr "Library Browser no js"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
 msgid "List of display modes made available to students"
-msgstr ""
+msgstr "List of display modes made available to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
 msgid ""
@@ -3323,24 +3566,27 @@ msgid ""
 "Professors need to be added to this list if questionaires are used, or other "
 "WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
+"List of e-mail addresses to which e-mail can be sent by a problem. "
+"Professors need to be added to this list if questionaires are used, or other "
+"WeBWorK problems which send e-mail as part of their answer mechanism."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
 msgid "List of options for Show Me Another button"
-msgstr ""
+msgstr "List of options for Show Me Another button"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
 msgid "Local"
-msgstr ""
+msgstr "Local"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
 msgid "Local Problems"
-msgstr ""
+msgstr "Local Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 msgid "Location"
-msgstr ""
+msgstr "Location"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
@@ -3349,33 +3595,35 @@ msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
+"Location %1 does not exist in the WeBWorK database.  Please check your input "
+"(perhaps you need to reload the location management page?)."
 
 #. ($locationID, join(', ', @addresses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
 msgid "Location %1 has been created, with addresses %2."
-msgstr ""
+msgstr "Location %1 has been created, with addresses %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
 msgid "Location deletion requires confirmation."
-msgstr ""
+msgstr "Location deletion requires confirmation."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
 msgid "Location description:"
-msgstr ""
+msgstr "Location description:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
 msgid "Location name:"
-msgstr ""
+msgstr "Location name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
 msgid "Log In Again"
-msgstr ""
+msgstr "Log In Again"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Log Out"
-msgstr ""
+msgstr "Log Out"
 
 #. ($add_courseID)
 #. ($rename_oldCourseID)
@@ -3386,22 +3634,22 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
 msgid "Log into %1"
-msgstr ""
+msgstr "Log into %1"
 
 #. (HTML::Entities::encode_entities($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Logged in as %1."
-msgstr ""
+msgstr "Logged in as %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "Login"
-msgstr ""
+msgstr "Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
 msgid "Login Info"
-msgstr ""
+msgstr "Login Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -3419,140 +3667,143 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
-msgstr ""
+msgstr "Login Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
 msgid "Login Status"
-msgstr ""
+msgstr "Login Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
 msgid "Logout"
-msgstr ""
+msgstr "Logout"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
 msgid "Main Menu"
-msgstr ""
+msgstr "Main Menu"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:859
 msgid "Make"
-msgstr ""
+msgstr "Make"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:162
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:354
 msgid "Make Archive"
-msgstr ""
+msgstr "Make Archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Make changes"
-msgstr ""
+msgstr "Make changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
 msgid "Make these changes in  course:"
-msgstr ""
+msgstr "Make these changes in  course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Manage Locations"
-msgstr ""
+msgstr "Manage Locations"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
-msgstr ""
+msgstr "Manual Grader"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
 msgid "Mark All"
-msgstr ""
+msgstr "Mark All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Mark Correct"
-msgstr ""
+msgstr "Mark Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
 msgid "Mark Correct?"
-msgstr ""
+msgstr "Mark Correct?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
 msgid "Match on what? (separate multiple IDs with commas)"
-msgstr ""
+msgstr "Match on what? (separate multiple IDs with commas)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
 msgid "Math Objects"
-msgstr ""
+msgstr "Math Objects"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
 msgid "Max attempts"
-msgstr ""
+msgstr "Max attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
 msgid "Max. Shown:"
-msgstr ""
+msgstr "Max. Shown:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
+"Maximum times Show me Another can be used per problem (-1 => unlimited)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Merge file:"
-msgstr ""
+msgstr "Merge file:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Message"
-msgstr ""
+msgstr "Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
 msgid "Message file:"
-msgstr ""
+msgstr "Message file:"
 
 #. ($emailDirectory, $output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
 msgid "Message saved to file <code>%1/%2</code>."
-msgstr ""
+msgstr "Message saved to file <code>%1/%2</code>."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
 msgid "Message:"
-msgstr ""
+msgstr "Message:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
 msgid "Messages"
-msgstr ""
+msgstr "Messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid "Method"
-msgstr ""
+msgstr "Method"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
+"Missing required input data. Please check that you have filled in all of the "
+"create location fields and resubmit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
 msgid "Move"
-msgstr ""
+msgstr "Move"
 
+# Msg is short for message
 #. ($recipient, $ur->email_address)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
 msgid "Msg sent to %1 at %2."
-msgstr ""
+msgstr "Msg sent to %1 at %2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
-#, fuzzy
 msgid "My Problems"
-msgstr "Problem List"
+msgstr "My Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
 msgid "Mysterious Package (with Ribbons)"
-msgstr ""
+msgstr "Mysterious Package (with Ribbons)"
 
+# Short for Number of Fields
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
 msgid "NO OF FIELDS"
-msgstr ""
+msgstr "NO OF FIELDS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
@@ -3564,81 +3815,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
 msgid "Name for new set here"
-msgstr ""
+msgstr "Name for new set here"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
 msgid "Name of course information file"
-msgstr ""
+msgstr "Name of course information file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
-msgstr ""
+msgstr "Name the new set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1552
 msgid "Necromancers Charm"
-msgstr ""
+msgstr "Necromancers Charm"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
 msgid "Never"
-msgstr ""
+msgstr "Never"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
 msgid "New File"
-msgstr ""
+msgstr "New File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New Folder"
-msgstr ""
+msgstr "New Folder"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
 msgid "New Name:"
-msgstr ""
+msgstr "New Name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
 msgid "New Password"
-msgstr ""
+msgstr "New Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
 msgid "New file name:"
-msgstr ""
+msgstr "New file name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New folder name:"
-msgstr ""
+msgstr "New folder name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
 msgid "New passwords saved"
-msgstr ""
+msgstr "New passwords saved"
 
+# No space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "NewVersion"
-msgstr ""
+msgstr "NewVersion"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1852
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
-msgstr ""
+msgstr "Newer problem set def files must be imported using Hmwk Sets Editor2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
 msgid "Next Problem"
-msgstr ""
+msgstr "Next Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
-msgstr ""
+msgstr "Next page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
@@ -3654,154 +3906,166 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
 msgid "No Description"
-msgstr ""
+msgstr "No Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
 msgid "No achievements shown.  Create an achievement!"
-msgstr ""
+msgstr "No achievements shown.  Create an achievement!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
 msgid "No action taken"
-msgstr ""
+msgstr "No action taken"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
 msgid ""
 "No authentication method found for your request.  If this recurs, please "
 "speak with your instructor."
 msgstr ""
+"No authentication method found for your request.  If this recurs, please "
+"speak with your instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
-msgstr ""
+msgstr "No change made to any set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
 msgstr ""
+"No changes specified.  You must mark the checkbox of the item(s) to be "
+"changed and enter the change data."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
 msgid "No changes were saved!"
-msgstr ""
+msgstr "No changes were saved!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
 msgid "No course id defined"
-msgstr ""
+msgstr "No course id defined"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
 msgid "No data exists for set %1 and problem %2"
-msgstr ""
+msgstr "No data exists for set %1 and problem %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
 msgid "No filename was specified for saving!  The message was not saved."
-msgstr ""
+msgstr "No filename was specified for saving!  The message was not saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
 msgid "No guest logins are available. Please try again in a few minutes."
-msgstr ""
+msgstr "No guest logins are available. Please try again in a few minutes."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
 msgid "No location specified to edit?! Please check your input data."
-msgstr ""
+msgstr "No location specified to edit?! Please check your input data."
 
 #. ($badID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
 msgid "No location with name %1 exists in the database"
-msgstr ""
+msgstr "No location with name %1 exists in the database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
 msgid "No merge data file"
-msgstr ""
+msgstr "No merge data file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
+"No new Achievement ID specified.  No new achievement created.  File not "
+"saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
 msgid "No problems matched the given parameters."
-msgstr ""
+msgstr "No problems matched the given parameters."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
 msgstr ""
+"No recipients selected. Please select one or more recipients from the list "
+"below."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
 msgid "No record for global set %1."
-msgstr ""
+msgstr "No record for global set %1."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
 msgid "No record for user %1."
-msgstr ""
+msgstr "No record for user %1."
 
 #. ($prob)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
 msgid "No record found for problem %1."
-msgstr ""
+msgstr "No record found for problem %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
 msgid "No record found."
-msgstr ""
+msgstr "No record found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:48
 msgid "No sets in this course yet"
-msgstr ""
+msgstr "No sets in this course yet"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
 msgid "No sets selected for scoring"
-msgstr ""
+msgstr "No sets selected for scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr ""
+"No sets shown.  Choose one of the options above to list the sets in the "
+"course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
 msgid "No source filePath specified"
-msgstr ""
+msgstr "No source filePath specified"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
 msgid "No source_file for problem in .def file"
-msgstr ""
+msgstr "No source_file for problem in .def file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
+"No students shown.  Choose one of the options above to list the students in "
+"the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
 msgid "No tests taken."
-msgstr ""
+msgstr "No tests taken."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:625
 msgid "No user specific data exists for user %1"
-msgstr ""
+msgstr "No user specific data exists for user %1"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
 msgid "No valid changes submitted for location %1."
-msgstr ""
+msgstr "No valid changes submitted for location %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
@@ -3809,7 +4073,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
 msgid "None"
-msgstr ""
+msgstr "None"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:120
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:130
@@ -3817,80 +4081,84 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:180
 msgid "None Specified"
-msgstr ""
+msgstr "None Specified"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
 msgid "None of the selected users are assigned to this set: %1"
-msgstr ""
+msgstr "None of the selected users are assigned to this set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
 msgid "Not logged in."
-msgstr ""
+msgstr "Not logged in."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
 msgid "Note"
-msgstr ""
+msgstr "Note"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
+"Note: grading the test grades all problems, not just those on this page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
 msgid "Number"
-msgstr ""
+msgstr "Number"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
 msgid "Number of Graded Submissions per Test (0=infty)"
-msgstr ""
+msgstr "Number of Graded Submissions per Test (0=infty)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:287
 msgid "Number of Problems per Page (0=all)"
-msgstr ""
+msgstr "Number of Problems per Page (0=all)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:270
 msgid "Number of Tests per Time Interval (0=infty)"
-msgstr ""
+msgstr "Number of Tests per Time Interval (0=infty)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1340
 msgid "Oil of Cleansing"
-msgstr ""
+msgstr "Oil of Cleansing"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
 msgid "Old Classlist Editor"
-msgstr ""
+msgstr "Old Classlist Editor"
 
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
 msgid "Old Hmwk Sets Editor"
-msgstr ""
+msgstr "Old Hmwk Sets Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
 msgid "One Column"
-msgstr ""
+msgstr "One Column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:306
 msgid "Only after set answer date"
-msgstr ""
+msgstr "Only after set answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:296
 msgid ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
 msgstr ""
+"Only this permission level and higher get buttons for sending e-mail to the "
+"instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
 msgid "Open"
-msgstr ""
+msgstr "Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
@@ -3900,182 +4168,194 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:803
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:826
 msgid "Open Date"
-msgstr ""
+msgstr "Open Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
 msgid "Open Problem Library"
-msgstr ""
+msgstr "Open Problem Library"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "Open in New Window"
-msgstr ""
+msgstr "Open in New Window"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
 msgid "Open in new window"
-msgstr ""
+msgstr "Open in new window"
 
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
 msgid "Open, closes %1."
-msgstr ""
+msgstr "Open, closes %1."
 
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
 msgid "Open, complete by %1."
-msgstr ""
+msgstr "Open, complete by %1."
 
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
 msgid "Open, reduced scoring starts on %1."
-msgstr ""
+msgstr "Open, reduced scoring starts on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
-msgstr ""
+msgstr "Open:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
 msgid "Opens"
-msgstr ""
+msgstr "Opens"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
-msgstr ""
+msgstr "Opens any homework set for 24 hours."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:195
 msgid "Optional Modules"
-msgstr ""
+msgstr "Optional Modules"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
 msgid "Order Problems Randomly"
-msgstr ""
+msgstr "Order Problems Randomly"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 msgid "Orig. Lib. Browser"
-msgstr ""
+msgstr "Orig. Lib. Browser"
 
+# Context is "7 Out Of 10"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
-msgstr ""
+msgstr "Out Of"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
 msgid "Over time, closed."
-msgstr ""
+msgstr "Over time, closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Overwrite"
-msgstr ""
+msgstr "Overwrite"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:382
 msgid "Overwrite existing files silently"
-msgstr ""
+msgstr "Overwrite existing files silently"
 
+# PG is a WeBWorK abreviation and should stay PG
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
 msgid "PG - Problem Display/Answer Checking"
-msgstr ""
+msgstr "PG - Problem Display/Answer Checking"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
 msgid "PG debug messages"
-msgstr ""
+msgstr "PG debug messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "PG internal errors"
-msgstr ""
+msgstr "PG internal errors"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
 msgid "PG question failed to render"
-msgstr ""
+msgstr "PG question failed to render"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
 msgid "PG question processing error messages"
-msgstr ""
+msgstr "PG question processing error messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG warning messages"
-msgstr ""
+msgstr "PG warning messages"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
 msgid "PGInfo"
-msgstr ""
+msgstr "PGInfo"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
 msgid "PGLab"
-msgstr ""
+msgstr "PGLab"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
 msgid "PGML"
-msgstr ""
+msgstr "PGML"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
 msgid "POD"
-msgstr ""
+msgstr "POD"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 
+# Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
 msgid "PROB NUMBER"
-msgstr ""
+msgstr "PROB NUMBER"
 
+# Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
 msgid "PROB VALUE"
-msgstr ""
+msgstr "PROB VALUE"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
 msgid "Pad Fields"
-msgstr ""
+msgstr "Pad Fields"
 
 #. (timestamp($self)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
 msgid "Page generated at %1"
-msgstr ""
+msgstr "Page generated at %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
 msgid "Password"
-msgstr ""
+msgstr "Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:921
 msgid "Password (Leave blank for regular proctoring)"
-msgstr ""
+msgstr "Password (Leave blank for regular proctoring)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
 msgid "Password:"
-msgstr ""
+msgstr "Password:"
 
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr ""
+msgstr "Past Answers for %1, set %2, problem %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
 msgid "Percent"
-msgstr ""
+msgstr "Percent"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:574
 msgid "Percentage of Active Students with Correct Answers"
-msgstr ""
+msgstr "Percentage of Active Students with Correct Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:570
 msgid ""
 "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
 "median number of attempts"
 msgstr ""
+"Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
+"median number of attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
+"Percentile cutoffs for number of attempts. The 50% column shows the median "
+"number of attempts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
@@ -4090,11 +4370,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 msgid "Permission Level"
-msgstr ""
+msgstr "Permission Level"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
 msgid "Permissions"
-msgstr ""
+msgstr "Permissions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
 msgid ""
@@ -4102,134 +4382,148 @@ msgid ""
 "will not show up in the courses list on the WeBWorK home page. It will still "
 "appear in the Course Administration listing."
 msgstr ""
+"Place a file named \"hide_directory\" in a course or other directory and it "
+"will not show up in the courses list on the WeBWorK home page. It will still "
+"appear in the Course Administration listing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1016
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given full credit."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"be given full credit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:811
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given half credit."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"be given half credit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:587
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its incorrect attempt count reset."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"have its incorrect attempt count reset."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:698
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its weight doubled."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"have its weight doubled."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1214
 msgid ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 msgstr ""
+"Please choose the set, the problem you would like to copy, and the problem "
+"you would like to copy it to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
 msgid "Please correct the following errors and try again:"
-msgstr ""
+msgstr "Please correct the following errors and try again:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:706
 msgid "Please enter in a value to match in the filter field."
-msgstr ""
+msgstr "Please enter in a value to match in the filter field."
 
 #. (CGI::b($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
 msgid "Please enter your username and password for %1 below:"
-msgstr ""
+msgstr "Please enter your username and password for %1 below:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
 msgid "Please provide a location name to delete."
-msgstr ""
+msgstr "Please provide a location name to delete."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
 msgid "Please select action to be performed."
-msgstr ""
+msgstr "Please select action to be performed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
 msgid "Please select at least one set and try again."
-msgstr ""
+msgstr "Please select at least one set and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
 msgid "Please select at least one user and try again."
-msgstr ""
+msgstr "Please select at least one user and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
-msgstr ""
+msgstr "Please specify a file to save to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
 msgid "Potion of Forgetfullness"
-msgstr ""
+msgstr "Potion of Forgetfullness"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
-msgstr ""
+msgstr "Preflight Log"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
 msgid "Preview Message"
-msgstr ""
+msgstr "Preview Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
 msgid "Preview My Answers"
-msgstr ""
+msgstr "Preview My Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
 msgid "Preview Test"
-msgstr ""
+msgstr "Preview Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
 msgid "Preview message"
-msgstr ""
+msgstr "Preview message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
 msgid "Preview set to:"
-msgstr ""
+msgstr "Preview set to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
 msgid "Previous Problem"
-msgstr ""
+msgstr "Previous Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
-msgstr ""
+msgstr "Previous page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "Primary sort"
-msgstr ""
+msgstr "Primary sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
 msgid "Print Test"
-msgstr ""
+msgstr "Print Test"
 
+# Short for Problem
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "Prob"
-msgstr ""
+msgstr "Prob"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
 msgid "Problem"
-msgstr ""
+msgstr "Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
 msgid "Problem #"
-msgstr ""
+msgstr "Problem #"
 
 #. ($prettyProblemID)
 #. (join('.',@seq)
@@ -4253,62 +4547,50 @@ msgstr "Problem %1"
 msgid "Problem %1."
 msgstr "Problem %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
-#, fuzzy
 msgid "Problem Editor"
-msgstr "Problem List"
+msgstr "Problem Editor"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
-#, fuzzy
 msgid "Problem Editor2"
-msgstr "Problem List"
+msgstr "Problem Editor2"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
-#, fuzzy
 msgid "Problem Editor3"
-msgstr "Problem List"
+msgstr "Problem Editor3"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
-#, fuzzy
 msgid "Problem List"
 msgstr "Problem List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
 msgid "Problem Number"
-msgstr ""
+msgstr "Problem Number"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
-#, fuzzy
 msgid "Problem Number "
-msgstr "Problem List"
+msgstr "Problem Number "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
-#, fuzzy
 msgid "Problem Techniques"
-msgstr "Problem List"
+msgstr "Problem Techniques"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
-#, fuzzy
 msgid "Problem Viewer"
-msgstr "Problem List"
+msgstr "Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
 msgid "Problem source is drawn from a grouping set"
-msgstr ""
+msgstr "Problem source is drawn from a grouping set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
@@ -4319,43 +4601,43 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
 msgid "Problems"
-msgstr ""
+msgstr "Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:62
 msgid "Problems for all students have been unassigned."
-msgstr ""
+msgstr "Problems for all students have been unassigned."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:65
 msgid "Problems for selected students have been reassigned."
-msgstr ""
+msgstr "Problems for selected students have been reassigned."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:57
 msgid "Problems have been assigned to all current users."
-msgstr ""
+msgstr "Problems have been assigned to all current users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Proctor"
-msgstr ""
+msgstr "Proctor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:203
 msgid "Proctor authorization required."
-msgstr ""
+msgstr "Proctor authorization required."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
 msgid "Proctor password:"
-msgstr ""
+msgstr "Proctor password:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
 msgid "Proctor username:"
-msgstr ""
+msgstr "Proctor username:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:259
 msgid "Proctored Gateway Quiz %2"
-msgstr ""
+msgstr "Proctored Gateway Quiz %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:268
 msgid "Proctored Gateway Quiz %2 Proctor Login"
-msgstr ""
+msgstr "Proctored Gateway Quiz %2 Proctor Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:841
@@ -4364,23 +4646,26 @@ msgid ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 msgstr ""
+"Proctored tests require proctor authorization to start and to grade.  "
+"Provide a password to have a single password for all students to start a "
+"proctored test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
 msgid "Publish"
-msgstr ""
+msgstr "Publish"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "RECITATION"
-msgstr ""
+msgstr "RECITATION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
 msgid "Read only"
-msgstr ""
+msgstr "Read only"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:735
 msgid "Really delete the items listed above?"
-msgstr ""
+msgstr "Really delete the items listed above?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
@@ -4402,56 +4687,57 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Recitation"
-msgstr ""
+msgstr "Recitation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
 msgid "Record Scores for Single Sets"
-msgstr ""
+msgstr "Record Scores for Single Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:477
 msgid "Reduced Scoring"
-msgstr ""
+msgstr "Reduced Scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
 msgid "Reduced Scoring Date"
-msgstr ""
+msgstr "Reduced Scoring Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
 msgid "Reduced Scoring Disabled"
-msgstr ""
+msgstr "Reduced Scoring Disabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
 msgid "Reduced Scoring Enabled"
-msgstr ""
+msgstr "Reduced Scoring Enabled"
 
 #. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
 msgid "Reduced Scoring Starts %1"
-msgstr ""
+msgstr "Reduced Scoring Starts %1"
 
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
 msgid "Reduced scoring started on %1."
-msgstr ""
+msgstr "Reduced scoring started on %1."
 
+# Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
-msgstr ""
+msgstr "Reduced:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:358
 msgid "Refresh"
-msgstr ""
+msgstr "Refresh"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2031
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2156
 msgid "Refresh Display"
-msgstr ""
+msgstr "Refresh Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
@@ -4460,23 +4746,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
 msgid "Refresh Listing"
-msgstr ""
+msgstr "Refresh Listing"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
 msgid "Relax IP restrictions when?"
-msgstr ""
+msgstr "Relax IP restrictions when?"
 
+# Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 msgid "Remaining"
-msgstr ""
+msgstr "Remaining"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
 msgid "Remember Me"
-msgstr ""
+msgstr "Remember Me"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:480
 msgid "Remember to return to your original problem when you're finished here!"
-msgstr ""
+msgstr "Remember to return to your original problem when you're finished here!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
@@ -4485,38 +4772,38 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Rename"
-msgstr ""
+msgstr "Rename"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
 msgid "Rename %1 to %2"
-msgstr ""
+msgstr "Rename %1 to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
 msgid "Rename Course"
-msgstr ""
+msgstr "Rename Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
 msgid "Rename file as:"
-msgstr ""
+msgstr "Rename file as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render"
-msgstr ""
+msgstr "Render"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
 msgid "Render All"
-msgstr ""
+msgstr "Render All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render Problem"
-msgstr ""
+msgstr "Render Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
 msgid "Renumber Problems"
-msgstr ""
+msgstr "Renumber Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
@@ -4524,68 +4811,71 @@ msgid ""
 "a test even if the close date has past. This item does not allow you to take "
 "additional versions of the test."
 msgstr ""
+"Reopens any gateway test for an additional 24 hours. This allows you to take "
+"a test even if the close date has past. This item does not allow you to take "
+"additional versions of the test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2326
 msgid "Reorder problems only"
-msgstr ""
+msgstr "Reorder problems only"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
-msgstr ""
+msgstr "Replace current problem: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
 msgid "Replace which users?"
-msgstr ""
+msgstr "Replace which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
 msgid "Reply-To:"
-msgstr ""
+msgstr "Reply-To:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
 msgid "Report Bugs in this Problem"
-msgstr ""
+msgstr "Report Bugs in this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
 msgid "Report bugs"
-msgstr ""
+msgstr "Report bugs"
 
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid "Report for course %1:"
-msgstr ""
+msgstr "Report for course %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
 msgid "Report on database structure for course %1:"
-msgstr ""
+msgstr "Report on database structure for course %1:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
 msgid "Request New Version"
-msgstr ""
+msgstr "Request New Version"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
 msgid "Request information"
-msgstr ""
+msgstr "Request information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
 msgid "Request new version now."
-msgstr ""
+msgstr "Request new version now."
 
 #. ($setName,$effectiveUserName)
 #. ($setName, $effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr ""
+msgstr "Requested set '%1' could not be found in the database for user %2."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -4594,6 +4884,9 @@ msgid ""
 "generator %2 was called.  Try re-entering the set from the problem sets "
 "listing page."
 msgstr ""
+"Requested set '%1' is a homework assignment but the gateway/quiz content "
+"generator %2 was called.  Try re-entering the set from the problem sets "
+"listing page."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
@@ -4601,6 +4894,8 @@ msgid ""
 "Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
 "authorization has been obtained."
 msgstr ""
+"Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
+"authorization has been obtained."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
@@ -4609,48 +4904,51 @@ msgid ""
 "assignment content generator %2 was called.  Try re-entering the set from "
 "the problem sets listing page."
 msgstr ""
+"Requested set '%1' is a test/quiz assignment but the regular homework "
+"assignment content generator %2 was called.  Try re-entering the set from "
+"the problem sets listing page."
 
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr ""
+msgstr "Requested set '%1' is not assigned to user %2."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
 msgid "Requested set '%1' is not available yet."
-msgstr ""
+msgstr "Requested set '%1' is not available yet."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
 msgid "Requested set '%1' is not yet open."
-msgstr ""
+msgstr "Requested set '%1' is not yet open."
 
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr ""
+msgstr "Requested version (%1) of set '%2' is not assigned to user %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
-msgstr ""
+msgstr "Rerandomize after"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:734
 msgid "Reset"
-msgstr ""
+msgstr "Reset"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Reset Form"
-msgstr ""
+msgstr "Reset Form"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:538
 msgid "Resets the number of incorrect attempts on a single homework problem."
-msgstr ""
+msgstr "Resets the number of incorrect attempts on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
 msgid "Ressurect which Gateway?"
-msgstr ""
+msgstr "Ressurect which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
 msgid ""
@@ -4659,95 +4957,99 @@ msgid ""
 "directory. Currently the archive facility is only available for mysql "
 "databases. It depends on the mysqldump application."
 msgstr ""
+"Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
+"the course database is restored from a subdirectory of the course's DATA "
+"directory. Currently the archive facility is only available for mysql "
+"databases. It depends on the mysqldump application."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:202
 msgid "Restrict Access by IP"
-msgstr ""
+msgstr "Restrict Access by IP"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
 msgid "Restrict Locations"
-msgstr ""
+msgstr "Restrict Locations"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
 msgid "Restrict Problem Progression"
-msgstr ""
+msgstr "Restrict Problem Progression"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
 msgid "Restrict To"
-msgstr ""
+msgstr "Restrict To"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
 msgid "Restrict release by set(s)"
-msgstr ""
+msgstr "Restrict release by set(s)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Result"
-msgstr ""
+msgstr "Result"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
 msgid "Result of last action performed"
-msgstr ""
+msgstr "Result of last action performed"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
 msgid "Result of last action performed: %1"
-msgstr ""
+msgstr "Result of last action performed: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
 msgid "Results for this submission"
-msgstr ""
+msgstr "Results for this submission"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
 msgid "Results of last action performed"
-msgstr ""
+msgstr "Results of last action performed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
 msgid "Results of last action performed: "
-msgstr ""
+msgstr "Results of last action performed: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
 msgid "Retitled"
-msgstr ""
+msgstr "Retitled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "Revert"
-msgstr ""
+msgstr "Revert"
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
-msgstr ""
+msgstr "Revert to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
 msgid "Ring of Reduction"
-msgstr ""
+msgstr "Ring of Reduction"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:272
 msgid "Robe of Longevity"
-msgstr ""
+msgstr "Robe of Longevity"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "SECTION"
-msgstr ""
+msgstr "SECTION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
 msgid "SET NAME"
-msgstr ""
+msgstr "SET NAME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
 msgid "STATUS"
-msgstr ""
+msgstr "STATUS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "STUDENT ID"
-msgstr ""
+msgstr "STUDENT ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
@@ -4757,19 +5059,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
-msgstr ""
+msgstr "Save"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
 msgid "Save %1"
-msgstr ""
+msgstr "Save %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
-msgstr ""
+msgstr "Save As"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
@@ -4777,15 +5079,15 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
 msgid "Save Changes"
-msgstr ""
+msgstr "Save Changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
 msgid "Save as"
-msgstr ""
+msgstr "Save as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
 msgid "Save as Default"
-msgstr ""
+msgstr "Save as Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
@@ -4797,38 +5099,38 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
 msgid "Save changes"
-msgstr ""
+msgstr "Save changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
 msgid "Save file to:"
-msgstr ""
+msgstr "Save file to:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
 msgid "Save to %1 and View"
-msgstr ""
+msgstr "Save to %1 and View"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
 msgid "Saved to file '%1'"
-msgstr ""
+msgstr "Saved to file '%1'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Schema and database field definitions do not agree"
-msgstr ""
+msgstr "Schema and database field definitions do not agree"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
 msgid "Schema and database table definitions do not agree"
-msgstr ""
+msgstr "Schema and database table definitions do not agree"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
@@ -4838,43 +5140,43 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
 msgid "Score"
-msgstr ""
+msgstr "Score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Score (%)"
-msgstr ""
+msgstr "Score (%)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
 msgid "Score required for release"
-msgstr ""
+msgstr "Score required for release"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
 msgid "Score selected set(s) and save to:"
-msgstr ""
+msgstr "Score selected set(s) and save to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
 msgid "Score summary for last submit:"
-msgstr ""
+msgstr "Score summary for last submit:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
 msgid "Score which sets?"
-msgstr ""
+msgstr "Score which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
 msgid "Scores"
-msgstr ""
+msgstr "Scores"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
 msgid "Scoring Download"
-msgstr ""
+msgstr "Scoring Download"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
 msgid "Scoring Message"
-msgstr ""
+msgstr "Scoring Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
 msgid "Scoring Tools"
-msgstr ""
+msgstr "Scoring Tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
@@ -4882,14 +5184,16 @@ msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
+"Screen and Hardcopy set header information can not be overridden for "
+"individual students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
 msgid "Scroll of Ressurection"
-msgstr ""
+msgstr "Scroll of Ressurection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
-msgstr ""
+msgstr "Secondary sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -4914,35 +5218,35 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
-msgstr ""
+msgstr "Section"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
 msgid "Section:"
-msgstr ""
+msgstr "Section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
 msgid "Seed"
-msgstr ""
+msgstr "Seed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
-msgstr ""
+msgstr "Select a Problem Collection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
-msgstr ""
+msgstr "Select a Set from this Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
 msgid "Select a course to delete."
-msgstr ""
+msgstr "Select a course to delete."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
 msgid ""
@@ -4950,66 +5254,71 @@ msgid ""
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
+"Select a course to rename.  The courseID is used in the url and can only "
+"contain alphanumeric characters and underscores. The course title appears on "
+"the course home page and can be any string."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
 msgid "Select a course to unarchive."
-msgstr ""
+msgstr "Select a course to unarchive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
 msgid "Select a database layout below."
-msgstr ""
+msgstr "Select a database layout below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "Select a listing format:"
-msgstr ""
+msgstr "Select a listing format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
 msgid "Select above then:"
-msgstr ""
+msgstr "Select above then:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
 msgid "Select all eligible courses"
-msgstr ""
+msgstr "Select all eligible courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
 msgid "Select all sets"
-msgstr ""
+msgstr "Select all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
 msgid "Select all users"
-msgstr ""
+msgstr "Select all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
 msgid "Select an action to perform"
-msgstr ""
+msgstr "Select an action to perform"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
 msgid "Select an action to perform:"
-msgstr ""
+msgstr "Select an action to perform:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
 msgid "Select course(s) to archive."
-msgstr ""
+msgstr "Select course(s) to archive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
 msgid "Select course(s) to hide or unhide."
-msgstr ""
+msgstr "Select course(s) to hide or unhide."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
 msgid ""
 "Select one or more sets and one or more users below to assign/unassign each "
 "selected set to/from all selected users."
 msgstr ""
+"Select one or more sets and one or more users below to assign/unassign each "
+"selected set to/from all selected users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
 msgid "Select sets below to assign them to the newly-created users."
-msgstr ""
+msgstr "Select sets below to assign them to the newly-created users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
 msgid ""
@@ -5021,6 +5330,13 @@ msgid ""
 "opening page.  To access the course, an instructor or student must know the "
 "full URL address for the course."
 msgstr ""
+"Select the course(s) you want to hide (or unhide) and then click \"Hide "
+"Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
+"does no harm (the action is skipped). Likewise unhiding a course that is "
+"already visible does no harm (the action is skipped).  Hidden courses are "
+"still active but are not listed in the list of WeBWorK courses on the "
+"opening page.  To access the course, an instructor or student must know the "
+"full URL address for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:489
 msgid ""
@@ -5028,74 +5344,79 @@ msgid ""
 "also select multiple users from the users list. You will receive hardcopy "
 "for each (set, user) pair."
 msgstr ""
+"Select the homework sets for which to generate hardcopy versions. You may "
+"also select multiple users from the users list. You will receive hardcopy "
+"for each (set, user) pair."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
 msgid ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
 msgstr ""
+"Select user(s) and/or set(s) below and click the action button of your "
+"choice."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "Selected students"
-msgstr ""
+msgstr "Selected students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
 msgid "Send E-mail"
-msgstr ""
+msgstr "Send E-mail"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Send Email"
-msgstr ""
+msgstr "Send Email"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
 msgid "Send to:"
-msgstr ""
+msgstr "Send to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
 msgid "Set"
-msgstr ""
+msgstr "Set"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
 msgid "Set %1 exists.  No set created"
-msgstr ""
+msgstr "Set %1 exists.  No set created"
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
 msgid "Set %1 has been created."
-msgstr ""
+msgstr "Set %1 has been created."
 
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
 msgid "Set %1 was assigned to %2"
-msgstr ""
+msgstr "Set %1 was assigned to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
 msgid "Set Assigner"
-msgstr ""
+msgstr "Set Assigner"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
 msgid "Set Definition Filename"
-msgstr ""
+msgstr "Set Definition Filename"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
 msgid "Set Definition Files"
-msgstr ""
+msgstr "Set Definition Files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
 msgid "Set Description"
-msgstr ""
+msgstr "Set Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
-msgstr ""
+msgstr "Set Detail 2 for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:423
 msgid "Set Detail for set %2"
-msgstr ""
+msgstr "Set Detail for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
@@ -5106,20 +5427,20 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
 msgid "Set Header"
-msgstr ""
+msgstr "Set Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
 msgid "Set ID"
-msgstr ""
+msgstr "Set ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 msgid "Set Info"
-msgstr ""
+msgstr "Set Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
 msgid "Set List"
-msgstr ""
+msgstr "Set List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
@@ -5127,7 +5448,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:802
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:825
 msgid "Set Name"
-msgstr ""
+msgstr "Set Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
@@ -5142,23 +5463,26 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
 msgid "Set Name "
-msgstr ""
+msgstr "Set Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
 msgid "Set headers are not used in display of gateway tests."
-msgstr ""
+msgstr "Set headers are not used in display of gateway tests."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
 "Set to true for log to mean base 10 log and false for log to mean natural "
 "logarithm"
 msgstr ""
+"Set to true for log to mean base 10 log and false for log to mean natural "
+"logarithm"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:355
 msgid ""
 "Set to true to display MathView equation editor icon next to each answer box"
 msgstr ""
+"Set to true to display MathView equation editor icon next to each answer box"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:360
 msgid ""
@@ -5168,139 +5492,144 @@ msgid ""
 "see their evaluated answer by hovering the mouse pointer over the typeset "
 "version of their answer."
 msgstr ""
+"Set to true to display the \"Entered\" column which automatically shows the "
+"evaluated student answer, e.g. 1 if student input is sin(pi/2). If this is "
+"set to false, e.g. to save space in the response area, the student can still "
+"see their evaluated answer by hovering the mouse pointer over the typeset "
+"version of their answer."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
 msgid "Sets"
-msgstr ""
+msgstr "Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
 msgid "Sets Assigned to User"
-msgstr ""
+msgstr "Sets Assigned to User"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
 msgid "Sets assigned to %1"
-msgstr ""
+msgstr "Sets assigned to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 msgid "Setting"
-msgstr ""
+msgstr "Setting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
 msgid "Shift dates so that the earliest is"
-msgstr ""
+msgstr "Shift dates so that the earliest is"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
 msgid "Show"
-msgstr ""
+msgstr "Show"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
 msgid "Show Auxiliary Resources"
-msgstr ""
+msgstr "Show Auxiliary Resources"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:323
 msgid "Show Date & Size"
-msgstr ""
+msgstr "Show Date & Size"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
 msgid "Show Hints"
-msgstr ""
+msgstr "Show Hints"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
 msgid "Show Me Another"
-msgstr ""
+msgstr "Show Me Another"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
 msgid "Show Past Answers"
-msgstr ""
+msgstr "Show Past Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:302
 msgid "Show Problems on Finished Tests"
-msgstr ""
+msgstr "Show Problems on Finished Tests"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:295
 msgid "Show Scores on Finished Assignments?"
-msgstr ""
+msgstr "Show Scores on Finished Assignments?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
 msgid "Show Solutions"
-msgstr ""
+msgstr "Show Solutions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:166
 msgid "Show Total Homework Grade on Grades Page"
-msgstr ""
+msgstr "Show Total Homework Grade on Grades Page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
 msgid "Show Which Users?"
-msgstr ""
+msgstr "Show Which Users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
 msgid "Show all paths"
-msgstr ""
+msgstr "Show all paths"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
 msgid "Show correct answers"
-msgstr ""
+msgstr "Show correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Show me another"
-msgstr ""
+msgstr "Show me another"
 
 #. ($exhausted)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
 msgid "Show me another %1"
-msgstr ""
+msgstr "Show me another %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
 msgid "Show path ..."
-msgstr ""
+msgstr "Show path ..."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
 msgid "Show saved answers?"
-msgstr ""
+msgstr "Show saved answers?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
 msgid "Show which sets?"
-msgstr ""
+msgstr "Show which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
 msgid "Show/Hide Site Description"
-msgstr ""
+msgstr "Show/Hide Site Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
 msgid "Show:"
-msgstr ""
+msgstr "Show:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "Showing"
-msgstr ""
+msgstr "Showing"
 
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
 msgid "Showing %1 out of %2 sets."
-msgstr ""
+msgstr "Showing %1 out of %2 sets."
 
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
 msgid "Showing %1 out of %2 users"
-msgstr ""
+msgstr "Showing %1 out of %2 users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:391
 msgid "Simple"
-msgstr ""
+msgstr "Simple"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
@@ -5308,26 +5637,26 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:68
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:71
 msgid "Site Information"
-msgstr ""
+msgstr "Site Information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid "Skip archiving this course"
-msgstr ""
+msgstr "Skip archiving this course"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
 msgid "Solution:"
-msgstr ""
+msgstr "Solution:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
 msgid "Solutions"
-msgstr ""
+msgstr "Solutions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
 msgid "Some answers will be graded later."
-msgstr ""
+msgstr "Some answers will be graded later."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:733
 msgid ""
@@ -5335,6 +5664,9 @@ msgid ""
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
 msgstr ""
+"Some of these files are directories. Only delete directories if you really "
+"know what you are doing. You can seriously damage your course if you delete "
+"the wrong thing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -5345,37 +5677,45 @@ msgid ""
 "\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
 "List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 msgstr ""
+"Some servers handle courses taking place in different timezones.  If this "
+"course is not showing the correct timezone, enter the correct value here.  "
+"The format consists of unix times, such as \"America/New_York\",\"America/"
+"Chicago\", \"America/Denver\", \"America/Phoenix\" or \"America/Los_Angeles"
+"\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
+"List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:484
 msgid ""
 "Something was wrong with your LTI parameters.  If this recurs, please speak "
 "with your instructor"
 msgstr ""
+"Something was wrong with your LTI parameters.  If this recurs, please speak "
+"with your instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
 msgid "Sort"
-msgstr ""
+msgstr "Sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
 msgid "Sort by"
-msgstr ""
+msgstr "Sort by"
 
 #. ($names{$primary}, $names{$secondary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
 msgid "Sort by %1 and then by %2"
-msgstr ""
+msgstr "Sort by %1 and then by %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
 msgid "Sort:"
-msgstr ""
+msgstr "Sort:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
 msgid "Source File"
-msgstr ""
+msgstr "Source File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1439
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1465
@@ -5387,16 +5727,20 @@ msgid ""
 "Source file paths cannot include .. or start with /: your source file path "
 "was modified."
 msgstr ""
+"Source file paths cannot include .. or start with /: your source file path "
+"was modified."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
 msgstr ""
+"Specify an ID, title, and institution for the new course. The course ID may "
+"contain only letters, numbers, hyphens, and underscores."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:392
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -5405,21 +5749,21 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:704
 msgid "Statistics"
-msgstr ""
+msgstr "Statistics"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
 msgid "Statistics for"
-msgstr ""
+msgstr "Statistics for"
 
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr ""
+msgstr "Statistics for %1 set %2. Closes %3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
 msgid "Statistics for %1 student %2"
-msgstr ""
+msgstr "Statistics for %1 student %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
@@ -5433,19 +5777,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Stop Acting"
-msgstr ""
+msgstr "Stop Acting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
 msgid "Stop Archiving"
-msgstr ""
+msgstr "Stop Archiving"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
 msgid "Stop archiving courses"
-msgstr ""
+msgstr "Stop archiving courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
@@ -5462,125 +5806,125 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 msgid "Student ID"
-msgstr ""
+msgstr "Student ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Student Name"
-msgstr ""
+msgstr "Student Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:767
 msgid "Student Progress"
-msgstr ""
+msgstr "Student Progress"
 
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr ""
+msgstr "Student Progress for %1 set %2. Closes %3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
 msgid "Student Progress for %1 student %2"
-msgstr ""
+msgstr "Student Progress for %1 student %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
 msgid "Student answers"
-msgstr ""
+msgstr "Student answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
-msgstr ""
+msgstr "Subject:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
 msgid "Subject: "
-msgstr ""
+msgstr "Subject: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
 msgid "Submission time:"
-msgstr ""
+msgstr "Submission time:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
 msgid "Submit"
-msgstr ""
+msgstr "Submit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
 msgid "Submit Answers"
-msgstr ""
+msgstr "Submit Answers"
 
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
 msgid "Submit Answers for %1"
-msgstr ""
+msgstr "Submit Answers for %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
-msgstr ""
+msgstr "Success"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
-msgstr ""
+msgstr "Success Index"
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
 msgid "Successfully archived the course %1."
-msgstr ""
+msgstr "Successfully archived the course %1."
 
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
 msgid "Successfully created new achievement %1"
-msgstr ""
+msgstr "Successfully created new achievement %1"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
 msgid "Successfully created new set %1"
-msgstr ""
+msgstr "Successfully created new set %1"
 
 #. ($add_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
 msgid "Successfully created the course %1"
-msgstr ""
+msgstr "Successfully created the course %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
 msgid "Successfully deleted the course %1."
-msgstr ""
+msgstr "Successfully deleted the course %1."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
 msgid "Successfully renamed the course %1 to %2"
-msgstr ""
+msgstr "Successfully renamed the course %1 to %2"
 
 #. ($unarchive_courseID, $new_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
 msgid "Successfully unarchived %1 to the course %2"
-msgstr ""
+msgstr "Successfully unarchived %1 to the course %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
 msgid "Table defined in database but missing in schema"
-msgstr ""
+msgstr "Table defined in database but missing in schema"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
 msgid "Table defined in schema but missing in database"
-msgstr ""
+msgstr "Table defined in schema but missing in database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
 msgid "Table is ok"
-msgstr ""
+msgstr "Table is ok"
 
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
@@ -5588,13 +5932,13 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
 msgid "Take %1 test"
-msgstr ""
+msgstr "Take %1 test"
 
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
 msgid "Take %1 test."
-msgstr ""
+msgstr "Take %1 test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
@@ -5607,48 +5951,48 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
 msgid "Take Action!"
-msgstr ""
+msgstr "Take Action!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
 msgid "Target Set:"
-msgstr ""
+msgstr "Target Set:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
-msgstr ""
+msgstr "Test Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
 msgid "Test Score"
-msgstr ""
+msgstr "Test Score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
 msgid "Test Time"
-msgstr ""
+msgstr "Test Time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
 msgid "Test Time Limit (min; 0=Close Date)"
-msgstr ""
+msgstr "Test Time Limit (min; 0=Close Date)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:752
 msgid "Text chapter:"
-msgstr ""
+msgstr "Text chapter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
 msgid "Text section:"
-msgstr ""
+msgstr "Text section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
 msgid "Textbook:"
-msgstr ""
+msgstr "Textbook:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1000
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:433
 msgid "That symbolic link takes you outside your course directory"
-msgstr ""
+msgstr "That symbolic link takes you outside your course directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:258
 msgid ""
@@ -5656,6 +6000,9 @@ msgid ""
 "student. If set to -1 then there is no limit to the number of times that "
 "Show Me Another can be used."
 msgstr ""
+"The Maximum number of times Show me Another can be used per problem by a "
+"student. If set to -1 then there is no limit to the number of times that "
+"Show Me Another can be used."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:248
 msgid ""
@@ -5669,10 +6016,19 @@ msgid ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
+"The Reduced Scoring Period is the default period before the due date during "
+"which all additional work done by the student counts at a reduced rate. When "
+"enabling reduced scoring for a set the reduced scoring date will be set to "
+"the due date minus this number. The reduced scoring date can then be "
+"changed. If the Reduced Scoring is enabled and if it is after the reduced "
+"scoring date, but before the due date, a message like \"This assignment has "
+"a Reduced Scoring Period that begins 11/08/2009 at 06:17pm EST and ends on "
+"the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
+"work done counts 50% of the original.\" will be displayed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
 msgid "The WeBWorK Project"
-msgstr ""
+msgstr "The WeBWorK Project"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
@@ -5680,6 +6036,9 @@ msgid ""
 "the weighted average of the status of those problems which count towards the "
 "parent grade."
 msgstr ""
+"The adjusted status of a problem is the larger of the problem's status and "
+"the weighted average of the status of those problems which count towards the "
+"parent grade."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:190
 msgid ""
@@ -5687,6 +6046,9 @@ msgid ""
 "available to student to view.  You can change this for individual homework, "
 "but WeBWorK will use this value when a set is created."
 msgstr ""
+"The amount of time (in minutes) after the due date that the Answers are "
+"available to student to view.  You can change this for individual homework, "
+"but WeBWorK will use this value when a set is created."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
 msgid ""
@@ -5694,18 +6056,21 @@ msgid ""
 "opened.  You can change this for individual homework, but WeBWorK will use "
 "this value when a set is created. "
 msgstr ""
+"The amount of time (in minutes) before the due date when the assignment is "
+"opened.  You can change this for individual homework, but WeBWorK will use "
+"this value when a set is created. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
 msgid "The answer above is NOT correct."
-msgstr ""
+msgstr "The answer above is NOT correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
 msgid "The answer above is correct."
-msgstr ""
+msgstr "The answer above is correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
 msgid "The answer will be graded later."
-msgstr ""
+msgstr "The answer will be graded later."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
 msgid ""
@@ -5715,12 +6080,19 @@ msgid ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 msgstr ""
+"The child problems for this problem will become visible to the student when "
+"they either have more incorrect attempts than is specified here, or when "
+"they run out of attempts, whichever comes first.  If \"max\" is specified "
+"here then child problems will only be available after a student runs out of "
+"attempts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
+"The configuration module did not find the data it needs to function.  Have "
+"your site administrator check that Constants.pm is up to date."
 
 #. ($archive_courseID, $archive_path)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
@@ -5728,30 +6100,36 @@ msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
 msgstr ""
+"The course '%1' has already been archived at '%2'. This earlier archive will "
+"be erased.  This cannot be undone."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
 msgid "The default display mode"
-msgstr ""
+msgstr "The default display mode"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
 msgid ""
 "The default number of attempts before the problem is re-randomized. ( 0 => "
 "never )"
 msgstr ""
+"The default number of attempts before the problem is re-randomized. ( 0 => "
+"never )"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:275
 msgid ""
 "The default number of attempts between re-randomization of the problems ( 0 "
 "=> never)"
 msgstr ""
+"The default number of attempts between re-randomization of the problems ( 0 "
+"=> never)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:249
 msgid "The directory you specified doesn't exist"
-msgstr ""
+msgstr "The directory you specified doesn't exist"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1361
 msgid "The display was already cleared."
-msgstr ""
+msgstr "The display was already cleared."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:390
 msgid ""
@@ -5761,11 +6139,16 @@ msgid ""
 "as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
+"The e-mail verbosity level controls how much information is automatically "
+"added to feedback e-mails.  Levels are<ol><li value=\"Simple\"> Simple: send "
+"only the feedback comment and context link<li value=\"Standard\"> Standard: "
+"as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
+"Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 
 #. ($achievementName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
 msgid "The evaluator for %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The evaluator for %1 has been renamed to '%2'."
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
@@ -5773,68 +6156,70 @@ msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
+"The file %1/%2 already exists and cannot be overwritten. The message was not "
+"saved"
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
 msgid "The file %1/%2 cannot be found."
-msgstr ""
+msgstr "The file %1/%2 cannot be found."
 
 #. ($emailDirectory,$openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
 msgid "The file %1/%2 is not readable by the webserver."
-msgstr ""
+msgstr "The file %1/%2 is not readable by the webserver."
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
 msgid "The file '%1' cannot be found."
-msgstr ""
+msgstr "The file '%1' cannot be found."
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
 msgid "The file '%1' cannot be read!"
-msgstr ""
+msgstr "The file '%1' cannot be read!"
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
 msgid "The file '%1' is a blank problem!"
-msgstr ""
+msgstr "The file '%1' is a blank problem!"
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
 msgid "The file '%1' is a directory!"
-msgstr ""
+msgstr "The file '%1' is a directory!"
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
 msgid "The file '%1' is protected!"
-msgstr ""
+msgstr "The file '%1' is protected!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
 msgid "The file does not appear to be a text file"
-msgstr ""
+msgstr "The file does not appear to be a text file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:94
 msgid "The file you are trying to download doesn't exist"
-msgstr ""
+msgstr "The file you are trying to download doesn't exist"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
 msgid "The following courses were successfully hidden: %1"
-msgstr ""
+msgstr "The following courses were successfully hidden: %1"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
 msgid "The following courses were successfully unhidden: %1"
-msgstr ""
+msgstr "The following courses were successfully unhidden: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
 msgid "The following upgrades are available for your WeBWorK system:"
-msgstr ""
+msgstr "The following upgrades are available for your WeBWorK system:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
@@ -5842,6 +6227,7 @@ msgstr ""
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
+"The following users are NOT assigned to this set and will be ignored: %1"
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
@@ -5849,6 +6235,8 @@ msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the score of problem %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
@@ -5856,23 +6244,26 @@ msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the weighted average of the problems: %1."
 
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The hardcopy header for set %1 has been renamed to '%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
+"The institution associated with the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
 msgid "The institution associated with the course %1 is now %2"
-msgstr ""
+msgstr "The institution associated with the course %1 is now %2"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
@@ -5880,17 +6271,21 @@ msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
+"The instructor account with user id %1 does not exist.  Please create the "
+"account manually via WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
+"The library index is older than the library, you need to run OPL-update."
 
 #. ($r->param('new_set_name')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
 msgid ""
 "The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
 msgstr ""
+"The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
 msgid ""
@@ -5898,6 +6293,9 @@ msgid ""
 "Its contents are displayed in the right panel next to the list of homework "
 "sets."
 msgstr ""
+"The name of course information file (located in the templates directory). "
+"Its contents are displayed in the right panel next to the list of homework "
+"sets."
 
 #. ($openDate, $dueDate, $answerDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
@@ -5905,10 +6303,12 @@ msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
+"The open date: %1, close date: %2, and answer date: %3 must be defined and "
+"in chronological order."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
 msgid "The password and password confirmation for the instructor must match."
-msgstr ""
+msgstr "The password and password confirmation for the instructor must match."
 
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
@@ -5916,6 +6316,8 @@ msgid ""
 "The password you entered in the %1 field does not match your current "
 "password. Please retype your current password and try again."
 msgstr ""
+"The password you entered in the %1 field does not match your current "
+"password. Please retype your current password and try again."
 
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
@@ -5923,16 +6325,19 @@ msgid ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 msgstr ""
+"The passwords you entered in the %1 and %2 fields don't match. Please retype "
+"your new password and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
 msgid "The path to the original file should be absolute"
-msgstr ""
+msgstr "The path to the original file should be absolute"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:505
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
+"The percentage of active students with correct answers for each problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
@@ -5940,50 +6345,54 @@ msgid ""
 "The percentage of students receiving at least these scores. The median score "
 "is in the 50% column."
 msgstr ""
+"The percentage of students receiving at least these scores. The median score "
+"is in the 50% column."
 
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
 msgid "The recorded score for this test is  %1/%2."
-msgstr ""
+msgstr "The recorded score for this test is  %1/%2."
 
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
 msgid "The recorded score for this test is %1/%2."
-msgstr ""
+msgstr "The recorded score for this test is %1/%2."
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
+"The reduced credit date should be between the open date %1 and close date %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1069
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1142
 msgid ""
 "The reduced scoring date should be between the open date and close date."
 msgstr ""
+"The reduced scoring date should be between the open date and close date."
 
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid "The score for this problem can count towards score of problem %1."
-msgstr ""
+msgstr "The score for this problem can count towards score of problem %1."
 
 #. ($setName,$effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
 msgid "The selected problem set (%1) is not a valid set for %2"
-msgstr ""
+msgstr "The selected problem set (%1) is not a valid set for %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
 msgid "The set %1 is assigned to %2."
-msgstr ""
+msgstr "The set %1 is assigned to %2."
 
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The set header for set %1 has been renamed to '%2'."
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
@@ -5991,16 +6400,18 @@ msgid ""
 "The set name '%1' is already in use.  Pick a different name if you would "
 "like to start a new set."
 msgstr ""
+"The set name '%1' is already in use.  Pick a different name if you would "
+"like to start a new set."
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr ""
+msgstr "The set-version (%1, version %2) is not assigned to user %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
-msgstr ""
+msgstr "The solution has been removed."
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
@@ -6008,17 +6419,20 @@ msgstr ""
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
+"The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
-msgstr ""
+msgstr "The test (which is number %1) may  no longer be submitted for a grade."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
 "The time limit on this assignment was exceeded. The assignment may be "
 "checked, but the result will not be counted."
 msgstr ""
+"The time limit on this assignment was exceeded. The assignment may be "
+"checked, but the result will not be counted."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:178
 msgid ""
@@ -6026,22 +6440,25 @@ msgid ""
 "individual basis, but WeBWorK will use this value for default when a set is "
 "created."
 msgstr ""
+"The time of the day that the assignment is due.  This can be changed on an "
+"individual basis, but WeBWorK will use this value for default when a set is "
+"created."
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
 msgid "The title of the course %1 has been changed from %2 to %3"
-msgstr ""
+msgstr "The title of the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
 msgid "The title of the course %1 is now %2"
-msgstr ""
+msgstr "The title of the course %1 is now %2"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
 msgid "The user %1 has been assigned %2."
-msgstr ""
+msgstr "The user %1 has been assigned %2."
 
 #. ($enableReducedScoring)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
@@ -6049,6 +6466,8 @@ msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for enableReducedScoring is not valid; it will be replaced with "
+"'N'."
 
 #. ($timeCap)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
@@ -6056,6 +6475,8 @@ msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
+"The value %1 for the capTimeLimit option is not valid; it will be replaced "
+"with '0'."
 
 #. ($hideScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
@@ -6063,6 +6484,8 @@ msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for the hideScore option is not valid; it will be replaced with "
+"'N'."
 
 #. ($hideWork)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
@@ -6070,6 +6493,8 @@ msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for the hideWork option is not valid; it will be replaced with "
+"'N'."
 
 #. ($relaxRestrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
@@ -6077,6 +6502,8 @@ msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
+"The value %1 for the relaxRestrictIP option is not valid; it will be "
+"replaced with 'No'."
 
 #. ($restrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
@@ -6084,27 +6511,32 @@ msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
+"The value %1 for the restrictIP option is not valid; it will be replaced "
+"with 'No'."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
 msgstr ""
+"The webwork server must be able to write to these directories. Please "
+"correct the permssion errors."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:128
 msgid "Theme (refresh page after saving changes to reveal new theme.)"
-msgstr ""
+msgstr "Theme (refresh page after saving changes to reveal new theme.)"
 
+# Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
 msgid "Then by"
-msgstr ""
+msgstr "Then by"
 
 #. ($count_line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:578
 msgid "There are %1 matching WeBWorK problems"
-msgstr ""
+msgstr "There are %1 matching WeBWorK problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:154
 msgid ""
@@ -6112,12 +6544,17 @@ msgid ""
 "Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
 "Column theme uses the full page width for each column"
 msgstr ""
+"There are currently two hardcopy themes to choose from: One Column and Two "
+"Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
+"Column theme uses the full page width for each column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
 msgid ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
+"There are currently two themes (or skins) to choose from: math3 and math4.  "
+"The theme specifies a unified look and feel for the WeBWorK course web pages."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
@@ -6127,6 +6564,8 @@ msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
+"There are extra database fields  which are not defined in the schema for at "
+"least one table.  They can only be removed manually from the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
@@ -6135,26 +6574,32 @@ msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
 msgstr ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database. They will not be renamed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:576
 msgid "There are no matching WeBWorK problems"
-msgstr ""
+msgstr "There are no matching WeBWorK problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
+"There are tables or fields missing from the database.  The database must be "
+"upgraded before archiving this course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
 msgid "There are upgrades available for the Open Problem Library."
-msgstr ""
+msgstr "There are upgrades available for the Open Problem Library."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
@@ -6162,6 +6607,8 @@ msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
+"There are upgrades available for your current branch of PG from branch %1 in "
+"remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
@@ -6169,6 +6616,8 @@ msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
+"There are upgrades available for your current branch of WeBWorK from branch "
+"%1 in remote %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
@@ -6177,6 +6626,10 @@ msgid ""
 "their name, you destroy all of the data for achievement $achievementID for "
 "this student."
 msgstr ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for achievement $achievementID for "
+"this student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6185,28 +6638,32 @@ msgid ""
 "their name, you destroy all of the data for homework set $setID for this "
 "student."
 msgstr ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for homework set $setID for this "
+"student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:276
 msgid "There is NO undo for unassigning a set."
-msgstr ""
+msgstr "There is NO undo for unassigning a set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:127
 msgid "There is NO undo for unassigning students."
-msgstr ""
+msgstr "There is NO undo for unassigning students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
 msgid "There is a new version of PG available."
-msgstr ""
+msgstr "There is a new version of PG available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
 msgid "There is a new version of WeBWorK available."
-msgstr ""
+msgstr "There is a new version of WeBWorK available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:472
 msgid "There is a written solution available"
-msgstr ""
+msgstr "There is a written solution available"
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
@@ -6216,38 +6673,50 @@ msgid ""
 "files can be edited using the \"Email\" link and the \"File Manager\" link "
 "in the left margin."
 msgstr ""
+"There is no additional grade information.  A message about additional grades "
+"can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. These "
+"files can be edited using the \"Email\" link and the \"File Manager\" link "
+"in the left margin."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
 msgstr ""
+"There is no library tree file for the library, you will need to run OPL-"
+"update."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:734
 msgid "There is no undo for deleting files or directories!"
-msgstr ""
+msgstr "There is no undo for deleting files or directories!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:474
 msgid ""
 "There is no written solution available for this problem, but you can still "
 "view the correct answers"
 msgstr ""
+"There is no written solution available for this problem, but you can still "
+"view the correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:476
 msgid "There is no written solution available for this problem."
-msgstr ""
+msgstr "There is no written solution available for this problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
+"There may be something wrong with this question. Please inform your "
+"instructor including the warning messages below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator if this recurs."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
@@ -6260,50 +6729,56 @@ msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
 msgstr ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:316
 msgid ""
 "These users and higher get the \"Show Past Answers\" button on the problem "
 "page."
 msgstr ""
+"These users and higher get the \"Show Past Answers\" button on the problem "
+"page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "This action can take a long time if there are many students."
-msgstr ""
+msgstr "This action can take a long time if there are many students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 msgid "This action will not overwrite existing users."
-msgstr ""
+msgstr "This action will not overwrite existing users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
 msgid "This answer is NOT completely correct."
-msgstr ""
+msgstr "This answer is NOT completely correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
 msgid "This answer is NOT correct."
-msgstr ""
+msgstr "This answer is NOT correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
 msgid "This answer is correct."
-msgstr ""
+msgstr "This answer is correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
 msgid ""
 "This course supports guest logins. Click %1 to log into this course as a "
 "guest."
 msgstr ""
+"This course supports guest logins. Click %1 to log into this course as a "
+"guest."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
 msgid "This homework set contains no problems."
-msgstr ""
+msgstr "This homework set contains no problems."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
 msgid "This homework set is closed."
-msgstr ""
+msgstr "This homework set is closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
 msgid "This homework set is not yet open."
-msgstr ""
+msgstr "This homework set is not yet open."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
@@ -6312,6 +6787,9 @@ msgid ""
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
+"This is a blank problem template file and can not be edited directly. Use "
+"the 'NewVersion' action below to create a local copy of the file and add it "
+"to the current problem set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6325,6 +6803,15 @@ msgid ""
 "in the edit assigned users field contains links which take you to a page "
 "where you can edit what students the set is assigned to."
 msgstr ""
+"This is a table showing the current Homework sets for this class.  The "
+"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
+"Users, Visibility to students, Reduced Credit Enabled, Date it was opened, "
+"Date it is due, and the Date during which the answers are posted.  The Edit "
+"Set Data field contains checkboxes for selection and a link to the set data "
+"editing page.  The cells in the Edit Problems fields contain links which "
+"take you to a page where you can edit the containing problems, and the cells "
+"in the edit assigned users field contains links which take you to a page "
+"where you can edit what students the set is assigned to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:93
 msgid ""
@@ -6335,6 +6822,12 @@ msgid ""
 "are earned.  The \"level\" category is used for the achievements associated "
 "to a users level."
 msgstr ""
+"This is the Achievement Editor.  It is used to edit the achievements "
+"available to students.  Please keep in mind the following facts: Achievments "
+"are displayed, and evaluated, in the order they are listed. The \"secret\" "
+"category creates achievements which are not visible to students until they "
+"are earned.  The \"level\" category is used for the achievements associated "
+"to a users level."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:91
 msgid ""
@@ -6348,6 +6841,15 @@ msgid ""
 "\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
 "page contains a table containing the student usernames and their information."
 msgstr ""
+"This is the classlist editor page, where you can view and edit the records "
+"of all the students currently enrolled in this course.  The top of the page "
+"contains forms which allow you to filter which students to view, sort your "
+"students in a chosen order, edit student records, give new passwords to "
+"students, import/export student records from/to external files, or add/"
+"delete students.  To use, please select the action you would like to "
+"perform, enter in the relevant information in the fields below, and hit the "
+"\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
+"page contains a table containing the student usernames and their information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:90
 msgid ""
@@ -6362,16 +6864,28 @@ msgid ""
 "of the page contains a table displaying the sets and several pieces of "
 "relevant information."
 msgstr ""
+"This is the homework sets editor page where you can view and edit the "
+"homework sets that exist in this course and the problems that they contain. "
+"The top of the page contains forms which allow you to filter which sets to "
+"display in the table, sort the sets in a chosen order, edit homework sets, "
+"publish homework sets, import/export sets from/to an external file, score "
+"sets, or create/delete sets.  To use, please select the action you would "
+"like to perform, enter in the relevant information in the fields below, and "
+"hit the \\\"Take Action!\\\" button at the bottom of the form.  The bottom "
+"of the page contains a table displaying the sets and several pieces of "
+"relevant information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:203
 msgid ""
 "This is the number of achievement points given to each user for completing a "
 "problem."
 msgstr ""
+"This is the number of achievement points given to each user for completing a "
+"problem."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
 msgid "This problem contains a video which must be viewed online."
-msgstr ""
+msgstr "This problem contains a video which must be viewed online."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
@@ -6379,22 +6893,24 @@ msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
+"This problem has open subproblems.  You can visit them by using the links to "
+"the left or visiting the set page."
 
 #. ($shownYet{$problemFile})
 #. ($prettyID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
 msgid "This problem uses the same source file as number %1."
-msgstr ""
+msgstr "This problem uses the same source file as number %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 msgid "This problem will not count towards your grade."
-msgstr ""
+msgstr "This problem will not count towards your grade."
 
 #. ($EMAIL)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
 msgid "This sample mail would be sent to %1"
-msgstr ""
+msgstr "This sample mail would be sent to %1"
 
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
@@ -6402,6 +6918,8 @@ msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
 msgstr ""
+"This score for this problem does not count for the score of problem %1 or "
+"for the set."
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -6410,17 +6928,20 @@ msgid ""
 "the file [Scoring]/%2. These files can be edited using the \"Email\" link "
 "and the \"File Manager\" link in the left margin."
 msgstr ""
+"This scoring message is generated from [TMPL]/email/%1. It is merged with "
+"the file [Scoring]/%2. These files can be edited using the \"Email\" link "
+"and the \"File Manager\" link in the left margin."
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
 msgid "This set %1 is assigned to %2."
-msgstr ""
+msgstr "This set %1 is assigned to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
 msgid "This set doesn't contain any problems yet."
-msgstr ""
+msgstr "This set doesn't contain any problems yet."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
@@ -6428,18 +6949,23 @@ msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
 msgstr ""
+"This set had a reduced scoring period that started on %1 and ended on %2.  "
+"During that period all work counted for %3% of its value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:271
 msgid ""
 "This set has a set-level proctor password to authorize logins. Enter the "
 "password below."
 msgstr ""
+"This set has a set-level proctor password to authorize logins. Enter the "
+"password below."
 
+# Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
-msgstr ""
+msgstr "This set is %1"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
@@ -6447,10 +6973,12 @@ msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
 msgstr ""
+"This set is in its reduced scoring period.  All work counts for %1% of its "
+"value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:178
 msgid "This set needs to be assigned to you before you can grade it."
-msgstr ""
+msgstr "This set needs to be assigned to you before you can grade it."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:182
 msgid ""
@@ -6459,6 +6987,10 @@ msgid ""
 "comma separated list.  The minimum score required on the sets is specified "
 "in the following field."
 msgstr ""
+"This set will be unavailable to students until they have earned a certain "
+"score on the sets specified in this field.  The sets should be written as a "
+"comma separated list.  The minimum score required on the sets is specified "
+"in the following field."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:218
 msgid ""
@@ -6471,26 +7003,34 @@ msgid ""
 "std_problem_grader (the all or nothing grader).  It will work with custom "
 "graders if they are written appropriately."
 msgstr ""
+"This sets whether the Reduced Scoring system will be enabled.  If enabled "
+"you will need to set the default length of the reduced scoring period and "
+"the value of work done in the reduced scoring period below.  <p> To use "
+"this, you also have to enable Reduced Scoring for individual assignments and "
+"set their Reduced Scoring Dates by editing the set data.<p> This works with "
+"the avg_problem_grader (which is the the default grader) and the  "
+"std_problem_grader (the all or nothing grader).  It will work with custom "
+"graders if they are written appropriately."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
 msgid "This source file does not exist!"
-msgstr ""
+msgstr "This source file does not exist!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
 msgid "This source file is a directory!"
-msgstr ""
+msgstr "This source file is a directory!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
 msgid "This source file is not a plain file!"
-msgstr ""
+msgstr "This source file is not a plain file!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
 msgid "This source file is not readable!"
-msgstr ""
+msgstr "This source file is not readable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:382
 msgid ""
@@ -6499,6 +7039,10 @@ msgid ""
 "value of -1 uses the default from course configuration. The value of 0 "
 "disables rerandomization."
 msgstr ""
+"This specifies the rerandomization period: the number of attempts before a "
+"new version of the problem is generated by changing the Seed value. The "
+"value of -1 uses the default from course configuration. The value of 0 "
+"disables rerandomization."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:257
 msgid ""
@@ -6511,6 +7055,14 @@ msgid ""
 "Hardcopy for Selected Sets' button at the end of the table.  There is also a "
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
+"This table lists out the available homework sets for this class, along with "
+"its current status. Click on the link on the name of the homework sets to "
+"take you to the problems in that homework set.  Clicking on the links in the "
+"table headings will sort the table by the field it corresponds to.  You can "
+"also select sets for download to PDF or TeX format using the linkx next to "
+"the problem set names, and then clicking on the 'Download PDF or TeX "
+"Hardcopy for Selected Sets' button at the end of the table.  There is also a "
+"clear button and an Email instructor button at the end of the table."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
 msgid ""
@@ -6520,39 +7072,45 @@ msgid ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 msgstr ""
+"This table shows the problems that are in this problem set.  The columns "
+"from left to right are: name of the problem, current number of attempts "
+"made, number of attempts remaining, the point worth, and the completion "
+"status.  Click on the link on the name of the problem to take you to the "
+"problem page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "Time"
-msgstr ""
+msgstr "Time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
 msgid "Time Interval for New Test Versions (min; 0=infty)"
-msgstr ""
+msgstr "Time Interval for New Test Versions (min; 0=infty)"
 
 #. ($elapsedTime,$allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "Time taken on test: %1 min (%2 min allowed)."
-msgstr ""
+msgstr "Time taken on test: %1 min (%2 min allowed)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:221
 msgid "Timestamp"
-msgstr ""
+msgstr "Timestamp"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:146
 msgid "Timezone for the course"
-msgstr ""
+msgstr "Timezone for the course"
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
 msgid "To access this set you must score at least %1% on set %2."
-msgstr ""
+msgstr "To access this set you must score at least %1% on set %2."
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
+"To access this set you must score at least %1% on the following sets: %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
 msgid ""
@@ -6560,23 +7118,31 @@ msgid ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
+"To add an additional instructor to the new course, specify user information "
+"below. The user ID may contain only numbers, letters, hyphens, periods "
+"(dots), commas,and underscores.\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
 msgstr ""
+"To add the WeBWorK administrators to the new course (as administrators) "
+"check the box below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:278
 msgid ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 msgstr ""
+"To change status (scores or grades) for this student for one set, click on "
+"the individual set link."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
+"To copy problem templates from an existing course, select the course below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
@@ -6584,6 +7150,8 @@ msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
+"To edit a specific student version of this set, edit (all of) her/his "
+"assigned sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
@@ -6591,6 +7159,8 @@ msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
+"To edit this text you must first make a copy of this file using the "
+"'NewVersion' action below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
@@ -6598,126 +7168,128 @@ msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
 msgstr ""
+"To edit this text you must use the 'NewVersion' action below to save it to "
+"another file."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
-#, fuzzy
 msgid "To this Problem"
-msgstr "Problem List"
+msgstr "To this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
 msgid "To:"
-msgstr ""
+msgstr "To:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
 msgid "Totals"
-msgstr ""
+msgstr "Totals"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only (not problem scores)"
-msgstr ""
+msgstr "Totals only (not problem scores)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only, only after answer date"
-msgstr ""
+msgstr "Totals only, only after answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
 msgid "Transfer"
-msgstr ""
+msgstr "Transfer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
 msgid "True"
-msgstr ""
+msgstr "True"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2266
 msgid "Try it"
-msgstr ""
+msgstr "Try it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:189
 msgid "Tunic of Extension"
-msgstr ""
+msgstr "Tunic of Extension"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:105
 msgid "Two Columns"
-msgstr ""
+msgstr "Two Columns"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 #. ($achievementName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr ""
+msgstr "Unable to change the evaluator for set %1. Unknown error."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
 msgid "Unable to obtain error messages from within the PG question."
-msgstr ""
+msgstr "Unable to obtain error messages from within the PG question."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
 msgid "Unable to write to '%1': %2"
-msgstr ""
+msgstr "Unable to write to '%1': %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
 msgid "Unarchive"
-msgstr ""
+msgstr "Unarchive"
 
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
 msgid "Unarchive %1 to course:"
-msgstr ""
+msgstr "Unarchive %1 to course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Unarchive Course"
-msgstr ""
+msgstr "Unarchive Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
 msgid "Unarchive Next Course"
-msgstr ""
+msgstr "Unarchive Next Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
 msgid "Unassign from All Users"
-msgstr ""
+msgstr "Unassign from All Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
 msgid "Unassign selected sets from selected users"
-msgstr ""
+msgstr "Unassign selected sets from selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
 "Unassignments were not done.  You need to both click to \"Allow unassign\" "
 "and click on the Unassign button."
 msgstr ""
+"Unassignments were not done.  You need to both click to \"Allow unassign\" "
+"and click on the Unassign button."
 
 #. ($unattempted,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
 msgid "Unattempted: %1/%2"
-msgstr ""
+msgstr "Unattempted: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
 msgid "Unclassified Problems"
-msgstr ""
+msgstr "Unclassified Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
 msgid "Ungraded"
-msgstr ""
+msgstr "Ungraded"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
 msgid "Unhide Courses"
-msgstr ""
+msgstr "Unhide Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
 msgid ""
@@ -6725,126 +7297,131 @@ msgid ""
 "date of the Gateway Test this will allow you to generate a new version of "
 "the test."
 msgstr ""
+"Unlock an additional version of a Gateway Test.  If used before the close "
+"date of the Gateway Test this will allow you to generate a new version of "
+"the test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:163
 msgid "Unpack"
-msgstr ""
+msgstr "Unpack"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:385
 msgid "Unpack archives automatically"
-msgstr ""
+msgstr "Unpack archives automatically"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Unselect all courses"
-msgstr ""
+msgstr "Unselect all courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
 msgid "Unselect all sets"
-msgstr ""
+msgstr "Unselect all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
 msgid "Unselect all users"
-msgstr ""
+msgstr "Unselect all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Update"
-msgstr ""
+msgstr "Update"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:803
 msgid "Update Display"
-msgstr ""
+msgstr "Update Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:724
 msgid "Update Menus"
-msgstr ""
+msgstr "Update Menus"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "Update settings and refresh page"
-msgstr ""
+msgstr "Update settings and refresh page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
 msgid "Update the checked directories?"
-msgstr ""
+msgstr "Update the checked directories?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
 msgid "Updated location description."
-msgstr ""
+msgstr "Updated location description."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
 msgid "Upgrade"
-msgstr ""
+msgstr "Upgrade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Upgrade Course Tables"
-msgstr ""
+msgstr "Upgrade Course Tables"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Upgrade Courses"
-msgstr ""
+msgstr "Upgrade Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
 msgid "Upgrade process completed"
-msgstr ""
+msgstr "Upgrade process completed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:370
 msgid "Upload"
-msgstr ""
+msgstr "Upload"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:161
 msgid "Use Date Picker"
-msgstr ""
+msgstr "Use Date Picker"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
 msgid "Use Default Header File"
-msgstr ""
+msgstr "Use Default Header File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
 msgid "Use Equation Editor?"
-msgstr ""
+msgstr "Use Equation Editor?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:239
 msgid "Use Item"
-msgstr ""
+msgstr "Use Item"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
 msgid "Use System Default"
-msgstr ""
+msgstr "Use System Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
 msgid "Use browser back button to return from preview mode"
-msgstr ""
+msgstr "Use browser back button to return from preview mode"
 
 #. (CGI::b("$achievementID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
 msgid "Use in achievement %1"
-msgstr ""
+msgstr "Use in achievement %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
 msgid "Use in new achievement:"
-msgstr ""
+msgstr "Use in new achievement:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
 msgid "Use log base 10 instead of base <i>e</i>"
-msgstr ""
+msgstr "Use log base 10 instead of base <i>e</i>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:370
 msgid "Use older answer checkers"
-msgstr ""
+msgstr "Use older answer checkers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
 msgid ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 msgstr ""
+"Use the interface below to quickly access commonly-used instructor tools, or "
+"select a tool from the list to the left."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
 msgid ""
@@ -6852,6 +7429,9 @@ msgid ""
 "or an error in a problem you are attempting. Along with your message, "
 "additional information about the state of the system will be included."
 msgstr ""
+"Use this form to report to your professor a problem with the WeBWorK system "
+"or an error in a problem you are attempting. Along with your message, "
+"additional information about the state of the system will be included."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
@@ -6859,28 +7439,30 @@ msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
+"User '%1' will not be copied from admin course as it is the initial "
+"instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
-msgstr ""
+msgstr "User ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
 msgid "User Settings"
-msgstr ""
+msgstr "User Settings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
 msgid "User Values"
-msgstr ""
+msgstr "User Values"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
 msgid "User's name is:"
-msgstr ""
+msgstr "User's name is:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
 msgid "User's username is:"
-msgstr ""
+msgstr "User's username is:"
 
 #. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
@@ -6890,30 +7472,32 @@ msgid ""
 "UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
 "database corruption."
 msgstr ""
+"UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
+"database corruption."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
 msgid "Username"
-msgstr ""
+msgstr "Username"
 
 #. ($user_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
 msgid "Username presented:  %1"
-msgstr ""
+msgstr "Username presented:  %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
-msgstr ""
+msgstr "Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
 msgid "Users Assigned to Set %2"
-msgstr ""
+msgstr "Users Assigned to Set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "Users List"
-msgstr ""
+msgstr "Users List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:311
 msgid ""
@@ -6921,23 +7505,30 @@ msgid ""
 "Normally guest users are not allowed to change the e-mail address since it "
 "does not make sense to send e-mail to anonymous accounts."
 msgstr ""
+"Users at this level and higher are allowed to change their e-mail address. "
+"Normally guest users are not allowed to change the e-mail address since it "
+"does not make sense to send e-mail to anonymous accounts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:287
 msgid ""
 "Users at this level and higher are allowed to change their password. "
 "Normally guest users are not allowed to change their password."
 msgstr ""
+"Users at this level and higher are allowed to change their password. "
+"Normally guest users are not allowed to change their password."
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Users sorted by %1, then by %2, then by %3"
-msgstr ""
+msgstr "Users sorted by %1, then by %2, then by %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:306
 msgid ""
 "Users with at least this permission level get a link in the left panel for "
 "reporting bugs to the bug tracking system in Rochester"
 msgstr ""
+"Users with at least this permission level get a link in the left panel for "
+"reporting bugs to the bug tracking system in Rochester"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:405
 msgid ""
@@ -6947,33 +7538,38 @@ msgid ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 msgstr ""
+"Users with this permssion level or greater will automatically be sent "
+"feedback from students (generated when they use the \"Contact instructor\" "
+"button on any problem page).  In addition the feedback message will be sent "
+"to addresses listed below.  To send ONLY to addresses listed below set "
+"permission level to \"nobody\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Using contents of the default message $default_msg_file instead."
-msgstr ""
+msgstr "Using contents of the default message $default_msg_file instead."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
 msgid "Using what display mode?: "
-msgstr ""
+msgstr "Using what display mode?: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
 msgid "Using what seed?: "
-msgstr ""
+msgstr "Using what seed?: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:222
 msgid "Value of work done in Reduced Scoring Period"
-msgstr ""
+msgstr "Value of work done in Reduced Scoring Period"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
 msgid "Variable Documentation:"
-msgstr ""
+msgstr "Variable Documentation:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
 msgid "Versions of a set can only be edited for one user at a time."
-msgstr ""
+msgstr "Versions of a set can only be edited for one user at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
@@ -6982,7 +7578,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "View"
-msgstr ""
+msgstr "View"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
@@ -6991,44 +7587,44 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
 msgid "View Problems"
-msgstr ""
+msgstr "View Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
 msgid "View equations as"
-msgstr ""
+msgstr "View equations as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
 msgid "View it"
-msgstr ""
+msgstr "View it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
-msgstr ""
+msgstr "View statistics by set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
 msgid "View statistics by student"
-msgstr ""
+msgstr "View statistics by student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
-msgstr ""
+msgstr "View student progress by set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
-msgstr ""
+msgstr "View student progress by student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "View/Edit"
-msgstr ""
+msgstr "View/Edit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
-msgstr ""
+msgstr "Viewing temporary file:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
@@ -7036,50 +7632,52 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:829
 msgid "Visibility"
-msgstr ""
+msgstr "Visibility"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
 msgid "Visible"
-msgstr ""
+msgstr "Visible"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
 msgid "Visible to Students"
-msgstr ""
+msgstr "Visible to Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
-msgstr ""
+msgstr "Warning"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
 msgid "Warning messages"
-msgstr ""
+msgstr "Warning messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
-msgstr ""
+msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 
 #. ($problem_desc , CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1223
 msgid "Warnings encountered while processing %1. Error text: %2"
-msgstr ""
+msgstr "Warnings encountered while processing %1. Error text: %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
 msgid "WeBWorK Error"
-msgstr ""
+msgstr "WeBWorK Error"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
 msgid "WeBWorK Warnings"
-msgstr ""
+msgstr "WeBWorK Warnings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
 msgid ""
 "WeBWorK currently has translations for four languages: \"English en\", "
 "\"Turkish tr\", \"Spanish es\", and \"French fr\" "
 msgstr ""
+"WeBWorK currently has translations for four languages: \"English en\", "
+"\"Turkish tr\", \"Spanish es\", and \"French fr\" "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:86
 msgid ""
@@ -7089,6 +7687,11 @@ msgid ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 msgstr ""
+"WeBWorK has encountered a software error while attempting to process this "
+"problem. It is likely that there is an error in the problem itself. If you "
+"are a student, report this error message to your professor to have it "
+"corrected. If you are a professor, please consult the error output below for "
+"more information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
 msgid ""
@@ -7099,34 +7702,44 @@ msgid ""
 "professor to have them corrected. If you are a professor, please consult the "
 "warning output below for more information."
 msgstr ""
+"WeBWorK has encountered warnings while processing your request. If this "
+"occured when viewing a problem, it was likely caused by an error or "
+"ambiguity in that problem. Otherwise, it may indicate a problem with the "
+"WeBWorK system itself. If you are a student, report these warnings to your "
+"professor to have them corrected. If you are a professor, please consult the "
+"warning output below for more information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:491
 msgid ""
 "WeBWorK was unable to generate a different version of this problem; close "
 "this tab, and return to the original problem."
 msgstr ""
+"WeBWorK was unable to generate a different version of this problem; close "
+"this tab, and return to the original problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:309
 msgid ""
 "WeBWorK was unable to generate a paper copy of this homework set.  Please "
 "inform your instructor. "
 msgstr ""
+"WeBWorK was unable to generate a paper copy of this homework set.  Please "
+"inform your instructor. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:344
 msgid "Weight"
-msgstr ""
+msgstr "Weight"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
-msgstr ""
+msgstr "Welcome to WeBWorK!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1289
 msgid "What could be inside?"
-msgstr ""
+msgstr "What could be inside?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
 msgid "What field should filtered users match on?"
-msgstr ""
+msgstr "What field should filtered users match on?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:370
 msgid ""
@@ -7134,12 +7747,17 @@ msgid ""
 "view another version of this problem.  If set to -1 the feature is disabled "
 "and if set to -2 the course default is used."
 msgstr ""
+"When a student has more attempts than is specified here they will be able to "
+"view another version of this problem.  If set to -1 the feature is disabled "
+"and if set to -2 the course default is used."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:301
 msgid ""
 "When acting as a student, this permission level and higher can submit "
 "answers for that student."
 msgstr ""
+"When acting as a student, this permission level and higher can submit "
+"answers for that student."
 
 #. (CGI::em($r->maketext("before")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2307
@@ -7147,6 +7765,8 @@ msgid ""
 "When changing problem numbers, we will move the problem to be %1 the chosen "
 "number."
 msgstr ""
+"When changing problem numbers, we will move the problem to be %1 the chosen "
+"number."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:384
 msgid ""
@@ -7157,6 +7777,12 @@ msgid ""
 "ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
 "percent sign</ul>"
 msgstr ""
+"When students click the <em>Email Instructor</em> button to send feedback, "
+"WeBWorK fills in the subject line.  Here you can set the subject line.  In "
+"it, you can have various bits of information filled in with the following "
+"escape sequences.<p><ul><li> %c = course ID<li> %u = user ID<li> %s = set "
+"ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
+"percent sign</ul>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:167
 msgid ""
@@ -7164,6 +7790,9 @@ msgid ""
 "total cumulative homework score.  This score includes all sets assigned to "
 "the student."
 msgstr ""
+"When this is on students will see a line on the Grades page which has their "
+"total cumulative homework score.  This score includes all sets assigned to "
+"the student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:333
 msgid ""
@@ -7171,6 +7800,9 @@ msgid ""
 "in the answer blank.  Below this level, old answers are never shown.  "
 "Typically, that is the desired behaviour for guest accounts."
 msgstr ""
+"When viewing a problem, WeBWorK usually puts the previously submitted answer "
+"in the answer blank.  Below this level, old answers are never shown.  "
+"Typically, that is the desired behaviour for guest accounts."
 
 #. (CGI::b($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:153
@@ -7179,6 +7811,9 @@ msgid ""
 "data for achievement %1 for this student. Make sure this is what you want to "
 "do."
 msgstr ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for achievement %1 for this student. Make sure this is what you want to "
+"do."
 
 #. (CGI::b($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:128
@@ -7188,6 +7823,10 @@ msgid ""
 "the set to these students and they will receive new versions of the "
 "problems. Make sure this is what you want to do before unchecking students."
 msgstr ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for homework set %1 for this student. You will then need to reassign "
+"the set to these students and they will receive new versions of the "
+"problems. Make sure this is what you want to do before unchecking students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:280
 msgid ""
@@ -7196,16 +7835,20 @@ msgid ""
 "student will receive a new version of each problem. Make sure this is what "
 "you want to do before unchecking sets."
 msgstr ""
+"When you uncheck a homework set (and save the changes), you destroy all of "
+"the data for that set for this student.   If you reassign the set, the "
+"student will receive a new version of each problem. Make sure this is what "
+"you want to do before unchecking sets."
 
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
 msgid "Will open on %1."
-msgstr ""
+msgstr "Will open on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Worth"
-msgstr ""
+msgstr "Worth"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
@@ -7213,6 +7856,8 @@ msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
+"Write permissions have not been enabled for '%1'.  Changes must be saved to "
+"another file for viewing."
 
 #. ($self->shortPath($currentDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
@@ -7220,12 +7865,16 @@ msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
+"Write permissions have not been enabled in '%1'.  Changes must be saved to a "
+"different directory for viewing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr ""
+"Write permissions have not been enabled in the templates directory.  No "
+"changes can be made."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
@@ -7240,7 +7889,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:455
 msgid ""
@@ -7248,6 +7897,9 @@ msgid ""
 "these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"You are currently checking answers to a different version of your problem - "
+"these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:460
 msgid ""
@@ -7255,62 +7907,67 @@ msgid ""
 "- these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"You are currently previewing answers to a different version of your problem "
+"- these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
 
 #. ($userSet->set_id, $r->connection->remote_ip)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:253
 msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 msgstr ""
+"You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
 msgid "You are not authorized to access the Instructor tools"
-msgstr ""
+msgstr "You are not authorized to access the Instructor tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
 msgid "You are not authorized to access the Instructor tools."
-msgstr ""
+msgstr "You are not authorized to access the Instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
 msgid "You are not authorized to access the instructor tools."
-msgstr ""
+msgstr "You are not authorized to access the instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
 msgid "You are not authorized to modify homework sets."
-msgstr ""
+msgstr "You are not authorized to modify homework sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
 msgid "You are not authorized to modify problems."
-msgstr ""
+msgstr "You are not authorized to modify problems."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
 msgid "You are not authorized to modify set definition files."
-msgstr ""
+msgstr "You are not authorized to modify set definition files."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
 msgid "You are not authorized to modify student data"
-msgstr ""
+msgstr "You are not authorized to modify student data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
 msgid "You are not authorized to perform this action."
-msgstr ""
+msgstr "You are not authorized to perform this action."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:246
 msgid ""
 "You are not permitted to generate a hardcopy for a set with hidden work."
 msgstr ""
+"You are not permitted to generate a hardcopy for a set with hidden work."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:234
 msgid "You are not permitted to generate a hardcopy for an unopened set."
-msgstr ""
+msgstr "You are not permitted to generate a hardcopy for an unopened set."
 
 #. ($showMeAnother{MaxReps},$solutionShown)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:484
@@ -7318,39 +7975,41 @@ msgid ""
 "You are only allowed to click on Show Me Another %quant(%1,time,times) per "
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
+"You are only allowed to click on Show Me Another %quant(%1,time,times) per "
+"problem. %2 Close this tab, and return to the original problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
 msgid "You are out of time.  Press grade now!"
-msgstr ""
+msgstr "You are out of time.  Press grade now!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:316
 msgid "You can also examine the following temporary files: "
-msgstr ""
+msgstr "You can also examine the following temporary files: "
 
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
-msgstr ""
+msgstr "You can earn partial credit on this problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
-msgstr ""
+msgstr "You can not specify an absolute path"
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
 msgid "You can only %1 one file at a time."
-msgstr ""
+msgstr "You can only %1 one file at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:98
 msgid "You can only download regular files."
-msgstr ""
+msgstr "You can only download regular files."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:508
 msgid "You can only edit text files"
-msgstr ""
+msgstr "You can only edit text files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:786
 msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
-msgstr ""
+msgstr "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
@@ -7358,93 +8017,97 @@ msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
 msgstr ""
+"You can use this feature %quant(%1,more time,more times,as many times as you "
+"want) on this problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:866
 msgid "You can't download directories"
-msgstr ""
+msgstr "You can't download directories"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:867
 msgid "You can't download files of that type"
-msgstr ""
+msgstr "You can't download files of that type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
 msgid "You can't edit a directory"
-msgstr ""
+msgstr "You can't edit a directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
 msgid "You can't view files of that type"
-msgstr ""
+msgstr "You can't view files of that type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
 msgid "You cannot archive the course you are currently using."
-msgstr ""
+msgstr "You cannot archive the course you are currently using."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
 msgid "You cannot delete the course you are currently using."
-msgstr ""
+msgstr "You cannot delete the course you are currently using."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
 msgid "You cannot delete yourself!"
-msgstr ""
+msgstr "You cannot delete yourself!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1842
 msgid ""
 "You cannot use this version of Set Detail to edit just-in-time type sets.  "
 "You must use Set Detail 2."
 msgstr ""
+"You cannot use this version of Set Detail to edit just-in-time type sets.  "
+"You must use Set Detail 2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
 msgid "You did not specify a new set name."
-msgstr ""
+msgstr "You did not specify a new set name."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
 msgid "You didn't enter any message."
-msgstr ""
+msgstr "You didn't enter any message."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
-msgstr ""
+msgstr "You do not have permission to change email addresses."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
 msgid "You do not have permission to change the hardcopy theme."
-msgstr ""
+msgstr "You do not have permission to change the hardcopy theme."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
-msgstr ""
+msgstr "You do not have permission to change your password."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
 msgid "You do not have permission to edit this file."
-msgstr ""
+msgstr "You do not have permission to edit this file."
 
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr ""
+msgstr "You do not have permission to generate hardcopy in %1 format."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "You do not have permission to view the details of this error."
-msgstr ""
+msgstr "You do not have permission to view the details of this error."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
-msgstr ""
+msgstr "You don't have any items!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
 msgid "You exceeded the allowed time."
-msgstr ""
+msgstr "You exceeded the allowed time."
 
 #. ($numLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
 msgid "You have %1 attempt(s) remaining on this test."
-msgstr ""
+msgstr "You have %1 attempt(s) remaining on this test."
 
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr ""
+msgstr "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 
 #. ($attempts_before_rr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
@@ -7452,41 +8115,45 @@ msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
+"You have %quant(%1,attempt,attempts) left before new version will be "
+"requested."
 
 #. ($attempts)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
 msgid "You have attempted this problem %quant(%1,time,times)."
-msgstr ""
+msgstr "You have attempted this problem %quant(%1,time,times)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
 msgid "You have been logged out of WeBWorK."
-msgstr ""
+msgstr "You have been logged out of WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
 msgid "You have less than 1 minute to complete this test."
-msgstr ""
+msgstr "You have less than 1 minute to complete this test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:882
 msgid "You have not chosen a file to upload."
-msgstr ""
+msgstr "You have not chosen a file to upload."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "You have requested that the following items be deleted"
-msgstr ""
+msgstr "You have requested that the following items be deleted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1005
 msgid "You have specified an illegal file"
-msgstr ""
+msgstr "You have specified an illegal file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1237
 msgid "You have specified an illegal path"
-msgstr ""
+msgstr "You have specified an illegal path"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:465
 msgid ""
 "You may check your answers to this problem without affecting the maximum "
 "number of tries to your original problem."
 msgstr ""
+"You may check your answers to this problem without affecting the maximum "
+"number of tries to your original problem."
 
 #. ($phrase_for_privileged_users)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:575
@@ -7495,14 +8162,17 @@ msgid ""
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 msgstr ""
+"You may choose to show any of the following data. Correct answers, hints, "
+"and solutions are only available %1 after the answer date of the homework "
+"set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
 msgid "You may not change your own password here!"
-msgstr ""
+msgstr "You may not change your own password here!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
 msgid "You may still check your answers."
-msgstr ""
+msgstr "You may still check your answers."
 
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
@@ -7510,6 +8180,8 @@ msgid ""
 "You must attempt this problem %quant(%1,time,times) before Show Me Another "
 "is available."
 msgstr ""
+"You must attempt this problem %quant(%1,time,times) before Show Me Another "
+"is available."
 
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
@@ -7517,10 +8189,12 @@ msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr ""
+"You must attempt this problem %quant(%1,time,times) before this feature is "
+"available"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
 msgid "You must confirm the password for the initial instructor."
-msgstr ""
+msgstr "You must confirm the password for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:541
@@ -7528,30 +8202,32 @@ msgid ""
 "You must log into this set via your Learning Management System (e.g. "
 "Blackboard, Moodle, etc...)."
 msgstr ""
+"You must log into this set via your Learning Management System (e.g. "
+"Blackboard, Moodle, etc...)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
 msgid "You must provide a student ID, a set ID, and a problem number."
-msgstr ""
+msgstr "You must provide a student ID, a set ID, and a problem number."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
 msgid "You must select a course to rename."
-msgstr ""
+msgstr "You must select a course to rename."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
 msgid "You must select at least one file for the archive"
-msgstr ""
+msgstr "You must select at least one file for the archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
 msgid "You must select at least one file to delete"
-msgstr ""
+msgstr "You must select at least one file to delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
 msgid "You must select one or more sets for scoring"
-msgstr ""
+msgstr "You must select one or more sets for scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
 msgid "You must specify a course ID."
-msgstr ""
+msgstr "You must specify a course ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
@@ -7560,49 +8236,49 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
 msgid "You must specify a course name."
-msgstr ""
+msgstr "You must specify a course name."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
 msgid "You must specify a file name"
-msgstr ""
+msgstr "You must specify a file name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
 msgid "You must specify a first name for the initial instructor."
-msgstr ""
+msgstr "You must specify a first name for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
 msgid "You must specify a last name for the initial instructor."
-msgstr ""
+msgstr "You must specify a last name for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
 msgid "You must specify a new institution for the course."
-msgstr ""
+msgstr "You must specify a new institution for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
 msgid "You must specify a new name for the course."
-msgstr ""
+msgstr "You must specify a new name for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
 msgid "You must specify a new title for the course."
-msgstr ""
+msgstr "You must specify a new title for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
 msgid "You must specify a password for the initial instructor."
-msgstr ""
+msgstr "You must specify a password for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
 msgid "You must specify a user ID."
-msgstr ""
+msgstr "You must specify a user ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
 msgid "You must specify an email address for the initial instructor."
-msgstr ""
+msgstr "You must specify an email address for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
 msgid "You must specify an file name in order to save a new file."
-msgstr ""
+msgstr "You must specify an file name in order to save a new file."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:488
 msgid ""
@@ -7610,32 +8286,35 @@ msgid ""
 "Canvas, etc...) to access this set.  Try logging in to the Learning "
 "Managment System and visiting the set from there."
 msgstr ""
+"You must use your Learning Managment System (E.G. Blackboard, Moodle, "
+"Canvas, etc...) to access this set.  Try logging in to the Learning "
+"Managment System and visiting the set from there."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1260
 msgid "You need to select a \"Target Set\" before you can edit it."
-msgstr ""
+msgstr "You need to select a \"Target Set\" before you can edit it."
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
 msgid "You need to select a file to %1."
-msgstr ""
+msgstr "You need to select a file to %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
 msgid "You need to select a set definition file to view."
-msgstr ""
+msgstr "You need to select a set definition file to view."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
-msgstr ""
+msgstr "You need to select a set from this course to view."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1369
 msgid "You need to select a set to view."
-msgstr ""
+msgstr "You need to select a set to view."
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
 msgid "You received a score of %1 for this attempt."
-msgstr ""
+msgstr "You received a score of %1 for this attempt."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
@@ -7643,6 +8322,8 @@ msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem and its graded subproblems."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
@@ -7650,106 +8331,117 @@ msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
 msgstr ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem."
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1213
 msgid "Your %1 name contains illegal characters"
-msgstr ""
+msgstr "Your %1 name contains illegal characters"
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1214
 msgid "Your %1 name may not begin with a dot"
-msgstr ""
+msgstr "Your %1 name may not begin with a dot"
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1215
 msgid "Your %1 name may not contain a path component"
-msgstr ""
+msgstr "Your %1 name may not contain a path component"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:495
 msgid ""
 "Your LTI OAuth verification failed.  If this recurs, please speak with your "
 "instructor"
 msgstr ""
+"Your LTI OAuth verification failed.  If this recurs, please speak with your "
+"instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:483
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:494
 msgid "Your authentication failed.  Please return to Oncourse and login again."
 msgstr ""
+"Your authentication failed.  Please return to Oncourse and login again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:237
 msgid ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
 msgstr ""
+"Your authentication failed.  Please try again. Please speak with your "
+"instructor if you need help."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
 msgid "Your browser does not support the video tag."
-msgstr ""
+msgstr "Your browser does not support the video tag."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
-msgstr ""
+msgstr "Your current branch of PG is up to date with branch %1 in remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
+"Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
 msgid "Your current branch of the Open Problem Library is up to date."
-msgstr ""
+msgstr "Your current branch of the Open Problem Library is up to date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
 msgid "Your display options have been saved."
-msgstr ""
+msgstr "Your display options have been saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
 msgid "Your email address has been changed."
-msgstr ""
+msgstr "Your email address has been changed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1239
 msgid "Your file name contains illegal characters"
-msgstr ""
+msgstr "Your file name contains illegal characters"
 
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
 msgid "Your overall recorded score is %1.  %2"
-msgstr ""
+msgstr "Your overall recorded score is %1.  %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
 msgid "Your recorded score on this test (number %1) is %2/%3."
-msgstr ""
+msgstr "Your recorded score on this test (number %1) is %2/%3."
 
+# $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
 msgid "Your score on this %1 WAS recorded."
-msgstr ""
+msgstr "Your score on this %1 WAS recorded."
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
 msgid "Your score on this %1 is %2/%3."
-msgstr ""
+msgstr "Your score on this %1 is %2/%3."
 
+# $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
 msgid "Your score on this %1 was NOT recorded."
-msgstr ""
+msgstr "Your score on this %1 was NOT recorded."
 
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr ""
+msgstr "Your score on this (checked, not recorded) submission is %1/%2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
 msgid "Your score on this problem was recorded."
-msgstr ""
+msgstr "Your score on this problem was recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
@@ -7757,21 +8449,26 @@ msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr ""
+"Your score was not recorded because there was a failure in storing the "
+"problem record to the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
 msgid "Your score was not recorded because this homework set is closed."
-msgstr ""
+msgstr "Your score was not recorded because this homework set is closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr ""
+"Your score was not recorded because this problem has not been assigned to "
+"you."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
+"Your score was not recorded because this problem set version is not open."
 
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
@@ -7779,230 +8476,158 @@ msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
+"Your score was not recorded because you have exceeded the time limit for "
+"this test. (Time taken: %1 min; allowed: %2 min.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
+"Your score was not recorded because you have no attempts remaining on this "
+"set version."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
 msgid "Your score was not recorded."
-msgstr ""
+msgstr "Your score was not recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
 msgid "Your score was not successfully sent to the LMS"
-msgstr ""
+msgstr "Your score was not successfully sent to the LMS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
 msgid "Your score was recorded."
-msgstr ""
+msgstr "Your score was recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
 msgid "Your score was successfully sent to the LMS"
-msgstr ""
+msgstr "Your score was successfully sent to the LMS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
 msgid "Your session has timed out due to inactivity. Please log in again."
-msgstr ""
+msgstr "Your session has timed out due to inactivity. Please log in again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
 msgid "Your systems are up to date!"
-msgstr ""
+msgstr "Your systems are up to date!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
-#, fuzzy
 msgid "[Edit]"
-msgstr "Problem List"
+msgstr "[Edit]"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
-#, fuzzy
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
 msgid "_ANSWER_LOG_DESCRIPTION"
-msgstr ""
-"This is the past answer viewer.  Students can only see their answers, and "
-"they will not be able to see which parts are correct.  Instructors can view "
-"any users answers using the form below and the answers will be colored "
-"according to correctness."
+msgstr "_ANSWER_LOG_DESCRIPTION"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the classlist editor page, where you can view and edit the records "
-"of all the students currently enrolled in this course.  The top of the page "
-"contains forms which allow you to filter which students to view, sort your "
-"students in a chosen order, edit student records, give new passwords to "
-"students, import/export student records from/to external files, or add/"
-"delete students. To use, please select the action you would like to perform, "
-"enter in the relevant information in the fields below, and hit the \"Take "
-"Action!\" button at the bottom of the form.  The bottom of the page contains "
-"a table containing the student usernames and their information."
+msgstr "_CLASSLIST_EDITOR_DESCRIPTION"
 
-#
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
-msgstr ""
-"%1 uses an external authentication system.  You've authenticated through "
-"that system, but aren't allowed to log in to this course."
+msgstr "_EXTERNAL_AUTH_MESSAGE"
 
-#
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
-msgstr ""
-"This course supports guest logins. Click %1 to log into this course as a "
-"guest."
+msgstr "_GUEST_LOGIN_MESSAGE"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_HMWKSETS_EDITOR_DESCRIPTION"
 
-#
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
-msgstr ""
-"If you check %1 your login information will be remembered by the browser you "
-"are using, allowing you to visit WeBWorK pages without typing your user name "
-"and password (until your session expires). This feature is not safe for "
-"public workstations, untrusted machines, and machines over which you do not "
-"have direct control."
+msgstr "_LOGIN_MESSAGE"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
 msgid "_PROBLEM_SET_SUMMARY"
-msgstr ""
-"This is a table showing the current Homework sets for this class.  The "
-"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
-"Users, Visibility to students, Reduced Scoring Enabled, Date it was opened, "
-"Date it is due, and the Date during which the answers are posted.  The Edit "
-"Set Data field contains checkboxes for selection and a link to the set data "
-"editing page.  The cells in the Edit Problems fields contain links which "
-"take you to a page where you can edit the containing problems, and the cells "
-"in the edit assigned users field contains links which take you to a page "
-"where you can edit what students the set is assigned to."
+msgstr "_PROBLEM_SET_SUMMARY"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
-msgstr ""
-"WeBWorK has encountered a software error while attempting to process this "
-"problem. It is likely that there is an error in the problem itself. If you "
-"are a student, report this error message to your professor to have it "
-"corrected. If you are a professor, please consult the error output below for "
-"more information."
+msgstr "_REQUEST_ERROR"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
 msgid "_USER_TABLE_SUMMARY"
-msgstr ""
-"A table showing all the current users along with several fields of user "
-"information. The fields from left to right are: Login Name, Login Status, "
-"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
-"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
-"the links in the column headers will sort the table by the field it "
-"corresponds to. The Login Name fields contain checkboxes for selecting the "
-"user.  Clicking the link of the name itself will allow you to act as the "
-"selected user.  There will also be an image link following the name which "
-"will take you to a page where you can edit the selected user's information.  "
-"Clicking the emails will allow you to email the corresponding user.  "
-"Clicking the links in the entries in the assigned sets columns will take you "
-"to a page where you can view and reassign the sets for the selected user."
+msgstr "_USER_TABLE_SUMMARY"
 
+# Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
-msgstr ""
+msgstr "a duplicate of the first selected set"
 
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
-msgstr ""
+msgstr "a new empty set"
 
+# Context is "Save to a new file named:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
 msgid "a new file named:"
-msgstr ""
+msgstr "a new file named:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
-msgstr ""
+msgstr "a single set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
 msgid "active"
-msgstr ""
+msgstr "active"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "add problems"
-msgstr ""
+msgstr "add problems"
 
 #. ($setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
-msgstr ""
+msgstr "addGlobalSet %1 in ProblemSetList:  %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
 msgid "added missing permission level for user"
-msgstr ""
+msgstr "added missing permission level for user"
 
+# #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "admin"
-msgstr ""
+msgstr "admin"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
 msgid "all achievements"
-msgstr ""
+msgstr "all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
-msgstr ""
+msgstr "all current users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
-msgstr ""
+msgstr "all set dates for one <b>user</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
@@ -8017,11 +8642,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:982
 msgid "all sets"
-msgstr ""
+msgstr "all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
 msgid "all students"
-msgstr ""
+msgstr "all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
@@ -8032,358 +8657,363 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
 msgid "all users"
-msgstr ""
+msgstr "all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "all users for one <b>set</b>"
-msgstr ""
+msgstr "all users for one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid "alphabetically"
-msgstr ""
+msgstr "alphabetically"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:661
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:672
 msgid "answer"
-msgstr ""
+msgstr "answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
 msgid "any users"
-msgstr ""
+msgstr "any users"
 
+# Context is "Create _____ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
+msgstr "as"
 
+# Context is "Import achievements from ____ assigning the achievements to ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
 msgid "assigning the achievements to"
-msgstr ""
+msgstr "assigning the achievements to"
 
+# Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 msgid "assigning this set to"
-msgstr ""
+msgstr "assigning this set to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
 msgid "avg attempts"
-msgstr ""
+msgstr "avg attempts"
 
+# Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
 msgid "blank problem template(s) to end of homework set"
-msgstr ""
+msgstr "blank problem template(s) to end of homework set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
 msgid "by last login date"
-msgstr ""
+msgstr "by last login date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
-msgstr ""
+msgstr "changes abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
-msgstr ""
+msgstr "changes saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 msgid "class list data"
-msgstr ""
+msgstr "class list data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
-msgstr ""
+msgstr "class list data for selected <b>users</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
 msgid "close"
-msgstr ""
+msgstr "close"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:685
 msgid "column"
-msgstr ""
+msgstr "column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
 msgid "columns:"
-msgstr ""
+msgstr "columns:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
 msgid "correct"
-msgstr ""
+msgstr "correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
 msgid "course files"
-msgstr ""
+msgstr "course files"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
 msgid "deleted %1 sets"
-msgstr ""
+msgstr "deleted %1 sets"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
 msgid "deleted %1 users"
-msgstr ""
+msgstr "deleted %1 users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
 msgid "editing all achievements"
-msgstr ""
+msgstr "editing all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
 msgid "editing all sets"
-msgstr ""
+msgstr "editing all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
 msgid "editing all users"
-msgstr ""
+msgstr "editing all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
 msgid "editing selected achievements"
-msgstr ""
+msgstr "editing selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
 msgid "editing selected sets"
-msgstr ""
+msgstr "editing selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing selected users"
-msgstr ""
+msgstr "editing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
 msgid "editing visible sets"
-msgstr ""
+msgstr "editing visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing visible users"
-msgstr ""
+msgstr "editing visible users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
 msgid "email:"
-msgstr ""
+msgstr "email:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
 msgid "empty"
-msgstr ""
+msgstr "empty"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
 msgid "enter matching set IDs below"
-msgstr ""
+msgstr "enter matching set IDs below"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
-#, fuzzy
 msgid "entry rows."
-msgstr "Problem List"
+msgstr "entry rows."
 
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
 msgid "error adding set location %1 for set %2: %3"
-msgstr ""
+msgstr "error adding set location %1 for set %2: %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
-msgstr ""
+msgstr "export abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
 msgid "exporting all achievements"
-msgstr ""
+msgstr "exporting all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
 msgid "exporting all sets"
-msgstr ""
+msgstr "exporting all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
 msgid "exporting selected achievements"
-msgstr ""
+msgstr "exporting selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
 msgid "exporting selected sets"
-msgstr ""
+msgstr "exporting selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
 msgid "exporting visible sets"
-msgstr ""
+msgstr "exporting visible sets"
 
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr ""
+msgstr "for  %1 (%2) who has been assigned %3 sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
-msgstr ""
+msgstr "for one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 msgid "for one <b>user</b>"
-msgstr ""
+msgstr "for one <b>user</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
 msgid "for students"
-msgstr ""
+msgstr "for students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
 msgid "from"
-msgstr ""
+msgstr "from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
 msgid "giving new passwords to all users"
-msgstr ""
+msgstr "giving new passwords to all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to selected users"
-msgstr ""
+msgstr "giving new passwords to selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to visible users"
-msgstr ""
+msgstr "giving new passwords to visible users"
 
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
 msgid "global %1 for set %2 not found."
-msgstr ""
+msgstr "global %1 for set %2 not found."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
 msgid "global set %1  not found."
-msgstr ""
+msgstr "global set %1  not found."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
 msgid "global set %1 not found."
-msgstr ""
+msgstr "global set %1 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
-msgstr ""
+msgstr "grade_proctor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "guest"
-msgstr ""
+msgstr "guest"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
-msgstr ""
+msgstr "hidden"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "hidden from"
-msgstr ""
+msgstr "hidden from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
-msgstr ""
+msgstr "hidden from students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
 msgid "hidden sets"
-msgstr ""
+msgstr "hidden sets"
 
+# doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
 #: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
 #: /opt/webwork/pg/lib/Value/Vector.pm:280
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
-msgstr ""
+msgstr "i"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
 msgid "illegal character in input: '/'"
-msgstr ""
+msgstr "illegal character in input: '/'"
 
+# Context is " Show users who match _____ in their _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
 msgid "in their"
-msgstr ""
+msgstr "in their"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
 msgid "inactive"
-msgstr ""
+msgstr "inactive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
 msgid "incorrect"
-msgstr ""
+msgstr "incorrect"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
 msgid "index"
-msgstr ""
+msgstr "index"
 
 #. ($restrictLoc, $setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
 msgid "input set location %1 already exists for set %2."
-msgstr ""
+msgstr "input set location %1 already exists for set %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
 msgid "list of insertable macros"
-msgstr ""
+msgstr "list of insertable macros"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "locations selected below"
-msgstr ""
+msgstr "locations selected below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
 msgid "login"
-msgstr ""
+msgstr "login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "login ID"
-msgstr ""
+msgstr "login ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
 msgid "login/studentID:"
-msgstr ""
+msgstr "login/studentID:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "login_proctor"
-msgstr ""
+msgstr "login_proctor"
 
+# Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "made visible for"
-msgstr ""
+msgstr "made visible for"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
 msgid "max"
-msgstr ""
+msgstr "max"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
 msgid "multiple sets"
-msgstr ""
+msgstr "multiple sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "new set:"
-msgstr ""
+msgstr "new set:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 msgid "new users"
-msgstr ""
+msgstr "new users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
 msgid "no achievements"
-msgstr ""
+msgstr "no achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
 msgid "no achievements."
-msgstr ""
+msgstr "no achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
 msgid "no location"
-msgstr ""
+msgstr "no location"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
@@ -8394,11 +9024,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:981
 msgid "no sets"
-msgstr ""
+msgstr "no sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
 msgid "no students"
-msgstr ""
+msgstr "no students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
@@ -8408,179 +9038,177 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
 msgid "no users"
-msgstr ""
+msgstr "no users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
-msgstr ""
+msgstr "nobody"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
 msgid "nth colum of merge file"
-msgstr ""
+msgstr "nth colum of merge file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
 msgid "number of students not defined"
-msgstr ""
+msgstr "number of students not defined"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
-msgstr ""
+msgstr "one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
 msgid "one <b>set</b> for  <b>users</b>"
-msgstr ""
+msgstr "one <b>set</b> for  <b>users</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "one <b>user</b> (on one <b>set</b>)"
-msgstr ""
+msgstr "one <b>user</b> (on one <b>set</b>)"
 
+# Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
 msgid "only"
-msgstr ""
+msgstr "only"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
 msgid "only best scores"
-msgstr ""
+msgstr "only best scores"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
 msgid "or Problems from"
-msgstr ""
+msgstr "or Problems from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "out of"
-msgstr ""
+msgstr "out of"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
 msgid "overwrite all data"
-msgstr ""
+msgstr "overwrite all data"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:678
 msgid "part"
-msgstr ""
+msgstr "part"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
 msgid "permissions for %1 not defined"
-msgstr ""
+msgstr "permissions for %1 not defined"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
 msgid "pg debug"
-msgstr ""
+msgstr "pg debug"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
 msgid "pg internal errors"
-msgstr ""
+msgstr "pg internal errors"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
 msgid "pg warning"
-msgstr ""
+msgstr "pg warning"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
 msgid "point"
-msgstr ""
+msgstr "point"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
 msgid "points"
-msgstr ""
+msgstr "points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
 msgid "preserve existing data"
-msgstr ""
+msgstr "preserve existing data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
 msgid "preview answers"
-msgstr ""
+msgstr "preview answers"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:667
-#, fuzzy
 msgid "problem"
-msgstr "Problem List"
+msgstr "problem"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
-#, fuzzy
 msgid "problems"
-msgstr "Problem List"
+msgstr "problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "professor"
-msgstr ""
+msgstr "professor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "progress"
-msgstr ""
+msgstr "progress"
 
 #. ($line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
 msgid "readSetDef error, can't read the line: ||%1||"
-msgstr ""
+msgstr "readSetDef error, can't read the line: ||%1||"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
 msgid "recitation #"
-msgstr ""
+msgstr "recitation #"
 
 #. ($studentName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
 msgid "record for user %1 not found"
-msgstr ""
+msgstr "record for user %1 not found"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
 msgid "record for visible user %1 not found"
-msgstr ""
+msgstr "record for visible user %1 not found"
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
+"restriction location %1 does not exist.  IP restrictions have been ignored."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:684
 msgid "row"
-msgstr ""
+msgstr "row"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
 msgid "section #"
-msgstr ""
+msgstr "section #"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
 msgid "section:"
-msgstr ""
+msgstr "section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
 msgid "selected <b>sets</b>"
-msgstr ""
+msgstr "selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
-msgstr ""
+msgstr "selected <b>users</b> to selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
 msgid "selected achievements"
-msgstr ""
+msgstr "selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
 msgid "selected achievements."
-msgstr ""
+msgstr "selected achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
@@ -8595,7 +9223,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:983
 msgid "selected sets"
-msgstr ""
+msgstr "selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
@@ -8609,184 +9237,186 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
 msgid "selected users"
-msgstr ""
+msgstr "selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
 msgid "separate multiple IDs with commas"
-msgstr ""
+msgstr "separate multiple IDs with commas"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
 msgid "set"
-msgstr ""
+msgstr "set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 msgid "sets"
-msgstr ""
+msgstr "sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
 msgid "sets checked below"
-msgstr ""
+msgstr "sets checked below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
 msgid "sets hidden from students"
-msgstr ""
+msgstr "sets hidden from students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
 msgid "sets visible to students"
-msgstr ""
+msgstr "sets visible to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
 msgid "sets with matching set IDs:"
-msgstr ""
+msgstr "sets with matching set IDs:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
 msgid "showing all sets"
-msgstr ""
+msgstr "showing all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
 msgid "showing all users"
-msgstr ""
+msgstr "showing all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
 msgid "showing hidden sets"
-msgstr ""
+msgstr "showing hidden sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
 msgid "showing matching sets"
-msgstr ""
+msgstr "showing matching sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing matching users"
-msgstr ""
+msgstr "showing matching users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
 msgid "showing no sets"
-msgstr ""
+msgstr "showing no sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing no users"
-msgstr ""
+msgstr "showing no users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
 msgid "showing selected sets"
-msgstr ""
+msgstr "showing selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing selected users"
-msgstr ""
+msgstr "showing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
-msgstr ""
+msgstr "showing visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
-msgstr ""
+msgstr "still open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "student"
-msgstr ""
+msgstr "student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
 msgid "students"
-msgstr ""
+msgstr "students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
 msgid "submission"
-msgstr ""
+msgstr "submission"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
 msgid "submission (test %1)"
-msgstr ""
+msgstr "submission (test %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "summary"
-msgstr ""
+msgstr "summary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "ta"
-msgstr ""
+msgstr "ta"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
 msgid "test"
-msgstr ""
+msgstr "test"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
 msgid "test (%1)"
-msgstr ""
+msgstr "test (%1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
 msgid "test date"
-msgstr ""
+msgstr "test date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
 msgid "test time"
-msgstr ""
+msgstr "test time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
 msgid "the following file"
-msgstr ""
+msgstr "the following file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1253
 msgid "the following file(s)"
-msgstr ""
+msgstr "the following file(s)"
 
 #. ($forcedSourceFile)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
 msgid "the original path to the file is %1"
-msgstr ""
+msgstr "the original path to the file is %1"
 
+# Context is "Sort by ___ then by ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
 msgid "then by"
-msgstr ""
+msgstr "then by"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
 msgid "then delete them"
-msgstr ""
+msgstr "then delete them"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "time"
-msgstr ""
+msgstr "time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
 msgid "time limit exceeded"
-msgstr ""
+msgstr "time limit exceeded"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "times"
-msgstr ""
+msgstr "times"
 
+# Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
 msgid "to"
-msgstr ""
+msgstr "to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
 msgid "to all users, create global data, and"
-msgstr ""
+msgstr "to all users, create global data, and"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
-msgstr ""
+msgstr "to one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
-msgstr ""
+msgstr "top score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
@@ -8795,42 +9425,44 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
 msgid "unable to write to directory %1"
-msgstr ""
+msgstr "unable to write to directory %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
 msgid "unlimited"
-msgstr ""
+msgstr "unlimited"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
 msgid "userID: %1 --"
-msgstr ""
+msgstr "userID: %1 --"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
+"username, last name, first name, section, achievement level, achievement "
+"score,"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "users"
-msgstr ""
+msgstr "users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
 msgid "users who match on selected field"
-msgstr ""
+msgstr "users who match on selected field"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
 msgid "users who match:"
-msgstr ""
+msgstr "users who match:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
-msgstr ""
+msgstr "visible"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
@@ -8838,12 +9470,12 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:685
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:851
 msgid "visible sets"
-msgstr ""
+msgstr "visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
-msgstr ""
+msgstr "visible to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
@@ -8853,64 +9485,64 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
 msgid "visible users"
-msgstr ""
+msgstr "visible users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
-msgstr ""
+msgstr "with set name(s):"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
-msgstr ""
+msgstr "won't be able to read from file %1/%2: does it exist? is it readable?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
+msgstr "your students"
+
+#
+msgid "navNext"
+msgstr "Next"
+
+#
+msgid "navNextGrey"
+msgstr "Next"
+
+#
+msgid "navPrev"
+msgstr "Previous"
+
+#
+msgid "navPrevGrey"
+msgstr "Previous"
+
+#
+msgid "navProbListGrey"
+msgstr "Problem List"
+
+#
+msgid "navUp"
+msgstr "Homework Sets"
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_1"
 msgstr ""
+"This assignment has a Reduced Scoring Period that begins %1 and ends on the "
+"due date, %2.  During this period all additional work done counts %3 % of "
+"the original."
 
 #
-#~ msgid "navNext"
-#~ msgstr "Next"
+msgid "_AUTO"
+msgstr "1"
 
 #
-#~ msgid "navNextGrey"
-#~ msgstr "Next"
+msgid "_REDUCED_CREDIT_MESSAGE_2"
+msgstr ""
+"This assignment had a Reduced Scoring Period that began %1 and ended on the "
+"due date, %2.  During that period all additional work done counted %3 % of "
+"the original."
 
-#
-#~ msgid "navPrev"
-#~ msgstr "Previous"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "Previous"
-
-#
+#, fuzzy
 #~ msgid "navProbList"
 #~ msgstr "Problem List"
-
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "Problem List"
-
-#
-#~ msgid "navUp"
-#~ msgstr "Homework Sets"
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "This assignment has a Reduced Scoring Period that begins %1 and ends on "
-#~ "the due date, %2.  During this period all additional work done counts %3 "
-#~ "% of the original."
-
-#
-#~ msgid "_AUTO"
-#~ msgstr "1"
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "This assignment had a Reduced Scoring Period that began %1 and ended on "
-#~ "the due date, %2.  During that period all additional work done counted %3 "
-#~ "% of the original."

--- a/lib/WeBWorK/Localize/en.po
+++ b/lib/WeBWorK/Localize/en.po
@@ -17,11 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+msgid "# of active students"
+msgstr "# of active students"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr "#corr"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr "#incorr"
 
@@ -34,15 +38,15 @@ msgid "% correct with review"
 msgstr "% correct with review"
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr "% students"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr "%1 (old editor)"
 
@@ -78,17 +82,17 @@ msgid "%1 students out of %2"
 msgstr "%1 students out of %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr "%1 title and institution changed from %2 to %3 and from %4 to %5"
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 users exported to file %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -123,8 +127,8 @@ msgstr "%1% Complete"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr "%1% correct"
 
@@ -161,7 +165,7 @@ msgstr "%1's password has been changed."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: Problem %2"
 
@@ -171,12 +175,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1: Problem %2 Show Me Another"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr "%1: The directory for the course not found."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr "%quant(%1,course was, courses were) successfully unhidden."
 
@@ -191,27 +195,27 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr "%quant(%1,file) unpacked successfully"
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
 "%quant(%1,of the questions remains,of the questions remain) unanswered."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr "%quant_1( course was, courses were) successfully hidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr "%score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr "(Any unsaved changes will be lost.)"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
@@ -219,11 +223,11 @@ msgstr ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(This problem will not count towards your grade.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
@@ -231,13 +235,13 @@ msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "(Your score on this %1 is not available until %2.)"
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr "(Your score on this %1 is not available.)"
 
@@ -342,19 +346,33 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr "A course with ID %1 already exists."
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
@@ -372,7 +390,7 @@ msgstr ""
 "please inform your instructor."
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
@@ -381,7 +399,7 @@ msgstr ""
 "edit that location instead?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -390,12 +408,12 @@ msgstr ""
 "in the class %3.  There were %4 message(s) that could not be sent."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr "A new file has been created at '%1'"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
@@ -456,37 +474,37 @@ msgstr ""
 "to a page where you can view and reassign the sets for the selected user."
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr "ADJ STATUS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr "ANSWERS NOT RECORDED"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr "ANSWERS NOT RECORDED --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "ANSWERS ONLY CHECKED -- "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "Abandon changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Abandon export"
@@ -496,12 +514,12 @@ msgid "Achievement"
 msgstr "Achievement"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr "Achievement %1 created with evaluator '%2'."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "Achievement %1 exists.  No achievement created"
 
@@ -518,13 +536,13 @@ msgstr "Achievement Evaluator Editor"
 msgid "Achievement Evaluator for achievement %1"
 msgstr "Achievement Evaluator for achievement %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr "Achievement ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr "Achievement ID exists!  No new achievement created.  File not saved."
 
@@ -540,12 +558,16 @@ msgstr "Achievement User Editor"
 msgid "Achievement has been assigned to all users."
 msgstr "Achievement has been assigned to all users."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+msgid "Achievement has been assigned to selected users."
+msgstr "Achievement has been assigned to selected users."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr "Achievement has been unassigned to all students."
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr "Achievement scores saved to %1"
 
@@ -565,17 +587,17 @@ msgid "Act as:"
 msgstr "Act as:"
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr "Acting as %1."
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr "Action %1 not found"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Active"
 
@@ -599,7 +621,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Add"
@@ -608,9 +630,9 @@ msgstr "Add"
 msgid "Add All"
 msgstr "Add All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr "Add Course"
 
@@ -622,7 +644,7 @@ msgstr "Add Students"
 msgid "Add Users"
 msgstr "Add Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr "Add WeBWorK administrators to new course"
 
@@ -630,12 +652,12 @@ msgstr "Add WeBWorK administrators to new course"
 msgid "Add a new test for which Gateway?"
 msgstr "Add a new test for which Gateway?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "Add as what filetype?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Add how many students?"
 
@@ -643,41 +665,41 @@ msgstr "Add how many students?"
 msgid "Add problems to"
 msgstr "Add problems to"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr "Add to what set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Add which new users?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr "Added %1 to %2 as problem %3"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "Added '%1' to %2 as new hardcopy header"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr "Added '%1' to %2 as new set header"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr "Added addresses %1 to location %2."
 
@@ -686,7 +708,7 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr "Additional addresses for receiving feedback e-mail."
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
@@ -695,7 +717,7 @@ msgstr ""
 "Please double check the integrity of the WeBWorK database before continuing."
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
@@ -704,7 +726,7 @@ msgstr ""
 "were skipped."
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
@@ -713,7 +735,7 @@ msgstr ""
 "were skipped."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
@@ -722,7 +744,7 @@ msgstr ""
 "entry and resubmit."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
@@ -730,11 +752,11 @@ msgstr ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr "Addresses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
@@ -744,7 +766,7 @@ msgstr ""
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -762,7 +784,7 @@ msgstr "Adds 24 hours to the close date of a homework."
 msgid "Adds 48 hours to the close date of a homework."
 msgstr "Adds 48 hours to the close date of a homework."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr "Adjusted Status"
 
@@ -775,7 +797,7 @@ msgid "After set answer date"
 msgstr "After set answer date"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -789,15 +811,15 @@ msgstr "All Selected Constraints Joined by \"And\""
 msgid "All assignments were made successfully."
 msgstr "All assignments were made successfully."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr "All of the answers above are correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr "All of the gradeable answers above are correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr "All of these files will also be made available for mail merge."
 
@@ -817,7 +839,7 @@ msgstr "All sets hidden from all students"
 msgid "All sets made visible for all students"
 msgstr "All sets made visible for all students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr "All students in course"
 
@@ -881,25 +903,25 @@ msgstr "Amulet of Extension"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr "An error occured while archiving the course %1:"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr "An error occured while changing the title of the course %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr "An error occured while deleting the course %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "An error occured while renaming the course %1 to %2:"
 
@@ -917,8 +939,8 @@ msgstr "Answer Date"
 msgid "Answer Log"
 msgstr "Answer Log"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Answer Preview"
 
@@ -931,12 +953,12 @@ msgid "Answer:"
 msgstr "Answer:"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr "AnswerGroupInfo"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr "AnswerHashInfo"
 
@@ -958,15 +980,20 @@ msgstr "Answers cannot be due until on or after the open date!"
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr "Answers cannot be made available until on or after the close date!"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "Any changes made below will be reflected in the achievement for ALL students."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -984,18 +1011,18 @@ msgstr ""
 "be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr "Append"
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr "Append to end of %1 set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr "Archive"
 
@@ -1009,26 +1036,26 @@ msgstr "Archive '%1' created successfully (%quant( %2, file))"
 msgid "Archive '%1' deleted"
 msgstr "Archive '%1' deleted"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr "Archive Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr "Archive Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr "Archive next course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr "Archive this Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr "Archived Courses"
 
@@ -1038,7 +1065,7 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr "Archiving course as %1.tar.gz. Reload FileManager to see it."
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
@@ -1047,7 +1074,7 @@ msgstr ""
 "cannot be undone!"
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
@@ -1055,10 +1082,14 @@ msgstr ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
 msgstr "Assign"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr "Assign %1 to all users, create global data, and %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1082,17 +1113,17 @@ msgstr "Assign to All Current Users"
 msgid "Assigned"
 msgstr "Assigned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Assigned Sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr "Assigned achievements to users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr "Assigned to"
 
@@ -1100,7 +1131,11 @@ msgstr "Assigned to"
 msgid "Assignment type"
 msgstr "Assignment type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+msgid "Assignments only"
+msgstr "Assignments only"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr "At least one of the answers above is NOT correct."
 
@@ -1109,7 +1144,7 @@ msgstr "At least one of the answers above is NOT correct."
 msgid "Att. to Open Children"
 msgstr "Att. to Open Children"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr "Attempt to upgrade directories"
 
@@ -1121,7 +1156,7 @@ msgstr "Attempted"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Attempts"
 
@@ -1129,13 +1164,14 @@ msgstr "Attempts"
 msgid "Audit"
 msgstr "Audit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr "Authentication failed.  Please speak to your instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "Author Info"
 
@@ -1143,12 +1179,12 @@ msgstr "Author Info"
 msgid "Automatic"
 msgstr "Automatic"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr "Automatically render problems on page load"
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr "Backup file <code>%1/%2</code> created."
 
@@ -1195,17 +1231,17 @@ msgstr ""
 "receive feedback. Feedback is also sent to any addresses specified in this "
 "blank. Separate email address entries by commas."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr "CLOSE DATE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr "CLOSE TIME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
-msgstr "Cake of Enlargment"
+msgid "Cake of Enlargement"
+msgstr "Cake of Enlargement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
 msgid "Can e-mail instructor"
@@ -1234,7 +1270,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr "Can't create archive '%1': command returned %2"
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr "Can't create course environment for %1 because %2"
 
@@ -1269,17 +1305,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "Can't get password record for user '%1': %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr "Can't open %1"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr "Can't open file %1"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr "Can't read merge file %1. No message sent"
 
@@ -1288,7 +1324,7 @@ msgstr "Can't read merge file %1. No message sent"
 msgid "Can't rename file: %1"
 msgstr "Can't rename file: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr "Can't rename to the same name."
 
@@ -1297,11 +1333,11 @@ msgstr "Can't rename to the same name."
 msgid "Can't unpack '%1': command returned %2"
 msgstr "Can't unpack '%1': command returned %2"
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr "Can't write to file %1"
 
@@ -1312,7 +1348,7 @@ msgstr "Can't write to file %1"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr "Cancel E-mail"
 
@@ -1325,8 +1361,8 @@ msgstr "Cannot open %1"
 msgid "Cap Test Time at Set Close Date?"
 msgstr "Cap Test Time at Set Close Date?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr "Category"
 
@@ -1350,11 +1386,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr "Causes a single homework problem to be worth twice as much."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr "Change Course Title to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr "Change CourseID to:"
 
@@ -1368,7 +1404,7 @@ msgstr "Change Display Settings"
 msgid "Change Email Address"
 msgstr "Change Email Address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr "Change Institution to:"
 
@@ -1377,32 +1413,32 @@ msgstr "Change Institution to:"
 msgid "Change Password"
 msgstr "Change Password"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr "Change User Settings"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr "Change course institution from %1 to %2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr "Change title from %1 to %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "Changes abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Changes in this file have not yet been permanently saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "Changes saved"
 
@@ -1418,20 +1454,20 @@ msgstr ""
 msgid "Chapter:"
 msgstr "Chapter:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "Check Answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr "Check Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr "Check that it's permissions are set correctly."
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
@@ -1439,7 +1475,7 @@ msgstr ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "Checking additional error messages"
 
@@ -1454,8 +1490,8 @@ msgstr "Choose the set which you would like to enable partial credit for."
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
-msgstr "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
+msgstr "Choose the set which you would like to resurrect."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
@@ -1495,8 +1531,8 @@ msgstr ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1517,7 +1553,7 @@ msgstr ""
 "associated with the restriction.  Contact your professor to have this "
 "problem resolved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr "Close"
 
@@ -1555,7 +1591,7 @@ msgid "Closes"
 msgstr "Closes"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr "Closes %1"
 
@@ -1564,39 +1600,39 @@ msgstr "Closes %1"
 msgid "Closes:"
 msgstr "Closes:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr "Collapse"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr "Collapse All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Comment"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr "Completed results for this assignment are not available until %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr "Completed results for this assignment are not available."
 
@@ -1604,7 +1640,7 @@ msgstr "Completed results for this assignment are not available."
 msgid "Completed."
 msgstr "Completed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -1614,7 +1650,7 @@ msgstr "Confirm"
 msgid "Confirm %1's New Password"
 msgstr "Confirm %1's New Password"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr "Confirm Password:"
 
@@ -1628,8 +1664,8 @@ msgid "Continue"
 msgstr "Continue"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "Copied auxiliary files from %1 to new location at %2"
 
@@ -1643,7 +1679,7 @@ msgstr "Copy"
 msgid "Copy file as:"
 msgstr "Copy file as:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr "Copy templates from:"
 
@@ -1651,8 +1687,8 @@ msgstr "Copy templates from:"
 msgid "Copy this Problem"
 msgstr "Copy this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Correct"
@@ -1661,7 +1697,7 @@ msgstr "Correct"
 msgid "Correct Adjusted Status"
 msgstr "Correct Adjusted Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr "Correct Answer"
 
@@ -1678,17 +1714,17 @@ msgid "Correct answers"
 msgstr "Correct answers"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr "Correct: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr "CorrectAnswers"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1706,48 +1742,49 @@ msgid "Couldn't change your email address: %1"
 msgstr "Couldn't change your email address: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr "Couldn't find OPL Branch %1 in remote %2"
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr "Couldn't find PG Branch %1 in remote %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr "Couldn't find WeBWorK Branch %1 in remote %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr "Couldn't save your display options: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr "Counter"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr "Counts for Parent"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr "Course %1 database is in order"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr "Course %1 databases must be updated before renaming this course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1757,13 +1794,13 @@ msgstr "Course Administration"
 msgid "Course Configuration"
 msgstr "Course Configuration"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr "Course ID may only contain letters, numbers, hyphens, and underscores."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr "Course ID:"
 
@@ -1772,13 +1809,13 @@ msgstr "Course ID:"
 msgid "Course Info"
 msgstr "Course Info"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr "Course Name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr "Course Title:"
 
@@ -1786,15 +1823,15 @@ msgstr "Course Title:"
 msgid "Course archived."
 msgstr "Course archived."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1817,7 +1854,7 @@ msgstr "Create"
 msgid "Create CSV"
 msgstr "Create CSV"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr "Create Location:"
 
@@ -1825,7 +1862,7 @@ msgstr "Create Location:"
 msgid "Create a New Set in This Course:"
 msgstr "Create a New Set in This Course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr "Create a new achievement with ID"
 
@@ -1833,12 +1870,12 @@ msgstr "Create a new achievement with ID"
 msgid "Create as what type of set?"
 msgstr "Create as what type of set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr "Create unattached problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1856,34 +1893,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr "Cupcake of Enlargement"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr "Current"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr "Currently defined locations are listed below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr "Data"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr "Database tables are ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr "Database tables need updating."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr "Database tables ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr "Database:"
 
@@ -1895,7 +1932,7 @@ msgstr "Date"
 msgid "Debug"
 msgstr "Debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1923,71 +1960,71 @@ msgstr "Default Length of Reduced Scoring Period in minutes"
 msgid "Default Time that the Assignment is Due"
 msgstr "Default Time that the Assignment is Due"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr "Delete Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr "Delete all existing addresses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr "Delete course after archiving. Caution there is no undo!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr "Delete course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "Delete how many?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr "Delete it?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr "Delete location:"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr "Deleted %quant(%1,achievement)"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr "Deleted Location(s): %1"
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr "Deleted addresses %1 from location."
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr "Deleting temp file at %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
@@ -1995,7 +2032,7 @@ msgstr ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr "Deletion destroys all achievement-related data and is not undoable!"
 
@@ -2003,7 +2040,7 @@ msgstr "Deletion destroys all achievement-related data and is not undoable!"
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr "Deletion destroys all set-related data and is not undoable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr "Deletion destroys all user-related data and is not undoable!"
 
@@ -2011,13 +2048,13 @@ msgstr "Deletion destroys all user-related data and is not undoable!"
 msgid "Deny From"
 msgstr "Deny From"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr "Description"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr "Didn't recognize action"
 
@@ -2035,20 +2072,20 @@ msgstr "Directory '%1' not removed: %2"
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr "Directory '%1' removed (items deleted: %2)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr "Directory permission errors "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr "Directory structure"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
@@ -2056,28 +2093,28 @@ msgstr ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr "Directory structure is ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr "Directory structure needs to be repaired manually before archiving."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr "Directory structure needs to be repaired manually before renaming."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr "Directory structure or permissions need to be repaired. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr "Display Mode:"
@@ -2085,6 +2122,11 @@ msgstr "Display Mode:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
 msgstr "Display Past Answers"
+
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
+msgstr "Display of scores for this set is not allowed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
@@ -2107,29 +2149,29 @@ msgstr "Do not uncheck a set unless you know what you are doing."
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr "Do not uncheck students, unless you know what you are doing."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr "Don't Archive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr "Don't Unarchive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr "Don't Upgrade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr "Don't delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr "Don't make changes"
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "Don't recognize saveMode: |%1|. Unknown error."
 
@@ -2138,17 +2180,17 @@ msgstr "Don't recognize saveMode: |%1|. Unknown error."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr "Don't recognize statistics display type: |%1|"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr "Don't rename"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr "Don't use in an achievement"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr "Done"
 
@@ -2178,8 +2220,8 @@ msgstr "Download Hardcopy"
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Download PDF or TeX Hardcopy for Current Set"
 
@@ -2199,6 +2241,16 @@ msgstr "Download:"
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "Drop"
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2228,7 +2280,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "E-mail Instructor"
 
@@ -2248,7 +2300,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr "E-mail verbosity level"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr "E-mail:"
 
@@ -2256,25 +2308,25 @@ msgstr "E-mail:"
 msgid "Earned"
 msgstr "Earned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Edit"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr "Edit %1 of set %2."
 
@@ -2287,19 +2339,19 @@ msgstr "Edit All Set Data"
 msgid "Edit Assigned Users"
 msgstr "Edit Assigned Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr "Edit Evaluator"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr "Edit Header"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr "Edit Location:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr "Edit Problem"
 
@@ -2321,7 +2373,7 @@ msgstr "Edit Set Data"
 msgid "Edit Target Set"
 msgstr "Edit Target Set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Edit Which Users?"
 
@@ -2337,17 +2389,17 @@ msgstr "Edit it"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr "Edit set %1 data for ALL students assigned to this set."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr "Edit set %1 for this user."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2364,23 +2416,23 @@ msgid "Edit which sets?"
 msgstr "Edit which sets?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr "Edit1"
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr "Edit2"
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr "Edit3"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr "Editing %1 in file '%2'"
 
@@ -2390,44 +2442,44 @@ msgid "Editing achievement in file '%1'"
 msgstr "Editing achievement in file '%1'"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr "Editing location %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr "Editing problem set %1 data for these individual students: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr "Editor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr "Editor rows:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "Email"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "Email Address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr "Email Body:"
 
@@ -2435,22 +2487,22 @@ msgstr "Email Body:"
 msgid "Email Instructor On Failed Attempt"
 msgstr "Email Instructor On Failed Attempt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr "Email Link"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr "Email address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "Email instructor"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
@@ -2460,7 +2512,7 @@ msgstr ""
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr "Emails to be sent to the following:"
 
@@ -2502,8 +2554,8 @@ msgstr ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -2553,22 +2605,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr "Enrolled, Drop, etc."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Enrollment Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Enter filename below"
 
@@ -2584,8 +2636,8 @@ msgstr ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Entered"
 
@@ -2617,7 +2669,7 @@ msgstr ""
 msgid "Error message:"
 msgstr "Error message:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr "Error messages"
 
@@ -2641,7 +2693,7 @@ msgstr ""
 "in set %1"
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr "Error: The original file %1 cannot be read."
@@ -2660,6 +2712,10 @@ msgstr "Error: answer date cannot be more than 10 years from now in set %1"
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr "Error: close date cannot be more than 10 years from now in set %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2677,7 +2733,7 @@ msgstr ""
 "hardcopy. Error text: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2688,7 +2744,7 @@ msgstr ""
 "ownership and permissions of the course's directory, e.g %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
@@ -2698,15 +2754,15 @@ msgstr ""
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr "Evaluator"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr "Evaluator File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
@@ -2714,7 +2770,7 @@ msgstr ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
@@ -2722,7 +2778,7 @@ msgstr ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
@@ -2731,24 +2787,24 @@ msgstr ""
 "Select addresses from the list to delete them:"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr "Existing file %1 could not be backed up and was lost."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr "Expand"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr "Expand All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Export"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr "Export selected achievements."
 
@@ -2756,7 +2812,7 @@ msgstr "Export selected achievements."
 msgid "Export selected sets"
 msgstr "Export selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Export to what kind of file?"
 
@@ -2764,12 +2820,12 @@ msgstr "Export to what kind of file?"
 msgid "Export which sets?"
 msgstr "Export which sets?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Export which users?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr "Exported achievements to %1"
 
@@ -2785,16 +2841,16 @@ msgstr ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr "FIRST NAME"
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr "Failed to create new achievement: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "Failed to create new achievement: no achievement ID specified!"
 
@@ -2807,7 +2863,7 @@ msgstr "Failed to create new set: %1"
 msgid "Failed to create new set: no set name specified!"
 msgstr "Failed to create new set: no set name specified!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
@@ -2839,10 +2895,10 @@ msgstr "Failed to enter student:"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr "Failed to open %1"
 
@@ -2852,11 +2908,11 @@ msgid "Failed to save: %1"
 msgstr "Failed to save: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr "False"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr "Feature exhausted for this problem"
 
@@ -2868,35 +2924,35 @@ msgstr "Feedback"
 msgid "Feedback by Section."
 msgstr "Feedback by Section."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr "FeedbackMessage"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr "Field is ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr "Field missing in database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr "Field missing in schema"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr "File '%1' exists.  File not saved.  No changes have been made."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
@@ -2945,7 +3001,7 @@ msgstr "File successfully copied"
 msgid "File successfully renamed"
 msgstr "File successfully renamed"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Filename"
 
@@ -2954,7 +3010,7 @@ msgstr "Filename"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr "Files with extension '.%1' usually belong in '%2'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "Filter by what text?"
 
@@ -2968,28 +3024,28 @@ msgstr "Filter:"
 msgid "First"
 msgstr "First"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "First Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr "First name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3001,7 +3057,7 @@ msgstr ""
 "Please specify a different file or move the needed file to the email "
 "directory"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr "Force problems to be numbered consecutively from one"
 
@@ -3013,6 +3069,10 @@ msgstr ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
+msgstr "Format"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
 msgstr "Format for the subject line in feedback e-mails"
@@ -3022,19 +3082,23 @@ msgstr "Format for the subject line in feedback e-mails"
 msgid "Format:"
 msgstr "Format:"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+msgid "Found no directories containing problems"
+msgstr "Found no directories containing problems"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr "From This Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr "From field must contain one valid email address."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "From:"
 
@@ -3062,7 +3126,7 @@ msgid "General"
 msgstr "General"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr "General Information"
 
@@ -3082,11 +3146,16 @@ msgstr "Get Library Set Problems"
 msgid "Get Target Set Problems"
 msgstr "Get Target Set Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr "Get a new version of this problem"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr "Give new password to"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Give new password to which users?"
 
@@ -3113,7 +3182,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "Global problem %1 for set %2 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr "Global set data will be shown instead of user specific data"
 
@@ -3121,21 +3190,31 @@ msgstr "Global set data will be shown instead of user specific data"
 msgid "Go"
 msgstr "Go"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr "Grade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr "Grade Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr "Grade Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr "Grader"
 
@@ -3163,7 +3242,7 @@ msgstr "Greater Tome of Enlightenment"
 msgid "Guest Login"
 msgstr "Guest Login"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr "HTTP Headers"
 
@@ -3190,12 +3269,16 @@ msgstr "Hardcopy Header"
 msgid "Hardcopy Theme"
 msgstr "Hardcopy Theme"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr "Headers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Help"
 
@@ -3207,12 +3290,12 @@ msgstr "Here is a new version of your problem."
 msgid "Hidden"
 msgstr "Hidden"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr "Hide All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr "Hide Courses"
 
@@ -3224,8 +3307,8 @@ msgstr "Hide Hints"
 msgid "Hide Hints from Students"
 msgstr "Hide Hints from Students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr "Hide Inactive Courses"
 
@@ -3237,7 +3320,7 @@ msgstr "Hide all paths"
 msgid "Hide path:"
 msgstr "Hide path:"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr "Hint:"
 
@@ -3251,13 +3334,13 @@ msgstr "Hints"
 msgid "Hmwk Sets Editor"
 msgstr "Hmwk Sets Editor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Homework Sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr "Homework Totals"
 
@@ -3265,15 +3348,15 @@ msgstr "Homework Totals"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr "Icon"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr "Icon File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3297,7 +3380,7 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
@@ -3307,7 +3390,7 @@ msgstr ""
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
@@ -3327,12 +3410,16 @@ msgstr ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
 msgstr "Illegal file '%1' specified"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr "Illegal filename contains '..'"
 
@@ -3340,9 +3427,11 @@ msgstr "Illegal filename contains '..'"
 msgid "Import"
 msgstr "Import"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
-msgstr "Import achievements from"
+# Context is "Import achievements from ____ assigning the achievements to ___"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "Import achievements from %1 assigning the achievements to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
@@ -3356,21 +3445,21 @@ msgstr "Import how many sets?"
 msgid "Import sets with names"
 msgstr "Import sets with names"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Import users from what file?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr "Imported %quant(%1,achievement)"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr "In progress: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Inactive"
 
@@ -3378,17 +3467,17 @@ msgstr "Inactive"
 msgid "Inactivity time before a user is required to login again"
 msgstr "Inactivity time before a user is required to login again"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr "Include Success Index"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr "Incorrect"
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr "Incorrect: %1/%2"
 
@@ -3397,7 +3486,7 @@ msgstr "Incorrect: %1/%2"
 msgid "Init"
 msgstr "Init"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr "Institution:"
 
@@ -3405,16 +3494,16 @@ msgstr "Institution:"
 msgid "Instructor Tools"
 msgstr "Instructor Tools"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr "Instructor solution preview: show the student solution after due date."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr "Invalid Reply-to address."
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3426,7 +3515,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr "Invalid headerType %1"
 
@@ -3443,16 +3532,20 @@ msgstr ""
 "It is before the open date.  You probably want to renumber the problems if "
 "you are deleting some from the middle."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr "Items"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr "Jump to Page:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr "Jump to Problem:"
 
@@ -3464,7 +3557,7 @@ msgstr "Just-In-Time parameters"
 msgid "Keywords:"
 msgstr "Keywords:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr "LAST NAME"
 
@@ -3485,28 +3578,28 @@ msgstr "Last"
 msgid "Last Answer"
 msgstr "Last Answer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Last Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr "Last column of merge file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr "Last name"
 
@@ -3536,18 +3629,18 @@ msgstr "Lesser Tome of Enlightenment"
 msgid "Level:"
 msgstr "Level:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Library Browser"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Library Browser 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr "Library Browser 3"
@@ -3584,13 +3677,13 @@ msgstr "Local"
 msgid "Local Problems"
 msgstr "Local Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr "Location"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -3599,20 +3692,20 @@ msgstr ""
 "(perhaps you need to reload the location management page?)."
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr "Location %1 has been created, with addresses %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr "Location deletion requires confirmation."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr "Location description:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr "Location name:"
 
@@ -3620,8 +3713,8 @@ msgstr "Location name:"
 msgid "Log In Again"
 msgstr "Log In Again"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Log Out"
 
@@ -3629,20 +3722,20 @@ msgstr "Log Out"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr "Log into %1"
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr "Logged in as %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr "Login"
 
@@ -3654,23 +3747,23 @@ msgstr "Login Info"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Login Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Login Status"
 
@@ -3678,7 +3771,7 @@ msgstr "Login Status"
 msgid "Logout"
 msgstr "Logout"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Main Menu"
 
@@ -3691,20 +3784,20 @@ msgstr "Make"
 msgid "Make Archive"
 msgstr "Make Archive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr "Make changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr "Make these changes in  course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr "Manage Locations"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr "Manual Grader"
@@ -3718,7 +3811,7 @@ msgid "Mark Correct"
 msgstr "Mark Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr "Mark Correct?"
 
@@ -3726,8 +3819,9 @@ msgstr "Mark Correct?"
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "Match on what? (separate multiple IDs with commas)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Math Objects"
 
@@ -3744,37 +3838,37 @@ msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr "Merge file:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr "Message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr "Message file:"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr "Message saved to file <code>%1/%2</code>."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr "Message:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr "Method"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
@@ -3782,13 +3876,13 @@ msgstr ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr "Move"
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr "Msg sent to %1 at %2."
 
@@ -3801,17 +3895,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr "Mysterious Package (with Ribbons)"
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr "NO OF FIELDS"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3852,12 +3946,12 @@ msgstr "New File"
 msgid "New Folder"
 msgstr "New Folder"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr "New Name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "New Password"
 
@@ -3869,13 +3963,13 @@ msgstr "New file name:"
 msgid "New folder name:"
 msgstr "New folder name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "New passwords saved"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr "NewVersion"
 
@@ -3883,15 +3977,17 @@ msgstr "NewVersion"
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr "Newer problem set def files must be imported using Hmwk Sets Editor2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Next Problem"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr "Next page"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3899,20 +3995,25 @@ msgstr "Next page"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "No"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr "No Description"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr "No achievements have been assigned yet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr "No achievements shown.  Create an achievement!"
 
@@ -3933,7 +4034,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "No change made to any set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3946,7 +4047,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr "No changes were saved!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr "No course id defined"
 
@@ -3956,28 +4057,28 @@ msgstr "No course id defined"
 msgid "No data exists for set %1 and problem %2"
 msgstr "No data exists for set %1 and problem %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr "No filename was specified for saving!  The message was not saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr "No guest logins are available. Please try again in a few minutes."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr "No location specified to edit?! Please check your input data."
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr "No location with name %1 exists in the database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr "No merge data file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
@@ -3985,11 +4086,11 @@ msgstr ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr "No problems matched the given parameters."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3999,22 +4100,22 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr "No record for global set %1."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr "No record for user %1."
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr "No record found for problem %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr "No record found."
 
@@ -4027,7 +4128,7 @@ msgstr "No sets in this course yet"
 msgid "No sets selected for scoring"
 msgstr "No sets selected for scoring"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -4036,15 +4137,15 @@ msgstr ""
 "course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr "No source filePath specified"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr "No source_file for problem in .def file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -4063,15 +4164,19 @@ msgid "No user specific data exists for user %1"
 msgstr "No user specific data exists for user %1"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
 msgstr "No valid changes submitted for location %1."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
+msgstr "No versions of this assignment have been taken."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr "None"
 
@@ -4085,27 +4190,32 @@ msgstr "None Specified"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr "None of the selected users are assigned to this set: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Not logged in."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Note"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "Note:"
+msgstr "Note:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 "Note: grading the test grades all problems, not just those on this page."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr "Number"
 
@@ -4121,8 +4231,8 @@ msgstr "Number of Problems per Page (0=all)"
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr "Number of Tests per Time Interval (0=infty)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr "OK"
 
@@ -4156,7 +4266,7 @@ msgstr ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr "Open"
 
@@ -4174,13 +4284,13 @@ msgstr "Open Date"
 msgid "Open Problem Library"
 msgstr "Open Problem Library"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr "Open in New Window"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr "Open in new window"
 
@@ -4194,10 +4304,10 @@ msgstr "Open, closes %1."
 msgid "Open, complete by %1."
 msgstr "Open, complete by %1."
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
-msgstr "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
@@ -4219,12 +4329,12 @@ msgstr "Optional Modules"
 msgid "Order Problems Randomly"
 msgstr "Order Problems Randomly"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr "Orig. Lib. Browser"
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4248,70 +4358,73 @@ msgstr "Overwrite existing files silently"
 msgid "PG - Problem Display/Answer Checking"
 msgstr "PG - Problem Display/Answer Checking"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr "PG debug messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr "PG internal errors"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr "PG question failed to render"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr "PG question processing error messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr "PG warning messages"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr "PGInfo"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr "PGLab"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr "PGML"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr "POD"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr "PROB NUMBER"
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr "PROB VALUE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Pad Fields"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr "Page generated at %1"
 
@@ -4324,7 +4437,7 @@ msgstr "Password"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr "Password (Leave blank for regular proctoring)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr "Password:"
 
@@ -4333,7 +4446,7 @@ msgstr "Password:"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "Past Answers for %1, set %2, problem %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr "Percent"
 
@@ -4349,7 +4462,7 @@ msgstr ""
 "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
 "median number of attempts"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
@@ -4357,18 +4470,18 @@ msgstr ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Permission Level"
 
@@ -4376,7 +4489,7 @@ msgstr "Permission Level"
 msgid "Permissions"
 msgstr "Permissions"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4426,7 +4539,7 @@ msgstr ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr "Please correct the following errors and try again:"
 
@@ -4439,7 +4552,7 @@ msgstr "Please enter in a value to match in the filter field."
 msgid "Please enter your username and password for %1 below:"
 msgstr "Please enter your username and password for %1 below:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr "Please provide a location name to delete."
 
@@ -4457,49 +4570,50 @@ msgstr "Please select at least one set and try again."
 msgid "Please select at least one user and try again."
 msgstr "Please select at least one user and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Please specify a file to save to."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr "Points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
-msgstr "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
+msgstr "Potion of Forgetfulness"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr "Preflight Log"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr "Preview Message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr "Preview My Answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr "Preview Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr "Preview message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr "Preview set to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Previous Problem"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr "Previous page"
@@ -4508,12 +4622,12 @@ msgstr "Previous page"
 msgid "Primary sort"
 msgstr "Primary sort"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr "Print Test"
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr "Prob"
 
@@ -4530,20 +4644,20 @@ msgstr "Problem #"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr "Problem %1"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr "Problem %1."
 
@@ -4561,8 +4675,8 @@ msgstr "Problem Editor2"
 msgid "Problem Editor3"
 msgstr "Problem Editor3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Problem List"
 
@@ -4578,28 +4692,29 @@ msgstr "Problem Number"
 msgid "Problem Number "
 msgstr "Problem Number "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Problem Techniques"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr "Problem source is drawn from a grouping set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Problems"
 
@@ -4650,11 +4765,11 @@ msgstr ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Publish"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr "RECITATION"
 
@@ -4668,28 +4783,28 @@ msgid "Really delete the items listed above?"
 msgstr "Really delete the items listed above?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "Recitation"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Record Scores for Single Sets"
 
@@ -4703,26 +4818,16 @@ msgid "Reduced Scoring Date"
 msgstr "Reduced Scoring Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr "Reduced Scoring Disabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
 msgstr "Reduced Scoring Enabled"
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr "Reduced Scoring Starts %1"
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
-msgstr "Reduced scoring started on %1."
 
 # Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
@@ -4739,12 +4844,12 @@ msgstr "Refresh"
 msgid "Refresh Display"
 msgstr "Refresh Display"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr "Refresh Listing"
 
@@ -4753,7 +4858,7 @@ msgid "Relax IP restrictions when?"
 msgstr "Relax IP restrictions when?"
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Remaining"
 
@@ -4765,7 +4870,7 @@ msgstr "Remember Me"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr "Remember to return to your original problem when you're finished here!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4775,13 +4880,13 @@ msgid "Rename"
 msgstr "Rename"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr "Rename %1 to %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr "Rename Course"
 
@@ -4789,19 +4894,19 @@ msgstr "Rename Course"
 msgid "Rename file as:"
 msgstr "Rename file as:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr "Render"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr "Render All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr "Render Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr "Renumber Problems"
 
@@ -4820,53 +4925,54 @@ msgid "Reorder problems only"
 msgstr "Reorder problems only"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr "Replace current problem: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Replace which users?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr "Reply-To:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr "Report Bugs in this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Report bugs"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr "Report for course %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr "Report on database structure for course %1:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr "Request New Version"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr "Request information"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr "Request new version now."
 
@@ -4937,8 +5043,8 @@ msgid "Reset"
 msgstr "Reset"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr "Reset Form"
 
@@ -4946,11 +5052,7 @@ msgstr "Reset Form"
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr "Resets the number of incorrect attempts on a single homework problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr "Ressurect which Gateway?"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4983,22 +5085,22 @@ msgstr "Restrict To"
 msgid "Restrict release by set(s)"
 msgstr "Restrict release by set(s)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Result"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr "Result of last action performed"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr "Result of last action performed: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr "Results for this submission"
 
@@ -5010,19 +5112,27 @@ msgstr "Results of last action performed"
 msgid "Results of last action performed: "
 msgstr "Results of last action performed: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr "Resurrect which Gateway?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
 msgstr "Retitled"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "Revert"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr "Revert to %1"
@@ -5035,19 +5145,19 @@ msgstr "Ring of Reduction"
 msgid "Robe of Longevity"
 msgstr "Robe of Longevity"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr "SECTION"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr "SET NAME"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr "STATUS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr "STUDENT ID"
 
@@ -5056,86 +5166,86 @@ msgstr "STUDENT ID"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "Save"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr "Save %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Save As"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr "Save Changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "Save as"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr "Save as Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "Save changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr "Save file to:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr "Save to %1 and View"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr "Saved to file '%1'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr "Schema and database field definitions do not agree"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr "Schema and database table definitions do not agree"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5150,11 +5260,11 @@ msgstr "Score (%)"
 msgid "Score required for release"
 msgstr "Score required for release"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Score selected set(s) and save to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr "Score summary for last submit:"
 
@@ -5179,7 +5289,7 @@ msgid "Scoring Tools"
 msgstr "Scoring Tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
@@ -5188,8 +5298,8 @@ msgstr ""
 "individual students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
-msgstr "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
+msgstr "Scroll of Resurrection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
@@ -5198,24 +5308,24 @@ msgstr "Secondary sort"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Section"
@@ -5230,11 +5340,15 @@ msgstr "Section:"
 msgid "Seed"
 msgstr "Seed"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr "Select"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+msgid "Select a Homework Set"
+msgstr "Select a Homework Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -5244,11 +5358,11 @@ msgstr "Select a Problem Collection"
 msgid "Select a Set from this Course"
 msgstr "Select a Set from this Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr "Select a course to delete."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5258,25 +5372,25 @@ msgstr ""
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr "Select a course to unarchive."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr "Select a database layout below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr "Select a listing format:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr "Select above then:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr "Select all eligible courses"
 
@@ -5284,27 +5398,27 @@ msgstr "Select all eligible courses"
 msgid "Select all sets"
 msgstr "Select all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Select all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Select an action to perform"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr "Select an action to perform:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr "Select course(s) to archive."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr "Select course(s) to hide or unhide."
 
@@ -5320,7 +5434,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr "Select sets below to assign them to the newly-created users."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5356,23 +5470,23 @@ msgstr ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr "Selected students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr "Send E-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr "Send Email"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr "Send to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Set"
 
@@ -5406,7 +5520,7 @@ msgid "Set Definition Files"
 msgstr "Set Definition Files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr "Set Description"
 
@@ -5419,7 +5533,7 @@ msgid "Set Detail for set %2"
 msgstr "Set Detail for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5433,12 +5547,12 @@ msgstr "Set Header"
 msgid "Set ID"
 msgstr "Set ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Set Info"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "Set List"
 
@@ -5466,9 +5580,13 @@ msgid "Set Name "
 msgstr "Set Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
 msgstr "Set headers are not used in display of gateway tests."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
@@ -5501,7 +5619,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Sets"
 
@@ -5513,7 +5631,7 @@ msgstr "Sets Assigned to User"
 msgid "Sets assigned to %1"
 msgstr "Sets assigned to %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr "Setting"
 
@@ -5522,11 +5640,11 @@ msgid "Shift dates so that the earliest is"
 msgstr "Shift dates so that the earliest is"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr "Show"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr "Show Auxiliary Resources"
 
@@ -5534,7 +5652,7 @@ msgstr "Show Auxiliary Resources"
 msgid "Show Date & Size"
 msgstr "Show Date & Size"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "Show Hints"
 
@@ -5542,8 +5660,8 @@ msgstr "Show Hints"
 msgid "Show Me Another"
 msgstr "Show Me Another"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Show Past Answers"
 
@@ -5555,8 +5673,8 @@ msgstr "Show Problems on Finished Tests"
 msgid "Show Scores on Finished Assignments?"
 msgstr "Show Scores on Finished Assignments?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "Show Solutions"
 
@@ -5564,7 +5682,7 @@ msgstr "Show Solutions"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr "Show Total Homework Grade on Grades Page"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Show Which Users?"
 
@@ -5573,17 +5691,17 @@ msgstr "Show Which Users?"
 msgid "Show all paths"
 msgstr "Show all paths"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Show correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr "Show me another"
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr "Show me another %1"
 
@@ -5592,7 +5710,7 @@ msgstr "Show me another %1"
 msgid "Show path ..."
 msgstr "Show path ..."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr "Show saved answers?"
 
@@ -5603,17 +5721,17 @@ msgstr "Show which sets?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Show/Hide Site Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Show:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr "Showing"
 
@@ -5623,7 +5741,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "Showing %1 out of %2 sets."
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr "Showing %1 out of %2 users"
 
@@ -5639,13 +5757,13 @@ msgstr "Simple"
 msgid "Site Information"
 msgstr "Site Information"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr "Skip archiving this course"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr "Solution:"
 
@@ -5654,7 +5772,7 @@ msgstr "Solution:"
 msgid "Solutions"
 msgstr "Solutions"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr "Some answers will be graded later."
 
@@ -5667,6 +5785,16 @@ msgstr ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -5692,14 +5820,14 @@ msgstr ""
 "Something was wrong with your LTI parameters.  If this recurs, please speak "
 "with your instructor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "Sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -5730,7 +5858,7 @@ msgstr ""
 "Source file paths cannot include .. or start with /: your source file path "
 "was modified."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5765,46 +5893,46 @@ msgstr "Statistics for %1 set %2. Closes %3"
 msgid "Statistics for %1 student %2"
 msgstr "Statistics for %1 student %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Stop Acting"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr "Stop Archiving"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr "Stop archiving courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "Student ID"
 
@@ -5834,14 +5962,14 @@ msgstr "Student Progress for %1 student %2"
 msgid "Student answers"
 msgstr "Student answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr "Subject:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr "Subject: "
 
@@ -5853,31 +5981,35 @@ msgstr "Submission time:"
 msgid "Submit"
 msgstr "Submit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "Submit Answers"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
 msgstr "Submit Answers for %1"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "Success"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr "Success Index"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr "Successfully archived the course %1."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr "Successfully created new achievement %1"
 
@@ -5887,42 +6019,42 @@ msgid "Successfully created new set %1"
 msgstr "Successfully created new set %1"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr "Successfully created the course %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr "Successfully deleted the course %1."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr "Successfully renamed the course %1 to %2"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "Successfully unarchived %1 to the course %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr "Table defined in database but missing in schema"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr "Table defined in schema but missing in database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr "Table is ok"
 
@@ -5940,16 +6072,16 @@ msgstr "Take %1 test"
 msgid "Take %1 test."
 msgstr "Take %1 test."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "Take Action!"
 
@@ -6026,11 +6158,11 @@ msgstr ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "The WeBWorK Project"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6060,15 +6192,15 @@ msgstr ""
 "opened.  You can change this for individual homework, but WeBWorK will use "
 "this value when a set is created. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr "The answer above is NOT correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "The answer above is correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr "The answer will be graded later."
 
@@ -6086,7 +6218,7 @@ msgstr ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
@@ -6095,7 +6227,7 @@ msgstr ""
 "your site administrator check that Constants.pm is up to date."
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6146,12 +6278,12 @@ msgstr ""
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "The evaluator for %1 has been renamed to '%2'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
@@ -6160,42 +6292,42 @@ msgstr ""
 "saved"
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr "The file %1/%2 cannot be found."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr "The file %1/%2 is not readable by the webserver."
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr "The file '%1' cannot be found."
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr "The file '%1' cannot be read!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr "The file '%1' is a blank problem!"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr "The file '%1' is a directory!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr "The file '%1' is protected!"
 
@@ -6208,29 +6340,29 @@ msgid "The file you are trying to download doesn't exist"
 msgstr "The file you are trying to download doesn't exist"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr "The following courses were successfully hidden: %1"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr "The following courses were successfully unhidden: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr "The following upgrades are available for your WeBWorK system:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
@@ -6239,7 +6371,7 @@ msgstr ""
 "the score of problem %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -6248,25 +6380,25 @@ msgstr ""
 "the weighted average of the problems: %1."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "The hardcopy header for set %1 has been renamed to '%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr "The institution associated with the course %1 is now %2"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
@@ -6274,7 +6406,7 @@ msgstr ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6298,7 +6430,7 @@ msgstr ""
 "sets."
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
@@ -6306,7 +6438,7 @@ msgstr ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr "The password and password confirmation for the instructor must match."
 
@@ -6328,8 +6460,8 @@ msgstr ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "The path to the original file should be absolute"
 
@@ -6339,7 +6471,7 @@ msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 "The percentage of active students with correct answers for each problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -6349,17 +6481,17 @@ msgstr ""
 "is in the 50% column."
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr "The recorded score for this test is  %1/%2."
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr "The recorded score for this test is %1/%2."
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -6373,23 +6505,23 @@ msgstr ""
 "The reduced scoring date should be between the open date and close date."
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "The score for this problem can count towards score of problem %1."
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "The selected problem set (%1) is not a valid set for %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr "The set %1 is assigned to %2."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr "The set header for set %1 has been renamed to '%2'."
@@ -6405,7 +6537,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "The set-version (%1, version %2) is not assigned to user %3."
 
@@ -6414,7 +6546,7 @@ msgid "The solution has been removed."
 msgstr "The solution has been removed."
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
@@ -6422,9 +6554,15 @@ msgstr ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr "The test (which is number %1) may  no longer be submitted for a grade."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6445,23 +6583,23 @@ msgstr ""
 "created."
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr "The title of the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr "The title of the course %1 is now %2"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr "The user %1 has been assigned %2."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
@@ -6470,7 +6608,7 @@ msgstr ""
 "'N'."
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
@@ -6479,7 +6617,9 @@ msgstr ""
 "with '0'."
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
@@ -6488,7 +6628,7 @@ msgstr ""
 "'N'."
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
@@ -6497,7 +6637,7 @@ msgstr ""
 "'N'."
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
@@ -6506,7 +6646,7 @@ msgstr ""
 "replaced with 'No'."
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
@@ -6514,7 +6654,7 @@ msgstr ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6528,8 +6668,8 @@ msgstr "Theme (refresh page after saving changes to reveal new theme.)"
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "Then by"
 
@@ -6556,10 +6696,10 @@ msgstr ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
@@ -6567,9 +6707,9 @@ msgstr ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
@@ -6577,7 +6717,7 @@ msgstr ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6589,7 +6729,7 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr "There are no matching WeBWorK problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
@@ -6597,12 +6737,12 @@ msgstr ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr "There are upgrades available for the Open Problem Library."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
@@ -6611,7 +6751,7 @@ msgstr ""
 "remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
@@ -6619,17 +6759,16 @@ msgstr ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6653,11 +6792,11 @@ msgstr "There is NO undo for unassigning a set."
 msgid "There is NO undo for unassigning students."
 msgstr "There is NO undo for unassigning students."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr "There is a new version of PG available."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr "There is a new version of WeBWorK available."
 
@@ -6678,7 +6817,7 @@ msgstr ""
 "files can be edited using the \"Email\" link and the \"File Manager\" link "
 "in the left margin."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6702,7 +6841,7 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr "There is no written solution available for this problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
@@ -6710,7 +6849,7 @@ msgstr ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
@@ -6718,13 +6857,13 @@ msgstr ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6748,15 +6887,15 @@ msgstr "This action can take a long time if there are many students."
 msgid "This action will not overwrite existing users."
 msgstr "This action will not overwrite existing users."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr "This answer is NOT completely correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr "This answer is NOT correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr "This answer is correct."
 
@@ -6768,20 +6907,20 @@ msgstr ""
 "This course supports guest logins. Click %1 to log into this course as a "
 "guest."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "This homework set contains no problems."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "This homework set is closed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "This homework set is not yet open."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
@@ -6790,6 +6929,10 @@ msgstr ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "This is a new (re-randomized) version of the problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6883,12 +7026,16 @@ msgstr ""
 "This is the number of achievement points given to each user for completing a "
 "problem."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr "This problem contains a video which must be viewed online."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
@@ -6896,24 +7043,24 @@ msgstr ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr "This problem uses the same source file as number %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "This problem will not count towards your grade."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr "This sample mail would be sent to %1"
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
@@ -6934,17 +7081,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr "This set %1 is assigned to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr "This set doesn't contain any problems yet."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6962,13 +7109,13 @@ msgstr ""
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr "This set is %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -7013,22 +7160,22 @@ msgstr ""
 "graders if they are written appropriately."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr "This source file does not exist!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr "This source file is a directory!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr "This source file is not a plain file!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr "This source file is not readable!"
 
@@ -7064,7 +7211,7 @@ msgstr ""
 "Hardcopy for Selected Sets' button at the end of the table.  There is also a "
 "clear button and an Email instructor button at the end of the table."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -7078,8 +7225,8 @@ msgstr ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr "Time"
 
@@ -7088,7 +7235,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr "Time Interval for New Test Versions (min; 0=infty)"
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr "Time taken on test: %1 min (%2 min allowed)."
 
@@ -7101,18 +7248,18 @@ msgid "Timezone for the course"
 msgstr "Timezone for the course"
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr "To access this set you must score at least %1% on set %2."
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 "To access this set you must score at least %1% on the following sets: %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
@@ -7122,7 +7269,7 @@ msgstr ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7138,14 +7285,14 @@ msgstr ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 "To copy problem templates from an existing course, select the course below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
@@ -7153,8 +7300,8 @@ msgstr ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
@@ -7162,8 +7309,8 @@ msgstr ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -7175,11 +7322,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "To this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr "To:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr "Totals"
 
@@ -7196,7 +7343,8 @@ msgid "Transfer"
 msgstr "Transfer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr "True"
 
@@ -7212,46 +7360,46 @@ msgstr "Tunic of Extension"
 msgid "Two Columns"
 msgstr "Two Columns"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr "Type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr "URI"
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "Unable to change the evaluator for set %1. Unknown error."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr "Unable to obtain error messages from within the PG question."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr "Unable to write to '%1': %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr "Unarchive"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr "Unarchive %1 to course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr "Unarchive Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr "Unarchive Next Course"
 
@@ -7273,7 +7421,7 @@ msgstr ""
 "and click on the Unassign button."
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr "Unattempted: %1/%2"
 
@@ -7281,13 +7429,13 @@ msgstr "Unattempted: %1/%2"
 msgid "Unclassified Problems"
 msgstr "Unclassified Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr "Ungraded"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr "Unhide Courses"
 
@@ -7309,7 +7457,7 @@ msgstr "Unpack"
 msgid "Unpack archives automatically"
 msgstr "Unpack archives automatically"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr "Unselect all courses"
 
@@ -7317,12 +7465,12 @@ msgstr "Unselect all courses"
 msgid "Unselect all sets"
 msgstr "Unselect all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Unselect all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr "Update"
 
@@ -7334,37 +7482,37 @@ msgstr "Update Display"
 msgid "Update Menus"
 msgstr "Update Menus"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr "Update settings and refresh page"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr "Update the checked directories?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr "Updated location description."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr "Upgrade Course Tables"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr "Upgrade Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr "Upgrade process completed"
 
@@ -7378,11 +7526,12 @@ msgid "Use Date Picker"
 msgstr "Use Date Picker"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr "Use Default Header File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr "Use Equation Editor?"
 
@@ -7390,20 +7539,20 @@ msgstr "Use Equation Editor?"
 msgid "Use Item"
 msgstr "Use Item"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Use System Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr "Use browser back button to return from preview mode"
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr "Use in achievement %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr "Use in new achievement:"
 
@@ -7423,7 +7572,7 @@ msgstr ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -7434,7 +7583,7 @@ msgstr ""
 "additional information about the state of the system will be included."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
@@ -7442,7 +7591,7 @@ msgstr ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr "User ID"
@@ -7464,8 +7613,8 @@ msgstr "User's name is:"
 msgid "User's username is:"
 msgstr "User's username is:"
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -7485,7 +7634,7 @@ msgid "Username presented:  %1"
 msgstr "Username presented:  %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -7495,7 +7644,7 @@ msgstr "Users"
 msgid "Users Assigned to Set %2"
 msgstr "Users Assigned to Set %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Users List"
 
@@ -7518,7 +7667,7 @@ msgstr ""
 "Normally guest users are not allowed to change their password."
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "Users sorted by %1, then by %2, then by %3"
 
@@ -7544,17 +7693,18 @@ msgstr ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
-msgstr "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
+msgstr "Using contents of the default message %1 instead."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr "Using what display mode?: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr "Using what seed?: "
 
@@ -7562,21 +7712,21 @@ msgstr "Using what seed?: "
 msgid "Value of work done in Reduced Scoring Period"
 msgstr "Value of work done in Reduced Scoring Period"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr "Variable Documentation:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr "Versions of a set can only be edited for one user at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "View"
 
@@ -7589,7 +7739,7 @@ msgstr "View"
 msgid "View Problems"
 msgstr "View Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "View equations as"
 
@@ -7620,8 +7770,8 @@ msgstr "View student progress by student"
 msgid "View/Edit"
 msgstr "View/Edit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr "Viewing temporary file:"
@@ -7644,17 +7794,17 @@ msgstr "Visible"
 msgid "Visible to Students"
 msgstr "Visible to Students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr "Warning"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr "Warning messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 
@@ -7663,11 +7813,16 @@ msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr "Warnings encountered while processing %1. Error text: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr "WeBWorK Error"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK Warnings"
 
@@ -7693,7 +7848,7 @@ msgstr ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7737,7 +7892,7 @@ msgstr "Welcome to WeBWorK!"
 msgid "What could be inside?"
 msgstr "What could be inside?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "What field should filtered users match on?"
 
@@ -7846,12 +8001,12 @@ msgstr ""
 msgid "Will open on %1."
 msgstr "Will open on %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Worth"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
@@ -7860,7 +8015,7 @@ msgstr ""
 "another file for viewing."
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
@@ -7868,7 +8023,7 @@ msgstr ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
@@ -7876,18 +8031,20 @@ msgstr ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Yes"
 
@@ -7922,15 +8079,15 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr "You are not authorized to access the Instructor tools"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr "You are not authorized to access the Instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "You are not authorized to access the instructor tools."
 
@@ -7940,7 +8097,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "You are not authorized to modify homework sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "You are not authorized to modify problems."
 
@@ -7949,13 +8106,13 @@ msgstr "You are not authorized to modify problems."
 msgid "You are not authorized to modify set definition files."
 msgstr "You are not authorized to modify set definition files."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "You are not authorized to modify student data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "You are not authorized to perform this action."
 
@@ -7978,7 +8135,7 @@ msgstr ""
 "You are only allowed to click on Show Me Another %quant(%1,time,times) per "
 "problem. %2 Close this tab, and return to the original problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr "You are out of time.  Press grade now!"
 
@@ -7989,6 +8146,10 @@ msgstr "You can also examine the following temporary files: "
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "You can earn partial credit on this problem."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -8012,7 +8173,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -8036,15 +8197,15 @@ msgstr "You can't edit a directory"
 msgid "You can't view files of that type"
 msgstr "You can't view files of that type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr "You cannot archive the course you are currently using."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr "You cannot delete the course you are currently using."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "You cannot delete yourself!"
 
@@ -8060,7 +8221,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "You did not specify a new set name."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr "You didn't enter any message."
 
@@ -8087,30 +8248,34 @@ msgstr "You do not have permission to edit this file."
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "You do not have permission to generate hardcopy in %1 format."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "You do not have permission to view the details of this error."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr "You don't have any Achievement data associated to you!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr "You don't have any items!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr "You exceeded the allowed time."
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "You have %1 attempt(s) remaining on this test."
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
@@ -8119,7 +8284,7 @@ msgstr ""
 "requested."
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "You have attempted this problem %quant(%1,time,times)."
 
@@ -8127,7 +8292,7 @@ msgstr "You have attempted this problem %quant(%1,time,times)."
 msgid "You have been logged out of WeBWorK."
 msgstr "You have been logged out of WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr "You have less than 1 minute to complete this test."
 
@@ -8166,11 +8331,15 @@ msgstr ""
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+msgid "You may not change your answers when going on to the next part!"
+msgstr "You may not change your answers when going on to the next part!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "You may not change your own password here!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr "You may still check your answers."
 
@@ -8184,7 +8353,7 @@ msgstr ""
 "is available."
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
@@ -8192,7 +8361,7 @@ msgstr ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr "You must confirm the password for the initial instructor."
 
@@ -8209,7 +8378,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr "You must provide a student ID, a set ID, and a problem number."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr "You must select a course to rename."
 
@@ -8221,20 +8390,25 @@ msgstr "You must select at least one file for the archive"
 msgid "You must select at least one file to delete"
 msgstr "You must select at least one file to delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr "You must select one or more sets for scoring"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+msgid "You must select one or more sets for scoring!"
+msgstr "You must select one or more sets for scoring!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+msgid "You must specify a %1 name"
+msgstr "You must specify a %1 name"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr "You must specify a course ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr "You must specify a course name."
 
@@ -8242,41 +8416,41 @@ msgstr "You must specify a course name."
 msgid "You must specify a file name"
 msgstr "You must specify a file name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr "You must specify a first name for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr "You must specify a last name for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr "You must specify a new institution for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr "You must specify a new name for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr "You must specify a new title for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr "You must specify a password for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "You must specify a user ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr "You must specify an email address for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "You must specify an file name in order to save a new file."
 
@@ -8312,12 +8486,12 @@ msgid "You need to select a set to view."
 msgstr "You need to select a set to view."
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr "You received a score of %1 for this attempt."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
@@ -8326,7 +8500,7 @@ msgstr ""
 "run out of attempts, for this problem and its graded subproblems."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8371,28 +8545,29 @@ msgstr ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr "Your browser does not support the video tag."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr "Your current branch of PG is up to date with branch %1 in remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr "Your current branch of the Open Problem Library is up to date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr "Your display options have been saved."
 
@@ -8404,47 +8579,60 @@ msgstr "Your email address has been changed."
 msgid "Your file name contains illegal characters"
 msgstr "Your file name contains illegal characters"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr "Your file name is not valid! "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr "Your message was sent successfully."
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Your overall recorded score is %1.  %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "Your recorded score on this test (number %1) is %2/%3."
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr "Your score on this %1 WAS recorded."
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr "Your score on this %1 is %2/%3."
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr "Your score on this %1 was NOT recorded."
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "Your score on this (checked, not recorded) submission is %1/%2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr "Your score on this problem was recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -8452,11 +8640,11 @@ msgstr ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Your score was not recorded because this homework set is closed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
@@ -8464,14 +8652,14 @@ msgstr ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
 "Your score was not recorded because this problem set version is not open."
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
@@ -8479,7 +8667,7 @@ msgstr ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
@@ -8487,38 +8675,38 @@ msgstr ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr "Your score was not recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr "Your score was not successfully sent to the LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Your score was recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr "Your score was successfully sent to the LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Your session has timed out due to inactivity. Please log in again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr "Your systems are up to date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr "[Edit]"
@@ -8531,7 +8719,7 @@ msgstr "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr "_ANSWER_LOG_DESCRIPTION"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr "_CLASSLIST_EDITOR_DESCRIPTION"
 
@@ -8554,19 +8742,24 @@ msgstr "_HMWKSETS_EDITOR_DESCRIPTION"
 msgid "_LOGIN_MESSAGE"
 msgstr "_LOGIN_MESSAGE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr "_PROBLEM_SET_SUMMARY"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr "_REQUEST_ERROR"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr "_USER_TABLE_SUMMARY"
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+msgid "a duplicate of the first selected achievement."
+msgstr "a duplicate of the first selected achievement."
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -8575,13 +8768,18 @@ msgid "a duplicate of the first selected set"
 msgstr "a duplicate of the first selected set"
 
 # Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+msgid "a new empty achievement."
+msgstr "a new empty achievement."
+
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "a new empty set"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr "a new file named:"
 
@@ -8590,7 +8788,7 @@ msgstr "a new file named:"
 msgid "a single set"
 msgstr "a single set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr "active"
 
@@ -8599,11 +8797,11 @@ msgid "add problems"
 msgstr "add problems"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr "addGlobalSet %1 in ProblemSetList:  %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr "added missing permission level for user"
 
@@ -8613,13 +8811,13 @@ msgid "admin"
 msgstr "admin"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr "all achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -8648,14 +8846,14 @@ msgstr "all sets"
 msgid "all students"
 msgstr "all students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "all users"
 
@@ -8663,31 +8861,37 @@ msgstr "all users"
 msgid "all users for one <b>set</b>"
 msgstr "all users for one <b>set</b>"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr "alphabetically"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr "answer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "any users"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr "as"
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
-msgstr "assigning the achievements to"
 
 # Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
@@ -8701,22 +8905,22 @@ msgstr "avg attempts"
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr "blank problem template(s) to end of homework set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr "by last login date"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "changes abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "changes saved"
@@ -8733,17 +8937,17 @@ msgstr "class list data for selected <b>users</b>"
 msgid "close"
 msgstr "close"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr "column"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr "columns:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "correct"
 
@@ -8757,7 +8961,7 @@ msgid "deleted %1 sets"
 msgstr "deleted %1 sets"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr "deleted %1 users"
 
@@ -8769,7 +8973,7 @@ msgstr "editing all achievements"
 msgid "editing all sets"
 msgstr "editing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "editing all users"
 
@@ -8781,7 +8985,7 @@ msgstr "editing selected achievements"
 msgid "editing selected sets"
 msgstr "editing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "editing selected users"
 
@@ -8789,7 +8993,7 @@ msgstr "editing selected users"
 msgid "editing visible sets"
 msgstr "editing visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "editing visible users"
 
@@ -8798,7 +9002,7 @@ msgstr "editing visible users"
 msgid "email:"
 msgstr "email:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr "empty"
 
@@ -8811,16 +9015,16 @@ msgid "entry rows."
 msgstr "entry rows."
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr "error adding set location %1 for set %2: %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "export abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr "exporting all achievements"
 
@@ -8828,7 +9032,7 @@ msgstr "exporting all achievements"
 msgid "exporting all sets"
 msgstr "exporting all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr "exporting selected achievements"
 
@@ -8862,15 +9066,15 @@ msgstr "for students"
 msgid "from"
 msgstr "from"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "giving new passwords to all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "giving new passwords to selected users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "giving new passwords to visible users"
 
@@ -8899,9 +9103,9 @@ msgstr "grade_proctor"
 msgid "guest"
 msgstr "guest"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "hidden"
@@ -8910,7 +9114,7 @@ msgstr "hidden"
 msgid "hidden from"
 msgstr "hidden from"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "hidden from students"
@@ -8922,45 +9126,50 @@ msgstr "hidden sets"
 # doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr "i"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+# does not need to be translated
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr "if"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr "illegal character in input: '/'"
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr "in their"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr "inactive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "incorrect"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr "index"
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr "input set location %1 already exists for set %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr "list of insertable macros"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr "locations selected below"
 
@@ -8968,7 +9177,7 @@ msgstr "locations selected below"
 msgid "login"
 msgstr "login"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr "login ID"
 
@@ -9003,15 +9212,15 @@ msgstr "new set:"
 msgid "new users"
 msgstr "new users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr "no achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr "no achievements."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr "no location"
 
@@ -9030,28 +9239,32 @@ msgstr "no sets"
 msgid "no students"
 msgstr "no students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "no users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr "nobody"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr "nth colum of merge file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
 msgstr "number of students not defined"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
@@ -9075,7 +9288,7 @@ msgstr "only"
 msgid "only best scores"
 msgstr "only best scores"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -9087,53 +9300,57 @@ msgstr "or"
 msgid "or Problems from"
 msgstr "or Problems from"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr "out of"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr "overwrite all data"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr "part"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr "permissions for %1 not defined"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr "pg debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr "pg internal errors"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr "pg warning"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr "point"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr "points"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr "preserve existing data"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr "preview answers"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr "problem"
 
@@ -9151,8 +9368,8 @@ msgid "progress"
 msgstr "progress"
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr "readSetDef error, can't read the line: ||%1||"
 
@@ -9166,19 +9383,19 @@ msgid "record for user %1 not found"
 msgstr "record for user %1 not found"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr "record for visible user %1 not found"
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr "row"
 
@@ -9200,13 +9417,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr "selected <b>users</b> to selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr "selected achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr "selected achievements."
 
@@ -9225,17 +9442,17 @@ msgstr "selected achievements."
 msgid "selected sets"
 msgstr "selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "selected users"
 
@@ -9273,7 +9490,7 @@ msgstr "sets with matching set IDs:"
 msgid "showing all sets"
 msgstr "showing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "showing all users"
 
@@ -9288,7 +9505,7 @@ msgstr "showing hidden sets"
 msgid "showing matching sets"
 msgstr "showing matching sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "showing matching users"
 
@@ -9296,7 +9513,7 @@ msgstr "showing matching users"
 msgid "showing no sets"
 msgstr "showing no sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "showing no users"
 
@@ -9304,13 +9521,17 @@ msgstr "showing no users"
 msgid "showing selected sets"
 msgstr "showing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "showing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
 msgstr "showing visible sets"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
@@ -9326,16 +9547,16 @@ msgstr "student"
 msgid "students"
 msgstr "students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr "submission"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr "submission (test %1)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr "summary"
 
@@ -9343,12 +9564,12 @@ msgstr "summary"
 msgid "ta"
 msgstr "ta"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr "test"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr "test (%1)"
 
@@ -9360,7 +9581,7 @@ msgstr "test date"
 msgid "test time"
 msgstr "test time"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr "the following file"
 
@@ -9369,14 +9590,14 @@ msgid "the following file(s)"
 msgstr "the following file(s)"
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr "the original path to the file is %1"
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr "then by"
 
@@ -9384,7 +9605,11 @@ msgstr "then by"
 msgid "then delete them"
 msgstr "then delete them"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "time"
 
@@ -9392,43 +9617,40 @@ msgstr "time"
 msgid "time limit exceeded"
 msgstr "time limit exceeded"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "times"
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
 msgstr "to"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
-msgstr "to all users, create global data, and"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr "to one <b>set</b>"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr "top score"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr "total"
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr "unable to write to directory %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "unlimited"
 
@@ -9437,7 +9659,7 @@ msgstr "unlimited"
 msgid "userID: %1 --"
 msgstr "userID: %1 --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
@@ -9445,21 +9667,21 @@ msgstr ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr "users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "users who match on selected field"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr "users who match:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "visible"
@@ -9472,20 +9694,25 @@ msgstr "visible"
 msgid "visible sets"
 msgstr "visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "visible to students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "visible users"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -9493,56 +9720,71 @@ msgstr "with set name(s):"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr "won't be able to read from file %1/%2: does it exist? is it readable?"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
 msgstr "your students"
 
-#
-msgid "navNext"
-msgstr "Next"
+#~ msgid "Import achievements from"
+#~ msgstr "Import achievements from"
+
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "Open, reduced scoring starts on %1."
+
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "Reduced Scoring Starts %1"
+
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "Reduced scoring started on %1."
 
 #
-msgid "navNextGrey"
-msgstr "Next"
+#~ msgid "navNext"
+#~ msgstr "Next"
 
 #
-msgid "navPrev"
-msgstr "Previous"
+#~ msgid "navNextGrey"
+#~ msgstr "Next"
 
 #
-msgid "navPrevGrey"
-msgstr "Previous"
+#~ msgid "navPrev"
+#~ msgstr "Previous"
 
 #
-msgid "navProbListGrey"
-msgstr "Problem List"
+#~ msgid "navPrevGrey"
+#~ msgstr "Previous"
 
 #
-msgid "navUp"
-msgstr "Homework Sets"
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_1"
-msgstr ""
-"This assignment has a Reduced Scoring Period that begins %1 and ends on the "
-"due date, %2.  During this period all additional work done counts %3 % of "
-"the original."
-
-#
-msgid "_AUTO"
-msgstr "1"
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_2"
-msgstr ""
-"This assignment had a Reduced Scoring Period that began %1 and ended on the "
-"due date, %2.  During that period all additional work done counted %3 % of "
-"the original."
-
-#, fuzzy
-#~ msgid "navProbList"
+#~ msgid "navProbListGrey"
 #~ msgstr "Problem List"
+
+#
+#~ msgid "navUp"
+#~ msgstr "Homework Sets"
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
+#~ msgstr ""
+#~ "This assignment has a Reduced Scoring Period that begins %1 and ends on "
+#~ "the due date, %2.  During this period all additional work done counts %3 "
+#~ "% of the original."
+
+#
+#~ msgid "_AUTO"
+#~ msgstr "1"
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
+#~ msgstr ""
+#~ "This assignment had a Reduced Scoring Period that began %1 and ended on "
+#~ "the due date, %2.  During that period all additional work done counted %3 "
+#~ "% of the original."
+
+#~ msgid "navProbList"
+#~ msgstr "navProbList"

--- a/lib/WeBWorK/Localize/en.po
+++ b/lib/WeBWorK/Localize/en.po
@@ -153,7 +153,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
 msgid "%1: Problem %2"
-msgstr ""
+msgstr "%1: Problem %2"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
@@ -4246,12 +4246,12 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
 msgid "Problem %1"
-msgstr ""
+msgstr "Problem %1"
 
 #. ($problemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
 msgid "Problem %1."
-msgstr ""
+msgstr "Problem %1."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566

--- a/lib/WeBWorK/Localize/en_us.po
+++ b/lib/WeBWorK/Localize/en_us.po
@@ -1,10 +1,10 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: WeBWorK Online Homework System\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: \n"
+"Language-Team: Webwork language team <gage@math.rochester.edu>\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -149,13 +149,11 @@ msgstr ""
 msgid "%1's password has been changed."
 msgstr ""
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
-#, fuzzy
 msgid "%1: Problem %2"
-msgstr "Problem List"
+msgstr "%1: Problem %2"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
@@ -4233,7 +4231,6 @@ msgstr ""
 msgid "Problem #"
 msgstr ""
 
-#
 #. ($prettyProblemID)
 #. (join('.',@seq)
 #. ($problemID)
@@ -4248,16 +4245,13 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
-#, fuzzy
 msgid "Problem %1"
-msgstr "Problem List"
+msgstr "Problem %1"
 
-#
 #. ($problemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
-#, fuzzy
 msgid "Problem %1."
-msgstr "Problem List"
+msgstr "Problem %1."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
@@ -7859,8 +7853,8 @@ msgstr ""
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "This is the classlist editor page, where you can view and edit the records "
-"of all the studentscurrently enrolled in this course.  The top of the page "
-"contains forms which allow you to filterwhich students to view, sort your "
+"of all the students currently enrolled in this course.  The top of the page "
+"contains forms which allow you to filter which students to view, sort your "
 "students in a chosen order, edit student records, give new passwords to "
 "students, import/export student records from/to external files, or add/"
 "delete students. To use, please select the action you would like to perform, "
@@ -7910,25 +7904,48 @@ msgstr ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
+"This is a table showing the current Homework sets for this class.  The "
+"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
+"Users, Visibility to students, Reduced Scoring Enabled, Date it was opened, "
+"Date it is due, and the Date during which the answers are posted.  The Edit "
+"Set Data field contains checkboxes for selection and a link to the set data "
+"editing page.  The cells in the Edit Problems fields contain links which "
+"take you to a page where you can edit the containing problems, and the cells "
+"in the edit assigned users field contains links which take you to a page "
+"where you can edit what students the set is assigned to."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
 msgstr ""
-"WeBWorK has encountered a software error while attempting to process "
-"thisproblem. It is likely that there is an error in the problem itself. If "
-"you are a student, report this error message to your professor to have it "
+"WeBWorK has encountered a software error while attempting to process this "
+"problem. It is likely that there is an error in the problem itself. If you "
+"are a student, report this error message to your professor to have it "
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+"A table showing all the current users along with several fields of user "
+"information. The fields from left to right are: Login Name, Login Status, "
+"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
+"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
+"the links in the column headers will sort the table by the field it "
+"corresponds to. The Login Name fields contain checkboxes for selecting the "
+"user.  Clicking the link of the name itself will allow you to act as the "
+"selected user.  There will also be an image link following the name which "
+"will take you to a page where you can edit the selected user's information.  "
+"Clicking the emails will allow you to email the corresponding user.  "
+"Clicking the links in the entries in the assigned sets columns will take you "
+"to a page where you can view and reassign the sets for the selected user."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115

--- a/lib/WeBWorK/Localize/en_us.po
+++ b/lib/WeBWorK/Localize/en_us.po
@@ -1,93 +1,98 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: WeBWorK Online Homework System\n"
+"Project-Id-Version: webwork2\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: \n"
-"Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: Webwork language team <gage@math.rochester.edu>\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: English (United States) (http://www.transifex.com/webwork/"
+"webwork2/language/en_US/)\n"
 "Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
 msgid "#corr"
-msgstr ""
+msgstr "#corr"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "#incorr"
-msgstr ""
+msgstr "#incorr"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
 msgid "% correct"
-msgstr ""
+msgstr "% correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
 msgid "% correct with review"
-msgstr ""
+msgstr "% correct with review"
 
+# Percent students
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
 msgid "% students"
-msgstr ""
+msgstr "% students"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
 msgid "%1 (old editor)"
-msgstr ""
+msgstr "%1 (old editor)"
 
+# Gateway (test 3)
 #. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
 msgid "%1 (test %2)"
-msgstr ""
+msgstr "%1 (test %2)"
 
-#
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
-#, fuzzy
 msgid "%1 Points:"
-msgstr "Problem List"
+msgstr "%1 Points:"
 
-#
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
-#, fuzzy
 msgid "%1 Problems:"
-msgstr "Problem List"
+msgstr "%1 Problems:"
 
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr ""
+msgstr "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
 
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
-msgstr ""
+msgstr "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
 
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
 msgid "%1 students out of %2"
-msgstr ""
+msgstr "%1 students out of %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
-msgstr ""
+msgstr "%1 title and institution changed from %2 to %3 and from %4 to %5"
 
 #. (scalar @userIDsToExport, $dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
 msgid "%1 users exported to file %2/%3"
-msgstr ""
+msgstr "%1 users exported to file %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
+"%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
@@ -97,57 +102,62 @@ msgid ""
 "Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
 "again."
 msgstr ""
+"%1 uses an external authentication system (e.g., Oncourse,  CAS,  "
+"Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
+"again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:97
 msgid ""
 "%1 uses an external authentication system.  You've authenticated through "
 "that system, but aren't allowed to log in to this course."
 msgstr ""
+"%1 uses an external authentication system.  You've authenticated through "
+"that system, but aren't allowed to log in to this course."
 
 #. ($levelpercentage)
 #. ($percentage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
 msgid "%1% Complete"
-msgstr ""
+msgstr "%1% Complete"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
 msgid "%1% correct"
-msgstr ""
+msgstr "%1% correct"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
 msgid "%1's Current Address"
-msgstr ""
+msgstr "%1's Current Address"
 
 #. ($user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
 msgid "%1's Current Password"
-msgstr ""
+msgstr "%1's Current Password"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
 msgid "%1's New Address"
-msgstr ""
+msgstr "%1's New Address"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
 msgid "%1's New Password"
-msgstr ""
+msgstr "%1's New Password"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
 msgid "%1's new password cannot be blank."
-msgstr ""
+msgstr "%1's new password cannot be blank."
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
 msgid "%1's password has been changed."
-msgstr ""
+msgstr "%1's password has been changed."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
@@ -158,46 +168,47 @@ msgstr "%1: Problem %2"
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
 msgid "%1: Problem %2 Show Me Another"
-msgstr ""
+msgstr "%1: Problem %2 Show Me Another"
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
 msgid "%1: The directory for the course not found."
-msgstr ""
+msgstr "%1: The directory for the course not found."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
 msgid "%quant(%1,course was, courses were) successfully unhidden."
-msgstr ""
+msgstr "%quant(%1,course was, courses were) successfully unhidden."
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:297
 msgid "%quant(%1,error) occured while generating hardcopy:"
-msgstr ""
+msgstr "%quant(%1,error) occured while generating hardcopy:"
 
 #. ($n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:802
 msgid "%quant(%1,file) unpacked successfully"
-msgstr ""
+msgstr "%quant(%1,file) unpacked successfully"
 
 #. ($numBlanks)
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
+"%quant(%1,of the questions remains,of the questions remain) unanswered."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
 msgid "%quant_1( course was, courses were) successfully hidden."
-msgstr ""
+msgstr "%quant_1( course was, courses were) successfully hidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "%score"
-msgstr ""
+msgstr "%score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
 msgid "(Any unsaved changes will be lost.)"
-msgstr ""
+msgstr "(Any unsaved changes will be lost.)"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
@@ -205,46 +216,51 @@ msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
+"(Instructor hint preview: show the student hint after the following number "
+"of attempts:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
 msgid "(This problem will not count towards your grade.)"
-msgstr ""
+msgstr "(This problem will not count towards your grade.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
+"(This test is overtime because it was not submitted in the allowed time.)"
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr ""
+msgstr "(Your score on this %1 is not available until %2.)"
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
 msgid "(Your score on this %1 is not available.)"
-msgstr ""
+msgstr "(Your score on this %1 is not available.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
 msgid "(correct)"
-msgstr ""
+msgstr "(correct)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
 msgid "(gw/quiz) After version answer date"
-msgstr ""
+msgstr "(gw/quiz) After version answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
 msgid "(incorrect)"
-msgstr ""
+msgstr "(incorrect)"
 
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
 msgid "(score %1)"
-msgstr ""
+msgstr "(score %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
 msgid "1 student"
-msgstr ""
+msgstr "1 student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
 msgid ""
@@ -260,7 +276,19 @@ msgid ""
 "std_problem_grader (the all or nothing grader). It will work with custom "
 "graders if they are written appropriately.</p>"
 msgstr ""
+"<p>After the Reduced Scoring Date all additional work done by the student "
+"counts at a reduced rate. Here is where you set the reduced rate which must "
+"be a percentage. For example if this value is 50% and a student views a "
+"problem during the Reduced Scoring Period, they will see the message \"You "
+"are in the Reduced Scoring Period: All additional work done counts 50% of "
+"the original.\" </p><p>To use this, you also have to enable Reduced Scoring "
+"and set the Reduced Scoring Date for individual assignments by editing the "
+"set data using the Hmwk Sets Editor.</p><p>This works with the "
+"avg_problem_grader (which is the the default grader) and the "
+"std_problem_grader (the all or nothing grader). It will work with custom "
+"graders if they are written appropriately.</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
@@ -274,7 +302,18 @@ msgid ""
 "least one display mode. If you select only one, then the options box will "
 "not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
+"<p>When viewing a problem, users may choose different methods of rendering "
+"formulas via an options box in the left panel. Here, you can adjust what "
+"display modes are listed.</p><p>Some display modes require other software to "
+"be installed on the server. Be sure to check that all display modes selected "
+"here work from your server.</p><p>The display modes are <ul><li> plainText: "
+"shows the raw LaTeX srings for formulas.<li> images: produces images using "
+"the external programs LaTeX and dvipng.<li> MathJax: a successor to jsMath, "
+"uses javascript to place render mathematics.</ul></p></p>You must use at "
+"least one display mode. If you select only one, then the options box will "
+"not give a choice of modes (since there will only be one active).</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
 msgid ""
 "<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
@@ -289,13 +328,24 @@ msgid ""
 "unless you check at least one of these options - the students would simply "
 "see a new version that they can not attempt or learn from.</p>"
 msgstr ""
+"<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
+"new problem</i> when Show Me Another is clicked</li> "
+"<li><b>SMAshowSolutions</b>: shows walk-through solution <i>for the new "
+"problem</i> when Show Me Another is clicked; a check is done first to make "
+"sure that a solution exists </li><li><b>SMAshowCorrect</b>: correct answers "
+"<i>for the new problem</i> can be viewed when Show Me Another is clicked; "
+"note that <b>SMAcheckAnswers</b> needs to be enabled at the same time</"
+"li><li><b>SMAshowHints</b>: show hints <i>for the new problem</i> (assuming "
+"they exist)</li></ul>Note: there is very little point enabling the button "
+"unless you check at least one of these options - the students would simply "
+"see a new version that they can not attempt or learn from.</p>"
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
 msgid "A course with ID %1 already exists."
-msgstr ""
+msgstr "A course with ID %1 already exists."
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
@@ -303,11 +353,13 @@ msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
+"A directory already exists with the name %1. You must first delete this "
+"existing course before you can unarchive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
 msgid "A file with that name already exists"
-msgstr ""
+msgstr "A file with that name already exists"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
@@ -315,6 +367,9 @@ msgid ""
 "check that no problems are missing and that they are all legible. If not, "
 "please inform your instructor."
 msgstr ""
+"A hardcopy file was generated, but it may not be complete or correct. Please "
+"check that no problems are missing and that they are all legible. If not, "
+"please inform your instructor."
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
@@ -322,6 +377,8 @@ msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
+"A location with the name %1 already exists in the database.  Did you mean to "
+"edit that location instead?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
@@ -329,11 +386,13 @@ msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
+"A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
+"in the class %3.  There were %4 message(s) that could not be sent."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
 msgid "A new file has been created at '%1'"
-msgstr ""
+msgstr "A new file has been created at '%1'"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
@@ -342,6 +401,8 @@ msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
 msgstr ""
+"A new file has been created at '%1' with the contents below.  No changes "
+"have been made to set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -349,7 +410,11 @@ msgid ""
 "to 100 indicates the grade earned. The number on the second line gives the "
 "number of incorrect attempts."
 msgstr ""
+"A period (.) indicates a problem has not been attempted, and a number from 0 "
+"to 100 indicates the grade earned. The number on the second line gives the "
+"number of incorrect attempts."
 
+# Leave symbol codes in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
 msgid ""
 "A switch to govern the use of a Progress Bar for the student; this also "
@@ -357,6 +422,10 @@ msgid ""
 "and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
 "(&#x2717;), or unattempted (no symbol)."
 msgstr ""
+"A switch to govern the use of a Progress Bar for the student; this also "
+"enables/disables the highlighting of the current problem in the side bar, "
+"and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
+"(&#x2717;), or unattempted (no symbol)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:101
 msgid ""
@@ -373,27 +442,40 @@ msgid ""
 "Clicking the links in the entries in the assigned sets columns will take you "
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
+"A table showing all the current users along with several fields of user "
+"information. The fields from left to right are: Login Name, Login Status, "
+"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
+"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
+"the links in the column headers will sort the table by the field it "
+"corresponds to. The Login Name fields contain checkboxes for selecting the "
+"user.  Clicking the link of the name itself will allow you to act as the "
+"selected user.  There will also be an image link following the name which "
+"will take you to a page where you can edit the selected user's information.  "
+"Clicking the emails will allow you to email the corresponding user.  "
+"Clicking the links in the entries in the assigned sets columns will take you "
+"to a page where you can view and reassign the sets for the selected user."
 
+# Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
 msgid "ADJ STATUS"
-msgstr ""
+msgstr "ADJ STATUS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
 msgid "ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "ANSWERS NOT RECORDED"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
 msgid "ANSWERS NOT RECORDED --"
-msgstr ""
+msgstr "ANSWERS NOT RECORDED --"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
 msgid "ANSWERS ONLY CHECKED -- "
-msgstr ""
+msgstr "ANSWERS ONLY CHECKED -- "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
@@ -402,106 +484,108 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
 msgid "Abandon changes"
-msgstr ""
+msgstr "Abandon changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
-msgstr ""
+msgstr "Abandon export"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
 msgid "Achievement"
-msgstr ""
+msgstr "Achievement"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
 msgid "Achievement %1 created with evaluator '%2'."
-msgstr ""
+msgstr "Achievement %1 created with evaluator '%2'."
 
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
 msgid "Achievement %1 exists.  No achievement created"
-msgstr ""
+msgstr "Achievement %1 exists.  No achievement created"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
 msgid "Achievement Editor"
-msgstr ""
+msgstr "Achievement Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:726
 msgid "Achievement Evaluator Editor"
-msgstr ""
+msgstr "Achievement Evaluator Editor"
 
 #. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:173
 msgid "Achievement Evaluator for achievement %1"
-msgstr ""
+msgstr "Achievement Evaluator for achievement %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 msgid "Achievement ID"
-msgstr ""
+msgstr "Achievement ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
-msgstr ""
+msgstr "Achievement ID exists!  No new achievement created.  File not saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:202
 msgid "Achievement Points Per Problem"
-msgstr ""
+msgstr "Achievement Points Per Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:736
 msgid "Achievement User Editor"
-msgstr ""
+msgstr "Achievement User Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
 msgid "Achievement has been assigned to all users."
-msgstr ""
+msgstr "Achievement has been assigned to all users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
-msgstr ""
+msgstr "Achievement has been unassigned to all students."
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
 msgid "Achievement scores saved to %1"
-msgstr ""
+msgstr "Achievement scores saved to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
 msgid "Achievements"
-msgstr ""
+msgstr "Achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "Act as"
-msgstr ""
+msgstr "Act as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:161
 msgid "Act as:"
-msgstr ""
+msgstr "Act as:"
 
 #. (HTML::Entities::encode_entities($eUserID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Acting as %1."
-msgstr ""
+msgstr "Acting as %1."
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
 msgid "Action %1 not found"
-msgstr ""
+msgstr "Action %1 not found"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Active"
-msgstr ""
+msgstr "Active"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:198
 msgid ""
 "Activiating this will enable Mathchievements for webwork.  Mathchievements "
 "can be managed by using the Achievement Editor link."
 msgstr ""
+"Activiating this will enable Mathchievements for webwork.  Mathchievements "
+"can be managed by using the Achievement Editor link."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:208
 msgid ""
@@ -509,61 +593,64 @@ msgid ""
 "students who earn achievements with items that allow them to affect their "
 "homework in a limited way."
 msgstr ""
+"Activiating this will enable achievement items. This features rewards "
+"students who earn achievements with items that allow them to affect their "
+"homework in a limited way."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
-msgstr ""
+msgstr "Add"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:942
 msgid "Add All"
-msgstr ""
+msgstr "Add All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
 msgid "Add Course"
-msgstr ""
+msgstr "Add Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
 msgid "Add Students"
-msgstr ""
+msgstr "Add Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
 msgid "Add Users"
-msgstr ""
+msgstr "Add Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid "Add WeBWorK administrators to new course"
-msgstr ""
+msgstr "Add WeBWorK administrators to new course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1384
 msgid "Add a new test for which Gateway?"
-msgstr ""
+msgstr "Add a new test for which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add as what filetype?"
-msgstr ""
+msgstr "Add as what filetype?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
 msgid "Add how many students?"
-msgstr ""
+msgstr "Add how many students?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
 msgid "Add problems to"
-msgstr ""
+msgstr "Add problems to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
 msgid "Add to what set?"
-msgstr ""
+msgstr "Add to what set?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
 msgid "Add which new users?"
-msgstr ""
+msgstr "Add which new users?"
 
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
@@ -575,28 +662,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
 msgid "Added %1 to %2 as problem %3"
-msgstr ""
+msgstr "Added %1 to %2 as problem %3"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
 msgid "Added '%1' to %2 as new hardcopy header"
-msgstr ""
+msgstr "Added '%1' to %2 as new hardcopy header"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
 msgid "Added '%1' to %2 as new set header"
-msgstr ""
+msgstr "Added '%1' to %2 as new set header"
 
 #. (join(', ', @toAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
 msgid "Added addresses %1 to location %2."
-msgstr ""
+msgstr "Added addresses %1 to location %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:409
 msgid "Additional addresses for receiving feedback e-mail."
-msgstr ""
+msgstr "Additional addresses for receiving feedback e-mail."
 
 #. ($badLocAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
@@ -604,6 +691,8 @@ msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
+"Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
+"Please double check the integrity of the WeBWorK database before continuing."
 
 #. (join(', ', @noAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
@@ -611,6 +700,8 @@ msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
+"Address(es) %1 in the add list is(are) already in the location %2, and so "
+"were skipped."
 
 #. (join(', ', @noDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
@@ -618,6 +709,8 @@ msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
+"Address(es) %1 in the delete list is(are) not in the location %2, and so "
+"were skipped."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
@@ -625,6 +718,8 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and resubmit."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
@@ -632,10 +727,12 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 msgid "Addresses"
-msgstr ""
+msgstr "Addresses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
 msgid ""
@@ -643,6 +740,9 @@ msgid ""
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"Addresses for new location.  Enter one per line, as single IP addresses e."
+"g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
+"g., 192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid ""
@@ -650,154 +750,158 @@ msgid ""
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
 "ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"Addresses to add to the location.  Enter one per line, as single IP "
+"addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
+"ranges (e.g., 192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:190
 msgid "Adds 24 hours to the close date of a homework."
-msgstr ""
+msgstr "Adds 24 hours to the close date of a homework."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:273
 msgid "Adds 48 hours to the close date of a homework."
-msgstr ""
+msgstr "Adds 48 hours to the close date of a homework."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 msgid "Adjusted Status"
-msgstr ""
+msgstr "Adjusted Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:595
 msgid "Advanced Search"
-msgstr ""
+msgstr "Advanced Search"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
 msgid "After set answer date"
-msgstr ""
+msgstr "After set answer date"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
+"After the reduced scoring period begins all work counts for %1% of its value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715
 msgid "All Selected Constraints Joined by \"And\""
-msgstr ""
+msgstr "All Selected Constraints Joined by \"And\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:52
 msgid "All assignments were made successfully."
-msgstr ""
+msgstr "All assignments were made successfully."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
 msgid "All of the answers above are correct."
-msgstr ""
+msgstr "All of the answers above are correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
 msgid "All of the gradeable answers above are correct."
-msgstr ""
+msgstr "All of the gradeable answers above are correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "All of these files will also be made available for mail merge."
-msgstr ""
+msgstr "All of these files will also be made available for mail merge."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
 msgid "All selected sets hidden from all students"
-msgstr ""
+msgstr "All selected sets hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
 msgid "All selected sets made visible for all students"
-msgstr ""
+msgstr "All selected sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
 msgid "All sets hidden from all students"
-msgstr ""
+msgstr "All sets hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
 msgid "All sets made visible for all students"
-msgstr ""
+msgstr "All sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "All students in course"
-msgstr ""
+msgstr "All students in course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:57
 msgid "All unassignments were made successfully."
-msgstr ""
+msgstr "All unassignments were made successfully."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
 msgid "All visible hidden from all students"
-msgstr ""
+msgstr "All visible hidden from all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
 msgid "All visible sets made visible for all students"
-msgstr ""
+msgstr "All visible sets made visible for all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
 msgid "Allow unassign"
-msgstr ""
+msgstr "Allow unassign"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
 msgid "Allowed error, as a percentage, for numerical comparisons"
-msgstr ""
+msgstr "Allowed error, as a percentage, for numerical comparisons"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
 msgid "Allowed to <em>act as</em> another user"
-msgstr ""
+msgstr "Allowed to <em>act as</em> another user"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
 msgid "Allowed to change their e-mail address"
-msgstr ""
+msgstr "Allowed to change their e-mail address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
 msgid "Allowed to change their password"
-msgstr ""
+msgstr "Allowed to change their password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
 msgid "Allowed to login to the course"
-msgstr ""
+msgstr "Allowed to login to the course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
 msgid "Allowed to see solutions before the answer date"
-msgstr ""
+msgstr "Allowed to see solutions before the answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:324
 msgid "Allowed to see the correct answers before the answer date"
-msgstr ""
+msgstr "Allowed to see the correct answers before the answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
 msgid "Allowed to view past answers"
-msgstr ""
+msgstr "Allowed to view past answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
 msgid "Allowed to view problems in sets which are not open yet"
-msgstr ""
+msgstr "Allowed to view problems in sets which are not open yet"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1441
 msgid "Amulet of Extension"
-msgstr ""
+msgstr "Amulet of Extension"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
 msgid "An error occured while archiving the course %1:"
-msgstr ""
+msgstr "An error occured while archiving the course %1:"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
 msgid "An error occured while changing the title of the course %1."
-msgstr ""
+msgstr "An error occured while changing the title of the course %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
 msgid "An error occured while deleting the course %1:"
-msgstr ""
+msgstr "An error occured while deleting the course %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
 msgid "An error occured while renaming the course %1 to %2:"
-msgstr ""
+msgstr "An error occured while renaming the course %1 to %2:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
@@ -807,57 +911,59 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:805
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:828
 msgid "Answer Date"
-msgstr ""
+msgstr "Answer Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
 msgid "Answer Log"
-msgstr ""
+msgstr "Answer Log"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Answer Preview"
-msgstr ""
+msgstr "Answer Preview"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1268
 msgid "Answer(s) submitted:"
-msgstr ""
+msgstr "Answer(s) submitted:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
 msgid "Answer:"
-msgstr ""
+msgstr "Answer:"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
 msgid "AnswerGroupInfo"
-msgstr ""
+msgstr "AnswerGroupInfo"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
 msgid "AnswerHashInfo"
-msgstr ""
+msgstr "AnswerHashInfo"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
 msgid "Answers"
-msgstr ""
+msgstr "Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
 msgid "Answers Available"
-msgstr ""
+msgstr "Answers Available"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
 msgid "Answers cannot be due until on or after the open date!"
-msgstr ""
+msgstr "Answers cannot be due until on or after the open date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1050
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1123
 msgid "Answers cannot be made available until on or after the close date!"
-msgstr ""
+msgstr "Answers cannot be made available until on or after the close date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
-msgstr ""
+msgstr "Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
@@ -865,6 +971,8 @@ msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
 msgstr ""
+"Any changes made below will be reflected in the set for ONLY the student(s) "
+"listed above."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -872,59 +980,62 @@ msgid ""
 "be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
+"Any time problem numbers are intentionally changed, the problems will always "
+"be renumbered consecutively, starting from one.  When deleting problems, "
+"gaps will be left in the numbering unless the box above is checked."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
 msgid "Append"
-msgstr ""
+msgstr "Append"
 
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
-msgstr ""
+msgstr "Append to end of %1 set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
 msgid "Archive"
-msgstr ""
+msgstr "Archive"
 
 #. ($archive, $n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
 msgid "Archive '%1' created successfully (%quant( %2, file))"
-msgstr ""
+msgstr "Archive '%1' created successfully (%quant( %2, file))"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:938
 msgid "Archive '%1' deleted"
-msgstr ""
+msgstr "Archive '%1' deleted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Archive Course"
-msgstr ""
+msgstr "Archive Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
 msgid "Archive Courses"
-msgstr ""
+msgstr "Archive Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
 msgid "Archive next course"
-msgstr ""
+msgstr "Archive next course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
 msgid "Archive this Course"
-msgstr ""
+msgstr "Archive this Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
 msgid "Archived Courses"
-msgstr ""
+msgstr "Archived Courses"
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
 msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
-msgstr ""
+msgstr "Archiving course as %1.tar.gz. Reload FileManager to see it."
 
 #. (CGI::b($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
@@ -932,6 +1043,8 @@ msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
+"Are you sure that you want to delete the course %1 after archiving? This "
+"cannot be undone!"
 
 #. (CGI::b($delete_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
@@ -939,67 +1052,70 @@ msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
+"Are you sure you want to delete the course %1? All course files and data "
+"will be destroyed. There is no undo available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
-msgstr ""
+msgstr "Assign"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
-msgstr ""
+msgstr "Assign All Sets to Current User"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
 msgid "Assign selected sets to selected users"
-msgstr ""
+msgstr "Assign selected sets to selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
-msgstr ""
+msgstr "Assign this set to which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "Assign to All Current Users"
-msgstr ""
+msgstr "Assign to All Current Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Assigned"
-msgstr ""
+msgstr "Assigned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
 msgid "Assigned Sets"
-msgstr ""
+msgstr "Assigned Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
 msgid "Assigned achievements to users"
-msgstr ""
+msgstr "Assigned achievements to users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
 msgid "Assigned to"
-msgstr ""
+msgstr "Assigned to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
 msgid "Assignment type"
-msgstr ""
+msgstr "Assignment type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
 msgid "At least one of the answers above is NOT correct."
-msgstr ""
+msgstr "At least one of the answers above is NOT correct."
 
+# Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
 msgid "Att. to Open Children"
-msgstr ""
+msgstr "Att. to Open Children"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
 msgid "Attempt to upgrade directories"
-msgstr ""
+msgstr "Attempt to upgrade directories"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
 msgid "Attempted"
-msgstr ""
+msgstr "Attempted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
@@ -1007,55 +1123,55 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
 msgid "Attempts"
-msgstr ""
+msgstr "Attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Audit"
-msgstr ""
+msgstr "Audit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
 msgid "Authentication failed.  Please speak to your instructor."
-msgstr ""
+msgstr "Authentication failed.  Please speak to your instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
 msgid "Author Info"
-msgstr ""
+msgstr "Author Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Automatic"
-msgstr ""
+msgstr "Automatic"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
 msgid "Automatically render problems on page load"
-msgstr ""
+msgstr "Automatically render problems on page load"
 
 #. ($emailDirectory,$old_default_msg_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
 msgid "Backup file <code>%1/%2</code> created."
-msgstr ""
+msgstr "Backup file <code>%1/%2</code> created."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:745
 msgid "Basic Search"
-msgstr ""
+msgstr "Basic Search"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Binary"
-msgstr ""
+msgstr "Binary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1163
 msgid "Box of Transmogrification"
-msgstr ""
+msgstr "Box of Transmogrification"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:885
 msgid "Browse"
-msgstr ""
+msgstr "Browse"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:455
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:812
 msgid "Browse from:"
-msgstr ""
+msgstr "Browse from:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
 msgid ""
@@ -1064,6 +1180,10 @@ msgid ""
 "have the same section as the user initiating the feedback.  I.E.  Feedback "
 "will only be sent to section leaders."
 msgstr ""
+"By default, feeback is always sent to all users specified to recieve "
+"feedback.  This variable sets the system to only email feedback to users who "
+"have the same section as the user initiating the feedback.  I.E.  Feedback "
+"will only be sent to section leaders."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:410
 msgid ""
@@ -1071,108 +1191,111 @@ msgid ""
 "receive feedback. Feedback is also sent to any addresses specified in this "
 "blank. Separate email address entries by commas."
 msgstr ""
+"By default, feeback is sent to all users above who have permission to "
+"receive feedback. Feedback is also sent to any addresses specified in this "
+"blank. Separate email address entries by commas."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
 msgid "CLOSE DATE"
-msgstr ""
+msgstr "CLOSE DATE"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
 msgid "CLOSE TIME"
-msgstr ""
+msgstr "CLOSE TIME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
 msgid "Cake of Enlargment"
-msgstr ""
+msgstr "Cake of Enlargment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
 msgid "Can e-mail instructor"
-msgstr ""
+msgstr "Can e-mail instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
 msgid "Can report bugs"
-msgstr ""
+msgstr "Can report bugs"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
 msgid "Can show old answers"
-msgstr ""
+msgstr "Can show old answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
 msgid "Can submit answers for a student"
-msgstr ""
+msgstr "Can submit answers for a student"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
 msgid "Can't copy file: %1"
-msgstr ""
+msgstr "Can't copy file: %1"
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
 msgid "Can't create archive '%1': command returned %2"
-msgstr ""
+msgstr "Can't create archive '%1': command returned %2"
 
 #. ($courseID,  $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
 msgid "Can't create course environment for %1 because %2"
-msgstr ""
+msgstr "Can't create course environment for %1 because %2"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
 msgid "Can't create directory: %1"
-msgstr ""
+msgstr "Can't create directory: %1"
 
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
 msgid "Can't create file '%1': %2"
-msgstr ""
+msgstr "Can't create file '%1': %2"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
 msgid "Can't create file: %1"
-msgstr ""
+msgstr "Can't create file: %1"
 
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
 msgid "Can't delete archive '%1': %2"
-msgstr ""
+msgstr "Can't delete archive '%1': %2"
 
 #. ($eUserID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
 msgid "Can't get password record for effective user '%1': %2"
-msgstr ""
+msgstr "Can't get password record for effective user '%1': %2"
 
 #. ($userID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
 msgid "Can't get password record for user '%1': %2"
-msgstr ""
+msgstr "Can't get password record for user '%1': %2"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
 msgid "Can't open %1"
-msgstr ""
+msgstr "Can't open %1"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
 msgid "Can't open file %1"
-msgstr ""
+msgstr "Can't open file %1"
 
 #. ($merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
 msgid "Can't read merge file %1. No message sent"
-msgstr ""
+msgstr "Can't read merge file %1. No message sent"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
 msgid "Can't rename file: %1"
-msgstr ""
+msgstr "Can't rename file: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
 msgid "Can't rename to the same name."
-msgstr ""
+msgstr "Can't rename to the same name."
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:805
 msgid "Can't unpack '%1': command returned %2"
-msgstr ""
+msgstr "Can't unpack '%1': command returned %2"
 
 #. ($!)
 #. ($fullPath)
@@ -1180,127 +1303,132 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
 msgid "Can't write to file %1"
-msgstr ""
+msgstr "Can't write to file %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
 msgid "Cancel E-mail"
-msgstr ""
+msgstr "Cancel E-mail"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
 msgid "Cannot open %1"
-msgstr ""
+msgstr "Cannot open %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
 msgid "Cap Test Time at Set Close Date?"
-msgstr ""
+msgstr "Cap Test Time at Set Close Date?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
 msgid "Category"
-msgstr ""
+msgstr "Category"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:451
 msgid ""
 "Cause the selected homework set to count for twice as many points as it "
 "normally would."
 msgstr ""
+"Cause the selected homework set to count for twice as many points as it "
+"normally would."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1164
 msgid ""
 "Causes a homework problem to become a clone of another problem from the same "
 "set."
 msgstr ""
+"Causes a homework problem to become a clone of another problem from the same "
+"set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
 msgid "Causes a single homework problem to be worth twice as much."
-msgstr ""
+msgstr "Causes a single homework problem to be worth twice as much."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
 msgid "Change Course Title to:"
-msgstr ""
+msgstr "Change Course Title to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
 msgid "Change CourseID to:"
-msgstr ""
+msgstr "Change CourseID to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
 msgid "Change Display Settings"
-msgstr ""
+msgstr "Change Display Settings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
 msgid "Change Email Address"
-msgstr ""
+msgstr "Change Email Address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
 msgid "Change Institution to:"
-msgstr ""
+msgstr "Change Institution to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
 msgid "Change Password"
-msgstr ""
+msgstr "Change Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
 msgid "Change User Settings"
-msgstr ""
+msgstr "Change User Settings"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
 msgid "Change course institution from %1 to %2"
-msgstr ""
+msgstr "Change course institution from %1 to %2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
 msgid "Change title from %1 to %2"
-msgstr ""
+msgstr "Change title from %1 to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
 msgid "Changes abandoned"
-msgstr ""
+msgstr "Changes abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
 msgid "Changes in this file have not yet been permanently saved."
-msgstr ""
+msgstr "Changes in this file have not yet been permanently saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
 msgid "Changes saved"
-msgstr ""
+msgstr "Changes saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1354
 msgid ""
 "Changing the problem seed for display, but there are no problems showing."
 msgstr ""
+"Changing the problem seed for display, but there are no problems showing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:598
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:727
 msgid "Chapter:"
-msgstr ""
+msgstr "Chapter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
 msgid "Check Answers"
-msgstr ""
+msgstr "Check Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
 msgid "Check Test"
-msgstr ""
+msgstr "Check Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
 msgid "Check that it's permissions are set correctly."
-msgstr ""
+msgstr "Check that it's permissions are set correctly."
 
 #. ($emailDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
@@ -1308,60 +1436,64 @@ msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
+"Check whether it exists and whether the directory %1 can be read by the "
+"webserver."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
 msgid "Checking additional error messages"
-msgstr ""
+msgstr "Checking additional error messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:477
 msgid "Choose the set which you would like to be worth twice as much."
-msgstr ""
+msgstr "Choose the set which you would like to be worth twice as much."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:386
 msgid "Choose the set which you would like to enable partial credit for."
-msgstr ""
+msgstr "Choose the set which you would like to enable partial credit for."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
 msgid "Choose the set which you would like to ressurect."
-msgstr ""
+msgstr "Choose the set which you would like to ressurect."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
 msgid "Choose the set whose close date you would like to extend."
-msgstr ""
+msgstr "Choose the set whose close date you would like to extend."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
-msgstr ""
+msgstr "Choose visibility of the sets to be affected"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
 msgid "Choose which sets to be affected"
-msgstr ""
+msgstr "Choose which sets to be affected"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:523
 msgid "Class values"
-msgstr ""
+msgstr "Class values"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
 msgid "Classlist Editor"
-msgstr ""
+msgstr "Classlist Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
 msgid "Clear"
-msgstr ""
+msgstr "Clear"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
 msgid "Clear Problem Display"
-msgstr ""
+msgstr "Clear Problem Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
 msgid ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 msgstr ""
+"Click on a student's name to see the student's version of the homework set. "
+"Click heading to sort table."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
@@ -1369,6 +1501,8 @@ msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
+"Click on the login name to edit individual problem set data, (e.g. due "
+"dates) for these students."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
@@ -1378,10 +1512,14 @@ msgid ""
 "associated with the restriction.  Contact your professor to have this "
 "problem resolved."
 msgstr ""
+"Client ip address %1 is not allowed to work this assignment, because the "
+"assignment has ip address restrictions and there are no allowed locations "
+"associated with the restriction.  Contact your professor to have this "
+"problem resolved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
@@ -1392,47 +1530,47 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Close Date"
-msgstr ""
+msgstr "Close Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
 msgid "Closed, answers available."
-msgstr ""
+msgstr "Closed, answers available."
 
 #. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
 msgid "Closed, answers on %1."
-msgstr ""
+msgstr "Closed, answers on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
 msgid "Closed, answers recently available."
-msgstr ""
+msgstr "Closed, answers recently available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
 msgid "Closed."
-msgstr ""
+msgstr "Closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
 msgid "Closes"
-msgstr ""
+msgstr "Closes"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
 msgid "Closes %1"
-msgstr ""
+msgstr "Closes %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
 msgid "Closes:"
-msgstr ""
+msgstr "Closes:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
 msgid "Collapse"
-msgstr ""
+msgstr "Collapse"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
 msgid "Collapse All"
-msgstr ""
+msgstr "Collapse All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
@@ -1451,104 +1589,102 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Comment"
-msgstr ""
+msgstr "Comment"
 
 #. ($self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
 msgid "Completed results for this assignment are not available until %1"
-msgstr ""
+msgstr "Completed results for this assignment are not available until %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Completed results for this assignment are not available."
-msgstr ""
+msgstr "Completed results for this assignment are not available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
 msgid "Completed."
-msgstr ""
+msgstr "Completed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "Confirm"
-msgstr ""
+msgstr "Confirm"
 
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
 msgid "Confirm %1's New Password"
-msgstr ""
+msgstr "Confirm %1's New Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
 msgid "Confirm Password:"
-msgstr ""
+msgstr "Confirm Password:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
 msgid "Congratulations, you earned a new level!"
-msgstr ""
+msgstr "Congratulations, you earned a new level!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
 msgid "Continue"
-msgstr ""
+msgstr "Continue"
 
 #. ($sourceDirectory, $outputDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
 msgid "Copied auxiliary files from %1 to new location at %2"
-msgstr ""
+msgstr "Copied auxiliary files from %1 to new location at %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy"
-msgstr ""
+msgstr "Copy"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy file as:"
-msgstr ""
+msgstr "Copy file as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
 msgid "Copy templates from:"
-msgstr ""
+msgstr "Copy templates from:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
-#, fuzzy
 msgid "Copy this Problem"
-msgstr "Problem List"
+msgstr "Copy this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
-msgstr ""
+msgstr "Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:644
 msgid "Correct Adjusted Status"
-msgstr ""
+msgstr "Correct Adjusted Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Correct Answer"
-msgstr ""
+msgstr "Correct Answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
 msgid "Correct Answers:"
-msgstr ""
+msgstr "Correct Answers:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
 msgid "Correct Status"
-msgstr ""
+msgstr "Correct Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
 msgid "Correct answers"
-msgstr ""
+msgstr "Correct answers"
 
 #. ($total_correct,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
 msgid "Correct: %1/%2"
-msgstr ""
+msgstr "Correct: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
 msgid "CorrectAnswers"
-msgstr ""
+msgstr "CorrectAnswers"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
@@ -1556,104 +1692,105 @@ msgstr ""
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
+"Could not add %1 problems to this set.  The number must be between 1 and %2"
 
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
 msgid "Couldn't change %1's password: %2"
-msgstr ""
+msgstr "Couldn't change %1's password: %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
 msgid "Couldn't change your email address: %1"
-msgstr ""
+msgstr "Couldn't change your email address: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
 msgid "Couldn't find OPL Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find OPL Branch %1 in remote %2"
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
 msgid "Couldn't find PG Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find PG Branch %1 in remote %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
-msgstr ""
+msgstr "Couldn't find WeBWorK Branch %1 in remote %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
 msgid "Couldn't save your display options: %1"
-msgstr ""
+msgstr "Couldn't save your display options: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
-msgstr ""
+msgstr "Counter"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
 msgid "Counts for Parent"
-msgstr ""
+msgstr "Counts for Parent"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
 msgid "Course %1 database is in order"
-msgstr ""
+msgstr "Course %1 database is in order"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
 msgid "Course %1 databases must be updated before renaming this course."
-msgstr ""
+msgstr "Course %1 databases must be updated before renaming this course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
-msgstr ""
+msgstr "Course Administration"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
 msgid "Course Configuration"
-msgstr ""
+msgstr "Course Configuration"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
-msgstr ""
+msgstr "Course ID may only contain letters, numbers, hyphens, and underscores."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
 msgid "Course ID:"
-msgstr ""
+msgstr "Course ID:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "Course Info"
-msgstr ""
+msgstr "Course Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
 msgid "Course Name:"
-msgstr ""
+msgstr "Course Name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
 msgid "Course Title:"
-msgstr ""
+msgstr "Course Title:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
 msgid "Course archived."
-msgstr ""
+msgstr "Course archived."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
-msgstr ""
+msgstr "Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
@@ -1665,36 +1802,41 @@ msgid ""
 "Course_Name (status :: date/time of most recent login) where status is "
 "\"hidden\" or \"visible\"."
 msgstr ""
+"Courses are listed either alphabetically or in order by the time of most "
+"recent login activity, oldest first. To change the listing order check the "
+"mode you want and click \"Refresh Listing\".  The listing format is: "
+"Course_Name (status :: date/time of most recent login) where status is "
+"\"hidden\" or \"visible\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "Create"
-msgstr ""
+msgstr "Create"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
 msgid "Create CSV"
-msgstr ""
+msgstr "Create CSV"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
 msgid "Create Location:"
-msgstr ""
+msgstr "Create Location:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
-msgstr ""
+msgstr "Create a New Set in This Course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
 msgid "Create a new achievement with ID"
-msgstr ""
+msgstr "Create a new achievement with ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
-msgstr ""
+msgstr "Create as what type of set?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
-msgstr ""
+msgstr "Create unattached problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
 msgid ""
@@ -1704,74 +1846,82 @@ msgid ""
 "is only available for mysql databases. It depends on the mysqldump "
 "application."
 msgstr ""
+"Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
+"directory. Before archiving, the course database is dumped into a "
+"subdirectory of the course's DATA directory. Currently the archive facility "
+"is only available for mysql databases. It depends on the mysqldump "
+"application."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:648
 msgid "Cupcake of Enlargement"
-msgstr ""
+msgstr "Cupcake of Enlargement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 msgid "Current"
-msgstr ""
+msgstr "Current"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
 msgid "Currently defined locations are listed below."
-msgstr ""
+msgstr "Currently defined locations are listed below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
 msgid "Data"
-msgstr ""
+msgstr "Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
 msgid "Database tables are ok"
-msgstr ""
+msgstr "Database tables are ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables need updating."
-msgstr ""
+msgstr "Database tables need updating."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables ok"
-msgstr ""
+msgstr "Database tables ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
 msgid "Database:"
-msgstr ""
+msgstr "Database:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:189
 msgid ""
 "Default Amount of Time (in minutes) after Due Date that Answers are Open"
 msgstr ""
+"Default Amount of Time (in minutes) after Due Date that Answers are Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:183
 msgid ""
 "Default Amount of Time (in minutes) before Due Date that the Assignment is "
 "Open"
 msgstr ""
+"Default Amount of Time (in minutes) before Due Date that the Assignment is "
+"Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:247
 msgid "Default Length of Reduced Scoring Period in minutes"
-msgstr ""
+msgstr "Default Length of Reduced Scoring Period in minutes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:177
 msgid "Default Time that the Assignment is Due"
-msgstr ""
+msgstr "Default Time that the Assignment is Due"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
@@ -1780,7 +1930,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
 msgid "Delete"
-msgstr ""
+msgstr "Delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
@@ -1788,110 +1938,112 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
 msgid "Delete Course"
-msgstr ""
+msgstr "Delete Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
 msgid "Delete all existing addresses"
-msgstr ""
+msgstr "Delete all existing addresses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
 msgid "Delete course after archiving. Caution there is no undo!"
-msgstr ""
+msgstr "Delete course after archiving. Caution there is no undo!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
 msgid "Delete course:"
-msgstr ""
+msgstr "Delete course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
 msgid "Delete how many?"
-msgstr ""
+msgstr "Delete how many?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
 msgid "Delete it?"
-msgstr ""
+msgstr "Delete it?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
 msgid "Delete location:"
-msgstr ""
+msgstr "Delete location:"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
 msgid "Deleted %quant(%1,achievement)"
-msgstr ""
+msgstr "Deleted %quant(%1,achievement)"
 
 #. (join(', ', @delLocations)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Deleted Location(s): %1"
-msgstr ""
+msgstr "Deleted Location(s): %1"
 
 #. (join(', ', @toDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
 msgid "Deleted addresses %1 from location."
-msgstr ""
+msgstr "Deleted addresses %1 from location."
 
 #. ($self->shortPath($self->{tempFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
 msgid "Deleting temp file at %1"
-msgstr ""
+msgstr "Deleting temp file at %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
+"Deletion deletes all location data and related addresses, and is not "
+"undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
 msgid "Deletion destroys all achievement-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all achievement-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
 msgid "Deletion destroys all set-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all set-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
 msgid "Deletion destroys all user-related data and is not undoable!"
-msgstr ""
+msgstr "Deletion destroys all user-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
 msgid "Deny From"
-msgstr ""
+msgstr "Deny From"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
 msgid "Didn't recognize action"
-msgstr ""
+msgstr "Didn't recognize action"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
 msgid "Directory"
-msgstr ""
+msgstr "Directory"
 
 #. ($file, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
 msgid "Directory '%1' not removed: %2"
-msgstr ""
+msgstr "Directory '%1' not removed: %2"
 
 #. ($file, $removed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:678
 msgid "Directory '%1' removed (items deleted: %2)"
-msgstr ""
+msgstr "Directory '%1' removed (items deleted: %2)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "Directory permission errors "
-msgstr ""
+msgstr "Directory permission errors "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
 msgid "Directory structure"
-msgstr ""
+msgstr "Directory structure"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
@@ -1901,102 +2053,104 @@ msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
+"Directory structure is missing directories or the webserver lacks sufficient "
+"privileges."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
 msgid "Directory structure is ok"
-msgstr ""
+msgstr "Directory structure is ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
 msgid "Directory structure needs to be repaired manually before archiving."
-msgstr ""
+msgstr "Directory structure needs to be repaired manually before archiving."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
 msgid "Directory structure needs to be repaired manually before renaming."
-msgstr ""
+msgstr "Directory structure needs to be repaired manually before renaming."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
 msgid "Directory structure or permissions need to be repaired. "
-msgstr ""
+msgstr "Directory structure or permissions need to be repaired. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
-msgstr ""
+msgstr "Display Mode:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
-msgstr ""
+msgstr "Display Past Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
-msgstr ""
+msgstr "Display options: Show"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
 msgid "Display the evaluated student answer"
-msgstr ""
+msgstr "Display the evaluated student answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
-msgstr ""
+msgstr "Do not unassign students unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:274
 msgid "Do not uncheck a set unless you know what you are doing."
-msgstr ""
+msgstr "Do not uncheck a set unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
 msgid "Do not uncheck students, unless you know what you are doing."
-msgstr ""
+msgstr "Do not uncheck students, unless you know what you are doing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Don't Archive"
-msgstr ""
+msgstr "Don't Archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
 msgid "Don't Unarchive"
-msgstr ""
+msgstr "Don't Unarchive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
 msgid "Don't Upgrade"
-msgstr ""
+msgstr "Don't Upgrade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
 msgid "Don't delete"
-msgstr ""
+msgstr "Don't delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
 msgid "Don't make changes"
-msgstr ""
+msgstr "Don't make changes"
 
 #. ($saveMode)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
 msgid "Don't recognize saveMode: |%1|. Unknown error."
-msgstr ""
+msgstr "Don't recognize saveMode: |%1|. Unknown error."
 
 #. ($type)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
 msgid "Don't recognize statistics display type: |%1|"
-msgstr ""
+msgstr "Don't recognize statistics display type: |%1|"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
 msgid "Don't rename"
-msgstr ""
+msgstr "Don't rename"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
 msgid "Don't use in an achievement"
-msgstr ""
+msgstr "Don't use in an achievement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
 msgid "Done"
-msgstr ""
+msgstr "Done"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
@@ -2006,49 +2160,49 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 #. ($set->set_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
 msgid "Download %1"
-msgstr ""
+msgstr "Download %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:267
 msgid "Download Hardcopy"
-msgstr ""
+msgstr "Download Hardcopy"
 
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr ""
+msgstr "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
 msgid "Download PDF or TeX Hardcopy for Current Set"
-msgstr ""
+msgstr "Download PDF or TeX Hardcopy for Current Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
-msgstr ""
+msgstr "Download PDF or TeX Hardcopy for Selected Sets"
 
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
 msgid "Download hardcopy of set %1 for %2?"
-msgstr ""
+msgstr "Download hardcopy of set %1 for %2?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
 msgid "Download:"
-msgstr ""
+msgstr "Download:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
-msgstr ""
+msgstr "Drop"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
-msgstr ""
+msgstr "Duplicate this set and name it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:371
 msgid ""
@@ -2061,36 +2215,46 @@ msgid ""
 "will be used by default, and choosing <i>true</i> means that the old answer "
 "checkers will be used by default."
 msgstr ""
+"During summer 2005, a newer version of the answer checkers was implemented "
+"for answers which are functions and numbers.  The newer checkers allow more "
+"functions in student answers, and behave better in certain cases.  Some "
+"problems are specifically coded to use new (or old) answer checkers.  "
+"However, for the bulk of the problems, you can choose what the default will "
+"be here.  <p>Choosing <i>false</i> here means that the newer answer checkers "
+"will be used by default, and choosing <i>true</i> means that the old answer "
+"checkers will be used by default."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
 msgid "E-Mail"
-msgstr ""
+msgstr "E-Mail"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
 msgid "E-mail Instructor"
-msgstr ""
+msgstr "E-mail Instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:399
 msgid "E-mail addresses which can receive e-mail from a pg problem"
-msgstr ""
+msgstr "E-mail addresses which can receive e-mail from a pg problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:404
 msgid ""
 "E-mail feedback from students automatically sent to this permission level "
 "and higher:"
 msgstr ""
+"E-mail feedback from students automatically sent to this permission level "
+"and higher:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:389
 msgid "E-mail verbosity level"
-msgstr ""
+msgstr "E-mail verbosity level"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
 msgid "E-mail:"
-msgstr ""
+msgstr "E-mail:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Earned"
-msgstr ""
+msgstr "Earned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
@@ -2106,82 +2270,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
 msgid "Edit"
-msgstr ""
+msgstr "Edit"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
 msgid "Edit %1 of set %2."
-msgstr ""
+msgstr "Edit %1 of set %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
-msgstr ""
+msgstr "Edit All Set Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
-msgstr ""
+msgstr "Edit Assigned Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
 msgid "Edit Evaluator"
-msgstr ""
+msgstr "Edit Evaluator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 msgid "Edit Header"
-msgstr ""
+msgstr "Edit Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
 msgid "Edit Location:"
-msgstr ""
+msgstr "Edit Location:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Edit Problem"
-msgstr ""
+msgstr "Edit Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
 msgid "Edit Problems"
-msgstr ""
+msgstr "Edit Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
 msgid "Edit Set"
-msgstr ""
+msgstr "Edit Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
-msgstr ""
+msgstr "Edit Set Data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
 msgid "Edit Target Set"
-msgstr ""
+msgstr "Edit Target Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
 msgid "Edit Which Users?"
-msgstr ""
+msgstr "Edit Which Users?"
 
 #. ($user)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:199
 msgid "Edit data for %1"
-msgstr ""
+msgstr "Edit data for %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
 msgid "Edit it"
-msgstr ""
+msgstr "Edit it"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
 msgid "Edit set %1 data for ALL students assigned to this set."
-msgstr ""
+msgstr "Edit set %1 data for ALL students assigned to this set."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "Edit set %1 for this user."
-msgstr ""
+msgstr "Edit set %1 for this user."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
 msgid ""
@@ -2190,63 +2354,66 @@ msgid ""
 "make all of your changes.  Or, click \"Manage Locations\" above to make no "
 "changes and return to the Manage Locations page."
 msgstr ""
+"Edit the current value of the location description, if desired, then add and "
+"select addresses to delete, and then click the \"Take Action\" button to "
+"make all of your changes.  Or, click \"Manage Locations\" above to make no "
+"changes and return to the Manage Locations page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
 msgid "Edit which sets?"
-msgstr ""
+msgstr "Edit which sets?"
 
+# Edit with a number 1 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
 msgid "Edit1"
-msgstr ""
+msgstr "Edit1"
 
+# Edit with a number 2 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
 msgid "Edit2"
-msgstr ""
+msgstr "Edit2"
 
+# Edit with a number 3 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
 msgid "Edit3"
-msgstr ""
+msgstr "Edit3"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
 msgid "Editing %1 in file '%2'"
-msgstr ""
+msgstr "Editing %1 in file '%2'"
 
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
 msgid "Editing achievement in file '%1'"
-msgstr ""
+msgstr "Editing achievement in file '%1'"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
 msgid "Editing location %1"
-msgstr ""
+msgstr "Editing location %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Editing problem set %1 data for these individual students: %2"
-msgstr ""
+msgstr "Editing problem set %1 data for these individual students: %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
-#, fuzzy
 msgid "Editor"
-msgstr "Problem List"
+msgstr "Editor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
-#, fuzzy
 msgid "Editor rows:"
-msgstr "Problem List"
+msgstr "Editor rows:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -2258,29 +2425,29 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
 msgid "Email Address"
-msgstr ""
+msgstr "Email Address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
 msgid "Email Body:"
-msgstr ""
+msgstr "Email Body:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
 msgid "Email Instructor On Failed Attempt"
-msgstr ""
+msgstr "Email Instructor On Failed Attempt"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Email Link"
-msgstr ""
+msgstr "Email Link"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
 msgid "Email address"
-msgstr ""
+msgstr "Email address"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
 msgid "Email instructor"
-msgstr ""
+msgstr "Email instructor"
 
 #. (scalar(@{$self->{ra_send_to}})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
@@ -2289,51 +2456,56 @@ msgid ""
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
+"Email is being sent to %quant(%1,recipient). You will be notified by email "
+"when the task is completed.  This may take several minutes if the class is "
+"large."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 msgid "Emails to be sent to the following:"
-msgstr ""
+msgstr "Emails to be sent to the following:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
 msgid "Enable Achievement Items"
-msgstr ""
+msgstr "Enable Achievement Items"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Enable Conditional Release"
-msgstr ""
+msgstr "Enable Conditional Release"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
 msgid "Enable Course Achievements"
-msgstr ""
+msgstr "Enable Course Achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
 msgid "Enable Progress Bar and current problem highlighting"
-msgstr ""
+msgstr "Enable Progress Bar and current problem highlighting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
 msgid "Enable Reduced Scoring"
-msgstr ""
+msgstr "Enable Reduced Scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
 msgid "Enable Show Me Another button"
-msgstr ""
+msgstr "Enable Show Me Another button"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
 msgid "Enable periodic re-randomization of problems"
-msgstr ""
+msgstr "Enable periodic re-randomization of problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:358
 msgid ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
+"Enable reduced scoring for a homework set.  This will allow you to submit "
+"answers for partial credit for 24 hours after the close date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Enabled"
-msgstr ""
+msgstr "Enabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
 msgid ""
@@ -2341,6 +2513,9 @@ msgid ""
 "attempts. Student would have to click Request New Version to obtain new "
 "version of the problem and to continue working on the problem"
 msgstr ""
+"Enables periodic re-randomization of problems after a given number of "
+"attempts. Student would have to click Request New Version to obtain new "
+"version of the problem and to continue working on the problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:213
 msgid ""
@@ -2350,12 +2525,19 @@ msgid ""
 "homework set until they have achieved the minimum score on all of the listed "
 "sets."
 msgstr ""
+"Enables the use of the conditional release system.  To use conditional "
+"release you need to specify a list of set names on the Problem Set Detail "
+"Page, along with a minimum score.  Students will not be able to access that "
+"homework set until they have achieved the minimum score on all of the listed "
+"sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
 msgid ""
 "Enables the use of the date picker on the Homework Sets Editor 2 page and "
 "the Problem Set Detail page"
 msgstr ""
+"Enables the use of the date picker on the Homework Sets Editor 2 page and "
+"the Problem Set Detail page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:253
 msgid ""
@@ -2363,14 +2545,17 @@ msgid ""
 "seeded version of the current problem, complete with solution (if it exists "
 "for that problem)."
 msgstr ""
+"Enables use of the Show Me Another button, which offers the student a newly-"
+"seeded version of the current problem, complete with solution (if it exists "
+"for that problem)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Enrolled"
-msgstr ""
+msgstr "Enrolled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
 msgid "Enrolled, Drop, etc."
-msgstr ""
+msgstr "Enrolled, Drop, etc."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
@@ -2381,40 +2566,42 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "Enrollment Status"
-msgstr ""
+msgstr "Enrollment Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
 msgid "Enter filename below"
-msgstr ""
+msgstr "Enter filename below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
 msgid "Enter filenames below"
-msgstr ""
+msgstr "Enter filenames below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:132
 msgid ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 msgstr ""
+"Enter information below for students you wish to add. Each student's "
+"password will initially be set to their student ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
 msgid "Entered"
-msgstr ""
+msgstr "Entered"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
 msgid "Entered student:"
-msgstr ""
+msgstr "Entered student:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
 msgid "Equation Display"
-msgstr ""
+msgstr "Equation Display"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1442
 msgid "Error adding set-level proctor: %1"
-msgstr ""
+msgstr "Error adding set-level proctor: %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1344
@@ -2423,24 +2610,26 @@ msgid ""
 "Error getting old set-proctor password from the database: %1.  No update to "
 "the password was done."
 msgstr ""
+"Error getting old set-proctor password from the database: %1.  No update to "
+"the password was done."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
 msgid "Error message:"
-msgstr ""
+msgstr "Error message:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
 msgid "Error messages"
-msgstr ""
+msgstr "Error messages"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
 msgid "Error: Answer date must come after close date in set %1"
-msgstr ""
+msgstr "Error: Answer date must come after close date in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1534
 msgid "Error: Close date must come after open date in set %1"
-msgstr ""
+msgstr "Error: Close date must come after open date in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1551
@@ -2448,33 +2637,35 @@ msgid ""
 "Error: Reduced scoring date must come between the open date and close date "
 "in set %1"
 msgstr ""
+"Error: Reduced scoring date must come between the open date and close date "
+"in set %1"
 
 #. ($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
-msgstr ""
+msgstr "Error: The original file %1 cannot be read."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1528
 msgid "Error: answer date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: answer date cannot be more than 10 years from now in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1082
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1526
 msgid "Error: close date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: close date cannot be more than 10 years from now in set %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
 msgid "Error: open date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "Error: open date cannot be more than 10 years from now in set %1"
 
 #. ($problem_desc, $problem_name, CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1230
@@ -2482,6 +2673,8 @@ msgid ""
 "Errors encountered while processing %1. This %2 has been omitted from the "
 "hardcopy. Error text: %3"
 msgstr ""
+"Errors encountered while processing %1. This %2 has been omitted from the "
+"hardcopy. Error text: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
@@ -2490,6 +2683,9 @@ msgid ""
 "create the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"Errors occured while hiding the courses listed below when attempting to "
+"create the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
@@ -2498,135 +2694,147 @@ msgid ""
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"Errors occured while unhiding the courses listed below when attempting "
+"delete the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 msgid "Evaluator"
-msgstr ""
+msgstr "Evaluator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
 msgid "Evaluator File"
-msgstr ""
+msgstr "Evaluator File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
+"Except for possible errors listed above, all selected courses are already "
+"hidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
+"Except for possible errors listed above, all selected courses are already "
+"unhidden."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
+"Existing addresses for the location are given in the scrolling list below.  "
+"Select addresses from the list to delete them:"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
 msgid "Existing file %1 could not be backed up and was lost."
-msgstr ""
+msgstr "Existing file %1 could not be backed up and was lost."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
 msgid "Expand"
-msgstr ""
+msgstr "Expand"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
 msgid "Expand All"
-msgstr ""
+msgstr "Expand All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
 msgid "Export"
-msgstr ""
+msgstr "Export"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
 msgid "Export selected achievements."
-msgstr ""
+msgstr "Export selected achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
 msgid "Export selected sets"
-msgstr ""
+msgstr "Export selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
 msgid "Export to what kind of file?"
-msgstr ""
+msgstr "Export to what kind of file?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
 msgid "Export which sets?"
-msgstr ""
+msgstr "Export which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
 msgid "Export which users?"
-msgstr ""
+msgstr "Export which users?"
 
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
 msgid "Exported achievements to %1"
-msgstr ""
+msgstr "Exported achievements to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
 msgid "Extend the close date for which Gateway?"
-msgstr ""
+msgstr "Extend the close date for which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1442
 msgid ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 msgstr ""
+"Extends the close date of a gateway test by 24 hours. Note: The test must "
+"still be open for this to work."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "FIRST NAME"
-msgstr ""
+msgstr "FIRST NAME"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
 msgid "Failed to create new achievement: %1"
-msgstr ""
+msgstr "Failed to create new achievement: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
 msgid "Failed to create new achievement: no achievement ID specified!"
-msgstr ""
+msgstr "Failed to create new achievement: no achievement ID specified!"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
 msgid "Failed to create new set: %1"
-msgstr ""
+msgstr "Failed to create new set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
-msgstr ""
+msgstr "Failed to create new set: no set name specified!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
+"Failed to duplicate achievement: no achievement selected for duplication!"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
 msgid "Failed to duplicate set: %1"
-msgstr ""
+msgstr "Failed to duplicate set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
-msgstr ""
+msgstr "Failed to duplicate set: no set name specified!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
-msgstr ""
+msgstr "Failed to duplicate set: no set selected for duplication!"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr ""
+msgstr "Failed to duplicate set: set %1 already exists!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
 msgid "Failed to enter student:"
-msgstr ""
+msgstr "Failed to enter student:"
 
 #. ($filePath)
 #. ($scoreFilePath)
@@ -2636,56 +2844,56 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
 msgid "Failed to open %1"
-msgstr ""
+msgstr "Failed to open %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
 msgid "Failed to save: %1"
-msgstr ""
+msgstr "Failed to save: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "False"
-msgstr ""
+msgstr "False"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
 msgid "Feature exhausted for this problem"
-msgstr ""
+msgstr "Feature exhausted for this problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
 msgid "Feedback"
-msgstr ""
+msgstr "Feedback"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:414
 msgid "Feedback by Section."
-msgstr ""
+msgstr "Feedback by Section."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
 msgid "FeedbackMessage"
-msgstr ""
+msgstr "FeedbackMessage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Field is ok"
-msgstr ""
+msgstr "Field is ok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
 msgid "Field missing in database"
-msgstr ""
+msgstr "Field missing in database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Field missing in schema"
-msgstr ""
+msgstr "Field missing in schema"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
 msgid "File '%1' exists.  File not saved.  No changes have been made."
-msgstr ""
+msgstr "File '%1' exists.  File not saved.  No changes have been made."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
@@ -2694,69 +2902,71 @@ msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
+"File '%1' exists. File not saved. No changes have been made.  You can change "
+"the file path for this problem manually from the 'Hmwk Sets Editor' page"
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
 msgid "File '%1' not removed: %2"
-msgstr ""
+msgstr "File '%1' not removed: %2"
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:681
 msgid "File '%1' successfully removed"
-msgstr ""
+msgstr "File '%1' successfully removed"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:935
 msgid "File '%2' uploaded successfully"
-msgstr ""
+msgstr "File '%2' uploaded successfully"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
-msgstr ""
+msgstr "File <b>%1</b> already exists. Overwrite it, or rename it as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
 msgid "File Compare"
-msgstr ""
+msgstr "File Compare"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
 msgid "File Manager"
-msgstr ""
+msgstr "File Manager"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
 msgid "File saved"
-msgstr ""
+msgstr "File saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
 msgid "File successfully copied"
-msgstr ""
+msgstr "File successfully copied"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:644
 msgid "File successfully renamed"
-msgstr ""
+msgstr "File successfully renamed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
 msgid "Filename"
-msgstr ""
+msgstr "Filename"
 
 #. ($extension,$location)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1168
 msgid "Files with extension '.%1' usually belong in '%2'"
-msgstr ""
+msgstr "Files with extension '.%1' usually belong in '%2'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
 msgid "Filter by what text?"
-msgstr ""
+msgstr "Filter by what text?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
 msgid "Filter:"
-msgstr ""
+msgstr "Filter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
 msgid "First"
-msgstr ""
+msgstr "First"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -2773,11 +2983,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
 msgid "First Name"
-msgstr ""
+msgstr "First Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
 msgid "First name"
-msgstr ""
+msgstr "First name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
 msgid ""
@@ -2786,179 +2996,185 @@ msgid ""
 "Please specify a different file or move the needed file to the email "
 "directory"
 msgstr ""
+"For security reasons, you cannot specify a message file from a directory "
+"higher than the email directory (you can't use ../blah/blah for example). "
+"Please specify a different file or move the needed file to the email "
+"directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
 msgid "Force problems to be numbered consecutively from one"
-msgstr ""
+msgstr "Force problems to be numbered consecutively from one"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2303
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+"Force problems to be numbered consecutively from one (always done when "
+"reordering problems)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
-msgstr ""
+msgstr "Format for the subject line in feedback e-mails"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
 msgid "Format:"
-msgstr ""
+msgstr "Format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
-msgstr ""
+msgstr "From This Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
 msgid "From field must contain one valid email address."
-msgstr ""
+msgstr "From field must contain one valid email address."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
 msgid "From:"
-msgstr ""
+msgstr "From:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1075
 msgid "GLOBAL Usage"
-msgstr ""
+msgstr "GLOBAL Usage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
 msgid "Gateway Name "
-msgstr ""
+msgstr "Gateway Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
 msgid "Gateway Quiz %2"
-msgstr ""
+msgstr "Gateway Quiz %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:808
 msgid "Gateway parameters"
-msgstr ""
+msgstr "Gateway parameters"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:120
 msgid "General"
-msgstr ""
+msgstr "General"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
 msgid "General Information"
-msgstr ""
+msgstr "General Information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate Hardcopy"
-msgstr ""
+msgstr "Generate Hardcopy"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate hardcopy for selected sets and selected users"
-msgstr ""
+msgstr "Generate hardcopy for selected sets and selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
 msgid "Get Library Set Problems"
-msgstr ""
+msgstr "Get Library Set Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
 msgid "Get Target Set Problems"
-msgstr ""
+msgstr "Get Target Set Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
 msgid "Give new password to"
-msgstr ""
+msgstr "Give new password to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
 msgid "Give new password to which users?"
-msgstr ""
+msgstr "Give new password to which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:968
 msgid "Gives full credit on a single homework problem."
-msgstr ""
+msgstr "Gives full credit on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1079
 msgid "Gives full credit on every problem in a set."
-msgstr ""
+msgstr "Gives full credit on every problem in a set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:762
 msgid "Gives half credit on a single homework problem."
-msgstr ""
+msgstr "Gives half credit on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:878
 msgid "Gives half credit on every problem in a set."
-msgstr ""
+msgstr "Gives half credit on every problem in a set."
 
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
 msgid "Global problem %1 for set %2 not found."
-msgstr ""
+msgstr "Global problem %1 for set %2 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "Global set data will be shown instead of user specific data"
-msgstr ""
+msgstr "Global set data will be shown instead of user specific data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:155
 msgid "Go"
-msgstr ""
+msgstr "Go"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 msgid "Grade"
-msgstr ""
+msgstr "Grade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
 msgid "Grade Problem"
-msgstr ""
+msgstr "Grade Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
 msgid "Grade Test"
-msgstr ""
+msgstr "Grade Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
 msgid "Grader"
-msgstr ""
+msgstr "Grader"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
 msgid "Grades"
-msgstr ""
+msgstr "Grades"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:97
 msgid "Grades have been saved for all current users."
-msgstr ""
+msgstr "Grades have been saved for all current users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:229
 msgid "Grading assignment:"
-msgstr ""
+msgstr "Grading assignment:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:967
 msgid "Greater Rod of Revelation"
-msgstr ""
+msgstr "Greater Rod of Revelation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1078
 msgid "Greater Tome of Enlightenment"
-msgstr ""
+msgstr "Greater Tome of Enlightenment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
 msgid "Guest Login"
-msgstr ""
+msgstr "Guest Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
 msgid "HTTP Headers"
-msgstr ""
+msgstr "HTTP Headers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
 msgid "Hardcopy Format:"
-msgstr ""
+msgstr "Hardcopy Format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
 msgid "Hardcopy Generator"
-msgstr ""
+msgstr "Hardcopy Generator"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
@@ -2967,100 +3183,103 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:783
 msgid "Hardcopy Header"
-msgstr ""
+msgstr "Hardcopy Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
 msgid "Hardcopy Theme"
-msgstr ""
+msgstr "Hardcopy Theme"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
 msgid "Headers"
-msgstr ""
+msgstr "Headers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
 msgid "Help"
-msgstr ""
+msgstr "Help"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:479
 msgid "Here is a new version of your problem."
-msgstr ""
+msgstr "Here is a new version of your problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
 msgid "Hidden"
-msgstr ""
+msgstr "Hidden"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
 msgid "Hide All"
-msgstr ""
+msgstr "Hide All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
 msgid "Hide Courses"
-msgstr ""
+msgstr "Hide Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
 msgid "Hide Hints"
-msgstr ""
+msgstr "Hide Hints"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
 msgid "Hide Hints from Students"
-msgstr ""
+msgstr "Hide Hints from Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Hide Inactive Courses"
-msgstr ""
+msgstr "Hide Inactive Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
 msgid "Hide all paths"
-msgstr ""
+msgstr "Hide all paths"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
 msgid "Hide path:"
-msgstr ""
+msgstr "Hide path:"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
 msgid "Hint:"
-msgstr ""
+msgstr "Hint:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
 msgid "Hints"
-msgstr ""
+msgstr "Hints"
 
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
 msgid "Hmwk Sets Editor"
-msgstr ""
+msgstr "Hmwk Sets Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
-msgstr ""
+msgstr "Homework Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
 msgid "Homework Totals"
-msgstr ""
+msgstr "Homework Totals"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
-msgstr ""
+msgstr "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
 msgid "Icon"
-msgstr ""
+msgstr "Icon"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
 msgid "Icon File"
-msgstr ""
+msgstr "Icon File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
 msgstr ""
+"If a password field is left blank, the student's current password will be "
+"maintained."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:454
 msgid ""
@@ -3069,6 +3288,10 @@ msgid ""
 "of the problem's status and the weighted average of the status of its child "
 "problems which have this flag enabled."
 msgstr ""
+"If this flag is set then this problem will count towards the grade of its "
+"parent problem.  In general the adjusted status on a problem is the larger "
+"of the problem's status and the weighted average of the status of its child "
+"problems which have this flag enabled."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
 msgid ""
@@ -3076,6 +3299,9 @@ msgid ""
 "emails will be notified whenever a student runs out of attempts on a problem "
 "and its children without receiving an adjusted status of 100%"
 msgstr ""
+"If this is enabled then instructors with the ability to receive feedback "
+"emails will be notified whenever a student runs out of attempts on a problem "
+"and its children without receiving an adjusted status of 100%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
@@ -3083,6 +3309,9 @@ msgid ""
 "they have completed all of the previous problems, and their child problems "
 "if necessary"
 msgstr ""
+"If this is enabled then students will be unable to attempt a problem until "
+"they have completed all of the previous problems, and their child problems "
+"if necessary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
 msgid ""
@@ -3092,91 +3321,97 @@ msgid ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 msgstr ""
+"If you check %1 your login information will be remembered by the browser you "
+"are using, allowing you to visit WeBWorK pages without typing your user name "
+"and password (until your session expires). This feature is not safe for "
+"public workstations, untrusted machines, and machines over which you do not "
+"have direct control."
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
-msgstr ""
+msgstr "Illegal file '%1' specified"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
 msgid "Illegal filename contains '..'"
-msgstr ""
+msgstr "Illegal filename contains '..'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
 msgid "Import"
-msgstr ""
+msgstr "Import"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "Import achievements from"
-msgstr ""
+msgstr "Import achievements from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
-msgstr ""
+msgstr "Import from where?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
 msgid "Import how many sets?"
-msgstr ""
+msgstr "Import how many sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
 msgid "Import sets with names"
-msgstr ""
+msgstr "Import sets with names"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
 msgid "Import users from what file?"
-msgstr ""
+msgstr "Import users from what file?"
 
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
 msgid "Imported %quant(%1,achievement)"
-msgstr ""
+msgstr "Imported %quant(%1,achievement)"
 
 #. ($total_inprogress, $num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "In progress: %1/%2"
-msgstr ""
+msgstr "In progress: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Inactive"
-msgstr ""
+msgstr "Inactive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:141
 msgid "Inactivity time before a user is required to login again"
-msgstr ""
+msgstr "Inactivity time before a user is required to login again"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
 msgid "Include Success Index"
-msgstr ""
+msgstr "Include Success Index"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
-msgstr ""
+msgstr "Incorrect"
 
 #. ($total_incorrect,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
 msgid "Incorrect: %1/%2"
-msgstr ""
+msgstr "Incorrect: %1/%2"
 
+# Short for Initial
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
 msgid "Init"
-msgstr ""
+msgstr "Init"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
 msgid "Institution:"
-msgstr ""
+msgstr "Institution:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
 msgid "Instructor Tools"
-msgstr ""
+msgstr "Instructor Tools"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
 msgid "Instructor solution preview: show the student solution after due date."
-msgstr ""
+msgstr "Instructor solution preview: show the student solution after due date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "Invalid Reply-to address."
-msgstr ""
+msgstr "Invalid Reply-to address."
 
 #. ($output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
@@ -3185,65 +3420,70 @@ msgid ""
 "All email file names must end in the extension \".msg\" choose a file name "
 "with a \".msg\" extension. The message was not saved."
 msgstr ""
+"Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
+"All email file names must end in the extension \".msg\" choose a file name "
+"with a \".msg\" extension. The message was not saved."
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
 msgid "Invalid headerType %1"
-msgstr ""
+msgstr "Invalid headerType %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
 msgid "Invalid user ID or password."
-msgstr ""
+msgstr "Invalid user ID or password."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2306
 msgid ""
 "It is before the open date.  You probably want to renumber the problems if "
 "you are deleting some from the middle."
 msgstr ""
+"It is before the open date.  You probably want to renumber the problems if "
+"you are deleting some from the middle."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
-msgstr ""
+msgstr "Items"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
 msgid "Jump to Page:"
-msgstr ""
+msgstr "Jump to Page:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
 msgid "Jump to Problem:"
-msgstr ""
+msgstr "Jump to Problem:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
 msgid "Just-In-Time parameters"
-msgstr ""
+msgstr "Just-In-Time parameters"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:772
 msgid "Keywords:"
-msgstr ""
+msgstr "Keywords:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "LAST NAME"
-msgstr ""
+msgstr "LAST NAME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1089
 msgid "LOCAL Usage"
-msgstr ""
+msgstr "LOCAL Usage"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:135
 msgid "Language (refresh page after saving changes to reveal new language.)"
-msgstr ""
+msgstr "Language (refresh page after saving changes to reveal new language.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
 msgid "Last"
-msgstr ""
+msgstr "Last"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
 msgid "Last Answer"
-msgstr ""
+msgstr "Last Answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -3260,19 +3500,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
 msgid "Last Name"
-msgstr ""
+msgstr "Last Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "Last column of merge file"
-msgstr ""
+msgstr "Last column of merge file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
 msgid "Last name"
-msgstr ""
+msgstr "Last name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Latest Answers"
-msgstr ""
+msgstr "Latest Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
 msgid ""
@@ -3280,42 +3520,45 @@ msgid ""
 "to login again.<p> This value should be entered as a number, so as 3600 "
 "instead of 60*60 for one hour"
 msgstr ""
+"Length of time, in seconds, a user has to be inactive before he is required "
+"to login again.<p> This value should be entered as a number, so as 3600 "
+"instead of 60*60 for one hour"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:761
 msgid "Lesser Rod of Revelation"
-msgstr ""
+msgstr "Lesser Rod of Revelation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:877
 msgid "Lesser Tome of Enlightenment"
-msgstr ""
+msgstr "Lesser Tome of Enlightenment"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:768
 msgid "Level:"
-msgstr ""
+msgstr "Level:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
-msgstr ""
+msgstr "Library Browser"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
-msgstr ""
+msgstr "Library Browser 2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
-msgstr ""
+msgstr "Library Browser 3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
 msgid "Library Browser no js"
-msgstr ""
+msgstr "Library Browser no js"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
 msgid "List of display modes made available to students"
-msgstr ""
+msgstr "List of display modes made available to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
 msgid ""
@@ -3323,24 +3566,27 @@ msgid ""
 "Professors need to be added to this list if questionaires are used, or other "
 "WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
+"List of e-mail addresses to which e-mail can be sent by a problem. "
+"Professors need to be added to this list if questionaires are used, or other "
+"WeBWorK problems which send e-mail as part of their answer mechanism."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
 msgid "List of options for Show Me Another button"
-msgstr ""
+msgstr "List of options for Show Me Another button"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
 msgid "Local"
-msgstr ""
+msgstr "Local"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
 msgid "Local Problems"
-msgstr ""
+msgstr "Local Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 msgid "Location"
-msgstr ""
+msgstr "Location"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
@@ -3349,33 +3595,35 @@ msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
+"Location %1 does not exist in the WeBWorK database.  Please check your input "
+"(perhaps you need to reload the location management page?)."
 
 #. ($locationID, join(', ', @addresses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
 msgid "Location %1 has been created, with addresses %2."
-msgstr ""
+msgstr "Location %1 has been created, with addresses %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
 msgid "Location deletion requires confirmation."
-msgstr ""
+msgstr "Location deletion requires confirmation."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
 msgid "Location description:"
-msgstr ""
+msgstr "Location description:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
 msgid "Location name:"
-msgstr ""
+msgstr "Location name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
 msgid "Log In Again"
-msgstr ""
+msgstr "Log In Again"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Log Out"
-msgstr ""
+msgstr "Log Out"
 
 #. ($add_courseID)
 #. ($rename_oldCourseID)
@@ -3386,22 +3634,22 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
 msgid "Log into %1"
-msgstr ""
+msgstr "Log into %1"
 
 #. (HTML::Entities::encode_entities($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Logged in as %1."
-msgstr ""
+msgstr "Logged in as %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "Login"
-msgstr ""
+msgstr "Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
 msgid "Login Info"
-msgstr ""
+msgstr "Login Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -3419,140 +3667,143 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
-msgstr ""
+msgstr "Login Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
 msgid "Login Status"
-msgstr ""
+msgstr "Login Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
 msgid "Logout"
-msgstr ""
+msgstr "Logout"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
 msgid "Main Menu"
-msgstr ""
+msgstr "Main Menu"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:859
 msgid "Make"
-msgstr ""
+msgstr "Make"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:162
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:354
 msgid "Make Archive"
-msgstr ""
+msgstr "Make Archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Make changes"
-msgstr ""
+msgstr "Make changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
 msgid "Make these changes in  course:"
-msgstr ""
+msgstr "Make these changes in  course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Manage Locations"
-msgstr ""
+msgstr "Manage Locations"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
-msgstr ""
+msgstr "Manual Grader"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
 msgid "Mark All"
-msgstr ""
+msgstr "Mark All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Mark Correct"
-msgstr ""
+msgstr "Mark Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
 msgid "Mark Correct?"
-msgstr ""
+msgstr "Mark Correct?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
 msgid "Match on what? (separate multiple IDs with commas)"
-msgstr ""
+msgstr "Match on what? (separate multiple IDs with commas)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
 msgid "Math Objects"
-msgstr ""
+msgstr "Math Objects"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
 msgid "Max attempts"
-msgstr ""
+msgstr "Max attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
 msgid "Max. Shown:"
-msgstr ""
+msgstr "Max. Shown:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
+"Maximum times Show me Another can be used per problem (-1 => unlimited)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Merge file:"
-msgstr ""
+msgstr "Merge file:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Message"
-msgstr ""
+msgstr "Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
 msgid "Message file:"
-msgstr ""
+msgstr "Message file:"
 
 #. ($emailDirectory, $output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
 msgid "Message saved to file <code>%1/%2</code>."
-msgstr ""
+msgstr "Message saved to file <code>%1/%2</code>."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
 msgid "Message:"
-msgstr ""
+msgstr "Message:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
 msgid "Messages"
-msgstr ""
+msgstr "Messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid "Method"
-msgstr ""
+msgstr "Method"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
+"Missing required input data. Please check that you have filled in all of the "
+"create location fields and resubmit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
 msgid "Move"
-msgstr ""
+msgstr "Move"
 
+# Msg is short for message
 #. ($recipient, $ur->email_address)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
 msgid "Msg sent to %1 at %2."
-msgstr ""
+msgstr "Msg sent to %1 at %2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
-#, fuzzy
 msgid "My Problems"
-msgstr "Problem List"
+msgstr "My Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
 msgid "Mysterious Package (with Ribbons)"
-msgstr ""
+msgstr "Mysterious Package (with Ribbons)"
 
+# Short for Number of Fields
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
 msgid "NO OF FIELDS"
-msgstr ""
+msgstr "NO OF FIELDS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
@@ -3564,81 +3815,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
 msgid "Name for new set here"
-msgstr ""
+msgstr "Name for new set here"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
 msgid "Name of course information file"
-msgstr ""
+msgstr "Name of course information file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
-msgstr ""
+msgstr "Name the new set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1552
 msgid "Necromancers Charm"
-msgstr ""
+msgstr "Necromancers Charm"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
 msgid "Never"
-msgstr ""
+msgstr "Never"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
 msgid "New File"
-msgstr ""
+msgstr "New File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New Folder"
-msgstr ""
+msgstr "New Folder"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
 msgid "New Name:"
-msgstr ""
+msgstr "New Name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
 msgid "New Password"
-msgstr ""
+msgstr "New Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
 msgid "New file name:"
-msgstr ""
+msgstr "New file name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New folder name:"
-msgstr ""
+msgstr "New folder name:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
 msgid "New passwords saved"
-msgstr ""
+msgstr "New passwords saved"
 
+# No space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "NewVersion"
-msgstr ""
+msgstr "NewVersion"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1852
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
-msgstr ""
+msgstr "Newer problem set def files must be imported using Hmwk Sets Editor2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
 msgid "Next Problem"
-msgstr ""
+msgstr "Next Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
-msgstr ""
+msgstr "Next page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
@@ -3654,154 +3906,166 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
 msgid "No Description"
-msgstr ""
+msgstr "No Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
 msgid "No achievements shown.  Create an achievement!"
-msgstr ""
+msgstr "No achievements shown.  Create an achievement!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
 msgid "No action taken"
-msgstr ""
+msgstr "No action taken"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
 msgid ""
 "No authentication method found for your request.  If this recurs, please "
 "speak with your instructor."
 msgstr ""
+"No authentication method found for your request.  If this recurs, please "
+"speak with your instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
-msgstr ""
+msgstr "No change made to any set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
 msgstr ""
+"No changes specified.  You must mark the checkbox of the item(s) to be "
+"changed and enter the change data."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
 msgid "No changes were saved!"
-msgstr ""
+msgstr "No changes were saved!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
 msgid "No course id defined"
-msgstr ""
+msgstr "No course id defined"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
 msgid "No data exists for set %1 and problem %2"
-msgstr ""
+msgstr "No data exists for set %1 and problem %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
 msgid "No filename was specified for saving!  The message was not saved."
-msgstr ""
+msgstr "No filename was specified for saving!  The message was not saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
 msgid "No guest logins are available. Please try again in a few minutes."
-msgstr ""
+msgstr "No guest logins are available. Please try again in a few minutes."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
 msgid "No location specified to edit?! Please check your input data."
-msgstr ""
+msgstr "No location specified to edit?! Please check your input data."
 
 #. ($badID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
 msgid "No location with name %1 exists in the database"
-msgstr ""
+msgstr "No location with name %1 exists in the database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
 msgid "No merge data file"
-msgstr ""
+msgstr "No merge data file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
+"No new Achievement ID specified.  No new achievement created.  File not "
+"saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
 msgid "No problems matched the given parameters."
-msgstr ""
+msgstr "No problems matched the given parameters."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
 msgstr ""
+"No recipients selected. Please select one or more recipients from the list "
+"below."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
 msgid "No record for global set %1."
-msgstr ""
+msgstr "No record for global set %1."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
 msgid "No record for user %1."
-msgstr ""
+msgstr "No record for user %1."
 
 #. ($prob)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
 msgid "No record found for problem %1."
-msgstr ""
+msgstr "No record found for problem %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
 msgid "No record found."
-msgstr ""
+msgstr "No record found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:48
 msgid "No sets in this course yet"
-msgstr ""
+msgstr "No sets in this course yet"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
 msgid "No sets selected for scoring"
-msgstr ""
+msgstr "No sets selected for scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr ""
+"No sets shown.  Choose one of the options above to list the sets in the "
+"course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
 msgid "No source filePath specified"
-msgstr ""
+msgstr "No source filePath specified"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
 msgid "No source_file for problem in .def file"
-msgstr ""
+msgstr "No source_file for problem in .def file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
+"No students shown.  Choose one of the options above to list the students in "
+"the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
 msgid "No tests taken."
-msgstr ""
+msgstr "No tests taken."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:625
 msgid "No user specific data exists for user %1"
-msgstr ""
+msgstr "No user specific data exists for user %1"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
 msgid "No valid changes submitted for location %1."
-msgstr ""
+msgstr "No valid changes submitted for location %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
@@ -3809,7 +4073,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
 msgid "None"
-msgstr ""
+msgstr "None"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:120
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:130
@@ -3817,80 +4081,84 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:180
 msgid "None Specified"
-msgstr ""
+msgstr "None Specified"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
 msgid "None of the selected users are assigned to this set: %1"
-msgstr ""
+msgstr "None of the selected users are assigned to this set: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
 msgid "Not logged in."
-msgstr ""
+msgstr "Not logged in."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
 msgid "Note"
-msgstr ""
+msgstr "Note"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
+"Note: grading the test grades all problems, not just those on this page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
 msgid "Number"
-msgstr ""
+msgstr "Number"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
 msgid "Number of Graded Submissions per Test (0=infty)"
-msgstr ""
+msgstr "Number of Graded Submissions per Test (0=infty)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:287
 msgid "Number of Problems per Page (0=all)"
-msgstr ""
+msgstr "Number of Problems per Page (0=all)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:270
 msgid "Number of Tests per Time Interval (0=infty)"
-msgstr ""
+msgstr "Number of Tests per Time Interval (0=infty)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1340
 msgid "Oil of Cleansing"
-msgstr ""
+msgstr "Oil of Cleansing"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
 msgid "Old Classlist Editor"
-msgstr ""
+msgstr "Old Classlist Editor"
 
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
 msgid "Old Hmwk Sets Editor"
-msgstr ""
+msgstr "Old Hmwk Sets Editor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
 msgid "One Column"
-msgstr ""
+msgstr "One Column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:306
 msgid "Only after set answer date"
-msgstr ""
+msgstr "Only after set answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:296
 msgid ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
 msgstr ""
+"Only this permission level and higher get buttons for sending e-mail to the "
+"instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
 msgid "Open"
-msgstr ""
+msgstr "Open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
@@ -3900,182 +4168,194 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:803
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:826
 msgid "Open Date"
-msgstr ""
+msgstr "Open Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
 msgid "Open Problem Library"
-msgstr ""
+msgstr "Open Problem Library"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "Open in New Window"
-msgstr ""
+msgstr "Open in New Window"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
 msgid "Open in new window"
-msgstr ""
+msgstr "Open in new window"
 
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
 msgid "Open, closes %1."
-msgstr ""
+msgstr "Open, closes %1."
 
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
 msgid "Open, complete by %1."
-msgstr ""
+msgstr "Open, complete by %1."
 
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
 msgid "Open, reduced scoring starts on %1."
-msgstr ""
+msgstr "Open, reduced scoring starts on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
-msgstr ""
+msgstr "Open:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
 msgid "Opens"
-msgstr ""
+msgstr "Opens"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
-msgstr ""
+msgstr "Opens any homework set for 24 hours."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:195
 msgid "Optional Modules"
-msgstr ""
+msgstr "Optional Modules"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
 msgid "Order Problems Randomly"
-msgstr ""
+msgstr "Order Problems Randomly"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 msgid "Orig. Lib. Browser"
-msgstr ""
+msgstr "Orig. Lib. Browser"
 
+# Context is "7 Out Of 10"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
-msgstr ""
+msgstr "Out Of"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
 msgid "Over time, closed."
-msgstr ""
+msgstr "Over time, closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Overwrite"
-msgstr ""
+msgstr "Overwrite"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:382
 msgid "Overwrite existing files silently"
-msgstr ""
+msgstr "Overwrite existing files silently"
 
+# PG is a WeBWorK abreviation and should stay PG
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
 msgid "PG - Problem Display/Answer Checking"
-msgstr ""
+msgstr "PG - Problem Display/Answer Checking"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
 msgid "PG debug messages"
-msgstr ""
+msgstr "PG debug messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "PG internal errors"
-msgstr ""
+msgstr "PG internal errors"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
 msgid "PG question failed to render"
-msgstr ""
+msgstr "PG question failed to render"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
 msgid "PG question processing error messages"
-msgstr ""
+msgstr "PG question processing error messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG warning messages"
-msgstr ""
+msgstr "PG warning messages"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
 msgid "PGInfo"
-msgstr ""
+msgstr "PGInfo"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
 msgid "PGLab"
-msgstr ""
+msgstr "PGLab"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
 msgid "PGML"
-msgstr ""
+msgstr "PGML"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
 msgid "POD"
-msgstr ""
+msgstr "POD"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
-msgstr ""
+msgstr "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 
+# Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
 msgid "PROB NUMBER"
-msgstr ""
+msgstr "PROB NUMBER"
 
+# Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
 msgid "PROB VALUE"
-msgstr ""
+msgstr "PROB VALUE"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
 msgid "Pad Fields"
-msgstr ""
+msgstr "Pad Fields"
 
 #. (timestamp($self)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
 msgid "Page generated at %1"
-msgstr ""
+msgstr "Page generated at %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
 msgid "Password"
-msgstr ""
+msgstr "Password"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:921
 msgid "Password (Leave blank for regular proctoring)"
-msgstr ""
+msgstr "Password (Leave blank for regular proctoring)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
 msgid "Password:"
-msgstr ""
+msgstr "Password:"
 
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr ""
+msgstr "Past Answers for %1, set %2, problem %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
 msgid "Percent"
-msgstr ""
+msgstr "Percent"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:574
 msgid "Percentage of Active Students with Correct Answers"
-msgstr ""
+msgstr "Percentage of Active Students with Correct Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:570
 msgid ""
 "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
 "median number of attempts"
 msgstr ""
+"Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
+"median number of attempts"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
+"Percentile cutoffs for number of attempts. The 50% column shows the median "
+"number of attempts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
@@ -4090,11 +4370,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 msgid "Permission Level"
-msgstr ""
+msgstr "Permission Level"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
 msgid "Permissions"
-msgstr ""
+msgstr "Permissions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
 msgid ""
@@ -4102,134 +4382,148 @@ msgid ""
 "will not show up in the courses list on the WeBWorK home page. It will still "
 "appear in the Course Administration listing."
 msgstr ""
+"Place a file named \"hide_directory\" in a course or other directory and it "
+"will not show up in the courses list on the WeBWorK home page. It will still "
+"appear in the Course Administration listing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1016
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given full credit."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"be given full credit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:811
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given half credit."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"be given half credit."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:587
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its incorrect attempt count reset."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"have its incorrect attempt count reset."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:698
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its weight doubled."
 msgstr ""
+"Please choose the set name and problem number of the question which should "
+"have its weight doubled."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1214
 msgid ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 msgstr ""
+"Please choose the set, the problem you would like to copy, and the problem "
+"you would like to copy it to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
 msgid "Please correct the following errors and try again:"
-msgstr ""
+msgstr "Please correct the following errors and try again:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:706
 msgid "Please enter in a value to match in the filter field."
-msgstr ""
+msgstr "Please enter in a value to match in the filter field."
 
 #. (CGI::b($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
 msgid "Please enter your username and password for %1 below:"
-msgstr ""
+msgstr "Please enter your username and password for %1 below:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
 msgid "Please provide a location name to delete."
-msgstr ""
+msgstr "Please provide a location name to delete."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
 msgid "Please select action to be performed."
-msgstr ""
+msgstr "Please select action to be performed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
 msgid "Please select at least one set and try again."
-msgstr ""
+msgstr "Please select at least one set and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
 msgid "Please select at least one user and try again."
-msgstr ""
+msgstr "Please select at least one user and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
-msgstr ""
+msgstr "Please specify a file to save to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
 msgid "Potion of Forgetfullness"
-msgstr ""
+msgstr "Potion of Forgetfullness"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
-msgstr ""
+msgstr "Preflight Log"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
 msgid "Preview Message"
-msgstr ""
+msgstr "Preview Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
 msgid "Preview My Answers"
-msgstr ""
+msgstr "Preview My Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
 msgid "Preview Test"
-msgstr ""
+msgstr "Preview Test"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
 msgid "Preview message"
-msgstr ""
+msgstr "Preview message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
 msgid "Preview set to:"
-msgstr ""
+msgstr "Preview set to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
 msgid "Previous Problem"
-msgstr ""
+msgstr "Previous Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
-msgstr ""
+msgstr "Previous page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "Primary sort"
-msgstr ""
+msgstr "Primary sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
 msgid "Print Test"
-msgstr ""
+msgstr "Print Test"
 
+# Short for Problem
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "Prob"
-msgstr ""
+msgstr "Prob"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
 msgid "Problem"
-msgstr ""
+msgstr "Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
 msgid "Problem #"
-msgstr ""
+msgstr "Problem #"
 
 #. ($prettyProblemID)
 #. (join('.',@seq)
@@ -4253,62 +4547,50 @@ msgstr "Problem %1"
 msgid "Problem %1."
 msgstr "Problem %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
-#, fuzzy
 msgid "Problem Editor"
-msgstr "Problem List"
+msgstr "Problem Editor"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
-#, fuzzy
 msgid "Problem Editor2"
-msgstr "Problem List"
+msgstr "Problem Editor2"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
-#, fuzzy
 msgid "Problem Editor3"
-msgstr "Problem List"
+msgstr "Problem Editor3"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
-#, fuzzy
 msgid "Problem List"
 msgstr "Problem List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
 msgid "Problem Number"
-msgstr ""
+msgstr "Problem Number"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
-#, fuzzy
 msgid "Problem Number "
-msgstr "Problem List"
+msgstr "Problem Number "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
-#, fuzzy
 msgid "Problem Techniques"
-msgstr "Problem List"
+msgstr "Problem Techniques"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
-#, fuzzy
 msgid "Problem Viewer"
-msgstr "Problem List"
+msgstr "Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
 msgid "Problem source is drawn from a grouping set"
-msgstr ""
+msgstr "Problem source is drawn from a grouping set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
@@ -4319,43 +4601,43 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
 msgid "Problems"
-msgstr ""
+msgstr "Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:62
 msgid "Problems for all students have been unassigned."
-msgstr ""
+msgstr "Problems for all students have been unassigned."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:65
 msgid "Problems for selected students have been reassigned."
-msgstr ""
+msgstr "Problems for selected students have been reassigned."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:57
 msgid "Problems have been assigned to all current users."
-msgstr ""
+msgstr "Problems have been assigned to all current users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Proctor"
-msgstr ""
+msgstr "Proctor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:203
 msgid "Proctor authorization required."
-msgstr ""
+msgstr "Proctor authorization required."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
 msgid "Proctor password:"
-msgstr ""
+msgstr "Proctor password:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
 msgid "Proctor username:"
-msgstr ""
+msgstr "Proctor username:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:259
 msgid "Proctored Gateway Quiz %2"
-msgstr ""
+msgstr "Proctored Gateway Quiz %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:268
 msgid "Proctored Gateway Quiz %2 Proctor Login"
-msgstr ""
+msgstr "Proctored Gateway Quiz %2 Proctor Login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:841
@@ -4364,23 +4646,26 @@ msgid ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 msgstr ""
+"Proctored tests require proctor authorization to start and to grade.  "
+"Provide a password to have a single password for all students to start a "
+"proctored test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
 msgid "Publish"
-msgstr ""
+msgstr "Publish"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "RECITATION"
-msgstr ""
+msgstr "RECITATION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
 msgid "Read only"
-msgstr ""
+msgstr "Read only"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:735
 msgid "Really delete the items listed above?"
-msgstr ""
+msgstr "Really delete the items listed above?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
@@ -4402,56 +4687,57 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Recitation"
-msgstr ""
+msgstr "Recitation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
 msgid "Record Scores for Single Sets"
-msgstr ""
+msgstr "Record Scores for Single Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:477
 msgid "Reduced Scoring"
-msgstr ""
+msgstr "Reduced Scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
 msgid "Reduced Scoring Date"
-msgstr ""
+msgstr "Reduced Scoring Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
 msgid "Reduced Scoring Disabled"
-msgstr ""
+msgstr "Reduced Scoring Disabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
 msgid "Reduced Scoring Enabled"
-msgstr ""
+msgstr "Reduced Scoring Enabled"
 
 #. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
 msgid "Reduced Scoring Starts %1"
-msgstr ""
+msgstr "Reduced Scoring Starts %1"
 
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
 msgid "Reduced scoring started on %1."
-msgstr ""
+msgstr "Reduced scoring started on %1."
 
+# Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
-msgstr ""
+msgstr "Reduced:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:358
 msgid "Refresh"
-msgstr ""
+msgstr "Refresh"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2031
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2156
 msgid "Refresh Display"
-msgstr ""
+msgstr "Refresh Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
@@ -4460,23 +4746,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
 msgid "Refresh Listing"
-msgstr ""
+msgstr "Refresh Listing"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
 msgid "Relax IP restrictions when?"
-msgstr ""
+msgstr "Relax IP restrictions when?"
 
+# Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 msgid "Remaining"
-msgstr ""
+msgstr "Remaining"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
 msgid "Remember Me"
-msgstr ""
+msgstr "Remember Me"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:480
 msgid "Remember to return to your original problem when you're finished here!"
-msgstr ""
+msgstr "Remember to return to your original problem when you're finished here!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
@@ -4485,38 +4772,38 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Rename"
-msgstr ""
+msgstr "Rename"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
 msgid "Rename %1 to %2"
-msgstr ""
+msgstr "Rename %1 to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
 msgid "Rename Course"
-msgstr ""
+msgstr "Rename Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
 msgid "Rename file as:"
-msgstr ""
+msgstr "Rename file as:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render"
-msgstr ""
+msgstr "Render"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
 msgid "Render All"
-msgstr ""
+msgstr "Render All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render Problem"
-msgstr ""
+msgstr "Render Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
 msgid "Renumber Problems"
-msgstr ""
+msgstr "Renumber Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
@@ -4524,68 +4811,71 @@ msgid ""
 "a test even if the close date has past. This item does not allow you to take "
 "additional versions of the test."
 msgstr ""
+"Reopens any gateway test for an additional 24 hours. This allows you to take "
+"a test even if the close date has past. This item does not allow you to take "
+"additional versions of the test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2326
 msgid "Reorder problems only"
-msgstr ""
+msgstr "Reorder problems only"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
-msgstr ""
+msgstr "Replace current problem: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
 msgid "Replace which users?"
-msgstr ""
+msgstr "Replace which users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
 msgid "Reply-To:"
-msgstr ""
+msgstr "Reply-To:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
 msgid "Report Bugs in this Problem"
-msgstr ""
+msgstr "Report Bugs in this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
 msgid "Report bugs"
-msgstr ""
+msgstr "Report bugs"
 
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid "Report for course %1:"
-msgstr ""
+msgstr "Report for course %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
 msgid "Report on database structure for course %1:"
-msgstr ""
+msgstr "Report on database structure for course %1:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
 msgid "Request New Version"
-msgstr ""
+msgstr "Request New Version"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
 msgid "Request information"
-msgstr ""
+msgstr "Request information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
 msgid "Request new version now."
-msgstr ""
+msgstr "Request new version now."
 
 #. ($setName,$effectiveUserName)
 #. ($setName, $effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr ""
+msgstr "Requested set '%1' could not be found in the database for user %2."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -4594,6 +4884,9 @@ msgid ""
 "generator %2 was called.  Try re-entering the set from the problem sets "
 "listing page."
 msgstr ""
+"Requested set '%1' is a homework assignment but the gateway/quiz content "
+"generator %2 was called.  Try re-entering the set from the problem sets "
+"listing page."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
@@ -4601,6 +4894,8 @@ msgid ""
 "Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
 "authorization has been obtained."
 msgstr ""
+"Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
+"authorization has been obtained."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
@@ -4609,48 +4904,51 @@ msgid ""
 "assignment content generator %2 was called.  Try re-entering the set from "
 "the problem sets listing page."
 msgstr ""
+"Requested set '%1' is a test/quiz assignment but the regular homework "
+"assignment content generator %2 was called.  Try re-entering the set from "
+"the problem sets listing page."
 
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr ""
+msgstr "Requested set '%1' is not assigned to user %2."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
 msgid "Requested set '%1' is not available yet."
-msgstr ""
+msgstr "Requested set '%1' is not available yet."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
 msgid "Requested set '%1' is not yet open."
-msgstr ""
+msgstr "Requested set '%1' is not yet open."
 
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr ""
+msgstr "Requested version (%1) of set '%2' is not assigned to user %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
-msgstr ""
+msgstr "Rerandomize after"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:734
 msgid "Reset"
-msgstr ""
+msgstr "Reset"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Reset Form"
-msgstr ""
+msgstr "Reset Form"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:538
 msgid "Resets the number of incorrect attempts on a single homework problem."
-msgstr ""
+msgstr "Resets the number of incorrect attempts on a single homework problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
 msgid "Ressurect which Gateway?"
-msgstr ""
+msgstr "Ressurect which Gateway?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
 msgid ""
@@ -4659,95 +4957,99 @@ msgid ""
 "directory. Currently the archive facility is only available for mysql "
 "databases. It depends on the mysqldump application."
 msgstr ""
+"Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
+"the course database is restored from a subdirectory of the course's DATA "
+"directory. Currently the archive facility is only available for mysql "
+"databases. It depends on the mysqldump application."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:202
 msgid "Restrict Access by IP"
-msgstr ""
+msgstr "Restrict Access by IP"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
 msgid "Restrict Locations"
-msgstr ""
+msgstr "Restrict Locations"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
 msgid "Restrict Problem Progression"
-msgstr ""
+msgstr "Restrict Problem Progression"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
 msgid "Restrict To"
-msgstr ""
+msgstr "Restrict To"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
 msgid "Restrict release by set(s)"
-msgstr ""
+msgstr "Restrict release by set(s)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Result"
-msgstr ""
+msgstr "Result"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
 msgid "Result of last action performed"
-msgstr ""
+msgstr "Result of last action performed"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
 msgid "Result of last action performed: %1"
-msgstr ""
+msgstr "Result of last action performed: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
 msgid "Results for this submission"
-msgstr ""
+msgstr "Results for this submission"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
 msgid "Results of last action performed"
-msgstr ""
+msgstr "Results of last action performed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
 msgid "Results of last action performed: "
-msgstr ""
+msgstr "Results of last action performed: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
 msgid "Retitled"
-msgstr ""
+msgstr "Retitled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "Revert"
-msgstr ""
+msgstr "Revert"
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
-msgstr ""
+msgstr "Revert to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
 msgid "Ring of Reduction"
-msgstr ""
+msgstr "Ring of Reduction"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:272
 msgid "Robe of Longevity"
-msgstr ""
+msgstr "Robe of Longevity"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "SECTION"
-msgstr ""
+msgstr "SECTION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
 msgid "SET NAME"
-msgstr ""
+msgstr "SET NAME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
 msgid "STATUS"
-msgstr ""
+msgstr "STATUS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "STUDENT ID"
-msgstr ""
+msgstr "STUDENT ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
@@ -4757,19 +5059,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
-msgstr ""
+msgstr "Save"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
 msgid "Save %1"
-msgstr ""
+msgstr "Save %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
-msgstr ""
+msgstr "Save As"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
@@ -4777,15 +5079,15 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
 msgid "Save Changes"
-msgstr ""
+msgstr "Save Changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
 msgid "Save as"
-msgstr ""
+msgstr "Save as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
 msgid "Save as Default"
-msgstr ""
+msgstr "Save as Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
@@ -4797,38 +5099,38 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
 msgid "Save changes"
-msgstr ""
+msgstr "Save changes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
 msgid "Save file to:"
-msgstr ""
+msgstr "Save file to:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
 msgid "Save to %1 and View"
-msgstr ""
+msgstr "Save to %1 and View"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
 msgid "Saved to file '%1'"
-msgstr ""
+msgstr "Saved to file '%1'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Schema and database field definitions do not agree"
-msgstr ""
+msgstr "Schema and database field definitions do not agree"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
 msgid "Schema and database table definitions do not agree"
-msgstr ""
+msgstr "Schema and database table definitions do not agree"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
@@ -4838,43 +5140,43 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
 msgid "Score"
-msgstr ""
+msgstr "Score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 msgid "Score (%)"
-msgstr ""
+msgstr "Score (%)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
 msgid "Score required for release"
-msgstr ""
+msgstr "Score required for release"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
 msgid "Score selected set(s) and save to:"
-msgstr ""
+msgstr "Score selected set(s) and save to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
 msgid "Score summary for last submit:"
-msgstr ""
+msgstr "Score summary for last submit:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
 msgid "Score which sets?"
-msgstr ""
+msgstr "Score which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
 msgid "Scores"
-msgstr ""
+msgstr "Scores"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
 msgid "Scoring Download"
-msgstr ""
+msgstr "Scoring Download"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
 msgid "Scoring Message"
-msgstr ""
+msgstr "Scoring Message"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
 msgid "Scoring Tools"
-msgstr ""
+msgstr "Scoring Tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
@@ -4882,14 +5184,16 @@ msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
+"Screen and Hardcopy set header information can not be overridden for "
+"individual students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
 msgid "Scroll of Ressurection"
-msgstr ""
+msgstr "Scroll of Ressurection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
-msgstr ""
+msgstr "Secondary sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
@@ -4914,35 +5218,35 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
-msgstr ""
+msgstr "Section"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
 msgid "Section:"
-msgstr ""
+msgstr "Section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
 msgid "Seed"
-msgstr ""
+msgstr "Seed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
-msgstr ""
+msgstr "Select a Problem Collection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
-msgstr ""
+msgstr "Select a Set from this Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
 msgid "Select a course to delete."
-msgstr ""
+msgstr "Select a course to delete."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
 msgid ""
@@ -4950,66 +5254,71 @@ msgid ""
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
+"Select a course to rename.  The courseID is used in the url and can only "
+"contain alphanumeric characters and underscores. The course title appears on "
+"the course home page and can be any string."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
 msgid "Select a course to unarchive."
-msgstr ""
+msgstr "Select a course to unarchive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
 msgid "Select a database layout below."
-msgstr ""
+msgstr "Select a database layout below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "Select a listing format:"
-msgstr ""
+msgstr "Select a listing format:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
 msgid "Select above then:"
-msgstr ""
+msgstr "Select above then:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
 msgid "Select all eligible courses"
-msgstr ""
+msgstr "Select all eligible courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
 msgid "Select all sets"
-msgstr ""
+msgstr "Select all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
 msgid "Select all users"
-msgstr ""
+msgstr "Select all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
 msgid "Select an action to perform"
-msgstr ""
+msgstr "Select an action to perform"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
 msgid "Select an action to perform:"
-msgstr ""
+msgstr "Select an action to perform:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
 msgid "Select course(s) to archive."
-msgstr ""
+msgstr "Select course(s) to archive."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
 msgid "Select course(s) to hide or unhide."
-msgstr ""
+msgstr "Select course(s) to hide or unhide."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
 msgid ""
 "Select one or more sets and one or more users below to assign/unassign each "
 "selected set to/from all selected users."
 msgstr ""
+"Select one or more sets and one or more users below to assign/unassign each "
+"selected set to/from all selected users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
 msgid "Select sets below to assign them to the newly-created users."
-msgstr ""
+msgstr "Select sets below to assign them to the newly-created users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
 msgid ""
@@ -5021,6 +5330,13 @@ msgid ""
 "opening page.  To access the course, an instructor or student must know the "
 "full URL address for the course."
 msgstr ""
+"Select the course(s) you want to hide (or unhide) and then click \"Hide "
+"Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
+"does no harm (the action is skipped). Likewise unhiding a course that is "
+"already visible does no harm (the action is skipped).  Hidden courses are "
+"still active but are not listed in the list of WeBWorK courses on the "
+"opening page.  To access the course, an instructor or student must know the "
+"full URL address for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:489
 msgid ""
@@ -5028,74 +5344,79 @@ msgid ""
 "also select multiple users from the users list. You will receive hardcopy "
 "for each (set, user) pair."
 msgstr ""
+"Select the homework sets for which to generate hardcopy versions. You may "
+"also select multiple users from the users list. You will receive hardcopy "
+"for each (set, user) pair."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
 msgid ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
 msgstr ""
+"Select user(s) and/or set(s) below and click the action button of your "
+"choice."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "Selected students"
-msgstr ""
+msgstr "Selected students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
 msgid "Send E-mail"
-msgstr ""
+msgstr "Send E-mail"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Send Email"
-msgstr ""
+msgstr "Send Email"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
 msgid "Send to:"
-msgstr ""
+msgstr "Send to:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
 msgid "Set"
-msgstr ""
+msgstr "Set"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
 msgid "Set %1 exists.  No set created"
-msgstr ""
+msgstr "Set %1 exists.  No set created"
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
 msgid "Set %1 has been created."
-msgstr ""
+msgstr "Set %1 has been created."
 
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
 msgid "Set %1 was assigned to %2"
-msgstr ""
+msgstr "Set %1 was assigned to %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
 msgid "Set Assigner"
-msgstr ""
+msgstr "Set Assigner"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
 msgid "Set Definition Filename"
-msgstr ""
+msgstr "Set Definition Filename"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
 msgid "Set Definition Files"
-msgstr ""
+msgstr "Set Definition Files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
 msgid "Set Description"
-msgstr ""
+msgstr "Set Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
-msgstr ""
+msgstr "Set Detail 2 for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:423
 msgid "Set Detail for set %2"
-msgstr ""
+msgstr "Set Detail for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
@@ -5106,20 +5427,20 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
 msgid "Set Header"
-msgstr ""
+msgstr "Set Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
 msgid "Set ID"
-msgstr ""
+msgstr "Set ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 msgid "Set Info"
-msgstr ""
+msgstr "Set Info"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
 msgid "Set List"
-msgstr ""
+msgstr "Set List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
@@ -5127,7 +5448,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:802
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:825
 msgid "Set Name"
-msgstr ""
+msgstr "Set Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
@@ -5142,23 +5463,26 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
 msgid "Set Name "
-msgstr ""
+msgstr "Set Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
 msgid "Set headers are not used in display of gateway tests."
-msgstr ""
+msgstr "Set headers are not used in display of gateway tests."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
 "Set to true for log to mean base 10 log and false for log to mean natural "
 "logarithm"
 msgstr ""
+"Set to true for log to mean base 10 log and false for log to mean natural "
+"logarithm"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:355
 msgid ""
 "Set to true to display MathView equation editor icon next to each answer box"
 msgstr ""
+"Set to true to display MathView equation editor icon next to each answer box"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:360
 msgid ""
@@ -5168,139 +5492,144 @@ msgid ""
 "see their evaluated answer by hovering the mouse pointer over the typeset "
 "version of their answer."
 msgstr ""
+"Set to true to display the \"Entered\" column which automatically shows the "
+"evaluated student answer, e.g. 1 if student input is sin(pi/2). If this is "
+"set to false, e.g. to save space in the response area, the student can still "
+"see their evaluated answer by hovering the mouse pointer over the typeset "
+"version of their answer."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
 msgid "Sets"
-msgstr ""
+msgstr "Sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
 msgid "Sets Assigned to User"
-msgstr ""
+msgstr "Sets Assigned to User"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
 msgid "Sets assigned to %1"
-msgstr ""
+msgstr "Sets assigned to %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 msgid "Setting"
-msgstr ""
+msgstr "Setting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
 msgid "Shift dates so that the earliest is"
-msgstr ""
+msgstr "Shift dates so that the earliest is"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
 msgid "Show"
-msgstr ""
+msgstr "Show"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
 msgid "Show Auxiliary Resources"
-msgstr ""
+msgstr "Show Auxiliary Resources"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:323
 msgid "Show Date & Size"
-msgstr ""
+msgstr "Show Date & Size"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
 msgid "Show Hints"
-msgstr ""
+msgstr "Show Hints"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
 msgid "Show Me Another"
-msgstr ""
+msgstr "Show Me Another"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
 msgid "Show Past Answers"
-msgstr ""
+msgstr "Show Past Answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:302
 msgid "Show Problems on Finished Tests"
-msgstr ""
+msgstr "Show Problems on Finished Tests"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:295
 msgid "Show Scores on Finished Assignments?"
-msgstr ""
+msgstr "Show Scores on Finished Assignments?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
 msgid "Show Solutions"
-msgstr ""
+msgstr "Show Solutions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:166
 msgid "Show Total Homework Grade on Grades Page"
-msgstr ""
+msgstr "Show Total Homework Grade on Grades Page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
 msgid "Show Which Users?"
-msgstr ""
+msgstr "Show Which Users?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
 msgid "Show all paths"
-msgstr ""
+msgstr "Show all paths"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
 msgid "Show correct answers"
-msgstr ""
+msgstr "Show correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Show me another"
-msgstr ""
+msgstr "Show me another"
 
 #. ($exhausted)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
 msgid "Show me another %1"
-msgstr ""
+msgstr "Show me another %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
 msgid "Show path ..."
-msgstr ""
+msgstr "Show path ..."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
 msgid "Show saved answers?"
-msgstr ""
+msgstr "Show saved answers?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
 msgid "Show which sets?"
-msgstr ""
+msgstr "Show which sets?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
 msgid "Show/Hide Site Description"
-msgstr ""
+msgstr "Show/Hide Site Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
 msgid "Show:"
-msgstr ""
+msgstr "Show:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "Showing"
-msgstr ""
+msgstr "Showing"
 
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
 msgid "Showing %1 out of %2 sets."
-msgstr ""
+msgstr "Showing %1 out of %2 sets."
 
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
 msgid "Showing %1 out of %2 users"
-msgstr ""
+msgstr "Showing %1 out of %2 users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:391
 msgid "Simple"
-msgstr ""
+msgstr "Simple"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
@@ -5308,26 +5637,26 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:68
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:71
 msgid "Site Information"
-msgstr ""
+msgstr "Site Information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid "Skip archiving this course"
-msgstr ""
+msgstr "Skip archiving this course"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
 msgid "Solution:"
-msgstr ""
+msgstr "Solution:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
 msgid "Solutions"
-msgstr ""
+msgstr "Solutions"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
 msgid "Some answers will be graded later."
-msgstr ""
+msgstr "Some answers will be graded later."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:733
 msgid ""
@@ -5335,6 +5664,9 @@ msgid ""
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
 msgstr ""
+"Some of these files are directories. Only delete directories if you really "
+"know what you are doing. You can seriously damage your course if you delete "
+"the wrong thing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -5345,37 +5677,45 @@ msgid ""
 "\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
 "List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 msgstr ""
+"Some servers handle courses taking place in different timezones.  If this "
+"course is not showing the correct timezone, enter the correct value here.  "
+"The format consists of unix times, such as \"America/New_York\",\"America/"
+"Chicago\", \"America/Denver\", \"America/Phoenix\" or \"America/Los_Angeles"
+"\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
+"List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:484
 msgid ""
 "Something was wrong with your LTI parameters.  If this recurs, please speak "
 "with your instructor"
 msgstr ""
+"Something was wrong with your LTI parameters.  If this recurs, please speak "
+"with your instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
 msgid "Sort"
-msgstr ""
+msgstr "Sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
 msgid "Sort by"
-msgstr ""
+msgstr "Sort by"
 
 #. ($names{$primary}, $names{$secondary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
 msgid "Sort by %1 and then by %2"
-msgstr ""
+msgstr "Sort by %1 and then by %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
 msgid "Sort:"
-msgstr ""
+msgstr "Sort:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
 msgid "Source File"
-msgstr ""
+msgstr "Source File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1439
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1465
@@ -5387,16 +5727,20 @@ msgid ""
 "Source file paths cannot include .. or start with /: your source file path "
 "was modified."
 msgstr ""
+"Source file paths cannot include .. or start with /: your source file path "
+"was modified."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
 msgstr ""
+"Specify an ID, title, and institution for the new course. The course ID may "
+"contain only letters, numbers, hyphens, and underscores."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:392
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -5405,21 +5749,21 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:704
 msgid "Statistics"
-msgstr ""
+msgstr "Statistics"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
 msgid "Statistics for"
-msgstr ""
+msgstr "Statistics for"
 
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr ""
+msgstr "Statistics for %1 set %2. Closes %3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
 msgid "Statistics for %1 student %2"
-msgstr ""
+msgstr "Statistics for %1 student %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
@@ -5433,19 +5777,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Stop Acting"
-msgstr ""
+msgstr "Stop Acting"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
 msgid "Stop Archiving"
-msgstr ""
+msgstr "Stop Archiving"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
 msgid "Stop archiving courses"
-msgstr ""
+msgstr "Stop archiving courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
@@ -5462,125 +5806,125 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 msgid "Student ID"
-msgstr ""
+msgstr "Student ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Student Name"
-msgstr ""
+msgstr "Student Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:767
 msgid "Student Progress"
-msgstr ""
+msgstr "Student Progress"
 
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr ""
+msgstr "Student Progress for %1 set %2. Closes %3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
 msgid "Student Progress for %1 student %2"
-msgstr ""
+msgstr "Student Progress for %1 student %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
 msgid "Student answers"
-msgstr ""
+msgstr "Student answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
-msgstr ""
+msgstr "Subject:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
 msgid "Subject: "
-msgstr ""
+msgstr "Subject: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
 msgid "Submission time:"
-msgstr ""
+msgstr "Submission time:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
 msgid "Submit"
-msgstr ""
+msgstr "Submit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
 msgid "Submit Answers"
-msgstr ""
+msgstr "Submit Answers"
 
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
 msgid "Submit Answers for %1"
-msgstr ""
+msgstr "Submit Answers for %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
-msgstr ""
+msgstr "Success"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
-msgstr ""
+msgstr "Success Index"
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
 msgid "Successfully archived the course %1."
-msgstr ""
+msgstr "Successfully archived the course %1."
 
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
 msgid "Successfully created new achievement %1"
-msgstr ""
+msgstr "Successfully created new achievement %1"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
 msgid "Successfully created new set %1"
-msgstr ""
+msgstr "Successfully created new set %1"
 
 #. ($add_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
 msgid "Successfully created the course %1"
-msgstr ""
+msgstr "Successfully created the course %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
 msgid "Successfully deleted the course %1."
-msgstr ""
+msgstr "Successfully deleted the course %1."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
 msgid "Successfully renamed the course %1 to %2"
-msgstr ""
+msgstr "Successfully renamed the course %1 to %2"
 
 #. ($unarchive_courseID, $new_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
 msgid "Successfully unarchived %1 to the course %2"
-msgstr ""
+msgstr "Successfully unarchived %1 to the course %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
 msgid "Table defined in database but missing in schema"
-msgstr ""
+msgstr "Table defined in database but missing in schema"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
 msgid "Table defined in schema but missing in database"
-msgstr ""
+msgstr "Table defined in schema but missing in database"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
 msgid "Table is ok"
-msgstr ""
+msgstr "Table is ok"
 
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
@@ -5588,13 +5932,13 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
 msgid "Take %1 test"
-msgstr ""
+msgstr "Take %1 test"
 
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
 msgid "Take %1 test."
-msgstr ""
+msgstr "Take %1 test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
@@ -5607,48 +5951,48 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
 msgid "Take Action!"
-msgstr ""
+msgstr "Take Action!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
 msgid "Target Set:"
-msgstr ""
+msgstr "Target Set:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
-msgstr ""
+msgstr "Test Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
 msgid "Test Score"
-msgstr ""
+msgstr "Test Score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
 msgid "Test Time"
-msgstr ""
+msgstr "Test Time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
 msgid "Test Time Limit (min; 0=Close Date)"
-msgstr ""
+msgstr "Test Time Limit (min; 0=Close Date)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:752
 msgid "Text chapter:"
-msgstr ""
+msgstr "Text chapter:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
 msgid "Text section:"
-msgstr ""
+msgstr "Text section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
 msgid "Textbook:"
-msgstr ""
+msgstr "Textbook:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1000
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:433
 msgid "That symbolic link takes you outside your course directory"
-msgstr ""
+msgstr "That symbolic link takes you outside your course directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:258
 msgid ""
@@ -5656,6 +6000,9 @@ msgid ""
 "student. If set to -1 then there is no limit to the number of times that "
 "Show Me Another can be used."
 msgstr ""
+"The Maximum number of times Show me Another can be used per problem by a "
+"student. If set to -1 then there is no limit to the number of times that "
+"Show Me Another can be used."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:248
 msgid ""
@@ -5669,10 +6016,19 @@ msgid ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
+"The Reduced Scoring Period is the default period before the due date during "
+"which all additional work done by the student counts at a reduced rate. When "
+"enabling reduced scoring for a set the reduced scoring date will be set to "
+"the due date minus this number. The reduced scoring date can then be "
+"changed. If the Reduced Scoring is enabled and if it is after the reduced "
+"scoring date, but before the due date, a message like \"This assignment has "
+"a Reduced Scoring Period that begins 11/08/2009 at 06:17pm EST and ends on "
+"the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
+"work done counts 50% of the original.\" will be displayed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
 msgid "The WeBWorK Project"
-msgstr ""
+msgstr "The WeBWorK Project"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
@@ -5680,6 +6036,9 @@ msgid ""
 "the weighted average of the status of those problems which count towards the "
 "parent grade."
 msgstr ""
+"The adjusted status of a problem is the larger of the problem's status and "
+"the weighted average of the status of those problems which count towards the "
+"parent grade."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:190
 msgid ""
@@ -5687,6 +6046,9 @@ msgid ""
 "available to student to view.  You can change this for individual homework, "
 "but WeBWorK will use this value when a set is created."
 msgstr ""
+"The amount of time (in minutes) after the due date that the Answers are "
+"available to student to view.  You can change this for individual homework, "
+"but WeBWorK will use this value when a set is created."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
 msgid ""
@@ -5694,18 +6056,21 @@ msgid ""
 "opened.  You can change this for individual homework, but WeBWorK will use "
 "this value when a set is created. "
 msgstr ""
+"The amount of time (in minutes) before the due date when the assignment is "
+"opened.  You can change this for individual homework, but WeBWorK will use "
+"this value when a set is created. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
 msgid "The answer above is NOT correct."
-msgstr ""
+msgstr "The answer above is NOT correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
 msgid "The answer above is correct."
-msgstr ""
+msgstr "The answer above is correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
 msgid "The answer will be graded later."
-msgstr ""
+msgstr "The answer will be graded later."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
 msgid ""
@@ -5715,12 +6080,19 @@ msgid ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 msgstr ""
+"The child problems for this problem will become visible to the student when "
+"they either have more incorrect attempts than is specified here, or when "
+"they run out of attempts, whichever comes first.  If \"max\" is specified "
+"here then child problems will only be available after a student runs out of "
+"attempts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
+"The configuration module did not find the data it needs to function.  Have "
+"your site administrator check that Constants.pm is up to date."
 
 #. ($archive_courseID, $archive_path)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
@@ -5728,30 +6100,36 @@ msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
 msgstr ""
+"The course '%1' has already been archived at '%2'. This earlier archive will "
+"be erased.  This cannot be undone."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
 msgid "The default display mode"
-msgstr ""
+msgstr "The default display mode"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
 msgid ""
 "The default number of attempts before the problem is re-randomized. ( 0 => "
 "never )"
 msgstr ""
+"The default number of attempts before the problem is re-randomized. ( 0 => "
+"never )"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:275
 msgid ""
 "The default number of attempts between re-randomization of the problems ( 0 "
 "=> never)"
 msgstr ""
+"The default number of attempts between re-randomization of the problems ( 0 "
+"=> never)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:249
 msgid "The directory you specified doesn't exist"
-msgstr ""
+msgstr "The directory you specified doesn't exist"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1361
 msgid "The display was already cleared."
-msgstr ""
+msgstr "The display was already cleared."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:390
 msgid ""
@@ -5761,11 +6139,16 @@ msgid ""
 "as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
+"The e-mail verbosity level controls how much information is automatically "
+"added to feedback e-mails.  Levels are<ol><li value=\"Simple\"> Simple: send "
+"only the feedback comment and context link<li value=\"Standard\"> Standard: "
+"as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
+"Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 
 #. ($achievementName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
 msgid "The evaluator for %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The evaluator for %1 has been renamed to '%2'."
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
@@ -5773,68 +6156,70 @@ msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
+"The file %1/%2 already exists and cannot be overwritten. The message was not "
+"saved"
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
 msgid "The file %1/%2 cannot be found."
-msgstr ""
+msgstr "The file %1/%2 cannot be found."
 
 #. ($emailDirectory,$openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
 msgid "The file %1/%2 is not readable by the webserver."
-msgstr ""
+msgstr "The file %1/%2 is not readable by the webserver."
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
 msgid "The file '%1' cannot be found."
-msgstr ""
+msgstr "The file '%1' cannot be found."
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
 msgid "The file '%1' cannot be read!"
-msgstr ""
+msgstr "The file '%1' cannot be read!"
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
 msgid "The file '%1' is a blank problem!"
-msgstr ""
+msgstr "The file '%1' is a blank problem!"
 
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
 msgid "The file '%1' is a directory!"
-msgstr ""
+msgstr "The file '%1' is a directory!"
 
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
 msgid "The file '%1' is protected!"
-msgstr ""
+msgstr "The file '%1' is protected!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
 msgid "The file does not appear to be a text file"
-msgstr ""
+msgstr "The file does not appear to be a text file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:94
 msgid "The file you are trying to download doesn't exist"
-msgstr ""
+msgstr "The file you are trying to download doesn't exist"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
 msgid "The following courses were successfully hidden: %1"
-msgstr ""
+msgstr "The following courses were successfully hidden: %1"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
 msgid "The following courses were successfully unhidden: %1"
-msgstr ""
+msgstr "The following courses were successfully unhidden: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
 msgid "The following upgrades are available for your WeBWorK system:"
-msgstr ""
+msgstr "The following upgrades are available for your WeBWorK system:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
@@ -5842,6 +6227,7 @@ msgstr ""
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
+"The following users are NOT assigned to this set and will be ignored: %1"
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
@@ -5849,6 +6235,8 @@ msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the score of problem %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
@@ -5856,23 +6244,26 @@ msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the weighted average of the problems: %1."
 
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The hardcopy header for set %1 has been renamed to '%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
+"The institution associated with the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
 msgid "The institution associated with the course %1 is now %2"
-msgstr ""
+msgstr "The institution associated with the course %1 is now %2"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
@@ -5880,17 +6271,21 @@ msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
+"The instructor account with user id %1 does not exist.  Please create the "
+"account manually via WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
+"The library index is older than the library, you need to run OPL-update."
 
 #. ($r->param('new_set_name')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
 msgid ""
 "The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
 msgstr ""
+"The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
 msgid ""
@@ -5898,6 +6293,9 @@ msgid ""
 "Its contents are displayed in the right panel next to the list of homework "
 "sets."
 msgstr ""
+"The name of course information file (located in the templates directory). "
+"Its contents are displayed in the right panel next to the list of homework "
+"sets."
 
 #. ($openDate, $dueDate, $answerDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
@@ -5905,10 +6303,12 @@ msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
+"The open date: %1, close date: %2, and answer date: %3 must be defined and "
+"in chronological order."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
 msgid "The password and password confirmation for the instructor must match."
-msgstr ""
+msgstr "The password and password confirmation for the instructor must match."
 
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
@@ -5916,6 +6316,8 @@ msgid ""
 "The password you entered in the %1 field does not match your current "
 "password. Please retype your current password and try again."
 msgstr ""
+"The password you entered in the %1 field does not match your current "
+"password. Please retype your current password and try again."
 
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
@@ -5923,16 +6325,19 @@ msgid ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 msgstr ""
+"The passwords you entered in the %1 and %2 fields don't match. Please retype "
+"your new password and try again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
 msgid "The path to the original file should be absolute"
-msgstr ""
+msgstr "The path to the original file should be absolute"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:505
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
+"The percentage of active students with correct answers for each problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
@@ -5940,50 +6345,54 @@ msgid ""
 "The percentage of students receiving at least these scores. The median score "
 "is in the 50% column."
 msgstr ""
+"The percentage of students receiving at least these scores. The median score "
+"is in the 50% column."
 
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
 msgid "The recorded score for this test is  %1/%2."
-msgstr ""
+msgstr "The recorded score for this test is  %1/%2."
 
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
 msgid "The recorded score for this test is %1/%2."
-msgstr ""
+msgstr "The recorded score for this test is %1/%2."
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
+"The reduced credit date should be between the open date %1 and close date %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1069
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1142
 msgid ""
 "The reduced scoring date should be between the open date and close date."
 msgstr ""
+"The reduced scoring date should be between the open date and close date."
 
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid "The score for this problem can count towards score of problem %1."
-msgstr ""
+msgstr "The score for this problem can count towards score of problem %1."
 
 #. ($setName,$effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
 msgid "The selected problem set (%1) is not a valid set for %2"
-msgstr ""
+msgstr "The selected problem set (%1) is not a valid set for %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
 msgid "The set %1 is assigned to %2."
-msgstr ""
+msgstr "The set %1 is assigned to %2."
 
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr ""
+msgstr "The set header for set %1 has been renamed to '%2'."
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
@@ -5991,16 +6400,18 @@ msgid ""
 "The set name '%1' is already in use.  Pick a different name if you would "
 "like to start a new set."
 msgstr ""
+"The set name '%1' is already in use.  Pick a different name if you would "
+"like to start a new set."
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr ""
+msgstr "The set-version (%1, version %2) is not assigned to user %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
-msgstr ""
+msgstr "The solution has been removed."
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
@@ -6008,17 +6419,20 @@ msgstr ""
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
+"The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
-msgstr ""
+msgstr "The test (which is number %1) may  no longer be submitted for a grade."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
 "The time limit on this assignment was exceeded. The assignment may be "
 "checked, but the result will not be counted."
 msgstr ""
+"The time limit on this assignment was exceeded. The assignment may be "
+"checked, but the result will not be counted."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:178
 msgid ""
@@ -6026,22 +6440,25 @@ msgid ""
 "individual basis, but WeBWorK will use this value for default when a set is "
 "created."
 msgstr ""
+"The time of the day that the assignment is due.  This can be changed on an "
+"individual basis, but WeBWorK will use this value for default when a set is "
+"created."
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
 msgid "The title of the course %1 has been changed from %2 to %3"
-msgstr ""
+msgstr "The title of the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
 msgid "The title of the course %1 is now %2"
-msgstr ""
+msgstr "The title of the course %1 is now %2"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
 msgid "The user %1 has been assigned %2."
-msgstr ""
+msgstr "The user %1 has been assigned %2."
 
 #. ($enableReducedScoring)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
@@ -6049,6 +6466,8 @@ msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for enableReducedScoring is not valid; it will be replaced with "
+"'N'."
 
 #. ($timeCap)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
@@ -6056,6 +6475,8 @@ msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
+"The value %1 for the capTimeLimit option is not valid; it will be replaced "
+"with '0'."
 
 #. ($hideScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
@@ -6063,6 +6484,8 @@ msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for the hideScore option is not valid; it will be replaced with "
+"'N'."
 
 #. ($hideWork)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
@@ -6070,6 +6493,8 @@ msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
+"The value %1 for the hideWork option is not valid; it will be replaced with "
+"'N'."
 
 #. ($relaxRestrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
@@ -6077,6 +6502,8 @@ msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
+"The value %1 for the relaxRestrictIP option is not valid; it will be "
+"replaced with 'No'."
 
 #. ($restrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
@@ -6084,27 +6511,32 @@ msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
+"The value %1 for the restrictIP option is not valid; it will be replaced "
+"with 'No'."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
 msgstr ""
+"The webwork server must be able to write to these directories. Please "
+"correct the permssion errors."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:128
 msgid "Theme (refresh page after saving changes to reveal new theme.)"
-msgstr ""
+msgstr "Theme (refresh page after saving changes to reveal new theme.)"
 
+# Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
 msgid "Then by"
-msgstr ""
+msgstr "Then by"
 
 #. ($count_line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:578
 msgid "There are %1 matching WeBWorK problems"
-msgstr ""
+msgstr "There are %1 matching WeBWorK problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:154
 msgid ""
@@ -6112,12 +6544,17 @@ msgid ""
 "Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
 "Column theme uses the full page width for each column"
 msgstr ""
+"There are currently two hardcopy themes to choose from: One Column and Two "
+"Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
+"Column theme uses the full page width for each column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
 msgid ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
+"There are currently two themes (or skins) to choose from: math3 and math4.  "
+"The theme specifies a unified look and feel for the WeBWorK course web pages."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
@@ -6127,6 +6564,8 @@ msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
+"There are extra database fields  which are not defined in the schema for at "
+"least one table.  They can only be removed manually from the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
@@ -6135,26 +6574,32 @@ msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
 msgstr ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database. They will not be renamed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:576
 msgid "There are no matching WeBWorK problems"
-msgstr ""
+msgstr "There are no matching WeBWorK problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
+"There are tables or fields missing from the database.  The database must be "
+"upgraded before archiving this course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
 msgid "There are upgrades available for the Open Problem Library."
-msgstr ""
+msgstr "There are upgrades available for the Open Problem Library."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
@@ -6162,6 +6607,8 @@ msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
+"There are upgrades available for your current branch of PG from branch %1 in "
+"remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
@@ -6169,6 +6616,8 @@ msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
+"There are upgrades available for your current branch of WeBWorK from branch "
+"%1 in remote %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
@@ -6177,6 +6626,10 @@ msgid ""
 "their name, you destroy all of the data for achievement $achievementID for "
 "this student."
 msgstr ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for achievement $achievementID for "
+"this student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6185,28 +6638,32 @@ msgid ""
 "their name, you destroy all of the data for homework set $setID for this "
 "student."
 msgstr ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for homework set $setID for this "
+"student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:276
 msgid "There is NO undo for unassigning a set."
-msgstr ""
+msgstr "There is NO undo for unassigning a set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:127
 msgid "There is NO undo for unassigning students."
-msgstr ""
+msgstr "There is NO undo for unassigning students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
 msgid "There is a new version of PG available."
-msgstr ""
+msgstr "There is a new version of PG available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
 msgid "There is a new version of WeBWorK available."
-msgstr ""
+msgstr "There is a new version of WeBWorK available."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:472
 msgid "There is a written solution available"
-msgstr ""
+msgstr "There is a written solution available"
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
@@ -6216,38 +6673,50 @@ msgid ""
 "files can be edited using the \"Email\" link and the \"File Manager\" link "
 "in the left margin."
 msgstr ""
+"There is no additional grade information.  A message about additional grades "
+"can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. These "
+"files can be edited using the \"Email\" link and the \"File Manager\" link "
+"in the left margin."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
 msgstr ""
+"There is no library tree file for the library, you will need to run OPL-"
+"update."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:734
 msgid "There is no undo for deleting files or directories!"
-msgstr ""
+msgstr "There is no undo for deleting files or directories!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:474
 msgid ""
 "There is no written solution available for this problem, but you can still "
 "view the correct answers"
 msgstr ""
+"There is no written solution available for this problem, but you can still "
+"view the correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:476
 msgid "There is no written solution available for this problem."
-msgstr ""
+msgstr "There is no written solution available for this problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
+"There may be something wrong with this question. Please inform your "
+"instructor including the warning messages below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator if this recurs."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
@@ -6260,50 +6729,56 @@ msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
 msgstr ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:316
 msgid ""
 "These users and higher get the \"Show Past Answers\" button on the problem "
 "page."
 msgstr ""
+"These users and higher get the \"Show Past Answers\" button on the problem "
+"page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "This action can take a long time if there are many students."
-msgstr ""
+msgstr "This action can take a long time if there are many students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 msgid "This action will not overwrite existing users."
-msgstr ""
+msgstr "This action will not overwrite existing users."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
 msgid "This answer is NOT completely correct."
-msgstr ""
+msgstr "This answer is NOT completely correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
 msgid "This answer is NOT correct."
-msgstr ""
+msgstr "This answer is NOT correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
 msgid "This answer is correct."
-msgstr ""
+msgstr "This answer is correct."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
 msgid ""
 "This course supports guest logins. Click %1 to log into this course as a "
 "guest."
 msgstr ""
+"This course supports guest logins. Click %1 to log into this course as a "
+"guest."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
 msgid "This homework set contains no problems."
-msgstr ""
+msgstr "This homework set contains no problems."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
 msgid "This homework set is closed."
-msgstr ""
+msgstr "This homework set is closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
 msgid "This homework set is not yet open."
-msgstr ""
+msgstr "This homework set is not yet open."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
@@ -6312,6 +6787,9 @@ msgid ""
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
+"This is a blank problem template file and can not be edited directly. Use "
+"the 'NewVersion' action below to create a local copy of the file and add it "
+"to the current problem set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6325,6 +6803,15 @@ msgid ""
 "in the edit assigned users field contains links which take you to a page "
 "where you can edit what students the set is assigned to."
 msgstr ""
+"This is a table showing the current Homework sets for this class.  The "
+"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
+"Users, Visibility to students, Reduced Credit Enabled, Date it was opened, "
+"Date it is due, and the Date during which the answers are posted.  The Edit "
+"Set Data field contains checkboxes for selection and a link to the set data "
+"editing page.  The cells in the Edit Problems fields contain links which "
+"take you to a page where you can edit the containing problems, and the cells "
+"in the edit assigned users field contains links which take you to a page "
+"where you can edit what students the set is assigned to."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:93
 msgid ""
@@ -6335,6 +6822,12 @@ msgid ""
 "are earned.  The \"level\" category is used for the achievements associated "
 "to a users level."
 msgstr ""
+"This is the Achievement Editor.  It is used to edit the achievements "
+"available to students.  Please keep in mind the following facts: Achievments "
+"are displayed, and evaluated, in the order they are listed. The \"secret\" "
+"category creates achievements which are not visible to students until they "
+"are earned.  The \"level\" category is used for the achievements associated "
+"to a users level."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:91
 msgid ""
@@ -6348,6 +6841,15 @@ msgid ""
 "\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
 "page contains a table containing the student usernames and their information."
 msgstr ""
+"This is the classlist editor page, where you can view and edit the records "
+"of all the students currently enrolled in this course.  The top of the page "
+"contains forms which allow you to filter which students to view, sort your "
+"students in a chosen order, edit student records, give new passwords to "
+"students, import/export student records from/to external files, or add/"
+"delete students.  To use, please select the action you would like to "
+"perform, enter in the relevant information in the fields below, and hit the "
+"\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
+"page contains a table containing the student usernames and their information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:90
 msgid ""
@@ -6362,16 +6864,28 @@ msgid ""
 "of the page contains a table displaying the sets and several pieces of "
 "relevant information."
 msgstr ""
+"This is the homework sets editor page where you can view and edit the "
+"homework sets that exist in this course and the problems that they contain. "
+"The top of the page contains forms which allow you to filter which sets to "
+"display in the table, sort the sets in a chosen order, edit homework sets, "
+"publish homework sets, import/export sets from/to an external file, score "
+"sets, or create/delete sets.  To use, please select the action you would "
+"like to perform, enter in the relevant information in the fields below, and "
+"hit the \\\"Take Action!\\\" button at the bottom of the form.  The bottom "
+"of the page contains a table displaying the sets and several pieces of "
+"relevant information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:203
 msgid ""
 "This is the number of achievement points given to each user for completing a "
 "problem."
 msgstr ""
+"This is the number of achievement points given to each user for completing a "
+"problem."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
 msgid "This problem contains a video which must be viewed online."
-msgstr ""
+msgstr "This problem contains a video which must be viewed online."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
@@ -6379,22 +6893,24 @@ msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
+"This problem has open subproblems.  You can visit them by using the links to "
+"the left or visiting the set page."
 
 #. ($shownYet{$problemFile})
 #. ($prettyID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
 msgid "This problem uses the same source file as number %1."
-msgstr ""
+msgstr "This problem uses the same source file as number %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 msgid "This problem will not count towards your grade."
-msgstr ""
+msgstr "This problem will not count towards your grade."
 
 #. ($EMAIL)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
 msgid "This sample mail would be sent to %1"
-msgstr ""
+msgstr "This sample mail would be sent to %1"
 
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
@@ -6402,6 +6918,8 @@ msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
 msgstr ""
+"This score for this problem does not count for the score of problem %1 or "
+"for the set."
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -6410,17 +6928,20 @@ msgid ""
 "the file [Scoring]/%2. These files can be edited using the \"Email\" link "
 "and the \"File Manager\" link in the left margin."
 msgstr ""
+"This scoring message is generated from [TMPL]/email/%1. It is merged with "
+"the file [Scoring]/%2. These files can be edited using the \"Email\" link "
+"and the \"File Manager\" link in the left margin."
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
 msgid "This set %1 is assigned to %2."
-msgstr ""
+msgstr "This set %1 is assigned to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
 msgid "This set doesn't contain any problems yet."
-msgstr ""
+msgstr "This set doesn't contain any problems yet."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
@@ -6428,18 +6949,23 @@ msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
 msgstr ""
+"This set had a reduced scoring period that started on %1 and ended on %2.  "
+"During that period all work counted for %3% of its value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:271
 msgid ""
 "This set has a set-level proctor password to authorize logins. Enter the "
 "password below."
 msgstr ""
+"This set has a set-level proctor password to authorize logins. Enter the "
+"password below."
 
+# Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
-msgstr ""
+msgstr "This set is %1"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
@@ -6447,10 +6973,12 @@ msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
 msgstr ""
+"This set is in its reduced scoring period.  All work counts for %1% of its "
+"value."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:178
 msgid "This set needs to be assigned to you before you can grade it."
-msgstr ""
+msgstr "This set needs to be assigned to you before you can grade it."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:182
 msgid ""
@@ -6459,6 +6987,10 @@ msgid ""
 "comma separated list.  The minimum score required on the sets is specified "
 "in the following field."
 msgstr ""
+"This set will be unavailable to students until they have earned a certain "
+"score on the sets specified in this field.  The sets should be written as a "
+"comma separated list.  The minimum score required on the sets is specified "
+"in the following field."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:218
 msgid ""
@@ -6471,26 +7003,34 @@ msgid ""
 "std_problem_grader (the all or nothing grader).  It will work with custom "
 "graders if they are written appropriately."
 msgstr ""
+"This sets whether the Reduced Scoring system will be enabled.  If enabled "
+"you will need to set the default length of the reduced scoring period and "
+"the value of work done in the reduced scoring period below.  <p> To use "
+"this, you also have to enable Reduced Scoring for individual assignments and "
+"set their Reduced Scoring Dates by editing the set data.<p> This works with "
+"the avg_problem_grader (which is the the default grader) and the  "
+"std_problem_grader (the all or nothing grader).  It will work with custom "
+"graders if they are written appropriately."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
 msgid "This source file does not exist!"
-msgstr ""
+msgstr "This source file does not exist!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
 msgid "This source file is a directory!"
-msgstr ""
+msgstr "This source file is a directory!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
 msgid "This source file is not a plain file!"
-msgstr ""
+msgstr "This source file is not a plain file!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
 msgid "This source file is not readable!"
-msgstr ""
+msgstr "This source file is not readable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:382
 msgid ""
@@ -6499,6 +7039,10 @@ msgid ""
 "value of -1 uses the default from course configuration. The value of 0 "
 "disables rerandomization."
 msgstr ""
+"This specifies the rerandomization period: the number of attempts before a "
+"new version of the problem is generated by changing the Seed value. The "
+"value of -1 uses the default from course configuration. The value of 0 "
+"disables rerandomization."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:257
 msgid ""
@@ -6511,6 +7055,14 @@ msgid ""
 "Hardcopy for Selected Sets' button at the end of the table.  There is also a "
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
+"This table lists out the available homework sets for this class, along with "
+"its current status. Click on the link on the name of the homework sets to "
+"take you to the problems in that homework set.  Clicking on the links in the "
+"table headings will sort the table by the field it corresponds to.  You can "
+"also select sets for download to PDF or TeX format using the linkx next to "
+"the problem set names, and then clicking on the 'Download PDF or TeX "
+"Hardcopy for Selected Sets' button at the end of the table.  There is also a "
+"clear button and an Email instructor button at the end of the table."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
 msgid ""
@@ -6520,39 +7072,45 @@ msgid ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 msgstr ""
+"This table shows the problems that are in this problem set.  The columns "
+"from left to right are: name of the problem, current number of attempts "
+"made, number of attempts remaining, the point worth, and the completion "
+"status.  Click on the link on the name of the problem to take you to the "
+"problem page."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "Time"
-msgstr ""
+msgstr "Time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
 msgid "Time Interval for New Test Versions (min; 0=infty)"
-msgstr ""
+msgstr "Time Interval for New Test Versions (min; 0=infty)"
 
 #. ($elapsedTime,$allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "Time taken on test: %1 min (%2 min allowed)."
-msgstr ""
+msgstr "Time taken on test: %1 min (%2 min allowed)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:221
 msgid "Timestamp"
-msgstr ""
+msgstr "Timestamp"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:146
 msgid "Timezone for the course"
-msgstr ""
+msgstr "Timezone for the course"
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
 msgid "To access this set you must score at least %1% on set %2."
-msgstr ""
+msgstr "To access this set you must score at least %1% on set %2."
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
+"To access this set you must score at least %1% on the following sets: %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
 msgid ""
@@ -6560,23 +7118,31 @@ msgid ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
+"To add an additional instructor to the new course, specify user information "
+"below. The user ID may contain only numbers, letters, hyphens, periods "
+"(dots), commas,and underscores.\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
 msgstr ""
+"To add the WeBWorK administrators to the new course (as administrators) "
+"check the box below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:278
 msgid ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 msgstr ""
+"To change status (scores or grades) for this student for one set, click on "
+"the individual set link."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
+"To copy problem templates from an existing course, select the course below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
@@ -6584,6 +7150,8 @@ msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
+"To edit a specific student version of this set, edit (all of) her/his "
+"assigned sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
@@ -6591,6 +7159,8 @@ msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
+"To edit this text you must first make a copy of this file using the "
+"'NewVersion' action below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
@@ -6598,126 +7168,128 @@ msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
 msgstr ""
+"To edit this text you must use the 'NewVersion' action below to save it to "
+"another file."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
-#, fuzzy
 msgid "To this Problem"
-msgstr "Problem List"
+msgstr "To this Problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
 msgid "To:"
-msgstr ""
+msgstr "To:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
 msgid "Totals"
-msgstr ""
+msgstr "Totals"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only (not problem scores)"
-msgstr ""
+msgstr "Totals only (not problem scores)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only, only after answer date"
-msgstr ""
+msgstr "Totals only, only after answer date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
 msgid "Transfer"
-msgstr ""
+msgstr "Transfer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
 msgid "True"
-msgstr ""
+msgstr "True"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2266
 msgid "Try it"
-msgstr ""
+msgstr "Try it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:189
 msgid "Tunic of Extension"
-msgstr ""
+msgstr "Tunic of Extension"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:105
 msgid "Two Columns"
-msgstr ""
+msgstr "Two Columns"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 #. ($achievementName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr ""
+msgstr "Unable to change the evaluator for set %1. Unknown error."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
 msgid "Unable to obtain error messages from within the PG question."
-msgstr ""
+msgstr "Unable to obtain error messages from within the PG question."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
 msgid "Unable to write to '%1': %2"
-msgstr ""
+msgstr "Unable to write to '%1': %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
 msgid "Unarchive"
-msgstr ""
+msgstr "Unarchive"
 
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
 msgid "Unarchive %1 to course:"
-msgstr ""
+msgstr "Unarchive %1 to course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Unarchive Course"
-msgstr ""
+msgstr "Unarchive Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
 msgid "Unarchive Next Course"
-msgstr ""
+msgstr "Unarchive Next Course"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
 msgid "Unassign from All Users"
-msgstr ""
+msgstr "Unassign from All Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
 msgid "Unassign selected sets from selected users"
-msgstr ""
+msgstr "Unassign selected sets from selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
 "Unassignments were not done.  You need to both click to \"Allow unassign\" "
 "and click on the Unassign button."
 msgstr ""
+"Unassignments were not done.  You need to both click to \"Allow unassign\" "
+"and click on the Unassign button."
 
 #. ($unattempted,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
 msgid "Unattempted: %1/%2"
-msgstr ""
+msgstr "Unattempted: %1/%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
 msgid "Unclassified Problems"
-msgstr ""
+msgstr "Unclassified Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
 msgid "Ungraded"
-msgstr ""
+msgstr "Ungraded"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
 msgid "Unhide Courses"
-msgstr ""
+msgstr "Unhide Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
 msgid ""
@@ -6725,126 +7297,131 @@ msgid ""
 "date of the Gateway Test this will allow you to generate a new version of "
 "the test."
 msgstr ""
+"Unlock an additional version of a Gateway Test.  If used before the close "
+"date of the Gateway Test this will allow you to generate a new version of "
+"the test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:163
 msgid "Unpack"
-msgstr ""
+msgstr "Unpack"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:385
 msgid "Unpack archives automatically"
-msgstr ""
+msgstr "Unpack archives automatically"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Unselect all courses"
-msgstr ""
+msgstr "Unselect all courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
 msgid "Unselect all sets"
-msgstr ""
+msgstr "Unselect all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
 msgid "Unselect all users"
-msgstr ""
+msgstr "Unselect all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Update"
-msgstr ""
+msgstr "Update"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:803
 msgid "Update Display"
-msgstr ""
+msgstr "Update Display"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:724
 msgid "Update Menus"
-msgstr ""
+msgstr "Update Menus"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "Update settings and refresh page"
-msgstr ""
+msgstr "Update settings and refresh page"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
 msgid "Update the checked directories?"
-msgstr ""
+msgstr "Update the checked directories?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
 msgid "Updated location description."
-msgstr ""
+msgstr "Updated location description."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
 msgid "Upgrade"
-msgstr ""
+msgstr "Upgrade"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Upgrade Course Tables"
-msgstr ""
+msgstr "Upgrade Course Tables"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Upgrade Courses"
-msgstr ""
+msgstr "Upgrade Courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
 msgid "Upgrade process completed"
-msgstr ""
+msgstr "Upgrade process completed"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:370
 msgid "Upload"
-msgstr ""
+msgstr "Upload"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:161
 msgid "Use Date Picker"
-msgstr ""
+msgstr "Use Date Picker"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
 msgid "Use Default Header File"
-msgstr ""
+msgstr "Use Default Header File"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
 msgid "Use Equation Editor?"
-msgstr ""
+msgstr "Use Equation Editor?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:239
 msgid "Use Item"
-msgstr ""
+msgstr "Use Item"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
 msgid "Use System Default"
-msgstr ""
+msgstr "Use System Default"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
 msgid "Use browser back button to return from preview mode"
-msgstr ""
+msgstr "Use browser back button to return from preview mode"
 
 #. (CGI::b("$achievementID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
 msgid "Use in achievement %1"
-msgstr ""
+msgstr "Use in achievement %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
 msgid "Use in new achievement:"
-msgstr ""
+msgstr "Use in new achievement:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
 msgid "Use log base 10 instead of base <i>e</i>"
-msgstr ""
+msgstr "Use log base 10 instead of base <i>e</i>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:370
 msgid "Use older answer checkers"
-msgstr ""
+msgstr "Use older answer checkers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
 msgid ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 msgstr ""
+"Use the interface below to quickly access commonly-used instructor tools, or "
+"select a tool from the list to the left."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
 msgid ""
@@ -6852,6 +7429,9 @@ msgid ""
 "or an error in a problem you are attempting. Along with your message, "
 "additional information about the state of the system will be included."
 msgstr ""
+"Use this form to report to your professor a problem with the WeBWorK system "
+"or an error in a problem you are attempting. Along with your message, "
+"additional information about the state of the system will be included."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
@@ -6859,28 +7439,30 @@ msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
+"User '%1' will not be copied from admin course as it is the initial "
+"instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
-msgstr ""
+msgstr "User ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
 msgid "User Settings"
-msgstr ""
+msgstr "User Settings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
 msgid "User Values"
-msgstr ""
+msgstr "User Values"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
 msgid "User's name is:"
-msgstr ""
+msgstr "User's name is:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
 msgid "User's username is:"
-msgstr ""
+msgstr "User's username is:"
 
 #. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
@@ -6890,30 +7472,32 @@ msgid ""
 "UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
 "database corruption."
 msgstr ""
+"UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
+"database corruption."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
 msgid "Username"
-msgstr ""
+msgstr "Username"
 
 #. ($user_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
 msgid "Username presented:  %1"
-msgstr ""
+msgstr "Username presented:  %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
-msgstr ""
+msgstr "Users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
 msgid "Users Assigned to Set %2"
-msgstr ""
+msgstr "Users Assigned to Set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "Users List"
-msgstr ""
+msgstr "Users List"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:311
 msgid ""
@@ -6921,23 +7505,30 @@ msgid ""
 "Normally guest users are not allowed to change the e-mail address since it "
 "does not make sense to send e-mail to anonymous accounts."
 msgstr ""
+"Users at this level and higher are allowed to change their e-mail address. "
+"Normally guest users are not allowed to change the e-mail address since it "
+"does not make sense to send e-mail to anonymous accounts."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:287
 msgid ""
 "Users at this level and higher are allowed to change their password. "
 "Normally guest users are not allowed to change their password."
 msgstr ""
+"Users at this level and higher are allowed to change their password. "
+"Normally guest users are not allowed to change their password."
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Users sorted by %1, then by %2, then by %3"
-msgstr ""
+msgstr "Users sorted by %1, then by %2, then by %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:306
 msgid ""
 "Users with at least this permission level get a link in the left panel for "
 "reporting bugs to the bug tracking system in Rochester"
 msgstr ""
+"Users with at least this permission level get a link in the left panel for "
+"reporting bugs to the bug tracking system in Rochester"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:405
 msgid ""
@@ -6947,33 +7538,38 @@ msgid ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 msgstr ""
+"Users with this permssion level or greater will automatically be sent "
+"feedback from students (generated when they use the \"Contact instructor\" "
+"button on any problem page).  In addition the feedback message will be sent "
+"to addresses listed below.  To send ONLY to addresses listed below set "
+"permission level to \"nobody\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Using contents of the default message $default_msg_file instead."
-msgstr ""
+msgstr "Using contents of the default message $default_msg_file instead."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
 msgid "Using what display mode?: "
-msgstr ""
+msgstr "Using what display mode?: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
 msgid "Using what seed?: "
-msgstr ""
+msgstr "Using what seed?: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:222
 msgid "Value of work done in Reduced Scoring Period"
-msgstr ""
+msgstr "Value of work done in Reduced Scoring Period"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
 msgid "Variable Documentation:"
-msgstr ""
+msgstr "Variable Documentation:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
 msgid "Versions of a set can only be edited for one user at a time."
-msgstr ""
+msgstr "Versions of a set can only be edited for one user at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
@@ -6982,7 +7578,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "View"
-msgstr ""
+msgstr "View"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
@@ -6991,44 +7587,44 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
 msgid "View Problems"
-msgstr ""
+msgstr "View Problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
 msgid "View equations as"
-msgstr ""
+msgstr "View equations as"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
 msgid "View it"
-msgstr ""
+msgstr "View it"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
-msgstr ""
+msgstr "View statistics by set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
 msgid "View statistics by student"
-msgstr ""
+msgstr "View statistics by student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
-msgstr ""
+msgstr "View student progress by set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
-msgstr ""
+msgstr "View student progress by student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "View/Edit"
-msgstr ""
+msgstr "View/Edit"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
-msgstr ""
+msgstr "Viewing temporary file:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
@@ -7036,50 +7632,52 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:829
 msgid "Visibility"
-msgstr ""
+msgstr "Visibility"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
 msgid "Visible"
-msgstr ""
+msgstr "Visible"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
 msgid "Visible to Students"
-msgstr ""
+msgstr "Visible to Students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
-msgstr ""
+msgstr "Warning"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
 msgid "Warning messages"
-msgstr ""
+msgstr "Warning messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
-msgstr ""
+msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 
 #. ($problem_desc , CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1223
 msgid "Warnings encountered while processing %1. Error text: %2"
-msgstr ""
+msgstr "Warnings encountered while processing %1. Error text: %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
 msgid "WeBWorK Error"
-msgstr ""
+msgstr "WeBWorK Error"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
 msgid "WeBWorK Warnings"
-msgstr ""
+msgstr "WeBWorK Warnings"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
 msgid ""
 "WeBWorK currently has translations for four languages: \"English en\", "
 "\"Turkish tr\", \"Spanish es\", and \"French fr\" "
 msgstr ""
+"WeBWorK currently has translations for four languages: \"English en\", "
+"\"Turkish tr\", \"Spanish es\", and \"French fr\" "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:86
 msgid ""
@@ -7089,6 +7687,11 @@ msgid ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 msgstr ""
+"WeBWorK has encountered a software error while attempting to process this "
+"problem. It is likely that there is an error in the problem itself. If you "
+"are a student, report this error message to your professor to have it "
+"corrected. If you are a professor, please consult the error output below for "
+"more information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
 msgid ""
@@ -7099,34 +7702,44 @@ msgid ""
 "professor to have them corrected. If you are a professor, please consult the "
 "warning output below for more information."
 msgstr ""
+"WeBWorK has encountered warnings while processing your request. If this "
+"occured when viewing a problem, it was likely caused by an error or "
+"ambiguity in that problem. Otherwise, it may indicate a problem with the "
+"WeBWorK system itself. If you are a student, report these warnings to your "
+"professor to have them corrected. If you are a professor, please consult the "
+"warning output below for more information."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:491
 msgid ""
 "WeBWorK was unable to generate a different version of this problem; close "
 "this tab, and return to the original problem."
 msgstr ""
+"WeBWorK was unable to generate a different version of this problem; close "
+"this tab, and return to the original problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:309
 msgid ""
 "WeBWorK was unable to generate a paper copy of this homework set.  Please "
 "inform your instructor. "
 msgstr ""
+"WeBWorK was unable to generate a paper copy of this homework set.  Please "
+"inform your instructor. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:344
 msgid "Weight"
-msgstr ""
+msgstr "Weight"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
-msgstr ""
+msgstr "Welcome to WeBWorK!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1289
 msgid "What could be inside?"
-msgstr ""
+msgstr "What could be inside?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
 msgid "What field should filtered users match on?"
-msgstr ""
+msgstr "What field should filtered users match on?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:370
 msgid ""
@@ -7134,12 +7747,17 @@ msgid ""
 "view another version of this problem.  If set to -1 the feature is disabled "
 "and if set to -2 the course default is used."
 msgstr ""
+"When a student has more attempts than is specified here they will be able to "
+"view another version of this problem.  If set to -1 the feature is disabled "
+"and if set to -2 the course default is used."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:301
 msgid ""
 "When acting as a student, this permission level and higher can submit "
 "answers for that student."
 msgstr ""
+"When acting as a student, this permission level and higher can submit "
+"answers for that student."
 
 #. (CGI::em($r->maketext("before")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2307
@@ -7147,6 +7765,8 @@ msgid ""
 "When changing problem numbers, we will move the problem to be %1 the chosen "
 "number."
 msgstr ""
+"When changing problem numbers, we will move the problem to be %1 the chosen "
+"number."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:384
 msgid ""
@@ -7157,6 +7777,12 @@ msgid ""
 "ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
 "percent sign</ul>"
 msgstr ""
+"When students click the <em>Email Instructor</em> button to send feedback, "
+"WeBWorK fills in the subject line.  Here you can set the subject line.  In "
+"it, you can have various bits of information filled in with the following "
+"escape sequences.<p><ul><li> %c = course ID<li> %u = user ID<li> %s = set "
+"ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
+"percent sign</ul>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:167
 msgid ""
@@ -7164,6 +7790,9 @@ msgid ""
 "total cumulative homework score.  This score includes all sets assigned to "
 "the student."
 msgstr ""
+"When this is on students will see a line on the Grades page which has their "
+"total cumulative homework score.  This score includes all sets assigned to "
+"the student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:333
 msgid ""
@@ -7171,6 +7800,9 @@ msgid ""
 "in the answer blank.  Below this level, old answers are never shown.  "
 "Typically, that is the desired behaviour for guest accounts."
 msgstr ""
+"When viewing a problem, WeBWorK usually puts the previously submitted answer "
+"in the answer blank.  Below this level, old answers are never shown.  "
+"Typically, that is the desired behaviour for guest accounts."
 
 #. (CGI::b($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:153
@@ -7179,6 +7811,9 @@ msgid ""
 "data for achievement %1 for this student. Make sure this is what you want to "
 "do."
 msgstr ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for achievement %1 for this student. Make sure this is what you want to "
+"do."
 
 #. (CGI::b($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:128
@@ -7188,6 +7823,10 @@ msgid ""
 "the set to these students and they will receive new versions of the "
 "problems. Make sure this is what you want to do before unchecking students."
 msgstr ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for homework set %1 for this student. You will then need to reassign "
+"the set to these students and they will receive new versions of the "
+"problems. Make sure this is what you want to do before unchecking students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:280
 msgid ""
@@ -7196,16 +7835,20 @@ msgid ""
 "student will receive a new version of each problem. Make sure this is what "
 "you want to do before unchecking sets."
 msgstr ""
+"When you uncheck a homework set (and save the changes), you destroy all of "
+"the data for that set for this student.   If you reassign the set, the "
+"student will receive a new version of each problem. Make sure this is what "
+"you want to do before unchecking sets."
 
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
 msgid "Will open on %1."
-msgstr ""
+msgstr "Will open on %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Worth"
-msgstr ""
+msgstr "Worth"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
@@ -7213,6 +7856,8 @@ msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
+"Write permissions have not been enabled for '%1'.  Changes must be saved to "
+"another file for viewing."
 
 #. ($self->shortPath($currentDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
@@ -7220,12 +7865,16 @@ msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
+"Write permissions have not been enabled in '%1'.  Changes must be saved to a "
+"different directory for viewing."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr ""
+"Write permissions have not been enabled in the templates directory.  No "
+"changes can be made."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
@@ -7240,7 +7889,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:455
 msgid ""
@@ -7248,6 +7897,9 @@ msgid ""
 "these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"You are currently checking answers to a different version of your problem - "
+"these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:460
 msgid ""
@@ -7255,62 +7907,67 @@ msgid ""
 "- these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"You are currently previewing answers to a different version of your problem "
+"- these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
 
 #. ($userSet->set_id, $r->connection->remote_ip)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:253
 msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 msgstr ""
+"You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
 msgid "You are not authorized to access the Instructor tools"
-msgstr ""
+msgstr "You are not authorized to access the Instructor tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
 msgid "You are not authorized to access the Instructor tools."
-msgstr ""
+msgstr "You are not authorized to access the Instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
 msgid "You are not authorized to access the instructor tools."
-msgstr ""
+msgstr "You are not authorized to access the instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
 msgid "You are not authorized to modify homework sets."
-msgstr ""
+msgstr "You are not authorized to modify homework sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
 msgid "You are not authorized to modify problems."
-msgstr ""
+msgstr "You are not authorized to modify problems."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
 msgid "You are not authorized to modify set definition files."
-msgstr ""
+msgstr "You are not authorized to modify set definition files."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
 msgid "You are not authorized to modify student data"
-msgstr ""
+msgstr "You are not authorized to modify student data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
 msgid "You are not authorized to perform this action."
-msgstr ""
+msgstr "You are not authorized to perform this action."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:246
 msgid ""
 "You are not permitted to generate a hardcopy for a set with hidden work."
 msgstr ""
+"You are not permitted to generate a hardcopy for a set with hidden work."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:234
 msgid "You are not permitted to generate a hardcopy for an unopened set."
-msgstr ""
+msgstr "You are not permitted to generate a hardcopy for an unopened set."
 
 #. ($showMeAnother{MaxReps},$solutionShown)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:484
@@ -7318,39 +7975,41 @@ msgid ""
 "You are only allowed to click on Show Me Another %quant(%1,time,times) per "
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
+"You are only allowed to click on Show Me Another %quant(%1,time,times) per "
+"problem. %2 Close this tab, and return to the original problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
 msgid "You are out of time.  Press grade now!"
-msgstr ""
+msgstr "You are out of time.  Press grade now!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:316
 msgid "You can also examine the following temporary files: "
-msgstr ""
+msgstr "You can also examine the following temporary files: "
 
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
-msgstr ""
+msgstr "You can earn partial credit on this problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
-msgstr ""
+msgstr "You can not specify an absolute path"
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
 msgid "You can only %1 one file at a time."
-msgstr ""
+msgstr "You can only %1 one file at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:98
 msgid "You can only download regular files."
-msgstr ""
+msgstr "You can only download regular files."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:508
 msgid "You can only edit text files"
-msgstr ""
+msgstr "You can only edit text files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:786
 msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
-msgstr ""
+msgstr "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
@@ -7358,93 +8017,97 @@ msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
 msgstr ""
+"You can use this feature %quant(%1,more time,more times,as many times as you "
+"want) on this problem"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:866
 msgid "You can't download directories"
-msgstr ""
+msgstr "You can't download directories"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:867
 msgid "You can't download files of that type"
-msgstr ""
+msgstr "You can't download files of that type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
 msgid "You can't edit a directory"
-msgstr ""
+msgstr "You can't edit a directory"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
 msgid "You can't view files of that type"
-msgstr ""
+msgstr "You can't view files of that type"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
 msgid "You cannot archive the course you are currently using."
-msgstr ""
+msgstr "You cannot archive the course you are currently using."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
 msgid "You cannot delete the course you are currently using."
-msgstr ""
+msgstr "You cannot delete the course you are currently using."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
 msgid "You cannot delete yourself!"
-msgstr ""
+msgstr "You cannot delete yourself!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1842
 msgid ""
 "You cannot use this version of Set Detail to edit just-in-time type sets.  "
 "You must use Set Detail 2."
 msgstr ""
+"You cannot use this version of Set Detail to edit just-in-time type sets.  "
+"You must use Set Detail 2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
 msgid "You did not specify a new set name."
-msgstr ""
+msgstr "You did not specify a new set name."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
 msgid "You didn't enter any message."
-msgstr ""
+msgstr "You didn't enter any message."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
-msgstr ""
+msgstr "You do not have permission to change email addresses."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
 msgid "You do not have permission to change the hardcopy theme."
-msgstr ""
+msgstr "You do not have permission to change the hardcopy theme."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
-msgstr ""
+msgstr "You do not have permission to change your password."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
 msgid "You do not have permission to edit this file."
-msgstr ""
+msgstr "You do not have permission to edit this file."
 
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr ""
+msgstr "You do not have permission to generate hardcopy in %1 format."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "You do not have permission to view the details of this error."
-msgstr ""
+msgstr "You do not have permission to view the details of this error."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
-msgstr ""
+msgstr "You don't have any items!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
 msgid "You exceeded the allowed time."
-msgstr ""
+msgstr "You exceeded the allowed time."
 
 #. ($numLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
 msgid "You have %1 attempt(s) remaining on this test."
-msgstr ""
+msgstr "You have %1 attempt(s) remaining on this test."
 
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr ""
+msgstr "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 
 #. ($attempts_before_rr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
@@ -7452,41 +8115,45 @@ msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
+"You have %quant(%1,attempt,attempts) left before new version will be "
+"requested."
 
 #. ($attempts)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
 msgid "You have attempted this problem %quant(%1,time,times)."
-msgstr ""
+msgstr "You have attempted this problem %quant(%1,time,times)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
 msgid "You have been logged out of WeBWorK."
-msgstr ""
+msgstr "You have been logged out of WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
 msgid "You have less than 1 minute to complete this test."
-msgstr ""
+msgstr "You have less than 1 minute to complete this test."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:882
 msgid "You have not chosen a file to upload."
-msgstr ""
+msgstr "You have not chosen a file to upload."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "You have requested that the following items be deleted"
-msgstr ""
+msgstr "You have requested that the following items be deleted"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1005
 msgid "You have specified an illegal file"
-msgstr ""
+msgstr "You have specified an illegal file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1237
 msgid "You have specified an illegal path"
-msgstr ""
+msgstr "You have specified an illegal path"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:465
 msgid ""
 "You may check your answers to this problem without affecting the maximum "
 "number of tries to your original problem."
 msgstr ""
+"You may check your answers to this problem without affecting the maximum "
+"number of tries to your original problem."
 
 #. ($phrase_for_privileged_users)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:575
@@ -7495,14 +8162,17 @@ msgid ""
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 msgstr ""
+"You may choose to show any of the following data. Correct answers, hints, "
+"and solutions are only available %1 after the answer date of the homework "
+"set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
 msgid "You may not change your own password here!"
-msgstr ""
+msgstr "You may not change your own password here!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
 msgid "You may still check your answers."
-msgstr ""
+msgstr "You may still check your answers."
 
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
@@ -7510,6 +8180,8 @@ msgid ""
 "You must attempt this problem %quant(%1,time,times) before Show Me Another "
 "is available."
 msgstr ""
+"You must attempt this problem %quant(%1,time,times) before Show Me Another "
+"is available."
 
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
@@ -7517,10 +8189,12 @@ msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr ""
+"You must attempt this problem %quant(%1,time,times) before this feature is "
+"available"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
 msgid "You must confirm the password for the initial instructor."
-msgstr ""
+msgstr "You must confirm the password for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:541
@@ -7528,30 +8202,32 @@ msgid ""
 "You must log into this set via your Learning Management System (e.g. "
 "Blackboard, Moodle, etc...)."
 msgstr ""
+"You must log into this set via your Learning Management System (e.g. "
+"Blackboard, Moodle, etc...)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
 msgid "You must provide a student ID, a set ID, and a problem number."
-msgstr ""
+msgstr "You must provide a student ID, a set ID, and a problem number."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
 msgid "You must select a course to rename."
-msgstr ""
+msgstr "You must select a course to rename."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
 msgid "You must select at least one file for the archive"
-msgstr ""
+msgstr "You must select at least one file for the archive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
 msgid "You must select at least one file to delete"
-msgstr ""
+msgstr "You must select at least one file to delete"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
 msgid "You must select one or more sets for scoring"
-msgstr ""
+msgstr "You must select one or more sets for scoring"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
 msgid "You must specify a course ID."
-msgstr ""
+msgstr "You must specify a course ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
@@ -7560,49 +8236,49 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
 msgid "You must specify a course name."
-msgstr ""
+msgstr "You must specify a course name."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
 msgid "You must specify a file name"
-msgstr ""
+msgstr "You must specify a file name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
 msgid "You must specify a first name for the initial instructor."
-msgstr ""
+msgstr "You must specify a first name for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
 msgid "You must specify a last name for the initial instructor."
-msgstr ""
+msgstr "You must specify a last name for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
 msgid "You must specify a new institution for the course."
-msgstr ""
+msgstr "You must specify a new institution for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
 msgid "You must specify a new name for the course."
-msgstr ""
+msgstr "You must specify a new name for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
 msgid "You must specify a new title for the course."
-msgstr ""
+msgstr "You must specify a new title for the course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
 msgid "You must specify a password for the initial instructor."
-msgstr ""
+msgstr "You must specify a password for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
 msgid "You must specify a user ID."
-msgstr ""
+msgstr "You must specify a user ID."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
 msgid "You must specify an email address for the initial instructor."
-msgstr ""
+msgstr "You must specify an email address for the initial instructor."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
 msgid "You must specify an file name in order to save a new file."
-msgstr ""
+msgstr "You must specify an file name in order to save a new file."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:488
 msgid ""
@@ -7610,32 +8286,35 @@ msgid ""
 "Canvas, etc...) to access this set.  Try logging in to the Learning "
 "Managment System and visiting the set from there."
 msgstr ""
+"You must use your Learning Managment System (E.G. Blackboard, Moodle, "
+"Canvas, etc...) to access this set.  Try logging in to the Learning "
+"Managment System and visiting the set from there."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1260
 msgid "You need to select a \"Target Set\" before you can edit it."
-msgstr ""
+msgstr "You need to select a \"Target Set\" before you can edit it."
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
 msgid "You need to select a file to %1."
-msgstr ""
+msgstr "You need to select a file to %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
 msgid "You need to select a set definition file to view."
-msgstr ""
+msgstr "You need to select a set definition file to view."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
-msgstr ""
+msgstr "You need to select a set from this course to view."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1369
 msgid "You need to select a set to view."
-msgstr ""
+msgstr "You need to select a set to view."
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
 msgid "You received a score of %1 for this attempt."
-msgstr ""
+msgstr "You received a score of %1 for this attempt."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
@@ -7643,6 +8322,8 @@ msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem and its graded subproblems."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
@@ -7650,106 +8331,117 @@ msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
 msgstr ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem."
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1213
 msgid "Your %1 name contains illegal characters"
-msgstr ""
+msgstr "Your %1 name contains illegal characters"
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1214
 msgid "Your %1 name may not begin with a dot"
-msgstr ""
+msgstr "Your %1 name may not begin with a dot"
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1215
 msgid "Your %1 name may not contain a path component"
-msgstr ""
+msgstr "Your %1 name may not contain a path component"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:495
 msgid ""
 "Your LTI OAuth verification failed.  If this recurs, please speak with your "
 "instructor"
 msgstr ""
+"Your LTI OAuth verification failed.  If this recurs, please speak with your "
+"instructor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:483
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:494
 msgid "Your authentication failed.  Please return to Oncourse and login again."
 msgstr ""
+"Your authentication failed.  Please return to Oncourse and login again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:237
 msgid ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
 msgstr ""
+"Your authentication failed.  Please try again. Please speak with your "
+"instructor if you need help."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
 msgid "Your browser does not support the video tag."
-msgstr ""
+msgstr "Your browser does not support the video tag."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
-msgstr ""
+msgstr "Your current branch of PG is up to date with branch %1 in remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
+"Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
 msgid "Your current branch of the Open Problem Library is up to date."
-msgstr ""
+msgstr "Your current branch of the Open Problem Library is up to date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
 msgid "Your display options have been saved."
-msgstr ""
+msgstr "Your display options have been saved."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
 msgid "Your email address has been changed."
-msgstr ""
+msgstr "Your email address has been changed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1239
 msgid "Your file name contains illegal characters"
-msgstr ""
+msgstr "Your file name contains illegal characters"
 
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
 msgid "Your overall recorded score is %1.  %2"
-msgstr ""
+msgstr "Your overall recorded score is %1.  %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
 msgid "Your recorded score on this test (number %1) is %2/%3."
-msgstr ""
+msgstr "Your recorded score on this test (number %1) is %2/%3."
 
+# $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
 msgid "Your score on this %1 WAS recorded."
-msgstr ""
+msgstr "Your score on this %1 WAS recorded."
 
+# $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
 msgid "Your score on this %1 is %2/%3."
-msgstr ""
+msgstr "Your score on this %1 is %2/%3."
 
+# $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
 msgid "Your score on this %1 was NOT recorded."
-msgstr ""
+msgstr "Your score on this %1 was NOT recorded."
 
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr ""
+msgstr "Your score on this (checked, not recorded) submission is %1/%2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
 msgid "Your score on this problem was recorded."
-msgstr ""
+msgstr "Your score on this problem was recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
@@ -7757,21 +8449,26 @@ msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr ""
+"Your score was not recorded because there was a failure in storing the "
+"problem record to the database."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
 msgid "Your score was not recorded because this homework set is closed."
-msgstr ""
+msgstr "Your score was not recorded because this homework set is closed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr ""
+"Your score was not recorded because this problem has not been assigned to "
+"you."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
+"Your score was not recorded because this problem set version is not open."
 
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
@@ -7779,230 +8476,158 @@ msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
+"Your score was not recorded because you have exceeded the time limit for "
+"this test. (Time taken: %1 min; allowed: %2 min.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
+"Your score was not recorded because you have no attempts remaining on this "
+"set version."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
 msgid "Your score was not recorded."
-msgstr ""
+msgstr "Your score was not recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
 msgid "Your score was not successfully sent to the LMS"
-msgstr ""
+msgstr "Your score was not successfully sent to the LMS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
 msgid "Your score was recorded."
-msgstr ""
+msgstr "Your score was recorded."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
 msgid "Your score was successfully sent to the LMS"
-msgstr ""
+msgstr "Your score was successfully sent to the LMS"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
 msgid "Your session has timed out due to inactivity. Please log in again."
-msgstr ""
+msgstr "Your session has timed out due to inactivity. Please log in again."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
 msgid "Your systems are up to date!"
-msgstr ""
+msgstr "Your systems are up to date!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
-#, fuzzy
 msgid "[Edit]"
-msgstr "Problem List"
+msgstr "[Edit]"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
-#, fuzzy
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
 msgid "_ANSWER_LOG_DESCRIPTION"
-msgstr ""
-"This is the past answer viewer.  Students can only see their answers, and "
-"they will not be able to see which parts are correct.  Instructors can view "
-"any users answers using the form below and the answers will be colored "
-"according to correctness."
+msgstr "_ANSWER_LOG_DESCRIPTION"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the classlist editor page, where you can view and edit the records "
-"of all the students currently enrolled in this course.  The top of the page "
-"contains forms which allow you to filter which students to view, sort your "
-"students in a chosen order, edit student records, give new passwords to "
-"students, import/export student records from/to external files, or add/"
-"delete students. To use, please select the action you would like to perform, "
-"enter in the relevant information in the fields below, and hit the \"Take "
-"Action!\" button at the bottom of the form.  The bottom of the page contains "
-"a table containing the student usernames and their information."
+msgstr "_CLASSLIST_EDITOR_DESCRIPTION"
 
-#
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
-msgstr ""
-"%1 uses an external authentication system.  You've authenticated through "
-"that system, but aren't allowed to log in to this course."
+msgstr "_EXTERNAL_AUTH_MESSAGE"
 
-#
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
-msgstr ""
-"This course supports guest logins. Click %1 to log into this course as a "
-"guest."
+msgstr "_GUEST_LOGIN_MESSAGE"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
-msgstr ""
-"This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_HMWKSETS_EDITOR_DESCRIPTION"
 
-#
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
-msgstr ""
-"If you check %1 your login information will be remembered by the browser you "
-"are using, allowing you to visit WeBWorK pages without typing your user name "
-"and password (until your session expires). This feature is not safe for "
-"public workstations, untrusted machines, and machines over which you do not "
-"have direct control."
+msgstr "_LOGIN_MESSAGE"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
 msgid "_PROBLEM_SET_SUMMARY"
-msgstr ""
-"This is a table showing the current Homework sets for this class.  The "
-"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
-"Users, Visibility to students, Reduced Scoring Enabled, Date it was opened, "
-"Date it is due, and the Date during which the answers are posted.  The Edit "
-"Set Data field contains checkboxes for selection and a link to the set data "
-"editing page.  The cells in the Edit Problems fields contain links which "
-"take you to a page where you can edit the containing problems, and the cells "
-"in the edit assigned users field contains links which take you to a page "
-"where you can edit what students the set is assigned to."
+msgstr "_PROBLEM_SET_SUMMARY"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
-msgstr ""
-"WeBWorK has encountered a software error while attempting to process this "
-"problem. It is likely that there is an error in the problem itself. If you "
-"are a student, report this error message to your professor to have it "
-"corrected. If you are a professor, please consult the error output below for "
-"more information."
+msgstr "_REQUEST_ERROR"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
 msgid "_USER_TABLE_SUMMARY"
-msgstr ""
-"A table showing all the current users along with several fields of user "
-"information. The fields from left to right are: Login Name, Login Status, "
-"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
-"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
-"the links in the column headers will sort the table by the field it "
-"corresponds to. The Login Name fields contain checkboxes for selecting the "
-"user.  Clicking the link of the name itself will allow you to act as the "
-"selected user.  There will also be an image link following the name which "
-"will take you to a page where you can edit the selected user's information.  "
-"Clicking the emails will allow you to email the corresponding user.  "
-"Clicking the links in the entries in the assigned sets columns will take you "
-"to a page where you can view and reassign the sets for the selected user."
+msgstr "_USER_TABLE_SUMMARY"
 
+# Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
-msgstr ""
+msgstr "a duplicate of the first selected set"
 
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
-msgstr ""
+msgstr "a new empty set"
 
+# Context is "Save to a new file named:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
 msgid "a new file named:"
-msgstr ""
+msgstr "a new file named:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
-msgstr ""
+msgstr "a single set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
 msgid "active"
-msgstr ""
+msgstr "active"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "add problems"
-msgstr ""
+msgstr "add problems"
 
 #. ($setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
-msgstr ""
+msgstr "addGlobalSet %1 in ProblemSetList:  %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
 msgid "added missing permission level for user"
-msgstr ""
+msgstr "added missing permission level for user"
 
+# #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "admin"
-msgstr ""
+msgstr "admin"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
 msgid "all achievements"
-msgstr ""
+msgstr "all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
-msgstr ""
+msgstr "all current users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
-msgstr ""
+msgstr "all set dates for one <b>user</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
@@ -8017,11 +8642,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:982
 msgid "all sets"
-msgstr ""
+msgstr "all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
 msgid "all students"
-msgstr ""
+msgstr "all students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
@@ -8032,358 +8657,363 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
 msgid "all users"
-msgstr ""
+msgstr "all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "all users for one <b>set</b>"
-msgstr ""
+msgstr "all users for one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid "alphabetically"
-msgstr ""
+msgstr "alphabetically"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:661
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:672
 msgid "answer"
-msgstr ""
+msgstr "answer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
 msgid "any users"
-msgstr ""
+msgstr "any users"
 
+# Context is "Create _____ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
+msgstr "as"
 
+# Context is "Import achievements from ____ assigning the achievements to ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
 msgid "assigning the achievements to"
-msgstr ""
+msgstr "assigning the achievements to"
 
+# Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 msgid "assigning this set to"
-msgstr ""
+msgstr "assigning this set to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
 msgid "avg attempts"
-msgstr ""
+msgstr "avg attempts"
 
+# Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
 msgid "blank problem template(s) to end of homework set"
-msgstr ""
+msgstr "blank problem template(s) to end of homework set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
 msgid "by last login date"
-msgstr ""
+msgstr "by last login date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
-msgstr ""
+msgstr "changes abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
-msgstr ""
+msgstr "changes saved"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 msgid "class list data"
-msgstr ""
+msgstr "class list data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
-msgstr ""
+msgstr "class list data for selected <b>users</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
 msgid "close"
-msgstr ""
+msgstr "close"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:685
 msgid "column"
-msgstr ""
+msgstr "column"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
 msgid "columns:"
-msgstr ""
+msgstr "columns:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
 msgid "correct"
-msgstr ""
+msgstr "correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
 msgid "course files"
-msgstr ""
+msgstr "course files"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
 msgid "deleted %1 sets"
-msgstr ""
+msgstr "deleted %1 sets"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
 msgid "deleted %1 users"
-msgstr ""
+msgstr "deleted %1 users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
 msgid "editing all achievements"
-msgstr ""
+msgstr "editing all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
 msgid "editing all sets"
-msgstr ""
+msgstr "editing all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
 msgid "editing all users"
-msgstr ""
+msgstr "editing all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
 msgid "editing selected achievements"
-msgstr ""
+msgstr "editing selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
 msgid "editing selected sets"
-msgstr ""
+msgstr "editing selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing selected users"
-msgstr ""
+msgstr "editing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
 msgid "editing visible sets"
-msgstr ""
+msgstr "editing visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing visible users"
-msgstr ""
+msgstr "editing visible users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
 msgid "email:"
-msgstr ""
+msgstr "email:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
 msgid "empty"
-msgstr ""
+msgstr "empty"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
 msgid "enter matching set IDs below"
-msgstr ""
+msgstr "enter matching set IDs below"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
-#, fuzzy
 msgid "entry rows."
-msgstr "Problem List"
+msgstr "entry rows."
 
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
 msgid "error adding set location %1 for set %2: %3"
-msgstr ""
+msgstr "error adding set location %1 for set %2: %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
-msgstr ""
+msgstr "export abandoned"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
 msgid "exporting all achievements"
-msgstr ""
+msgstr "exporting all achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
 msgid "exporting all sets"
-msgstr ""
+msgstr "exporting all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
 msgid "exporting selected achievements"
-msgstr ""
+msgstr "exporting selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
 msgid "exporting selected sets"
-msgstr ""
+msgstr "exporting selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
 msgid "exporting visible sets"
-msgstr ""
+msgstr "exporting visible sets"
 
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr ""
+msgstr "for  %1 (%2) who has been assigned %3 sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
-msgstr ""
+msgstr "for one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 msgid "for one <b>user</b>"
-msgstr ""
+msgstr "for one <b>user</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
 msgid "for students"
-msgstr ""
+msgstr "for students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
 msgid "from"
-msgstr ""
+msgstr "from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
 msgid "giving new passwords to all users"
-msgstr ""
+msgstr "giving new passwords to all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to selected users"
-msgstr ""
+msgstr "giving new passwords to selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to visible users"
-msgstr ""
+msgstr "giving new passwords to visible users"
 
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
 msgid "global %1 for set %2 not found."
-msgstr ""
+msgstr "global %1 for set %2 not found."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
 msgid "global set %1  not found."
-msgstr ""
+msgstr "global set %1  not found."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
 msgid "global set %1 not found."
-msgstr ""
+msgstr "global set %1 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
-msgstr ""
+msgstr "grade_proctor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "guest"
-msgstr ""
+msgstr "guest"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
-msgstr ""
+msgstr "hidden"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "hidden from"
-msgstr ""
+msgstr "hidden from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
-msgstr ""
+msgstr "hidden from students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
 msgid "hidden sets"
-msgstr ""
+msgstr "hidden sets"
 
+# doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
 #: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
 #: /opt/webwork/pg/lib/Value/Vector.pm:280
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
-msgstr ""
+msgstr "i"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
 msgid "illegal character in input: '/'"
-msgstr ""
+msgstr "illegal character in input: '/'"
 
+# Context is " Show users who match _____ in their _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
 msgid "in their"
-msgstr ""
+msgstr "in their"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
 msgid "inactive"
-msgstr ""
+msgstr "inactive"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
 msgid "incorrect"
-msgstr ""
+msgstr "incorrect"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
 msgid "index"
-msgstr ""
+msgstr "index"
 
 #. ($restrictLoc, $setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
 msgid "input set location %1 already exists for set %2."
-msgstr ""
+msgstr "input set location %1 already exists for set %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
 msgid "list of insertable macros"
-msgstr ""
+msgstr "list of insertable macros"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "locations selected below"
-msgstr ""
+msgstr "locations selected below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
 msgid "login"
-msgstr ""
+msgstr "login"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "login ID"
-msgstr ""
+msgstr "login ID"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
 msgid "login/studentID:"
-msgstr ""
+msgstr "login/studentID:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "login_proctor"
-msgstr ""
+msgstr "login_proctor"
 
+# Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "made visible for"
-msgstr ""
+msgstr "made visible for"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
 msgid "max"
-msgstr ""
+msgstr "max"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
 msgid "multiple sets"
-msgstr ""
+msgstr "multiple sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "new set:"
-msgstr ""
+msgstr "new set:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 msgid "new users"
-msgstr ""
+msgstr "new users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
 msgid "no achievements"
-msgstr ""
+msgstr "no achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
 msgid "no achievements."
-msgstr ""
+msgstr "no achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
 msgid "no location"
-msgstr ""
+msgstr "no location"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
@@ -8394,11 +9024,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:981
 msgid "no sets"
-msgstr ""
+msgstr "no sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
 msgid "no students"
-msgstr ""
+msgstr "no students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
@@ -8408,179 +9038,177 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
 msgid "no users"
-msgstr ""
+msgstr "no users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
-msgstr ""
+msgstr "nobody"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
 msgid "nth colum of merge file"
-msgstr ""
+msgstr "nth colum of merge file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
 msgid "number of students not defined"
-msgstr ""
+msgstr "number of students not defined"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
-msgstr ""
+msgstr "one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
 msgid "one <b>set</b> for  <b>users</b>"
-msgstr ""
+msgstr "one <b>set</b> for  <b>users</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "one <b>user</b> (on one <b>set</b>)"
-msgstr ""
+msgstr "one <b>user</b> (on one <b>set</b>)"
 
+# Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
 msgid "only"
-msgstr ""
+msgstr "only"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
 msgid "only best scores"
-msgstr ""
+msgstr "only best scores"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 msgid "or"
-msgstr ""
+msgstr "or"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
 msgid "or Problems from"
-msgstr ""
+msgstr "or Problems from"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "out of"
-msgstr ""
+msgstr "out of"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
 msgid "overwrite all data"
-msgstr ""
+msgstr "overwrite all data"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:678
 msgid "part"
-msgstr ""
+msgstr "part"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
 msgid "permissions for %1 not defined"
-msgstr ""
+msgstr "permissions for %1 not defined"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
 msgid "pg debug"
-msgstr ""
+msgstr "pg debug"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
 msgid "pg internal errors"
-msgstr ""
+msgstr "pg internal errors"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
 msgid "pg warning"
-msgstr ""
+msgstr "pg warning"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
 msgid "point"
-msgstr ""
+msgstr "point"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
 msgid "points"
-msgstr ""
+msgstr "points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
 msgid "preserve existing data"
-msgstr ""
+msgstr "preserve existing data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
 msgid "preview answers"
-msgstr ""
+msgstr "preview answers"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:667
-#, fuzzy
 msgid "problem"
-msgstr "Problem List"
+msgstr "problem"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
-#, fuzzy
 msgid "problems"
-msgstr "Problem List"
+msgstr "problems"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "professor"
-msgstr ""
+msgstr "professor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "progress"
-msgstr ""
+msgstr "progress"
 
 #. ($line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
 msgid "readSetDef error, can't read the line: ||%1||"
-msgstr ""
+msgstr "readSetDef error, can't read the line: ||%1||"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
 msgid "recitation #"
-msgstr ""
+msgstr "recitation #"
 
 #. ($studentName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
 msgid "record for user %1 not found"
-msgstr ""
+msgstr "record for user %1 not found"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
 msgid "record for visible user %1 not found"
-msgstr ""
+msgstr "record for visible user %1 not found"
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
+"restriction location %1 does not exist.  IP restrictions have been ignored."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:684
 msgid "row"
-msgstr ""
+msgstr "row"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
 msgid "section #"
-msgstr ""
+msgstr "section #"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
 msgid "section:"
-msgstr ""
+msgstr "section:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
 msgid "selected <b>sets</b>"
-msgstr ""
+msgstr "selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
-msgstr ""
+msgstr "selected <b>users</b> to selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
 msgid "selected achievements"
-msgstr ""
+msgstr "selected achievements"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
 msgid "selected achievements."
-msgstr ""
+msgstr "selected achievements."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
@@ -8595,7 +9223,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:983
 msgid "selected sets"
-msgstr ""
+msgstr "selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
@@ -8609,184 +9237,186 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
 msgid "selected users"
-msgstr ""
+msgstr "selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
 msgid "separate multiple IDs with commas"
-msgstr ""
+msgstr "separate multiple IDs with commas"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
 msgid "set"
-msgstr ""
+msgstr "set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 msgid "sets"
-msgstr ""
+msgstr "sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
 msgid "sets checked below"
-msgstr ""
+msgstr "sets checked below"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
 msgid "sets hidden from students"
-msgstr ""
+msgstr "sets hidden from students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
 msgid "sets visible to students"
-msgstr ""
+msgstr "sets visible to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
 msgid "sets with matching set IDs:"
-msgstr ""
+msgstr "sets with matching set IDs:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
 msgid "showing all sets"
-msgstr ""
+msgstr "showing all sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
 msgid "showing all users"
-msgstr ""
+msgstr "showing all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
 msgid "showing hidden sets"
-msgstr ""
+msgstr "showing hidden sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
 msgid "showing matching sets"
-msgstr ""
+msgstr "showing matching sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing matching users"
-msgstr ""
+msgstr "showing matching users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
 msgid "showing no sets"
-msgstr ""
+msgstr "showing no sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing no users"
-msgstr ""
+msgstr "showing no users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
 msgid "showing selected sets"
-msgstr ""
+msgstr "showing selected sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing selected users"
-msgstr ""
+msgstr "showing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
-msgstr ""
+msgstr "showing visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
-msgstr ""
+msgstr "still open"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "student"
-msgstr ""
+msgstr "student"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
 msgid "students"
-msgstr ""
+msgstr "students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
 msgid "submission"
-msgstr ""
+msgstr "submission"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
 msgid "submission (test %1)"
-msgstr ""
+msgstr "submission (test %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "summary"
-msgstr ""
+msgstr "summary"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "ta"
-msgstr ""
+msgstr "ta"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
 msgid "test"
-msgstr ""
+msgstr "test"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
 msgid "test (%1)"
-msgstr ""
+msgstr "test (%1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
 msgid "test date"
-msgstr ""
+msgstr "test date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
 msgid "test time"
-msgstr ""
+msgstr "test time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
 msgid "the following file"
-msgstr ""
+msgstr "the following file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1253
 msgid "the following file(s)"
-msgstr ""
+msgstr "the following file(s)"
 
 #. ($forcedSourceFile)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
 msgid "the original path to the file is %1"
-msgstr ""
+msgstr "the original path to the file is %1"
 
+# Context is "Sort by ___ then by ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
 msgid "then by"
-msgstr ""
+msgstr "then by"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
 msgid "then delete them"
-msgstr ""
+msgstr "then delete them"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "time"
-msgstr ""
+msgstr "time"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
 msgid "time limit exceeded"
-msgstr ""
+msgstr "time limit exceeded"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "times"
-msgstr ""
+msgstr "times"
 
+# Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
 msgid "to"
-msgstr ""
+msgstr "to"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
 msgid "to all users, create global data, and"
-msgstr ""
+msgstr "to all users, create global data, and"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
-msgstr ""
+msgstr "to one <b>set</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
-msgstr ""
+msgstr "top score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
@@ -8795,42 +9425,44 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
 msgid "unable to write to directory %1"
-msgstr ""
+msgstr "unable to write to directory %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
 msgid "unlimited"
-msgstr ""
+msgstr "unlimited"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
 msgid "userID: %1 --"
-msgstr ""
+msgstr "userID: %1 --"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
+"username, last name, first name, section, achievement level, achievement "
+"score,"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "users"
-msgstr ""
+msgstr "users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
 msgid "users who match on selected field"
-msgstr ""
+msgstr "users who match on selected field"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
 msgid "users who match:"
-msgstr ""
+msgstr "users who match:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
-msgstr ""
+msgstr "visible"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
@@ -8838,12 +9470,12 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:685
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:851
 msgid "visible sets"
-msgstr ""
+msgstr "visible sets"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
-msgstr ""
+msgstr "visible to students"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
@@ -8853,64 +9485,64 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
 msgid "visible users"
-msgstr ""
+msgstr "visible users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
-msgstr ""
+msgstr "with set name(s):"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
-msgstr ""
+msgstr "won't be able to read from file %1/%2: does it exist? is it readable?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
+msgstr "your students"
+
+#
+msgid "navNext"
+msgstr "Next"
+
+#
+msgid "navNextGrey"
+msgstr "Next"
+
+#
+msgid "navPrev"
+msgstr "Previous"
+
+#
+msgid "navPrevGrey"
+msgstr "Previous"
+
+#
+msgid "navProbListGrey"
+msgstr "Problem List"
+
+#
+msgid "navUp"
+msgstr "Homework Sets"
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_1"
 msgstr ""
+"This assignment has a Reduced Scoring Period that begins %1 and ends on the "
+"due date, %2.  During this period all additional work done counts %3 % of "
+"the original."
 
 #
-#~ msgid "navNext"
-#~ msgstr "Next"
+msgid "_AUTO"
+msgstr "1"
 
 #
-#~ msgid "navNextGrey"
-#~ msgstr "Next"
+msgid "_REDUCED_CREDIT_MESSAGE_2"
+msgstr ""
+"This assignment had a Reduced Scoring Period that began %1 and ended on the "
+"due date, %2.  During that period all additional work done counted %3 % of "
+"the original."
 
-#
-#~ msgid "navPrev"
-#~ msgstr "Previous"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "Previous"
-
-#
+#, fuzzy
 #~ msgid "navProbList"
 #~ msgstr "Problem List"
-
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "Problem List"
-
-#
-#~ msgid "navUp"
-#~ msgstr "Homework Sets"
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "This assignment has a Reduced Scoring Period that begins %1 and ends on "
-#~ "the due date, %2.  During this period all additional work done counts %3 "
-#~ "% of the original."
-
-#
-#~ msgid "_AUTO"
-#~ msgstr "1"
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "This assignment had a Reduced Scoring Period that began %1 and ended on "
-#~ "the due date, %2.  During that period all additional work done counted %3 "
-#~ "% of the original."

--- a/lib/WeBWorK/Localize/en_us.po
+++ b/lib/WeBWorK/Localize/en_us.po
@@ -17,11 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+msgid "# of active students"
+msgstr "# of active students"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr "#corr"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr "#incorr"
 
@@ -34,15 +38,15 @@ msgid "% correct with review"
 msgstr "% correct with review"
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr "% students"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr "%1 (old editor)"
 
@@ -78,17 +82,17 @@ msgid "%1 students out of %2"
 msgstr "%1 students out of %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr "%1 title and institution changed from %2 to %3 and from %4 to %5"
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 users exported to file %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -123,8 +127,8 @@ msgstr "%1% Complete"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr "%1% correct"
 
@@ -161,7 +165,7 @@ msgstr "%1's password has been changed."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: Problem %2"
 
@@ -171,12 +175,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1: Problem %2 Show Me Another"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr "%1: The directory for the course not found."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr "%quant(%1,course was, courses were) successfully unhidden."
 
@@ -191,27 +195,27 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr "%quant(%1,file) unpacked successfully"
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
 "%quant(%1,of the questions remains,of the questions remain) unanswered."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr "%quant_1( course was, courses were) successfully hidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr "%score"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr "(Any unsaved changes will be lost.)"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
@@ -219,11 +223,11 @@ msgstr ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(This problem will not count towards your grade.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
@@ -231,13 +235,13 @@ msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "(Your score on this %1 is not available until %2.)"
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr "(Your score on this %1 is not available.)"
 
@@ -342,19 +346,33 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr "A course with ID %1 already exists."
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
@@ -372,7 +390,7 @@ msgstr ""
 "please inform your instructor."
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
@@ -381,7 +399,7 @@ msgstr ""
 "edit that location instead?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -390,12 +408,12 @@ msgstr ""
 "in the class %3.  There were %4 message(s) that could not be sent."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr "A new file has been created at '%1'"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
@@ -456,37 +474,37 @@ msgstr ""
 "to a page where you can view and reassign the sets for the selected user."
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr "ADJ STATUS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr "ANSWERS NOT RECORDED"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr "ANSWERS NOT RECORDED --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "ANSWERS ONLY CHECKED -- "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "Abandon changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Abandon export"
@@ -496,12 +514,12 @@ msgid "Achievement"
 msgstr "Achievement"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr "Achievement %1 created with evaluator '%2'."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "Achievement %1 exists.  No achievement created"
 
@@ -518,13 +536,13 @@ msgstr "Achievement Evaluator Editor"
 msgid "Achievement Evaluator for achievement %1"
 msgstr "Achievement Evaluator for achievement %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr "Achievement ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr "Achievement ID exists!  No new achievement created.  File not saved."
 
@@ -540,12 +558,16 @@ msgstr "Achievement User Editor"
 msgid "Achievement has been assigned to all users."
 msgstr "Achievement has been assigned to all users."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+msgid "Achievement has been assigned to selected users."
+msgstr "Achievement has been assigned to selected users."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr "Achievement has been unassigned to all students."
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr "Achievement scores saved to %1"
 
@@ -565,17 +587,17 @@ msgid "Act as:"
 msgstr "Act as:"
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr "Acting as %1."
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr "Action %1 not found"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Active"
 
@@ -599,7 +621,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Add"
@@ -608,9 +630,9 @@ msgstr "Add"
 msgid "Add All"
 msgstr "Add All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr "Add Course"
 
@@ -622,7 +644,7 @@ msgstr "Add Students"
 msgid "Add Users"
 msgstr "Add Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr "Add WeBWorK administrators to new course"
 
@@ -630,12 +652,12 @@ msgstr "Add WeBWorK administrators to new course"
 msgid "Add a new test for which Gateway?"
 msgstr "Add a new test for which Gateway?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "Add as what filetype?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Add how many students?"
 
@@ -643,41 +665,41 @@ msgstr "Add how many students?"
 msgid "Add problems to"
 msgstr "Add problems to"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr "Add to what set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Add which new users?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr "Added %1 to %2 as problem %3"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "Added '%1' to %2 as new hardcopy header"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr "Added '%1' to %2 as new set header"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr "Added addresses %1 to location %2."
 
@@ -686,7 +708,7 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr "Additional addresses for receiving feedback e-mail."
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
@@ -695,7 +717,7 @@ msgstr ""
 "Please double check the integrity of the WeBWorK database before continuing."
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
@@ -704,7 +726,7 @@ msgstr ""
 "were skipped."
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
@@ -713,7 +735,7 @@ msgstr ""
 "were skipped."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
@@ -722,7 +744,7 @@ msgstr ""
 "entry and resubmit."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
@@ -730,11 +752,11 @@ msgstr ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr "Addresses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
@@ -744,7 +766,7 @@ msgstr ""
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -762,7 +784,7 @@ msgstr "Adds 24 hours to the close date of a homework."
 msgid "Adds 48 hours to the close date of a homework."
 msgstr "Adds 48 hours to the close date of a homework."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr "Adjusted Status"
 
@@ -775,7 +797,7 @@ msgid "After set answer date"
 msgstr "After set answer date"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -789,15 +811,15 @@ msgstr "All Selected Constraints Joined by \"And\""
 msgid "All assignments were made successfully."
 msgstr "All assignments were made successfully."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr "All of the answers above are correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr "All of the gradeable answers above are correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr "All of these files will also be made available for mail merge."
 
@@ -817,7 +839,7 @@ msgstr "All sets hidden from all students"
 msgid "All sets made visible for all students"
 msgstr "All sets made visible for all students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr "All students in course"
 
@@ -881,25 +903,25 @@ msgstr "Amulet of Extension"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr "An error occured while archiving the course %1:"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr "An error occured while changing the title of the course %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr "An error occured while deleting the course %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "An error occured while renaming the course %1 to %2:"
 
@@ -917,8 +939,8 @@ msgstr "Answer Date"
 msgid "Answer Log"
 msgstr "Answer Log"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Answer Preview"
 
@@ -931,12 +953,12 @@ msgid "Answer:"
 msgstr "Answer:"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr "AnswerGroupInfo"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr "AnswerHashInfo"
 
@@ -958,15 +980,20 @@ msgstr "Answers cannot be due until on or after the open date!"
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr "Answers cannot be made available until on or after the close date!"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "Any changes made below will be reflected in the achievement for ALL students."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -984,18 +1011,18 @@ msgstr ""
 "be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr "Append"
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr "Append to end of %1 set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr "Archive"
 
@@ -1009,26 +1036,26 @@ msgstr "Archive '%1' created successfully (%quant( %2, file))"
 msgid "Archive '%1' deleted"
 msgstr "Archive '%1' deleted"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr "Archive Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr "Archive Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr "Archive next course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr "Archive this Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr "Archived Courses"
 
@@ -1038,7 +1065,7 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr "Archiving course as %1.tar.gz. Reload FileManager to see it."
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
@@ -1047,7 +1074,7 @@ msgstr ""
 "cannot be undone!"
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
@@ -1055,10 +1082,14 @@ msgstr ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
 msgstr "Assign"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr "Assign %1 to all users, create global data, and %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1082,17 +1113,17 @@ msgstr "Assign to All Current Users"
 msgid "Assigned"
 msgstr "Assigned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Assigned Sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr "Assigned achievements to users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr "Assigned to"
 
@@ -1100,7 +1131,11 @@ msgstr "Assigned to"
 msgid "Assignment type"
 msgstr "Assignment type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+msgid "Assignments only"
+msgstr "Assignments only"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr "At least one of the answers above is NOT correct."
 
@@ -1109,7 +1144,7 @@ msgstr "At least one of the answers above is NOT correct."
 msgid "Att. to Open Children"
 msgstr "Att. to Open Children"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr "Attempt to upgrade directories"
 
@@ -1121,7 +1156,7 @@ msgstr "Attempted"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Attempts"
 
@@ -1129,13 +1164,14 @@ msgstr "Attempts"
 msgid "Audit"
 msgstr "Audit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr "Authentication failed.  Please speak to your instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "Author Info"
 
@@ -1143,12 +1179,12 @@ msgstr "Author Info"
 msgid "Automatic"
 msgstr "Automatic"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr "Automatically render problems on page load"
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr "Backup file <code>%1/%2</code> created."
 
@@ -1195,17 +1231,17 @@ msgstr ""
 "receive feedback. Feedback is also sent to any addresses specified in this "
 "blank. Separate email address entries by commas."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr "CLOSE DATE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr "CLOSE TIME"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
-msgstr "Cake of Enlargment"
+msgid "Cake of Enlargement"
+msgstr "Cake of Enlargement"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
 msgid "Can e-mail instructor"
@@ -1234,7 +1270,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr "Can't create archive '%1': command returned %2"
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr "Can't create course environment for %1 because %2"
 
@@ -1269,17 +1305,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "Can't get password record for user '%1': %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr "Can't open %1"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr "Can't open file %1"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr "Can't read merge file %1. No message sent"
 
@@ -1288,7 +1324,7 @@ msgstr "Can't read merge file %1. No message sent"
 msgid "Can't rename file: %1"
 msgstr "Can't rename file: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr "Can't rename to the same name."
 
@@ -1297,11 +1333,11 @@ msgstr "Can't rename to the same name."
 msgid "Can't unpack '%1': command returned %2"
 msgstr "Can't unpack '%1': command returned %2"
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr "Can't write to file %1"
 
@@ -1312,7 +1348,7 @@ msgstr "Can't write to file %1"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr "Cancel E-mail"
 
@@ -1325,8 +1361,8 @@ msgstr "Cannot open %1"
 msgid "Cap Test Time at Set Close Date?"
 msgstr "Cap Test Time at Set Close Date?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr "Category"
 
@@ -1350,11 +1386,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr "Causes a single homework problem to be worth twice as much."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr "Change Course Title to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr "Change CourseID to:"
 
@@ -1368,7 +1404,7 @@ msgstr "Change Display Settings"
 msgid "Change Email Address"
 msgstr "Change Email Address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr "Change Institution to:"
 
@@ -1377,32 +1413,32 @@ msgstr "Change Institution to:"
 msgid "Change Password"
 msgstr "Change Password"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr "Change User Settings"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr "Change course institution from %1 to %2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr "Change title from %1 to %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "Changes abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Changes in this file have not yet been permanently saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "Changes saved"
 
@@ -1418,20 +1454,20 @@ msgstr ""
 msgid "Chapter:"
 msgstr "Chapter:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "Check Answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr "Check Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr "Check that it's permissions are set correctly."
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
@@ -1439,7 +1475,7 @@ msgstr ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "Checking additional error messages"
 
@@ -1454,8 +1490,8 @@ msgstr "Choose the set which you would like to enable partial credit for."
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
-msgstr "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
+msgstr "Choose the set which you would like to resurrect."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
@@ -1495,8 +1531,8 @@ msgstr ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1517,7 +1553,7 @@ msgstr ""
 "associated with the restriction.  Contact your professor to have this "
 "problem resolved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr "Close"
 
@@ -1555,7 +1591,7 @@ msgid "Closes"
 msgstr "Closes"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr "Closes %1"
 
@@ -1564,39 +1600,39 @@ msgstr "Closes %1"
 msgid "Closes:"
 msgstr "Closes:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr "Collapse"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr "Collapse All"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Comment"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr "Completed results for this assignment are not available until %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr "Completed results for this assignment are not available."
 
@@ -1604,7 +1640,7 @@ msgstr "Completed results for this assignment are not available."
 msgid "Completed."
 msgstr "Completed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -1614,7 +1650,7 @@ msgstr "Confirm"
 msgid "Confirm %1's New Password"
 msgstr "Confirm %1's New Password"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr "Confirm Password:"
 
@@ -1628,8 +1664,8 @@ msgid "Continue"
 msgstr "Continue"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "Copied auxiliary files from %1 to new location at %2"
 
@@ -1643,7 +1679,7 @@ msgstr "Copy"
 msgid "Copy file as:"
 msgstr "Copy file as:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr "Copy templates from:"
 
@@ -1651,8 +1687,8 @@ msgstr "Copy templates from:"
 msgid "Copy this Problem"
 msgstr "Copy this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Correct"
@@ -1661,7 +1697,7 @@ msgstr "Correct"
 msgid "Correct Adjusted Status"
 msgstr "Correct Adjusted Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr "Correct Answer"
 
@@ -1678,17 +1714,17 @@ msgid "Correct answers"
 msgstr "Correct answers"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr "Correct: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr "CorrectAnswers"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1706,48 +1742,49 @@ msgid "Couldn't change your email address: %1"
 msgstr "Couldn't change your email address: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr "Couldn't find OPL Branch %1 in remote %2"
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr "Couldn't find PG Branch %1 in remote %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr "Couldn't find WeBWorK Branch %1 in remote %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr "Couldn't save your display options: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr "Counter"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr "Counts for Parent"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr "Course %1 database is in order"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr "Course %1 databases must be updated before renaming this course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1757,13 +1794,13 @@ msgstr "Course Administration"
 msgid "Course Configuration"
 msgstr "Course Configuration"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr "Course ID may only contain letters, numbers, hyphens, and underscores."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr "Course ID:"
 
@@ -1772,13 +1809,13 @@ msgstr "Course ID:"
 msgid "Course Info"
 msgstr "Course Info"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr "Course Name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr "Course Title:"
 
@@ -1786,15 +1823,15 @@ msgstr "Course Title:"
 msgid "Course archived."
 msgstr "Course archived."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1817,7 +1854,7 @@ msgstr "Create"
 msgid "Create CSV"
 msgstr "Create CSV"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr "Create Location:"
 
@@ -1825,7 +1862,7 @@ msgstr "Create Location:"
 msgid "Create a New Set in This Course:"
 msgstr "Create a New Set in This Course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr "Create a new achievement with ID"
 
@@ -1833,12 +1870,12 @@ msgstr "Create a new achievement with ID"
 msgid "Create as what type of set?"
 msgstr "Create as what type of set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr "Create unattached problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1856,34 +1893,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr "Cupcake of Enlargement"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr "Current"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr "Currently defined locations are listed below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr "Data"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr "Database tables are ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr "Database tables need updating."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr "Database tables ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr "Database:"
 
@@ -1895,7 +1932,7 @@ msgstr "Date"
 msgid "Debug"
 msgstr "Debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1923,71 +1960,71 @@ msgstr "Default Length of Reduced Scoring Period in minutes"
 msgid "Default Time that the Assignment is Due"
 msgstr "Default Time that the Assignment is Due"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr "Delete Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr "Delete all existing addresses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr "Delete course after archiving. Caution there is no undo!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr "Delete course:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "Delete how many?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr "Delete it?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr "Delete location:"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr "Deleted %quant(%1,achievement)"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr "Deleted Location(s): %1"
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr "Deleted addresses %1 from location."
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr "Deleting temp file at %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
@@ -1995,7 +2032,7 @@ msgstr ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr "Deletion destroys all achievement-related data and is not undoable!"
 
@@ -2003,7 +2040,7 @@ msgstr "Deletion destroys all achievement-related data and is not undoable!"
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr "Deletion destroys all set-related data and is not undoable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr "Deletion destroys all user-related data and is not undoable!"
 
@@ -2011,13 +2048,13 @@ msgstr "Deletion destroys all user-related data and is not undoable!"
 msgid "Deny From"
 msgstr "Deny From"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr "Description"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr "Didn't recognize action"
 
@@ -2035,20 +2072,20 @@ msgstr "Directory '%1' not removed: %2"
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr "Directory '%1' removed (items deleted: %2)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr "Directory permission errors "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr "Directory structure"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
@@ -2056,28 +2093,28 @@ msgstr ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr "Directory structure is ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr "Directory structure needs to be repaired manually before archiving."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr "Directory structure needs to be repaired manually before renaming."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr "Directory structure or permissions need to be repaired. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr "Display Mode:"
@@ -2085,6 +2122,11 @@ msgstr "Display Mode:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
 msgstr "Display Past Answers"
+
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
+msgstr "Display of scores for this set is not allowed."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
@@ -2107,29 +2149,29 @@ msgstr "Do not uncheck a set unless you know what you are doing."
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr "Do not uncheck students, unless you know what you are doing."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr "Don't Archive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr "Don't Unarchive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr "Don't Upgrade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr "Don't delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr "Don't make changes"
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "Don't recognize saveMode: |%1|. Unknown error."
 
@@ -2138,17 +2180,17 @@ msgstr "Don't recognize saveMode: |%1|. Unknown error."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr "Don't recognize statistics display type: |%1|"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr "Don't rename"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr "Don't use in an achievement"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr "Done"
 
@@ -2178,8 +2220,8 @@ msgstr "Download Hardcopy"
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Download PDF or TeX Hardcopy for Current Set"
 
@@ -2199,6 +2241,16 @@ msgstr "Download:"
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "Drop"
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2228,7 +2280,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr "E-Mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "E-mail Instructor"
 
@@ -2248,7 +2300,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr "E-mail verbosity level"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr "E-mail:"
 
@@ -2256,25 +2308,25 @@ msgstr "E-mail:"
 msgid "Earned"
 msgstr "Earned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Edit"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr "Edit %1 of set %2."
 
@@ -2287,19 +2339,19 @@ msgstr "Edit All Set Data"
 msgid "Edit Assigned Users"
 msgstr "Edit Assigned Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr "Edit Evaluator"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr "Edit Header"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr "Edit Location:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr "Edit Problem"
 
@@ -2321,7 +2373,7 @@ msgstr "Edit Set Data"
 msgid "Edit Target Set"
 msgstr "Edit Target Set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Edit Which Users?"
 
@@ -2337,17 +2389,17 @@ msgstr "Edit it"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr "Edit set %1 data for ALL students assigned to this set."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr "Edit set %1 for this user."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2364,23 +2416,23 @@ msgid "Edit which sets?"
 msgstr "Edit which sets?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr "Edit1"
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr "Edit2"
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr "Edit3"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr "Editing %1 in file '%2'"
 
@@ -2390,44 +2442,44 @@ msgid "Editing achievement in file '%1'"
 msgstr "Editing achievement in file '%1'"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr "Editing location %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr "Editing problem set %1 data for these individual students: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr "Editor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr "Editor rows:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "Email"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "Email Address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr "Email Body:"
 
@@ -2435,22 +2487,22 @@ msgstr "Email Body:"
 msgid "Email Instructor On Failed Attempt"
 msgstr "Email Instructor On Failed Attempt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr "Email Link"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr "Email address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "Email instructor"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
@@ -2460,7 +2512,7 @@ msgstr ""
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr "Emails to be sent to the following:"
 
@@ -2502,8 +2554,8 @@ msgstr ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -2553,22 +2605,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr "Enrolled, Drop, etc."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Enrollment Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Enter filename below"
 
@@ -2584,8 +2636,8 @@ msgstr ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Entered"
 
@@ -2617,7 +2669,7 @@ msgstr ""
 msgid "Error message:"
 msgstr "Error message:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr "Error messages"
 
@@ -2641,7 +2693,7 @@ msgstr ""
 "in set %1"
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr "Error: The original file %1 cannot be read."
@@ -2660,6 +2712,10 @@ msgstr "Error: answer date cannot be more than 10 years from now in set %1"
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr "Error: close date cannot be more than 10 years from now in set %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2677,7 +2733,7 @@ msgstr ""
 "hardcopy. Error text: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2688,7 +2744,7 @@ msgstr ""
 "ownership and permissions of the course's directory, e.g %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
@@ -2698,15 +2754,15 @@ msgstr ""
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr "Evaluator"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr "Evaluator File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
@@ -2714,7 +2770,7 @@ msgstr ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
@@ -2722,7 +2778,7 @@ msgstr ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
@@ -2731,24 +2787,24 @@ msgstr ""
 "Select addresses from the list to delete them:"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr "Existing file %1 could not be backed up and was lost."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr "Expand"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr "Expand All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Export"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr "Export selected achievements."
 
@@ -2756,7 +2812,7 @@ msgstr "Export selected achievements."
 msgid "Export selected sets"
 msgstr "Export selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Export to what kind of file?"
 
@@ -2764,12 +2820,12 @@ msgstr "Export to what kind of file?"
 msgid "Export which sets?"
 msgstr "Export which sets?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Export which users?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr "Exported achievements to %1"
 
@@ -2785,16 +2841,16 @@ msgstr ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr "FIRST NAME"
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr "Failed to create new achievement: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "Failed to create new achievement: no achievement ID specified!"
 
@@ -2807,7 +2863,7 @@ msgstr "Failed to create new set: %1"
 msgid "Failed to create new set: no set name specified!"
 msgstr "Failed to create new set: no set name specified!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
@@ -2839,10 +2895,10 @@ msgstr "Failed to enter student:"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr "Failed to open %1"
 
@@ -2852,11 +2908,11 @@ msgid "Failed to save: %1"
 msgstr "Failed to save: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr "False"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr "Feature exhausted for this problem"
 
@@ -2868,35 +2924,35 @@ msgstr "Feedback"
 msgid "Feedback by Section."
 msgstr "Feedback by Section."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr "FeedbackMessage"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr "Field is ok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr "Field missing in database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr "Field missing in schema"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr "File '%1' exists.  File not saved.  No changes have been made."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
@@ -2945,7 +3001,7 @@ msgstr "File successfully copied"
 msgid "File successfully renamed"
 msgstr "File successfully renamed"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Filename"
 
@@ -2954,7 +3010,7 @@ msgstr "Filename"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr "Files with extension '.%1' usually belong in '%2'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "Filter by what text?"
 
@@ -2968,28 +3024,28 @@ msgstr "Filter:"
 msgid "First"
 msgstr "First"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "First Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr "First name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3001,7 +3057,7 @@ msgstr ""
 "Please specify a different file or move the needed file to the email "
 "directory"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr "Force problems to be numbered consecutively from one"
 
@@ -3013,6 +3069,10 @@ msgstr ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
+msgstr "Format"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
 msgstr "Format for the subject line in feedback e-mails"
@@ -3022,19 +3082,23 @@ msgstr "Format for the subject line in feedback e-mails"
 msgid "Format:"
 msgstr "Format:"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+msgid "Found no directories containing problems"
+msgstr "Found no directories containing problems"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr "From This Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr "From field must contain one valid email address."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "From:"
 
@@ -3062,7 +3126,7 @@ msgid "General"
 msgstr "General"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr "General Information"
 
@@ -3082,11 +3146,16 @@ msgstr "Get Library Set Problems"
 msgid "Get Target Set Problems"
 msgstr "Get Target Set Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr "Get a new version of this problem"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr "Give new password to"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Give new password to which users?"
 
@@ -3113,7 +3182,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "Global problem %1 for set %2 not found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr "Global set data will be shown instead of user specific data"
 
@@ -3121,21 +3190,31 @@ msgstr "Global set data will be shown instead of user specific data"
 msgid "Go"
 msgstr "Go"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr "Grade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr "Grade Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr "Grade Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr "Grader"
 
@@ -3163,7 +3242,7 @@ msgstr "Greater Tome of Enlightenment"
 msgid "Guest Login"
 msgstr "Guest Login"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr "HTTP Headers"
 
@@ -3190,12 +3269,16 @@ msgstr "Hardcopy Header"
 msgid "Hardcopy Theme"
 msgstr "Hardcopy Theme"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr "Headers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Help"
 
@@ -3207,12 +3290,12 @@ msgstr "Here is a new version of your problem."
 msgid "Hidden"
 msgstr "Hidden"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr "Hide All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr "Hide Courses"
 
@@ -3224,8 +3307,8 @@ msgstr "Hide Hints"
 msgid "Hide Hints from Students"
 msgstr "Hide Hints from Students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr "Hide Inactive Courses"
 
@@ -3237,7 +3320,7 @@ msgstr "Hide all paths"
 msgid "Hide path:"
 msgstr "Hide path:"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr "Hint:"
 
@@ -3251,13 +3334,13 @@ msgstr "Hints"
 msgid "Hmwk Sets Editor"
 msgstr "Hmwk Sets Editor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Homework Sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr "Homework Totals"
 
@@ -3265,15 +3348,15 @@ msgstr "Homework Totals"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr "Icon"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr "Icon File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3297,7 +3380,7 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
@@ -3307,7 +3390,7 @@ msgstr ""
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
@@ -3327,12 +3410,16 @@ msgstr ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
 msgstr "Illegal file '%1' specified"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr "Illegal filename contains '..'"
 
@@ -3340,9 +3427,11 @@ msgstr "Illegal filename contains '..'"
 msgid "Import"
 msgstr "Import"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
-msgstr "Import achievements from"
+# Context is "Import achievements from ____ assigning the achievements to ___"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "Import achievements from %1 assigning the achievements to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
@@ -3356,21 +3445,21 @@ msgstr "Import how many sets?"
 msgid "Import sets with names"
 msgstr "Import sets with names"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Import users from what file?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr "Imported %quant(%1,achievement)"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr "In progress: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Inactive"
 
@@ -3378,17 +3467,17 @@ msgstr "Inactive"
 msgid "Inactivity time before a user is required to login again"
 msgstr "Inactivity time before a user is required to login again"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr "Include Success Index"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr "Incorrect"
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr "Incorrect: %1/%2"
 
@@ -3397,7 +3486,7 @@ msgstr "Incorrect: %1/%2"
 msgid "Init"
 msgstr "Init"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr "Institution:"
 
@@ -3405,16 +3494,16 @@ msgstr "Institution:"
 msgid "Instructor Tools"
 msgstr "Instructor Tools"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr "Instructor solution preview: show the student solution after due date."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr "Invalid Reply-to address."
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3426,7 +3515,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr "Invalid headerType %1"
 
@@ -3443,16 +3532,20 @@ msgstr ""
 "It is before the open date.  You probably want to renumber the problems if "
 "you are deleting some from the middle."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr "Items"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr "Jump to Page:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr "Jump to Problem:"
 
@@ -3464,7 +3557,7 @@ msgstr "Just-In-Time parameters"
 msgid "Keywords:"
 msgstr "Keywords:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr "LAST NAME"
 
@@ -3485,28 +3578,28 @@ msgstr "Last"
 msgid "Last Answer"
 msgstr "Last Answer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Last Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr "Last column of merge file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr "Last name"
 
@@ -3536,18 +3629,18 @@ msgstr "Lesser Tome of Enlightenment"
 msgid "Level:"
 msgstr "Level:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Library Browser"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Library Browser 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr "Library Browser 3"
@@ -3584,13 +3677,13 @@ msgstr "Local"
 msgid "Local Problems"
 msgstr "Local Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr "Location"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -3599,20 +3692,20 @@ msgstr ""
 "(perhaps you need to reload the location management page?)."
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr "Location %1 has been created, with addresses %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr "Location deletion requires confirmation."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr "Location description:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr "Location name:"
 
@@ -3620,8 +3713,8 @@ msgstr "Location name:"
 msgid "Log In Again"
 msgstr "Log In Again"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Log Out"
 
@@ -3629,20 +3722,20 @@ msgstr "Log Out"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr "Log into %1"
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr "Logged in as %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr "Login"
 
@@ -3654,23 +3747,23 @@ msgstr "Login Info"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Login Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Login Status"
 
@@ -3678,7 +3771,7 @@ msgstr "Login Status"
 msgid "Logout"
 msgstr "Logout"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Main Menu"
 
@@ -3691,20 +3784,20 @@ msgstr "Make"
 msgid "Make Archive"
 msgstr "Make Archive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr "Make changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr "Make these changes in  course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr "Manage Locations"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr "Manual Grader"
@@ -3718,7 +3811,7 @@ msgid "Mark Correct"
 msgstr "Mark Correct"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr "Mark Correct?"
 
@@ -3726,8 +3819,9 @@ msgstr "Mark Correct?"
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "Match on what? (separate multiple IDs with commas)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Math Objects"
 
@@ -3744,37 +3838,37 @@ msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr "Merge file:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr "Message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr "Message file:"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr "Message saved to file <code>%1/%2</code>."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr "Message:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr "Method"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
@@ -3782,13 +3876,13 @@ msgstr ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr "Move"
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr "Msg sent to %1 at %2."
 
@@ -3801,17 +3895,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr "Mysterious Package (with Ribbons)"
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr "NO OF FIELDS"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3852,12 +3946,12 @@ msgstr "New File"
 msgid "New Folder"
 msgstr "New Folder"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr "New Name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "New Password"
 
@@ -3869,13 +3963,13 @@ msgstr "New file name:"
 msgid "New folder name:"
 msgstr "New folder name:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "New passwords saved"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr "NewVersion"
 
@@ -3883,15 +3977,17 @@ msgstr "NewVersion"
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr "Newer problem set def files must be imported using Hmwk Sets Editor2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Next Problem"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr "Next page"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3899,20 +3995,25 @@ msgstr "Next page"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "No"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr "No Description"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr "No achievements have been assigned yet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr "No achievements shown.  Create an achievement!"
 
@@ -3933,7 +4034,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "No change made to any set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3946,7 +4047,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr "No changes were saved!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr "No course id defined"
 
@@ -3956,28 +4057,28 @@ msgstr "No course id defined"
 msgid "No data exists for set %1 and problem %2"
 msgstr "No data exists for set %1 and problem %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr "No filename was specified for saving!  The message was not saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr "No guest logins are available. Please try again in a few minutes."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr "No location specified to edit?! Please check your input data."
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr "No location with name %1 exists in the database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr "No merge data file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
@@ -3985,11 +4086,11 @@ msgstr ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr "No problems matched the given parameters."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3999,22 +4100,22 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr "No record for global set %1."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr "No record for user %1."
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr "No record found for problem %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr "No record found."
 
@@ -4027,7 +4128,7 @@ msgstr "No sets in this course yet"
 msgid "No sets selected for scoring"
 msgstr "No sets selected for scoring"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -4036,15 +4137,15 @@ msgstr ""
 "course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr "No source filePath specified"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr "No source_file for problem in .def file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -4063,15 +4164,19 @@ msgid "No user specific data exists for user %1"
 msgstr "No user specific data exists for user %1"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
 msgstr "No valid changes submitted for location %1."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
+msgstr "No versions of this assignment have been taken."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr "None"
 
@@ -4085,27 +4190,32 @@ msgstr "None Specified"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr "None of the selected users are assigned to this set: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Not logged in."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Note"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "Note:"
+msgstr "Note:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 "Note: grading the test grades all problems, not just those on this page."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr "Number"
 
@@ -4121,8 +4231,8 @@ msgstr "Number of Problems per Page (0=all)"
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr "Number of Tests per Time Interval (0=infty)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr "OK"
 
@@ -4156,7 +4266,7 @@ msgstr ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr "Open"
 
@@ -4174,13 +4284,13 @@ msgstr "Open Date"
 msgid "Open Problem Library"
 msgstr "Open Problem Library"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr "Open in New Window"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr "Open in new window"
 
@@ -4194,10 +4304,10 @@ msgstr "Open, closes %1."
 msgid "Open, complete by %1."
 msgstr "Open, complete by %1."
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
-msgstr "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
@@ -4219,12 +4329,12 @@ msgstr "Optional Modules"
 msgid "Order Problems Randomly"
 msgstr "Order Problems Randomly"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr "Orig. Lib. Browser"
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4248,70 +4358,73 @@ msgstr "Overwrite existing files silently"
 msgid "PG - Problem Display/Answer Checking"
 msgstr "PG - Problem Display/Answer Checking"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr "PG debug messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr "PG internal errors"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr "PG question failed to render"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr "PG question processing error messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr "PG warning messages"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr "PGInfo"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr "PGLab"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr "PGML"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr "POD"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr "PROB NUMBER"
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr "PROB VALUE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Pad Fields"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr "Page generated at %1"
 
@@ -4324,7 +4437,7 @@ msgstr "Password"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr "Password (Leave blank for regular proctoring)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr "Password:"
 
@@ -4333,7 +4446,7 @@ msgstr "Password:"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "Past Answers for %1, set %2, problem %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr "Percent"
 
@@ -4349,7 +4462,7 @@ msgstr ""
 "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
 "median number of attempts"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
@@ -4357,18 +4470,18 @@ msgstr ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Permission Level"
 
@@ -4376,7 +4489,7 @@ msgstr "Permission Level"
 msgid "Permissions"
 msgstr "Permissions"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4426,7 +4539,7 @@ msgstr ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr "Please correct the following errors and try again:"
 
@@ -4439,7 +4552,7 @@ msgstr "Please enter in a value to match in the filter field."
 msgid "Please enter your username and password for %1 below:"
 msgstr "Please enter your username and password for %1 below:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr "Please provide a location name to delete."
 
@@ -4457,49 +4570,50 @@ msgstr "Please select at least one set and try again."
 msgid "Please select at least one user and try again."
 msgstr "Please select at least one user and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Please specify a file to save to."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr "Points"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
-msgstr "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
+msgstr "Potion of Forgetfulness"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr "Preflight Log"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr "Preview Message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr "Preview My Answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr "Preview Test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr "Preview message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr "Preview set to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Previous Problem"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr "Previous page"
@@ -4508,12 +4622,12 @@ msgstr "Previous page"
 msgid "Primary sort"
 msgstr "Primary sort"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr "Print Test"
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr "Prob"
 
@@ -4530,20 +4644,20 @@ msgstr "Problem #"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr "Problem %1"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr "Problem %1."
 
@@ -4561,8 +4675,8 @@ msgstr "Problem Editor2"
 msgid "Problem Editor3"
 msgstr "Problem Editor3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Problem List"
 
@@ -4578,28 +4692,29 @@ msgstr "Problem Number"
 msgid "Problem Number "
 msgstr "Problem Number "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Problem Techniques"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr "Problem source is drawn from a grouping set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Problems"
 
@@ -4650,11 +4765,11 @@ msgstr ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Publish"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr "RECITATION"
 
@@ -4668,28 +4783,28 @@ msgid "Really delete the items listed above?"
 msgstr "Really delete the items listed above?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "Recitation"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Record Scores for Single Sets"
 
@@ -4703,26 +4818,16 @@ msgid "Reduced Scoring Date"
 msgstr "Reduced Scoring Date"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr "Reduced Scoring Disabled"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
 msgstr "Reduced Scoring Enabled"
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr "Reduced Scoring Starts %1"
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
-msgstr "Reduced scoring started on %1."
 
 # Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
@@ -4739,12 +4844,12 @@ msgstr "Refresh"
 msgid "Refresh Display"
 msgstr "Refresh Display"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr "Refresh Listing"
 
@@ -4753,7 +4858,7 @@ msgid "Relax IP restrictions when?"
 msgstr "Relax IP restrictions when?"
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Remaining"
 
@@ -4765,7 +4870,7 @@ msgstr "Remember Me"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr "Remember to return to your original problem when you're finished here!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4775,13 +4880,13 @@ msgid "Rename"
 msgstr "Rename"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr "Rename %1 to %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr "Rename Course"
 
@@ -4789,19 +4894,19 @@ msgstr "Rename Course"
 msgid "Rename file as:"
 msgstr "Rename file as:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr "Render"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr "Render All"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr "Render Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr "Renumber Problems"
 
@@ -4820,53 +4925,54 @@ msgid "Reorder problems only"
 msgstr "Reorder problems only"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr "Replace current problem: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Replace which users?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr "Reply-To:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr "Report Bugs in this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Report bugs"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr "Report for course %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr "Report on database structure for course %1:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr "Request New Version"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr "Request information"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr "Request new version now."
 
@@ -4937,8 +5043,8 @@ msgid "Reset"
 msgstr "Reset"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr "Reset Form"
 
@@ -4946,11 +5052,7 @@ msgstr "Reset Form"
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr "Resets the number of incorrect attempts on a single homework problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr "Ressurect which Gateway?"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4983,22 +5085,22 @@ msgstr "Restrict To"
 msgid "Restrict release by set(s)"
 msgstr "Restrict release by set(s)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Result"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr "Result of last action performed"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr "Result of last action performed: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr "Results for this submission"
 
@@ -5010,19 +5112,27 @@ msgstr "Results of last action performed"
 msgid "Results of last action performed: "
 msgstr "Results of last action performed: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr "Resurrect which Gateway?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
 msgstr "Retitled"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "Revert"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr "Revert to %1"
@@ -5035,19 +5145,19 @@ msgstr "Ring of Reduction"
 msgid "Robe of Longevity"
 msgstr "Robe of Longevity"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr "SECTION"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr "SET NAME"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr "STATUS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr "STUDENT ID"
 
@@ -5056,86 +5166,86 @@ msgstr "STUDENT ID"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "Save"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr "Save %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Save As"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr "Save Changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "Save as"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr "Save as Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "Save changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr "Save file to:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr "Save to %1 and View"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr "Saved to file '%1'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr "Schema and database field definitions do not agree"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr "Schema and database table definitions do not agree"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5150,11 +5260,11 @@ msgstr "Score (%)"
 msgid "Score required for release"
 msgstr "Score required for release"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Score selected set(s) and save to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr "Score summary for last submit:"
 
@@ -5179,7 +5289,7 @@ msgid "Scoring Tools"
 msgstr "Scoring Tools"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
@@ -5188,8 +5298,8 @@ msgstr ""
 "individual students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
-msgstr "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
+msgstr "Scroll of Resurrection"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
@@ -5198,24 +5308,24 @@ msgstr "Secondary sort"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Section"
@@ -5230,11 +5340,15 @@ msgstr "Section:"
 msgid "Seed"
 msgstr "Seed"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr "Select"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+msgid "Select a Homework Set"
+msgstr "Select a Homework Set"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -5244,11 +5358,11 @@ msgstr "Select a Problem Collection"
 msgid "Select a Set from this Course"
 msgstr "Select a Set from this Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr "Select a course to delete."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5258,25 +5372,25 @@ msgstr ""
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr "Select a course to unarchive."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr "Select a database layout below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr "Select a listing format:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr "Select above then:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr "Select all eligible courses"
 
@@ -5284,27 +5398,27 @@ msgstr "Select all eligible courses"
 msgid "Select all sets"
 msgstr "Select all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Select all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Select an action to perform"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr "Select an action to perform:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr "Select course(s) to archive."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr "Select course(s) to hide or unhide."
 
@@ -5320,7 +5434,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr "Select sets below to assign them to the newly-created users."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5356,23 +5470,23 @@ msgstr ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr "Selected students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr "Send E-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr "Send Email"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr "Send to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Set"
 
@@ -5406,7 +5520,7 @@ msgid "Set Definition Files"
 msgstr "Set Definition Files"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr "Set Description"
 
@@ -5419,7 +5533,7 @@ msgid "Set Detail for set %2"
 msgstr "Set Detail for set %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5433,12 +5547,12 @@ msgstr "Set Header"
 msgid "Set ID"
 msgstr "Set ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Set Info"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "Set List"
 
@@ -5466,9 +5580,13 @@ msgid "Set Name "
 msgstr "Set Name "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
 msgstr "Set headers are not used in display of gateway tests."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
@@ -5501,7 +5619,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Sets"
 
@@ -5513,7 +5631,7 @@ msgstr "Sets Assigned to User"
 msgid "Sets assigned to %1"
 msgstr "Sets assigned to %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr "Setting"
 
@@ -5522,11 +5640,11 @@ msgid "Shift dates so that the earliest is"
 msgstr "Shift dates so that the earliest is"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr "Show"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr "Show Auxiliary Resources"
 
@@ -5534,7 +5652,7 @@ msgstr "Show Auxiliary Resources"
 msgid "Show Date & Size"
 msgstr "Show Date & Size"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "Show Hints"
 
@@ -5542,8 +5660,8 @@ msgstr "Show Hints"
 msgid "Show Me Another"
 msgstr "Show Me Another"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Show Past Answers"
 
@@ -5555,8 +5673,8 @@ msgstr "Show Problems on Finished Tests"
 msgid "Show Scores on Finished Assignments?"
 msgstr "Show Scores on Finished Assignments?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "Show Solutions"
 
@@ -5564,7 +5682,7 @@ msgstr "Show Solutions"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr "Show Total Homework Grade on Grades Page"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Show Which Users?"
 
@@ -5573,17 +5691,17 @@ msgstr "Show Which Users?"
 msgid "Show all paths"
 msgstr "Show all paths"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Show correct answers"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr "Show me another"
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr "Show me another %1"
 
@@ -5592,7 +5710,7 @@ msgstr "Show me another %1"
 msgid "Show path ..."
 msgstr "Show path ..."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr "Show saved answers?"
 
@@ -5603,17 +5721,17 @@ msgstr "Show which sets?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Show/Hide Site Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Show:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr "Showing"
 
@@ -5623,7 +5741,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "Showing %1 out of %2 sets."
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr "Showing %1 out of %2 users"
 
@@ -5639,13 +5757,13 @@ msgstr "Simple"
 msgid "Site Information"
 msgstr "Site Information"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr "Skip archiving this course"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr "Solution:"
 
@@ -5654,7 +5772,7 @@ msgstr "Solution:"
 msgid "Solutions"
 msgstr "Solutions"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr "Some answers will be graded later."
 
@@ -5667,6 +5785,16 @@ msgstr ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -5692,14 +5820,14 @@ msgstr ""
 "Something was wrong with your LTI parameters.  If this recurs, please speak "
 "with your instructor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "Sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -5730,7 +5858,7 @@ msgstr ""
 "Source file paths cannot include .. or start with /: your source file path "
 "was modified."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5765,46 +5893,46 @@ msgstr "Statistics for %1 set %2. Closes %3"
 msgid "Statistics for %1 student %2"
 msgstr "Statistics for %1 student %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Stop Acting"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr "Stop Archiving"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr "Stop archiving courses"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "Student ID"
 
@@ -5834,14 +5962,14 @@ msgstr "Student Progress for %1 student %2"
 msgid "Student answers"
 msgstr "Student answers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr "Subject:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr "Subject: "
 
@@ -5853,31 +5981,35 @@ msgstr "Submission time:"
 msgid "Submit"
 msgstr "Submit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "Submit Answers"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
 msgstr "Submit Answers for %1"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "Success"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr "Success Index"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr "Successfully archived the course %1."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr "Successfully created new achievement %1"
 
@@ -5887,42 +6019,42 @@ msgid "Successfully created new set %1"
 msgstr "Successfully created new set %1"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr "Successfully created the course %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr "Successfully deleted the course %1."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr "Successfully renamed the course %1 to %2"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "Successfully unarchived %1 to the course %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr "Table defined in database but missing in schema"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr "Table defined in schema but missing in database"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr "Table is ok"
 
@@ -5940,16 +6072,16 @@ msgstr "Take %1 test"
 msgid "Take %1 test."
 msgstr "Take %1 test."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "Take Action!"
 
@@ -6026,11 +6158,11 @@ msgstr ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "The WeBWorK Project"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6060,15 +6192,15 @@ msgstr ""
 "opened.  You can change this for individual homework, but WeBWorK will use "
 "this value when a set is created. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr "The answer above is NOT correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "The answer above is correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr "The answer will be graded later."
 
@@ -6086,7 +6218,7 @@ msgstr ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
@@ -6095,7 +6227,7 @@ msgstr ""
 "your site administrator check that Constants.pm is up to date."
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6146,12 +6278,12 @@ msgstr ""
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "The evaluator for %1 has been renamed to '%2'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
@@ -6160,42 +6292,42 @@ msgstr ""
 "saved"
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr "The file %1/%2 cannot be found."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr "The file %1/%2 is not readable by the webserver."
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr "The file '%1' cannot be found."
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr "The file '%1' cannot be read!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr "The file '%1' is a blank problem!"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr "The file '%1' is a directory!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr "The file '%1' is protected!"
 
@@ -6208,29 +6340,29 @@ msgid "The file you are trying to download doesn't exist"
 msgstr "The file you are trying to download doesn't exist"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr "The following courses were successfully hidden: %1"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr "The following courses were successfully unhidden: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr "The following upgrades are available for your WeBWorK system:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
@@ -6239,7 +6371,7 @@ msgstr ""
 "the score of problem %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -6248,25 +6380,25 @@ msgstr ""
 "the weighted average of the problems: %1."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "The hardcopy header for set %1 has been renamed to '%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr "The institution associated with the course %1 is now %2"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
@@ -6274,7 +6406,7 @@ msgstr ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6298,7 +6430,7 @@ msgstr ""
 "sets."
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
@@ -6306,7 +6438,7 @@ msgstr ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr "The password and password confirmation for the instructor must match."
 
@@ -6328,8 +6460,8 @@ msgstr ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "The path to the original file should be absolute"
 
@@ -6339,7 +6471,7 @@ msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 "The percentage of active students with correct answers for each problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -6349,17 +6481,17 @@ msgstr ""
 "is in the 50% column."
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr "The recorded score for this test is  %1/%2."
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr "The recorded score for this test is %1/%2."
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -6373,23 +6505,23 @@ msgstr ""
 "The reduced scoring date should be between the open date and close date."
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "The score for this problem can count towards score of problem %1."
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "The selected problem set (%1) is not a valid set for %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr "The set %1 is assigned to %2."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr "The set header for set %1 has been renamed to '%2'."
@@ -6405,7 +6537,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "The set-version (%1, version %2) is not assigned to user %3."
 
@@ -6414,7 +6546,7 @@ msgid "The solution has been removed."
 msgstr "The solution has been removed."
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
@@ -6422,9 +6554,15 @@ msgstr ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr "The test (which is number %1) may  no longer be submitted for a grade."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6445,23 +6583,23 @@ msgstr ""
 "created."
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr "The title of the course %1 has been changed from %2 to %3"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr "The title of the course %1 is now %2"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr "The user %1 has been assigned %2."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
@@ -6470,7 +6608,7 @@ msgstr ""
 "'N'."
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
@@ -6479,7 +6617,9 @@ msgstr ""
 "with '0'."
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
@@ -6488,7 +6628,7 @@ msgstr ""
 "'N'."
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
@@ -6497,7 +6637,7 @@ msgstr ""
 "'N'."
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
@@ -6506,7 +6646,7 @@ msgstr ""
 "replaced with 'No'."
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
@@ -6514,7 +6654,7 @@ msgstr ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6528,8 +6668,8 @@ msgstr "Theme (refresh page after saving changes to reveal new theme.)"
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "Then by"
 
@@ -6556,10 +6696,10 @@ msgstr ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
@@ -6567,9 +6707,9 @@ msgstr ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
@@ -6577,7 +6717,7 @@ msgstr ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6589,7 +6729,7 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr "There are no matching WeBWorK problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
@@ -6597,12 +6737,12 @@ msgstr ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr "There are upgrades available for the Open Problem Library."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
@@ -6611,7 +6751,7 @@ msgstr ""
 "remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
@@ -6619,17 +6759,16 @@ msgstr ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6653,11 +6792,11 @@ msgstr "There is NO undo for unassigning a set."
 msgid "There is NO undo for unassigning students."
 msgstr "There is NO undo for unassigning students."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr "There is a new version of PG available."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr "There is a new version of WeBWorK available."
 
@@ -6678,7 +6817,7 @@ msgstr ""
 "files can be edited using the \"Email\" link and the \"File Manager\" link "
 "in the left margin."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6702,7 +6841,7 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr "There is no written solution available for this problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
@@ -6710,7 +6849,7 @@ msgstr ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
@@ -6718,13 +6857,13 @@ msgstr ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6748,15 +6887,15 @@ msgstr "This action can take a long time if there are many students."
 msgid "This action will not overwrite existing users."
 msgstr "This action will not overwrite existing users."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr "This answer is NOT completely correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr "This answer is NOT correct."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr "This answer is correct."
 
@@ -6768,20 +6907,20 @@ msgstr ""
 "This course supports guest logins. Click %1 to log into this course as a "
 "guest."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "This homework set contains no problems."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "This homework set is closed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "This homework set is not yet open."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
@@ -6790,6 +6929,10 @@ msgstr ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "This is a new (re-randomized) version of the problem."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6883,12 +7026,16 @@ msgstr ""
 "This is the number of achievement points given to each user for completing a "
 "problem."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr "This problem contains a video which must be viewed online."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
@@ -6896,24 +7043,24 @@ msgstr ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr "This problem uses the same source file as number %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "This problem will not count towards your grade."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr "This sample mail would be sent to %1"
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
@@ -6934,17 +7081,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr "This set %1 is assigned to %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr "This set doesn't contain any problems yet."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6962,13 +7109,13 @@ msgstr ""
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr "This set is %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -7013,22 +7160,22 @@ msgstr ""
 "graders if they are written appropriately."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr "This source file does not exist!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr "This source file is a directory!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr "This source file is not a plain file!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr "This source file is not readable!"
 
@@ -7064,7 +7211,7 @@ msgstr ""
 "Hardcopy for Selected Sets' button at the end of the table.  There is also a "
 "clear button and an Email instructor button at the end of the table."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -7078,8 +7225,8 @@ msgstr ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr "Time"
 
@@ -7088,7 +7235,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr "Time Interval for New Test Versions (min; 0=infty)"
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr "Time taken on test: %1 min (%2 min allowed)."
 
@@ -7101,18 +7248,18 @@ msgid "Timezone for the course"
 msgstr "Timezone for the course"
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr "To access this set you must score at least %1% on set %2."
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 "To access this set you must score at least %1% on the following sets: %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
@@ -7122,7 +7269,7 @@ msgstr ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7138,14 +7285,14 @@ msgstr ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 "To copy problem templates from an existing course, select the course below."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
@@ -7153,8 +7300,8 @@ msgstr ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
@@ -7162,8 +7309,8 @@ msgstr ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -7175,11 +7322,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "To this Problem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr "To:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr "Totals"
 
@@ -7196,7 +7343,8 @@ msgid "Transfer"
 msgstr "Transfer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr "True"
 
@@ -7212,46 +7360,46 @@ msgstr "Tunic of Extension"
 msgid "Two Columns"
 msgstr "Two Columns"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr "Type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr "URI"
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "Unable to change the evaluator for set %1. Unknown error."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr "Unable to obtain error messages from within the PG question."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr "Unable to write to '%1': %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr "Unarchive"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr "Unarchive %1 to course:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr "Unarchive Course"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr "Unarchive Next Course"
 
@@ -7273,7 +7421,7 @@ msgstr ""
 "and click on the Unassign button."
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr "Unattempted: %1/%2"
 
@@ -7281,13 +7429,13 @@ msgstr "Unattempted: %1/%2"
 msgid "Unclassified Problems"
 msgstr "Unclassified Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr "Ungraded"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr "Unhide Courses"
 
@@ -7309,7 +7457,7 @@ msgstr "Unpack"
 msgid "Unpack archives automatically"
 msgstr "Unpack archives automatically"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr "Unselect all courses"
 
@@ -7317,12 +7465,12 @@ msgstr "Unselect all courses"
 msgid "Unselect all sets"
 msgstr "Unselect all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Unselect all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr "Update"
 
@@ -7334,37 +7482,37 @@ msgstr "Update Display"
 msgid "Update Menus"
 msgstr "Update Menus"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr "Update settings and refresh page"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr "Update the checked directories?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr "Updated location description."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr "Upgrade Course Tables"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr "Upgrade Courses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr "Upgrade process completed"
 
@@ -7378,11 +7526,12 @@ msgid "Use Date Picker"
 msgstr "Use Date Picker"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr "Use Default Header File"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr "Use Equation Editor?"
 
@@ -7390,20 +7539,20 @@ msgstr "Use Equation Editor?"
 msgid "Use Item"
 msgstr "Use Item"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Use System Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr "Use browser back button to return from preview mode"
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr "Use in achievement %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr "Use in new achievement:"
 
@@ -7423,7 +7572,7 @@ msgstr ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -7434,7 +7583,7 @@ msgstr ""
 "additional information about the state of the system will be included."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
@@ -7442,7 +7591,7 @@ msgstr ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr "User ID"
@@ -7464,8 +7613,8 @@ msgstr "User's name is:"
 msgid "User's username is:"
 msgstr "User's username is:"
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -7485,7 +7634,7 @@ msgid "Username presented:  %1"
 msgstr "Username presented:  %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -7495,7 +7644,7 @@ msgstr "Users"
 msgid "Users Assigned to Set %2"
 msgstr "Users Assigned to Set %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Users List"
 
@@ -7518,7 +7667,7 @@ msgstr ""
 "Normally guest users are not allowed to change their password."
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "Users sorted by %1, then by %2, then by %3"
 
@@ -7544,17 +7693,18 @@ msgstr ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
-msgstr "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
+msgstr "Using contents of the default message %1 instead."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr "Using what display mode?: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr "Using what seed?: "
 
@@ -7562,21 +7712,21 @@ msgstr "Using what seed?: "
 msgid "Value of work done in Reduced Scoring Period"
 msgstr "Value of work done in Reduced Scoring Period"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr "Variable Documentation:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr "Versions of a set can only be edited for one user at a time."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "View"
 
@@ -7589,7 +7739,7 @@ msgstr "View"
 msgid "View Problems"
 msgstr "View Problems"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "View equations as"
 
@@ -7620,8 +7770,8 @@ msgstr "View student progress by student"
 msgid "View/Edit"
 msgstr "View/Edit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr "Viewing temporary file:"
@@ -7644,17 +7794,17 @@ msgstr "Visible"
 msgid "Visible to Students"
 msgstr "Visible to Students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr "Warning"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr "Warning messages"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 
@@ -7663,11 +7813,16 @@ msgstr "Warning: Deletion destroys all user-related data and is not undoable!"
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr "Warnings encountered while processing %1. Error text: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr "WeBWorK Error"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK Warnings"
 
@@ -7693,7 +7848,7 @@ msgstr ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7737,7 +7892,7 @@ msgstr "Welcome to WeBWorK!"
 msgid "What could be inside?"
 msgstr "What could be inside?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "What field should filtered users match on?"
 
@@ -7846,12 +8001,12 @@ msgstr ""
 msgid "Will open on %1."
 msgstr "Will open on %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Worth"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
@@ -7860,7 +8015,7 @@ msgstr ""
 "another file for viewing."
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
@@ -7868,7 +8023,7 @@ msgstr ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
@@ -7876,18 +8031,20 @@ msgstr ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Yes"
 
@@ -7922,15 +8079,15 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr "You are not authorized to access the Instructor tools"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr "You are not authorized to access the Instructor tools."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "You are not authorized to access the instructor tools."
 
@@ -7940,7 +8097,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "You are not authorized to modify homework sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "You are not authorized to modify problems."
 
@@ -7949,13 +8106,13 @@ msgstr "You are not authorized to modify problems."
 msgid "You are not authorized to modify set definition files."
 msgstr "You are not authorized to modify set definition files."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "You are not authorized to modify student data"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "You are not authorized to perform this action."
 
@@ -7978,7 +8135,7 @@ msgstr ""
 "You are only allowed to click on Show Me Another %quant(%1,time,times) per "
 "problem. %2 Close this tab, and return to the original problem."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr "You are out of time.  Press grade now!"
 
@@ -7989,6 +8146,10 @@ msgstr "You can also examine the following temporary files: "
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "You can earn partial credit on this problem."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -8012,7 +8173,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -8036,15 +8197,15 @@ msgstr "You can't edit a directory"
 msgid "You can't view files of that type"
 msgstr "You can't view files of that type"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr "You cannot archive the course you are currently using."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr "You cannot delete the course you are currently using."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "You cannot delete yourself!"
 
@@ -8060,7 +8221,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "You did not specify a new set name."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr "You didn't enter any message."
 
@@ -8087,30 +8248,34 @@ msgstr "You do not have permission to edit this file."
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "You do not have permission to generate hardcopy in %1 format."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "You do not have permission to view the details of this error."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr "You don't have any Achievement data associated to you!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr "You don't have any items!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr "You exceeded the allowed time."
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "You have %1 attempt(s) remaining on this test."
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
@@ -8119,7 +8284,7 @@ msgstr ""
 "requested."
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "You have attempted this problem %quant(%1,time,times)."
 
@@ -8127,7 +8292,7 @@ msgstr "You have attempted this problem %quant(%1,time,times)."
 msgid "You have been logged out of WeBWorK."
 msgstr "You have been logged out of WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr "You have less than 1 minute to complete this test."
 
@@ -8166,11 +8331,15 @@ msgstr ""
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+msgid "You may not change your answers when going on to the next part!"
+msgstr "You may not change your answers when going on to the next part!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "You may not change your own password here!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr "You may still check your answers."
 
@@ -8184,7 +8353,7 @@ msgstr ""
 "is available."
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
@@ -8192,7 +8361,7 @@ msgstr ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr "You must confirm the password for the initial instructor."
 
@@ -8209,7 +8378,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr "You must provide a student ID, a set ID, and a problem number."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr "You must select a course to rename."
 
@@ -8221,20 +8390,25 @@ msgstr "You must select at least one file for the archive"
 msgid "You must select at least one file to delete"
 msgstr "You must select at least one file to delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr "You must select one or more sets for scoring"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+msgid "You must select one or more sets for scoring!"
+msgstr "You must select one or more sets for scoring!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+msgid "You must specify a %1 name"
+msgstr "You must specify a %1 name"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr "You must specify a course ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr "You must specify a course name."
 
@@ -8242,41 +8416,41 @@ msgstr "You must specify a course name."
 msgid "You must specify a file name"
 msgstr "You must specify a file name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr "You must specify a first name for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr "You must specify a last name for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr "You must specify a new institution for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr "You must specify a new name for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr "You must specify a new title for the course."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr "You must specify a password for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "You must specify a user ID."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr "You must specify an email address for the initial instructor."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "You must specify an file name in order to save a new file."
 
@@ -8312,12 +8486,12 @@ msgid "You need to select a set to view."
 msgstr "You need to select a set to view."
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr "You received a score of %1 for this attempt."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
@@ -8326,7 +8500,7 @@ msgstr ""
 "run out of attempts, for this problem and its graded subproblems."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8371,28 +8545,29 @@ msgstr ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr "Your browser does not support the video tag."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr "Your current branch of PG is up to date with branch %1 in remote %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr "Your current branch of the Open Problem Library is up to date."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr "Your display options have been saved."
 
@@ -8404,47 +8579,60 @@ msgstr "Your email address has been changed."
 msgid "Your file name contains illegal characters"
 msgstr "Your file name contains illegal characters"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr "Your file name is not valid! "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr "Your message was sent successfully."
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Your overall recorded score is %1.  %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "Your recorded score on this test (number %1) is %2/%3."
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr "Your score on this %1 WAS recorded."
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr "Your score on this %1 is %2/%3."
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr "Your score on this %1 was NOT recorded."
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "Your score on this (checked, not recorded) submission is %1/%2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr "Your score on this problem was recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -8452,11 +8640,11 @@ msgstr ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Your score was not recorded because this homework set is closed."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
@@ -8464,14 +8652,14 @@ msgstr ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
 "Your score was not recorded because this problem set version is not open."
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
@@ -8479,7 +8667,7 @@ msgstr ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
@@ -8487,38 +8675,38 @@ msgstr ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr "Your score was not recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr "Your score was not successfully sent to the LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Your score was recorded."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr "Your score was successfully sent to the LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Your session has timed out due to inactivity. Please log in again."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr "Your systems are up to date!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr "[Edit]"
@@ -8531,7 +8719,7 @@ msgstr "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr "_ANSWER_LOG_DESCRIPTION"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr "_CLASSLIST_EDITOR_DESCRIPTION"
 
@@ -8554,19 +8742,24 @@ msgstr "_HMWKSETS_EDITOR_DESCRIPTION"
 msgid "_LOGIN_MESSAGE"
 msgstr "_LOGIN_MESSAGE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr "_PROBLEM_SET_SUMMARY"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr "_REQUEST_ERROR"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr "_USER_TABLE_SUMMARY"
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+msgid "a duplicate of the first selected achievement."
+msgstr "a duplicate of the first selected achievement."
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -8575,13 +8768,18 @@ msgid "a duplicate of the first selected set"
 msgstr "a duplicate of the first selected set"
 
 # Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+msgid "a new empty achievement."
+msgstr "a new empty achievement."
+
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "a new empty set"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr "a new file named:"
 
@@ -8590,7 +8788,7 @@ msgstr "a new file named:"
 msgid "a single set"
 msgstr "a single set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr "active"
 
@@ -8599,11 +8797,11 @@ msgid "add problems"
 msgstr "add problems"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr "addGlobalSet %1 in ProblemSetList:  %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr "added missing permission level for user"
 
@@ -8613,13 +8811,13 @@ msgid "admin"
 msgstr "admin"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr "all achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -8648,14 +8846,14 @@ msgstr "all sets"
 msgid "all students"
 msgstr "all students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "all users"
 
@@ -8663,31 +8861,37 @@ msgstr "all users"
 msgid "all users for one <b>set</b>"
 msgstr "all users for one <b>set</b>"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr "alphabetically"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr "answer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "any users"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr "as"
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
-msgstr "assigning the achievements to"
 
 # Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
@@ -8701,22 +8905,22 @@ msgstr "avg attempts"
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr "blank problem template(s) to end of homework set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr "by last login date"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "changes abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "changes saved"
@@ -8733,17 +8937,17 @@ msgstr "class list data for selected <b>users</b>"
 msgid "close"
 msgstr "close"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr "column"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr "columns:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "correct"
 
@@ -8757,7 +8961,7 @@ msgid "deleted %1 sets"
 msgstr "deleted %1 sets"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr "deleted %1 users"
 
@@ -8769,7 +8973,7 @@ msgstr "editing all achievements"
 msgid "editing all sets"
 msgstr "editing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "editing all users"
 
@@ -8781,7 +8985,7 @@ msgstr "editing selected achievements"
 msgid "editing selected sets"
 msgstr "editing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "editing selected users"
 
@@ -8789,7 +8993,7 @@ msgstr "editing selected users"
 msgid "editing visible sets"
 msgstr "editing visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "editing visible users"
 
@@ -8798,7 +9002,7 @@ msgstr "editing visible users"
 msgid "email:"
 msgstr "email:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr "empty"
 
@@ -8811,16 +9015,16 @@ msgid "entry rows."
 msgstr "entry rows."
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr "error adding set location %1 for set %2: %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "export abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr "exporting all achievements"
 
@@ -8828,7 +9032,7 @@ msgstr "exporting all achievements"
 msgid "exporting all sets"
 msgstr "exporting all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr "exporting selected achievements"
 
@@ -8862,15 +9066,15 @@ msgstr "for students"
 msgid "from"
 msgstr "from"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "giving new passwords to all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "giving new passwords to selected users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "giving new passwords to visible users"
 
@@ -8899,9 +9103,9 @@ msgstr "grade_proctor"
 msgid "guest"
 msgstr "guest"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "hidden"
@@ -8910,7 +9114,7 @@ msgstr "hidden"
 msgid "hidden from"
 msgstr "hidden from"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "hidden from students"
@@ -8922,45 +9126,50 @@ msgstr "hidden sets"
 # doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr "i"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+# does not need to be translated
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr "if"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr "illegal character in input: '/'"
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr "in their"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr "inactive"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "incorrect"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr "index"
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr "input set location %1 already exists for set %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr "list of insertable macros"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr "locations selected below"
 
@@ -8968,7 +9177,7 @@ msgstr "locations selected below"
 msgid "login"
 msgstr "login"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr "login ID"
 
@@ -9003,15 +9212,15 @@ msgstr "new set:"
 msgid "new users"
 msgstr "new users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr "no achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr "no achievements."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr "no location"
 
@@ -9030,28 +9239,32 @@ msgstr "no sets"
 msgid "no students"
 msgstr "no students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "no users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr "nobody"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr "nth colum of merge file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
 msgstr "number of students not defined"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
@@ -9075,7 +9288,7 @@ msgstr "only"
 msgid "only best scores"
 msgstr "only best scores"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -9087,53 +9300,57 @@ msgstr "or"
 msgid "or Problems from"
 msgstr "or Problems from"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr "out of"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr "overwrite all data"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr "part"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr "permissions for %1 not defined"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr "pg debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr "pg internal errors"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr "pg warning"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr "point"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr "points"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr "preserve existing data"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr "preview answers"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr "problem"
 
@@ -9151,8 +9368,8 @@ msgid "progress"
 msgstr "progress"
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr "readSetDef error, can't read the line: ||%1||"
 
@@ -9166,19 +9383,19 @@ msgid "record for user %1 not found"
 msgstr "record for user %1 not found"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr "record for visible user %1 not found"
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr "row"
 
@@ -9200,13 +9417,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr "selected <b>users</b> to selected <b>sets</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr "selected achievements"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr "selected achievements."
 
@@ -9225,17 +9442,17 @@ msgstr "selected achievements."
 msgid "selected sets"
 msgstr "selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "selected users"
 
@@ -9273,7 +9490,7 @@ msgstr "sets with matching set IDs:"
 msgid "showing all sets"
 msgstr "showing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "showing all users"
 
@@ -9288,7 +9505,7 @@ msgstr "showing hidden sets"
 msgid "showing matching sets"
 msgstr "showing matching sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "showing matching users"
 
@@ -9296,7 +9513,7 @@ msgstr "showing matching users"
 msgid "showing no sets"
 msgstr "showing no sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "showing no users"
 
@@ -9304,13 +9521,17 @@ msgstr "showing no users"
 msgid "showing selected sets"
 msgstr "showing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "showing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
 msgstr "showing visible sets"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
@@ -9326,16 +9547,16 @@ msgstr "student"
 msgid "students"
 msgstr "students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr "submission"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr "submission (test %1)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr "summary"
 
@@ -9343,12 +9564,12 @@ msgstr "summary"
 msgid "ta"
 msgstr "ta"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr "test"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr "test (%1)"
 
@@ -9360,7 +9581,7 @@ msgstr "test date"
 msgid "test time"
 msgstr "test time"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr "the following file"
 
@@ -9369,14 +9590,14 @@ msgid "the following file(s)"
 msgstr "the following file(s)"
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr "the original path to the file is %1"
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr "then by"
 
@@ -9384,7 +9605,11 @@ msgstr "then by"
 msgid "then delete them"
 msgstr "then delete them"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "time"
 
@@ -9392,43 +9617,40 @@ msgstr "time"
 msgid "time limit exceeded"
 msgstr "time limit exceeded"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "times"
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
 msgstr "to"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
-msgstr "to all users, create global data, and"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr "to one <b>set</b>"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr "top score"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr "total"
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr "unable to write to directory %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "unlimited"
 
@@ -9437,7 +9659,7 @@ msgstr "unlimited"
 msgid "userID: %1 --"
 msgstr "userID: %1 --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
@@ -9445,21 +9667,21 @@ msgstr ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr "users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "users who match on selected field"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr "users who match:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "visible"
@@ -9472,20 +9694,25 @@ msgstr "visible"
 msgid "visible sets"
 msgstr "visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "visible to students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "visible users"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -9493,56 +9720,71 @@ msgstr "with set name(s):"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr "won't be able to read from file %1/%2: does it exist? is it readable?"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
 msgstr "your students"
 
-#
-msgid "navNext"
-msgstr "Next"
+#~ msgid "Import achievements from"
+#~ msgstr "Import achievements from"
+
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "Open, reduced scoring starts on %1."
+
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "Reduced Scoring Starts %1"
+
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "Reduced scoring started on %1."
 
 #
-msgid "navNextGrey"
-msgstr "Next"
+#~ msgid "navNext"
+#~ msgstr "Next"
 
 #
-msgid "navPrev"
-msgstr "Previous"
+#~ msgid "navNextGrey"
+#~ msgstr "Next"
 
 #
-msgid "navPrevGrey"
-msgstr "Previous"
+#~ msgid "navPrev"
+#~ msgstr "Previous"
 
 #
-msgid "navProbListGrey"
-msgstr "Problem List"
+#~ msgid "navPrevGrey"
+#~ msgstr "Previous"
 
 #
-msgid "navUp"
-msgstr "Homework Sets"
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_1"
-msgstr ""
-"This assignment has a Reduced Scoring Period that begins %1 and ends on the "
-"due date, %2.  During this period all additional work done counts %3 % of "
-"the original."
-
-#
-msgid "_AUTO"
-msgstr "1"
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_2"
-msgstr ""
-"This assignment had a Reduced Scoring Period that began %1 and ended on the "
-"due date, %2.  During that period all additional work done counted %3 % of "
-"the original."
-
-#, fuzzy
-#~ msgid "navProbList"
+#~ msgid "navProbListGrey"
 #~ msgstr "Problem List"
+
+#
+#~ msgid "navUp"
+#~ msgstr "Homework Sets"
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
+#~ msgstr ""
+#~ "This assignment has a Reduced Scoring Period that begins %1 and ends on "
+#~ "the due date, %2.  During this period all additional work done counts %3 "
+#~ "% of the original."
+
+#
+#~ msgid "_AUTO"
+#~ msgstr "1"
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
+#~ msgstr ""
+#~ "This assignment had a Reduced Scoring Period that began %1 and ended on "
+#~ "the due date, %2.  During that period all additional work done counted %3 "
+#~ "% of the original."
+
+#~ msgid "navProbList"
+#~ msgstr "navProbList"

--- a/lib/WeBWorK/Localize/es.po
+++ b/lib/WeBWorK/Localize/es.po
@@ -1,49 +1,43 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: WeBWorK Online Homework System\n"
+"Project-Id-Version: webwork2\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2016-03-21 14:37-0500\n"
-"Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: Webwork Language team\n"
-"Language: es_MX\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/webwork/webwork2/language/"
+"es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
-#, fuzzy
 msgid "#corr"
-msgstr "correcto"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
-#, fuzzy
 msgid "#incorr"
-msgstr "incorrecto"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
-#, fuzzy
 msgid "% correct"
-msgstr "%1% correcto"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
 msgid "% correct with review"
 msgstr ""
 
-#
+# Percent students
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
-#, fuzzy
 msgid "% students"
-msgstr "tr: visible to students"
+msgstr ""
 
 #. ($prettySetID)
 #. ($prettyProblemID)
@@ -52,68 +46,52 @@ msgstr "tr: visible to students"
 msgid "%1 (old editor)"
 msgstr ""
 
-#
+# Gateway (test 3)
 #. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
-#, fuzzy
 msgid "%1 (test %2)"
-msgstr "tr: %1 (test %2)"
+msgstr ""
 
-#
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
-#, fuzzy
 msgid "%1 Points:"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
-#, fuzzy
 msgid "%1 Problems:"
-msgstr "Problemas"
+msgstr ""
 
-#
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
-#, fuzzy
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr "tr: %1 sets exported, %2 sets skipped. Skipped sets: (%3)"
+msgstr ""
 
-#
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
-#, fuzzy
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
-msgstr "tr: %1 sets exported, %2 sets skipped. Skipped sets: (%3)"
+msgstr ""
 
-#
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
-#, fuzzy
 msgid "%1 students out of %2"
-msgstr "tr: visible to students"
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
-#
 #. (scalar @userIDsToExport, $dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
-#, fuzzy
 msgid "%1 users exported to file %2/%3"
-msgstr "tr: %1 users exported to file %2/%3"
+msgstr ""
 
-#
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
-#, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
-"tr: %1 users replaced, %2 users added, %3 users skipped.  Skipped users: (%4)"
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
@@ -130,88 +108,66 @@ msgid ""
 "that system, but aren't allowed to log in to this course."
 msgstr ""
 
-#
 #. ($levelpercentage)
 #. ($percentage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
-#, fuzzy
 msgid "%1% Complete"
-msgstr "tr: completely"
+msgstr ""
 
-#
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
-#, fuzzy
 msgid "%1% correct"
-msgstr "%1% correcto"
+msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
-#, fuzzy
 msgid "%1's Current Address"
-msgstr " %1's E-mail actual"
+msgstr ""
 
-#
 #. ($user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
-#, fuzzy
 msgid "%1's Current Password"
-msgstr "Contraseña actual"
+msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
-#, fuzzy
 msgid "%1's New Address"
-msgstr "%1's nuevo correo"
+msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
-#, fuzzy
 msgid "%1's New Password"
-msgstr "Nueva Contraseña"
+msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
-#, fuzzy
 msgid "%1's new password cannot be blank."
-msgstr "%1 nueva contraseña no puede dejarse en blanco."
+msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
-#, fuzzy
 msgid "%1's password has been changed."
-msgstr "La contraseña de %1 ha sido cambiada."
+msgstr ""
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
-#, fuzzy
 msgid "%1: Problem %2"
-msgstr "%1: Problema %2."
+msgstr ""
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
-#, fuzzy
 msgid "%1: Problem %2 Show Me Another"
-msgstr "%1: Problema %2."
+msgstr ""
 
-#
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
-#, fuzzy
 msgid "%1: The directory for the course not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
@@ -228,24 +184,19 @@ msgstr ""
 msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
-#
 #. ($numBlanks)
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
-#, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
-"[quant,_1,de las preguntas permanecen,  pregunta permanece ] sin contestar."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
-#, fuzzy
 msgid "%score"
-msgstr "Calificación"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
@@ -259,59 +210,47 @@ msgid ""
 "of attempts:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
-#, fuzzy
 msgid "(This problem will not count towards your grade.)"
-msgstr "(Este problema no cuenta para tu evaluación)."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
-#, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
-#, fuzzy
 msgid "(Your score on this %1 is not available.)"
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
-#, fuzzy
 msgid "(correct)"
-msgstr "correcto"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
 msgid "(gw/quiz) After version answer date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
-#, fuzzy
 msgid "(incorrect)"
-msgstr "incorrecto"
+msgstr ""
 
-#
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
-#, fuzzy
 msgid "(score %1)"
-msgstr "Calificación"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
-#, fuzzy
 msgid "1 student"
-msgstr "tr: Student ID"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
 msgid ""
@@ -328,6 +267,7 @@ msgid ""
 "graders if they are written appropriately.</p>"
 msgstr ""
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
@@ -342,6 +282,7 @@ msgid ""
 "not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
 msgid ""
 "<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
@@ -357,14 +298,12 @@ msgid ""
 "see a new version that they can not attempt or learn from.</p>"
 msgstr ""
 
-#
 #. ($add_courseID)
 #. ($rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
-#, fuzzy
 msgid "A course with ID %1 already exists."
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr ""
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
@@ -373,12 +312,10 @@ msgid ""
 "existing course before you can unarchive."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
-#, fuzzy
 msgid "A file with that name already exists"
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
@@ -401,24 +338,18 @@ msgid ""
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
-#, fuzzy
 msgid "A new file has been created at '%1'"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
-#, fuzzy
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
 msgstr ""
-"tr: A new file has been created at '%1' with the contents below. No changes "
-"have been made to set %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -427,6 +358,7 @@ msgid ""
 "number of incorrect attempts."
 msgstr ""
 
+# Leave symbol codes in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
 msgid ""
 "A switch to govern the use of a Progress Bar for the student; this also "
@@ -451,36 +383,28 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
+# Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
 msgid "ADJ STATUS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
-#, fuzzy
 msgid "ANSWERS NOT RECORDED"
-msgstr "SOLAMENTE PREVISUALIZACIÓN -- RESPUESTAS NO GUARDADAS"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
-#, fuzzy
 msgid "ANSWERS NOT RECORDED --"
-msgstr "SOLAMENTE PREVISUALIZACIÓN -- RESPUESTAS NO GUARDADAS"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
-#, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
-msgstr "RESPUESTAS SOLO VERIFICADAS--RESPUESTAS NO GUARDADAS"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
-#, fuzzy
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
-msgstr "RESPUESTAS SOLO VERIFICADAS--RESPUESTAS NO GUARDADAS"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
@@ -490,29 +414,24 @@ msgstr "RESPUESTAS SOLO VERIFICADAS--RESPUESTAS NO GUARDADAS"
 msgid "Abandon changes"
 msgstr "tr: Abandon changes"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "tr: Abandon export"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
-#, fuzzy
 msgid "Achievement"
-msgstr "tr: selected sets"
+msgstr ""
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
-#
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
-#, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
 msgid "Achievement Editor"
@@ -545,29 +464,23 @@ msgstr ""
 msgid "Achievement User Editor"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
-#, fuzzy
 msgid "Achievement has been assigned to all users."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
-#
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
-#, fuzzy
 msgid "Achievement scores saved to %1"
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
-#, fuzzy
 msgid "Achievements"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "Act as"
@@ -579,22 +492,17 @@ msgstr ""
 msgid "Act as:"
 msgstr ""
 
-#
 #. (HTML::Entities::encode_entities($eUserID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
-#, fuzzy
 msgid "Acting as %1."
-msgstr "Actuando como %1"
+msgstr ""
 
-#
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
-#, fuzzy
 msgid "Action %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Active"
 msgstr "tr: Active"
@@ -612,7 +520,6 @@ msgid ""
 "homework in a limited way."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
@@ -624,23 +531,17 @@ msgstr "tr: Add"
 msgid "Add All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
-#, fuzzy
 msgid "Add Course"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
-#, fuzzy
 msgid "Add Students"
-msgstr "tr: visible to students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
-#, fuzzy
 msgid "Add Users"
 msgstr "Agregar usuarios"
 
@@ -652,37 +553,28 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
-#, fuzzy
 msgid "Add as what filetype?"
 msgstr "tr: Add as what filetype?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
 msgid "Add how many students?"
 msgstr "tr: Add how many students?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
-#, fuzzy
 msgid "Add problems to"
-msgstr "tr: Add problem"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
-#, fuzzy
 msgid "Add to what set?"
-msgstr "tr: Add to which set?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
 msgid "Add which new users?"
 msgstr "tr: Add which new users?"
 
-#
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_path, $setID, $targetProblemNumber)
@@ -692,25 +584,20 @@ msgstr "tr: Add which new users?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
-#, fuzzy
 msgid "Added %1 to %2 as problem %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
-#, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
-msgstr "tr: Added '%1' to %2 as new set header"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
-#, fuzzy
 msgid "Added '%1' to %2 as new set header"
-msgstr "tr: Added '%1' to %2 as new set header"
+msgstr ""
 
 #. (join(', ', @toAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
@@ -756,11 +643,9 @@ msgid ""
 "entry and try again."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Addresses"
-msgstr "tr: Email Address"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
 msgid ""
@@ -792,11 +677,9 @@ msgstr ""
 msgid "Advanced Search"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
-#, fuzzy
 msgid "After set answer date"
-msgstr "tr: Answer Date"
+msgstr ""
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
@@ -812,45 +695,33 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
-#, fuzzy
 msgid "All of the answers above are correct."
-msgstr "Todas las respuestas son correctas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
-#, fuzzy
 msgid "All of the gradeable answers above are correct."
-msgstr "Todas las respuestas son correctas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
-#, fuzzy
 msgid "All selected sets hidden from all students"
-msgstr "tr: All selected sets %1 all students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
-#, fuzzy
 msgid "All selected sets made visible for all students"
-msgstr "tr: All selected sets %1 all students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
-#, fuzzy
 msgid "All sets hidden from all students"
-msgstr "tr: hidden from students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
-#, fuzzy
 msgid "All sets made visible for all students"
-msgstr "tr: visible to students"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "All students in course"
@@ -860,53 +731,39 @@ msgstr ""
 msgid "All unassignments were made successfully."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
-#, fuzzy
 msgid "All visible hidden from all students"
-msgstr "tr: All visible sets %1 all students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
-#, fuzzy
 msgid "All visible sets made visible for all students"
-msgstr "tr: All visible sets %1 all students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
-#, fuzzy
 msgid "Allow unassign"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
 msgid "Allowed error, as a percentage, for numerical comparisons"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
-#, fuzzy
 msgid "Allowed to <em>act as</em> another user"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
-#, fuzzy
 msgid "Allowed to change their e-mail address"
-msgstr "No se pudo cambiar su dirección de correo."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
-#, fuzzy
 msgid "Allowed to change their password"
-msgstr "No se puede cambiar la contraseña %2 de %1."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
-#, fuzzy
 msgid "Allowed to login to the course"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
 msgid "Allowed to see solutions before the answer date"
@@ -916,11 +773,9 @@ msgstr ""
 msgid "Allowed to see the correct answers before the answer date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
-#, fuzzy
 msgid "Allowed to view past answers"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
 msgid "Allowed to view problems in sets which are not open yet"
@@ -954,7 +809,6 @@ msgstr ""
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:782
@@ -965,13 +819,10 @@ msgstr ""
 msgid "Answer Date"
 msgstr "tr: Answer Date"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
-#, fuzzy
 msgid "Answer Log"
-msgstr "Checar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Answer Preview"
@@ -981,31 +832,27 @@ msgstr "Previsualizar respuesta"
 msgid "Answer(s) submitted:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
-#, fuzzy
 msgid "Answer:"
-msgstr "Checar respuestas"
+msgstr ""
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
 msgid "AnswerGroupInfo"
 msgstr ""
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
 msgid "AnswerHashInfo"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
-#, fuzzy
 msgid "Answers"
-msgstr "Checar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
-#, fuzzy
 msgid "Answers Available"
-msgstr "Cerrada, respuestas disponibles"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
@@ -1017,7 +864,6 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
@@ -1026,15 +872,12 @@ msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr ""
 "tr: Any changes made below will be reflected in the set for ALL students."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
-#, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
 msgstr ""
-"tr: Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -1048,19 +891,15 @@ msgstr ""
 msgid "Append"
 msgstr ""
 
-#
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
-#, fuzzy
 msgid "Append to end of %1 set"
-msgstr "tr: Append to end of set %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
-#, fuzzy
 msgid "Archive"
-msgstr "Cursos"
+msgstr ""
 
 #. ($archive, $n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
@@ -1078,30 +917,22 @@ msgstr ""
 msgid "Archive Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
-#, fuzzy
 msgid "Archive Courses"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
-#, fuzzy
 msgid "Archive next course"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
-#, fuzzy
 msgid "Archive this Course"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
-#, fuzzy
 msgid "Archived Courses"
-msgstr "Cursos"
+msgstr ""
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
@@ -1122,24 +953,19 @@ msgid ""
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
-#, fuzzy
 msgid "Assign"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
-#, fuzzy
 msgid "Assign selected sets to selected users"
-msgstr "tr: Assign this set to which users?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
 msgstr "tr: Assign this set to which users?"
@@ -1149,45 +975,34 @@ msgstr "tr: Assign this set to which users?"
 msgid "Assign to All Current Users"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Assigned"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
-#, fuzzy
 msgid "Assigned Sets"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
-#, fuzzy
 msgid "Assigned achievements to users"
-msgstr "tr: Assign this set to which users?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
-#, fuzzy
 msgid "Assigned to"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
-#, fuzzy
 msgid "Assignment type"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
-#, fuzzy
 msgid "At least one of the answers above is NOT correct."
-msgstr "Al menos una de las respuestas no es %1 correcta"
+msgstr ""
 
+# Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
 msgid "Att. to Open Children"
 msgstr ""
@@ -1196,23 +1011,18 @@ msgstr ""
 msgid "Attempt to upgrade directories"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
-#, fuzzy
 msgid "Attempted"
-msgstr "Intentos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
-#, fuzzy
 msgid "Attempts"
-msgstr "Intentos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Audit"
 msgstr "tr: Enrolled"
@@ -1222,7 +1032,6 @@ msgstr "tr: Enrolled"
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
 msgid "Author Info"
@@ -1289,36 +1098,26 @@ msgstr ""
 msgid "Cake of Enlargment"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
-#, fuzzy
 msgid "Can e-mail instructor"
-msgstr "E-mail del profesor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
-#, fuzzy
 msgid "Can report bugs"
-msgstr "Reportar problemas (bugs)"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
-#, fuzzy
 msgid "Can show old answers"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
-#, fuzzy
 msgid "Can submit answers for a student"
-msgstr "Enviar respuestas por %1"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
-#, fuzzy
 msgid "Can't copy file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
@@ -1330,75 +1129,55 @@ msgstr ""
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
-#, fuzzy
 msgid "Can't create directory: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
-#, fuzzy
 msgid "Can't create file '%1': %2"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
-#, fuzzy
 msgid "Can't create file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
-#, fuzzy
 msgid "Can't delete archive '%1': %2"
-msgstr "No se puede obtener la contraseña para el usuario '%1': %2"
+msgstr ""
 
-#
 #. ($eUserID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
-#, fuzzy
 msgid "Can't get password record for effective user '%1': %2"
-msgstr "No se puede obtener la contraseña para el usuario efectivo '%1': %2"
+msgstr ""
 
-#
 #. ($userID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
-#, fuzzy
 msgid "Can't get password record for user '%1': %2"
-msgstr "No se puede obtener la contraseña para el usuario '%1': %2"
+msgstr ""
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
-#, fuzzy
 msgid "Can't open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
-#, fuzzy
 msgid "Can't open file %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
-#, fuzzy
 msgid "Can't read merge file %1. No message sent"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
-#, fuzzy
 msgid "Can't rename file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
 msgid "Can't rename to the same name."
@@ -1409,37 +1188,29 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#
 #. ($!)
 #. ($fullPath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
-#, fuzzy
 msgid "Can't write to file %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
-#, fuzzy
 msgid "Cancel"
-msgstr "tr: Cancel Edit"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
-#, fuzzy
 msgid "Cancel E-mail"
-msgstr "tr: Cancel Edit"
+msgstr ""
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
-#, fuzzy
 msgid "Cannot open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
 msgid "Cap Test Time at Set Close Date?"
@@ -1474,36 +1245,28 @@ msgstr ""
 msgid "Change CourseID to:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
-#, fuzzy
 msgid "Change Display Settings"
-msgstr "tr: Display Options"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
-#, fuzzy
 msgid "Change Email Address"
-msgstr "Cambio de e-mail"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
 msgid "Change Institution to:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
-#, fuzzy
 msgid "Change Password"
-msgstr "Cambio de contraseña"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
-#, fuzzy
 msgid "Change User Settings"
-msgstr "Cambio de opciones de usuario"
+msgstr ""
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
@@ -1515,25 +1278,20 @@ msgstr ""
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
-#, fuzzy
 msgid "Changes abandoned"
-msgstr "tr: changes abandoned"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "tr: Changes in this file have not yet been permanently saved."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
-#, fuzzy
 msgid "Changes saved"
-msgstr "tr: changes saved"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1354
 msgid ""
@@ -1546,17 +1304,13 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
-#, fuzzy
 msgid "Check Answers"
-msgstr "Checar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
-#, fuzzy
 msgid "Check Test"
-msgstr "Checar respuestas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
 msgid "Check that it's permissions are set correctly."
@@ -1569,7 +1323,6 @@ msgid ""
 "webserver."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
 msgid "Checking additional error messages"
 msgstr "tr: Checking additional error messages"
@@ -1593,12 +1346,10 @@ msgstr ""
 msgid "Choose the set whose close date you would like to extend."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
 msgstr "tr: Choose visibility of the sets to be affected"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
 msgid "Choose which sets to be affected"
 msgstr "tr: Choose which sets to be affected"
@@ -1608,21 +1359,17 @@ msgstr "tr: Choose which sets to be affected"
 msgid "Class values"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
 msgid "Classlist Editor"
 msgstr "Editor de la lista de clases"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
 msgid "Clear"
 msgstr "tr: Clear"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
-#, fuzzy
 msgid "Clear Problem Display"
-msgstr "Lista de problemas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
 msgid ""
@@ -1630,16 +1377,12 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
-#, fuzzy
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
-"tr: Click on the login name to edit individual problem set data, (e.g. due "
-"dates) for these students."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
@@ -1650,13 +1393,10 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
-#, fuzzy
 msgid "Close"
-msgstr "tr: Closed"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:781
@@ -1665,55 +1405,40 @@ msgstr "tr: Closed"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:804
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Close Date"
-msgstr "tr: Due Date"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
-#, fuzzy
 msgid "Closed, answers available."
-msgstr "Cerrada, respuestas disponibles"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
-#, fuzzy
 msgid "Closed, answers on %1."
-msgstr "Cerrada, respuestas el %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
-#, fuzzy
 msgid "Closed, answers recently available."
-msgstr "Cerrada, respuestas recientemente disponibles"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
-#, fuzzy
 msgid "Closed."
-msgstr "tr: Closed"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
-#, fuzzy
 msgid "Closes"
-msgstr "tr: Closed"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
-#, fuzzy
 msgid "Closes %1"
-msgstr "tr: Revert to %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
-#, fuzzy
 msgid "Closes:"
-msgstr "tr: Closed"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
 msgid "Collapse"
@@ -1723,7 +1448,6 @@ msgstr ""
 msgid "Collapse All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
@@ -1752,47 +1476,38 @@ msgstr ""
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
-#, fuzzy
 msgid "Completed."
-msgstr "tr: completely"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "Confirm"
 msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
-#, fuzzy
 msgid "Confirm %1's New Password"
-msgstr "Confirme su nueva contraseña."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
-#, fuzzy
 msgid "Confirm Password:"
-msgstr "Confirme su nueva contraseña."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
 msgid "Congratulations, you earned a new level!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
 msgid "Continue"
 msgstr "tr: Continue"
 
-#
 #. ($sourceDirectory, $outputDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
-#, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
-msgstr "tr: Copied auxiliary files from %1 to  new location at %2"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
@@ -1808,13 +1523,10 @@ msgstr ""
 msgid "Copy templates from:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
-#, fuzzy
 msgid "Copy this Problem"
-msgstr "tr: Edit this problem"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
@@ -1825,42 +1537,30 @@ msgstr "Correcto"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
-#, fuzzy
 msgid "Correct Answer"
-msgstr "Checar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
-#, fuzzy
 msgid "Correct Answers:"
-msgstr "Checar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
-#, fuzzy
 msgid "Correct Status"
-msgstr "Correcto"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
-#, fuzzy
 msgid "Correct answers"
-msgstr "Mostrar las respuestas correctas"
+msgstr ""
 
-#
 #. ($total_correct,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
-#, fuzzy
 msgid "Correct: %1/%2"
-msgstr "tr: set %1/problem %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
-#, fuzzy
 msgid "CorrectAnswers"
-msgstr "Checar respuestas"
+msgstr ""
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
@@ -1869,20 +1569,16 @@ msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
 
-#
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
-#, fuzzy
 msgid "Couldn't change %1's password: %2"
-msgstr "No se puede cambiar la contraseña %2 de %1."
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
-#, fuzzy
 msgid "Couldn't change your email address: %1"
-msgstr "No se pudo cambiar su dirección de correo."
+msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
@@ -1899,12 +1595,10 @@ msgstr ""
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
-#, fuzzy
 msgid "Couldn't save your display options: %1"
-msgstr "No se pudo cambiar su dirección de correo."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
@@ -1928,14 +1622,12 @@ msgstr ""
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
 msgstr "Administración del curso"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
 msgid "Course Configuration"
 msgstr "Configuración del curso"
@@ -1945,40 +1637,30 @@ msgstr "Configuración del curso"
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
-#, fuzzy
 msgid "Course ID:"
-msgstr "Información del curso"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "Course Info"
 msgstr "Información del curso"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
-#, fuzzy
 msgid "Course Name:"
-msgstr "tr: First Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
-#, fuzzy
 msgid "Course Title:"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
-#, fuzzy
 msgid "Course archived."
-msgstr "tr: First Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
@@ -1996,23 +1678,18 @@ msgid ""
 "\"hidden\" or \"visible\"."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "Create"
 msgstr "tr: Create"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
-#, fuzzy
 msgid "Create CSV"
-msgstr "tr: Create"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
-#, fuzzy
 msgid "Create Location:"
-msgstr "tr: Recitation"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
@@ -2022,7 +1699,6 @@ msgstr ""
 msgid "Create a new achievement with ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
 msgstr "tr: Create as what type of set?"
@@ -2071,18 +1747,14 @@ msgstr ""
 msgid "Database tables ok"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
-#, fuzzy
 msgid "Database:"
-msgstr "tr: export abandoned"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
-#, fuzzy
 msgid "Date"
-msgstr "tr: Open Date"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
 msgid "Debug"
@@ -2113,7 +1785,6 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
@@ -2123,15 +1794,13 @@ msgstr ""
 msgid "Delete"
 msgstr "tr: Delete"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
-#, fuzzy
 msgid "Delete Course"
-msgstr "tr: Delete"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
 msgid "Delete all existing addresses"
@@ -2141,37 +1810,28 @@ msgstr ""
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
-#, fuzzy
 msgid "Delete course:"
-msgstr "tr: Delete"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
 msgid "Delete how many?"
 msgstr "tr: Delete how many?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
-#, fuzzy
 msgid "Delete it?"
-msgstr "tr: Delete"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
-#, fuzzy
 msgid "Delete location:"
-msgstr "tr: Delete"
+msgstr ""
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
-#, fuzzy
 msgid "Deleted %quant(%1,achievement)"
-msgstr "tr: selected sets"
+msgstr ""
 
 #. (join(', ', @delLocations)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
@@ -2183,65 +1843,47 @@ msgstr ""
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
-#
 #. ($self->shortPath($self->{tempFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
-#, fuzzy
 msgid "Deleting temp file at %1"
-msgstr "tr: Deleting temp file at %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
-#, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
-#, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
-#, fuzzy
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
-#, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
 msgid "Deny From"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
-#, fuzzy
 msgid "Description"
-msgstr "tr: Recitation"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
 msgid "Didn't recognize action"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
-#, fuzzy
 msgid "Directory"
-msgstr "tr: Proctor"
+msgstr ""
 
 #. ($file, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
@@ -2257,13 +1899,11 @@ msgstr ""
 msgid "Directory permission errors "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
-#, fuzzy
 msgid "Directory structure"
-msgstr "tr: Proctor"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
@@ -2293,32 +1933,24 @@ msgstr ""
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
-#, fuzzy
 msgid "Display Mode:"
-msgstr "tr: Display Mode"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
-#, fuzzy
 msgid "Display Past Answers"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
-#, fuzzy
 msgid "Display options: Show"
-msgstr "tr: Display Options"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
-#, fuzzy
 msgid "Display the evaluated student answer"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
@@ -2338,36 +1970,26 @@ msgstr ""
 msgid "Don't Archive"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
-#, fuzzy
 msgid "Don't Unarchive"
-msgstr "tr: Save changes"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
-#, fuzzy
 msgid "Don't Upgrade"
-msgstr "tr: Delete"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
-#, fuzzy
 msgid "Don't delete"
-msgstr "tr: Delete"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
-#, fuzzy
 msgid "Don't make changes"
-msgstr "tr: Save changes"
+msgstr ""
 
-#
 #. ($saveMode)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
-#, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
-msgstr "tr: Unrecognized saveMode: |%1|. Unknown error."
+msgstr ""
 
 #. ($type)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
@@ -2380,17 +2002,14 @@ msgstr ""
 msgid "Don't rename"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
-#, fuzzy
 msgid "Don't use in an achievement"
-msgstr "tr: Save changes"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
 msgid "Done"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:158
@@ -2398,16 +2017,13 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:69
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
-#, fuzzy
 msgid "Download"
-msgstr "Bajar Calificaciones"
+msgstr ""
 
-#
 #. ($set->set_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
-#, fuzzy
 msgid "Download %1"
-msgstr "Bajar Calificaciones"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
@@ -2415,43 +2031,33 @@ msgstr "Bajar Calificaciones"
 msgid "Download Hardcopy"
 msgstr ""
 
-#
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
-#, fuzzy
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr "Baja la copia escrita de: [plural,_1,Set,Sets] "
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "tr: Download PDF or TeX Hardcopy for Current Set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
 msgstr "tr: Download PDF or TeX Hardcopy for Selected Sets"
 
-#
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
-#, fuzzy
 msgid "Download hardcopy of set %1 for %2?"
-msgstr "Obtén una copia escrita de esta tarea."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
-#, fuzzy
 msgid "Download:"
-msgstr "Bajar Calificaciones"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "tr: Drop"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr "tr: Duplicate this set and name it"
@@ -2472,11 +2078,9 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
-#, fuzzy
 msgid "E-mail Instructor"
-msgstr "E-mail del profesor"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:399
 msgid "E-mail addresses which can receive e-mail from a pg problem"
@@ -2492,17 +2096,14 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
-#, fuzzy
 msgid "E-mail:"
-msgstr "E-mail"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Earned"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
@@ -2519,20 +2120,16 @@ msgstr ""
 msgid "Edit"
 msgstr "tr: Edit"
 
-#
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
-#, fuzzy
 msgid "Edit %1 of set %2."
-msgstr "tr: Editing %1 in file '%2'"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
 msgstr "tr: Edit All Set Data"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
@@ -2542,49 +2139,36 @@ msgstr "tr: Edit Assigned Users"
 msgid "Edit Evaluator"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#, fuzzy
 msgid "Edit Header"
-msgstr "tr: Set Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
-#, fuzzy
 msgid "Edit Location:"
-msgstr "tr: Recitation"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
-#, fuzzy
 msgid "Edit Problem"
-msgstr "tr: Edit Problems"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
 msgid "Edit Problems"
 msgstr "tr: Edit Problems"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
-#, fuzzy
 msgid "Edit Set"
-msgstr "tr: Edit Set Data"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
 msgstr "tr: Edit Set Data"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
-#, fuzzy
 msgid "Edit Target Set"
-msgstr "tr: Edit Set Data"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
 msgid "Edit Which Users?"
 msgstr "tr: Edit Which Users?"
@@ -2594,12 +2178,10 @@ msgstr "tr: Edit Which Users?"
 msgid "Edit data for %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
-#, fuzzy
 msgid "Edit it"
-msgstr "tr: Edit"
+msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
@@ -2621,43 +2203,35 @@ msgid ""
 "changes and return to the Manage Locations page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
 msgid "Edit which sets?"
 msgstr "tr: Edit which sets?"
 
-#
+# Edit with a number 1 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
-#, fuzzy
 msgid "Edit1"
-msgstr "tr: Edit"
+msgstr ""
 
-#
+# Edit with a number 2 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
-#, fuzzy
 msgid "Edit2"
-msgstr "tr: Edit"
+msgstr ""
 
-#
+# Edit with a number 3 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
-#, fuzzy
 msgid "Edit3"
-msgstr "tr: Edit"
+msgstr ""
 
-#
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
-#, fuzzy
 msgid "Editing %1 in file '%2'"
-msgstr "tr: Editing %1 in file '%2'"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
-#, fuzzy
 msgid "Editing achievement in file '%1'"
-msgstr "tr: Editing %1 in file '%2'"
+msgstr ""
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
@@ -2670,27 +2244,21 @@ msgstr ""
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
-#, fuzzy
 msgid "Editor"
-msgstr "tr: Edit"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
-#, fuzzy
 msgid "Editor rows:"
-msgstr "tr: Edit Problems"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "E-mail"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
@@ -2703,35 +2271,25 @@ msgstr "E-mail"
 msgid "Email Address"
 msgstr "tr: Email Address"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
-#, fuzzy
 msgid "Email Body:"
-msgstr "E-mail"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
-#, fuzzy
 msgid "Email Instructor On Failed Attempt"
-msgstr "E-mail del profesor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
-#, fuzzy
 msgid "Email Link"
-msgstr "E-mail"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
-#, fuzzy
 msgid "Email address"
-msgstr "tr: Email Address"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
-#, fuzzy
 msgid "Email instructor"
 msgstr "E-mail del profesor"
 
@@ -2747,39 +2305,31 @@ msgstr ""
 msgid "Emails to be sent to the following:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
-#, fuzzy
 msgid "Enable Achievement Items"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Enable Conditional Release"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
-#, fuzzy
 msgid "Enable Course Achievements"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
 msgid "Enable Progress Bar and current problem highlighting"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
-#, fuzzy
 msgid "Enable Reduced Scoring"
-msgstr "tr: Enable Reduced Credit"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
-#, fuzzy
 msgid "Enable Show Me Another button"
-msgstr "tr: Show in another window"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
 msgid "Enable periodic re-randomization of problems"
@@ -2791,12 +2341,10 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
-#, fuzzy
 msgid "Enabled"
-msgstr "tr: Enable"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
 msgid ""
@@ -2827,7 +2375,6 @@ msgid ""
 "for that problem)."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Enrolled"
 msgstr "tr: Enrolled"
@@ -2836,7 +2383,6 @@ msgstr "tr: Enrolled"
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
@@ -2848,12 +2394,10 @@ msgstr ""
 msgid "Enrollment Status"
 msgstr "tr: Enrollment Status"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
 msgid "Enter filename below"
 msgstr "tr: Enter filename below"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
 msgid "Enter filenames below"
 msgstr "tr: Enter filenames below"
@@ -2864,17 +2408,14 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
 msgid "Entered"
 msgstr "Enviado"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
-#, fuzzy
 msgid "Entered student:"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
 msgid "Equation Display"
@@ -2894,17 +2435,13 @@ msgid ""
 "the password was done."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
-#, fuzzy
 msgid "Error message:"
-msgstr "Mensajes"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
-#, fuzzy
 msgid "Error messages"
-msgstr "Mensajes"
+msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
@@ -2923,13 +2460,11 @@ msgid ""
 "in set %1"
 msgstr ""
 
-#
 #. ($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
-#, fuzzy
 msgid "Error: The original file %1 cannot be read."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
@@ -3014,44 +2549,35 @@ msgstr ""
 msgid "Expand All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
 msgid "Export"
 msgstr "tr: Export"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
-#, fuzzy
 msgid "Export selected achievements."
-msgstr "tr: Export selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
 msgid "Export selected sets"
 msgstr "tr: Export selected sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
 msgid "Export to what kind of file?"
 msgstr "tr: Export to what kind of file?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
 msgid "Export which sets?"
 msgstr "tr: Export which sets?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
 msgid "Export which users?"
 msgstr "tr: Export which users?"
 
-#
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
-#, fuzzy
 msgid "Exported achievements to %1"
-msgstr "tr: Export selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
 msgid "Extend the close date for which Gateway?"
@@ -3067,70 +2593,52 @@ msgstr ""
 msgid "FIRST NAME"
 msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
-#, fuzzy
 msgid "Failed to create new achievement: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
-#, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
-msgstr "tr: Failed to create new set: no set name specified!"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
-#, fuzzy
 msgid "Failed to create new set: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
 msgstr "tr: Failed to create new set: no set name specified!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
-#, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
-msgstr "tr: Failed to duplicate set: no set selected for duplication!"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
-#, fuzzy
 msgid "Failed to duplicate set: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
 msgstr "tr: Failed to duplicate set: no set name specified!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
 msgstr "tr: Failed to duplicate set: no set selected for duplication!"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
-#, fuzzy
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
-#, fuzzy
 msgid "Failed to enter student:"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr ""
 
-#
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
@@ -3138,31 +2646,24 @@ msgstr "tr: Failed to duplicate set: %1"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
-#, fuzzy
 msgid "Failed to open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
-#, fuzzy
 msgid "Failed to save: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "False"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid "Feature exhausted for this problem"
-msgstr "tr: report bugs in this problem"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
-#, fuzzy
 msgid "Feedback"
 msgstr "Retroalimentación"
 
@@ -3170,11 +2671,9 @@ msgstr "Retroalimentación"
 msgid "Feedback by Section."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
-#, fuzzy
 msgid "FeedbackMessage"
-msgstr "Retroalimentación"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
@@ -3199,18 +2698,13 @@ msgstr ""
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
-#, fuzzy
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
-"tr: File '%1' exists. File not saved. No changes have been made. You can "
-"change the file path for this problem manually from the 'Hmwk Sets Editor' "
-"page"
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
@@ -3232,22 +2726,17 @@ msgstr ""
 msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
-#, fuzzy
 msgid "File Compare"
-msgstr "tr: Filename"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
 msgid "File Manager"
 msgstr "Administrador de archivos"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
-#, fuzzy
 msgid "File saved"
-msgstr "tr: Filename"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
 msgid "File successfully copied"
@@ -3257,7 +2746,6 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
 msgid "Filename"
 msgstr "tr: Filename"
@@ -3267,26 +2755,20 @@ msgstr "tr: Filename"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
 msgid "Filter by what text?"
 msgstr "tr: Filter by what text?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
-#, fuzzy
 msgid "Filter:"
-msgstr "tr: Filter"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#, fuzzy
 msgid "First"
-msgstr "tr: First Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
@@ -3304,11 +2786,9 @@ msgstr "tr: First Name"
 msgid "First Name"
 msgstr "tr: First Name"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
-#, fuzzy
 msgid "First name"
-msgstr "tr: First Name"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
 msgid ""
@@ -3332,23 +2812,19 @@ msgstr ""
 msgid "Format for the subject line in feedback e-mails"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
-#, fuzzy
 msgid "Format:"
-msgstr "tr: Hardcopy Header"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
-#, fuzzy
 msgid "From field must contain one valid email address."
-msgstr "No se pudo cambiar su dirección de correo."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
@@ -3361,13 +2837,11 @@ msgstr ""
 msgid "GLOBAL Usage"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
-#, fuzzy
 msgid "Gateway Name "
-msgstr "tr: Last Name"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
 msgid "Gateway Quiz %2"
@@ -3382,12 +2856,10 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
-#, fuzzy
 msgid "General Information"
-msgstr "tr: Options Information"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate Hardcopy"
@@ -3397,25 +2869,18 @@ msgstr ""
 msgid "Generate hardcopy for selected sets and selected users"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
-#, fuzzy
 msgid "Get Library Set Problems"
-msgstr "Problema siguiente"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
-#, fuzzy
 msgid "Get Target Set Problems"
-msgstr "tr: Edit Set Data"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
-#, fuzzy
 msgid "Give new password to"
-msgstr "tr: Give new password to which users?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
 msgid "Give new password to which users?"
 msgstr "tr: Give new password to which users?"
@@ -3436,13 +2901,11 @@ msgstr ""
 msgid "Gives half credit on every problem in a set."
 msgstr ""
 
-#
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
-#, fuzzy
 msgid "Global problem %1 for set %2 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
@@ -3453,35 +2916,25 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#, fuzzy
 msgid "Grade"
-msgstr "Notas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
-#, fuzzy
 msgid "Grade Problem"
-msgstr "Problema siguiente"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
-#, fuzzy
 msgid "Grade Test"
-msgstr "Notas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
-#, fuzzy
 msgid "Grader"
-msgstr "Notas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
-#, fuzzy
 msgid "Grades"
 msgstr "Notas"
 
@@ -3501,31 +2954,23 @@ msgstr ""
 msgid "Greater Tome of Enlightenment"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
 msgid "Guest Login"
 msgstr "tr: Guest Login"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
-#, fuzzy
 msgid "HTTP Headers"
-msgstr "tr: Set Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
-#, fuzzy
 msgid "Hardcopy Format:"
-msgstr "tr: Hardcopy Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
-#, fuzzy
 msgid "Hardcopy Generator"
-msgstr "tr: Hardcopy Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:763
@@ -3535,21 +2980,16 @@ msgstr "tr: Hardcopy Header"
 msgid "Hardcopy Header"
 msgstr "tr: Hardcopy Header"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
-#, fuzzy
 msgid "Hardcopy Theme"
-msgstr "tr: Hardcopy Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
-#, fuzzy
 msgid "Headers"
-msgstr "tr: Set Header"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
 msgid "Help"
 msgstr "tr: Help"
@@ -3558,7 +2998,6 @@ msgstr "tr: Help"
 msgid "Here is a new version of your problem."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
 msgid "Hidden"
 msgstr "tr: Hidden"
@@ -3567,72 +3006,55 @@ msgstr "tr: Hidden"
 msgid "Hide All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Hide Courses"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
-#, fuzzy
 msgid "Hide Hints"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
-#, fuzzy
 msgid "Hide Hints from Students"
-msgstr "tr: hidden from students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
-#, fuzzy
 msgid "Hide Inactive Courses"
-msgstr "Cursos"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
 msgid "Hide all paths"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Hide path:"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
-#, fuzzy
 msgid "Hint:"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
-#, fuzzy
 msgid "Hints"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
 msgid "Hmwk Sets Editor"
 msgstr "Editor de tareas"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Tareas"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
-#, fuzzy
 msgid "Homework Totals"
-msgstr "Tareas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
@@ -3646,7 +3068,6 @@ msgstr ""
 msgid "Icon File"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
 msgid ""
 "If a password field is left blank, the student's current password will be "
@@ -3686,61 +3107,49 @@ msgid ""
 "have direct control."
 msgstr ""
 
-#
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
-#, fuzzy
 msgid "Illegal file '%1' specified"
-msgstr "tr: The file '%1' is protected!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
 msgid "Illegal filename contains '..'"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
 msgid "Import"
 msgstr "tr: Import"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-#, fuzzy
 msgid "Import achievements from"
-msgstr "tr: Export selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
 msgstr "tr: Import from where?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
 msgid "Import how many sets?"
 msgstr "tr: Import how many sets?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
 msgid "Import sets with names"
 msgstr "tr: Import sets with names"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
 msgid "Import users from what file?"
 msgstr "tr: Import users from what file?"
 
-#
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
-#, fuzzy
 msgid "Imported %quant(%1,achievement)"
-msgstr "tr: Export selected sets"
+msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "In progress: %1/%2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Inactive"
 msgstr "tr: Inactive"
@@ -3749,37 +3158,29 @@ msgstr "tr: Inactive"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
-#, fuzzy
 msgid "Include Success Index"
-msgstr "tr: Include Index"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
-#, fuzzy
 msgid "Incorrect"
-msgstr "incorrecto"
+msgstr ""
 
-#
 #. ($total_incorrect,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
-#, fuzzy
 msgid "Incorrect: %1/%2"
-msgstr "incorrecto"
+msgstr ""
 
+# Short for Initial
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
 msgid "Init"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
-#, fuzzy
 msgid "Institution:"
-msgstr "tr: Recitation"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
 msgid "Instructor Tools"
 msgstr "Herramientas del instructor"
@@ -3806,7 +3207,6 @@ msgstr ""
 msgid "Invalid headerType %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
 msgid "Invalid user ID or password."
@@ -3822,18 +3222,14 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
-#, fuzzy
 msgid "Jump to Page:"
-msgstr "Problema siguiente"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
-#, fuzzy
 msgid "Jump to Problem:"
-msgstr "Problema siguiente"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
 msgid "Just-In-Time parameters"
@@ -3855,20 +3251,15 @@ msgstr ""
 msgid "Language (refresh page after saving changes to reveal new language.)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
-#, fuzzy
 msgid "Last"
-msgstr "tr: Last Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
-#, fuzzy
 msgid "Last Answer"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
@@ -3890,17 +3281,13 @@ msgstr "tr: Last Name"
 msgid "Last column of merge file"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
-#, fuzzy
 msgid "Last name"
-msgstr "tr: Last Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Latest Answers"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
 msgid ""
@@ -3921,32 +3308,25 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Explorador de bibliotecas"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
-#, fuzzy
 msgid "Library Browser 2"
-msgstr "Explorador de bibliotecas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
-#, fuzzy
 msgid "Library Browser 3"
-msgstr "Explorador de bibliotecas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
-#, fuzzy
 msgid "Library Browser no js"
-msgstr "Explorador de bibliotecas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
 msgid "List of display modes made available to students"
@@ -3959,29 +3339,23 @@ msgid ""
 "WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
-#, fuzzy
 msgid "List of options for Show Me Another button"
-msgstr "tr: Show in another window"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
 msgid "Local"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
-#, fuzzy
 msgid "Local Problems"
-msgstr "Problemas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Location"
-msgstr "tr: Recitation"
+msgstr ""
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
@@ -3991,37 +3365,28 @@ msgid ""
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
-#
 #. ($locationID, join(', ', @addresses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
-#, fuzzy
 msgid "Location %1 has been created, with addresses %2."
-msgstr "tr: Set %1 exists.  No set created"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
-#, fuzzy
 msgid "Location description:"
-msgstr "tr: Show/Hide Site Description"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
-#, fuzzy
 msgid "Location name:"
-msgstr "tr: no action"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
-#, fuzzy
 msgid "Log In Again"
-msgstr "Volver a iniciar sesión"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Log Out"
@@ -4038,28 +3403,21 @@ msgstr "Salir"
 msgid "Log into %1"
 msgstr ""
 
-#
 #. (HTML::Entities::encode_entities($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
-#, fuzzy
 msgid "Logged in as %1."
-msgstr "Autentificado como: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
-#, fuzzy
 msgid "Login"
-msgstr "tr: Login Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
-#, fuzzy
 msgid "Login Info"
-msgstr "tr: Login Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
@@ -4078,19 +3436,15 @@ msgstr "tr: Login Name"
 msgid "Login Name"
 msgstr "tr: Login Name"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
-#, fuzzy
 msgid "Login Status"
-msgstr "tr: Login Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
 msgid "Logout"
 msgstr "Salir"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
 msgid "Main Menu"
 msgstr "Ana Menü"
@@ -4104,11 +3458,9 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
-#, fuzzy
 msgid "Make changes"
-msgstr "tr: Save changes"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
 msgid "Make these changes in  course:"
@@ -4119,46 +3471,36 @@ msgstr ""
 msgid "Manage Locations"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
-#, fuzzy
 msgid "Manual Grader"
-msgstr "Notas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
 msgid "Mark All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Mark Correct"
-msgstr "Correcto"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
-#, fuzzy
 msgid "Mark Correct?"
-msgstr "Correcto"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "tr: Match on what? (separate multiple IDs with commas)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
 msgid "Math Objects"
 msgstr "tr: Math Objects"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
-#, fuzzy
 msgid "Max attempts"
-msgstr "intentos"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
 msgid "Max. Shown:"
@@ -4168,36 +3510,27 @@ msgstr ""
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
-#, fuzzy
 msgid "Merge file:"
-msgstr "tr: header file"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
-#, fuzzy
 msgid "Message"
-msgstr "Mensajes"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
-#, fuzzy
 msgid "Message file:"
-msgstr "tr: header file"
+msgstr ""
 
 #. ($emailDirectory, $output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
-#, fuzzy
 msgid "Message:"
-msgstr "Mensajes"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
 msgid "Messages"
 msgstr "Mensajes"
@@ -4217,26 +3550,25 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
+# Msg is short for message
 #. ($recipient, $ur->email_address)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
-#, fuzzy
 msgid "My Problems"
-msgstr "Problemas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
+# Short for Number of Fields
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
 msgid "NO OF FIELDS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
@@ -4246,24 +3578,18 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
-#, fuzzy
 msgid "Name"
-msgstr " ## edited - ozcanNombre"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
-#, fuzzy
 msgid "Name for new set here"
-msgstr "tr: Name the new set"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
-#, fuzzy
 msgid "Name of course information file"
-msgstr "tr: course information"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
 msgstr "tr: Name the new set"
@@ -4272,13 +3598,11 @@ msgstr "tr: Name the new set"
 msgid "Necromancers Charm"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
-#, fuzzy
 msgid "Never"
-msgstr "tr: Revert"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
@@ -4292,33 +3616,28 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
-#, fuzzy
 msgid "New Name:"
-msgstr "tr: Set Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
 msgid "New Password"
 msgstr "tr: New Password"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
-#, fuzzy
 msgid "New file name:"
-msgstr "tr: Filename"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New folder name:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
 msgid "New passwords saved"
 msgstr "tr: New passwords saved"
 
+# No space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "NewVersion"
@@ -4328,7 +3647,6 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
 msgid "Next Problem"
@@ -4338,7 +3656,6 @@ msgstr "Problema siguiente"
 msgid "Next page"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4355,22 +3672,18 @@ msgstr ""
 msgid "No"
 msgstr "tr: No"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
-#, fuzzy
 msgid "No Description"
-msgstr "tr: Show/Hide Site Description"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
-#, fuzzy
 msgid "No action taken"
-msgstr "tr: no action"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
 msgid ""
@@ -4378,7 +3691,6 @@ msgid ""
 "speak with your instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
 msgstr "tr: No change made to any set"
@@ -4389,26 +3701,20 @@ msgid ""
 "changed and enter the change data."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
-#, fuzzy
 msgid "No changes were saved!"
-msgstr "tr: changes saved"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
-#, fuzzy
 msgid "No course id defined"
-msgstr "Cursos"
+msgstr ""
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
-#, fuzzy
 msgid "No data exists for set %1 and problem %2"
-msgstr "tr: set %1/problem %2"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
 msgid "No filename was specified for saving!  The message was not saved."
@@ -4427,11 +3733,9 @@ msgstr ""
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
-#, fuzzy
 msgid "No merge data file"
-msgstr "tr: header file"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
 msgid ""
@@ -4449,28 +3753,22 @@ msgid ""
 "below."
 msgstr ""
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
-#, fuzzy
 msgid "No record for global set %1."
-msgstr "tr: Set Header for set %1"
+msgstr ""
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
-#, fuzzy
 msgid "No record for user %1."
-msgstr "tr: Set Header for set %1"
+msgstr ""
 
-#
 #. ($prob)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
-#, fuzzy
 msgid "No record found for problem %1."
-msgstr "tr: Set Header for set %1"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
 msgid "No record found."
@@ -4480,13 +3778,11 @@ msgstr ""
 msgid "No sets in this course yet"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
 msgid "No sets selected for scoring"
 msgstr "tr: No sets selected for scoring"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
@@ -4504,21 +3800,15 @@ msgstr ""
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
-#, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
-"tr: No sets shown.  Choose one of the options above to list the sets in the "
-"course."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
-#, fuzzy
 msgid "No tests taken."
-msgstr "tr: no action"
+msgstr ""
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
@@ -4553,12 +3843,10 @@ msgstr ""
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
 msgid "Not logged in."
 msgstr "No ha iniciado sesión"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
 msgid "Note"
@@ -4569,12 +3857,10 @@ msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
-#, fuzzy
 msgid "Number"
-msgstr "tr: Problem Viewer"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
 msgid "Number of Graded Submissions per Test (0=infty)"
@@ -4597,17 +3883,14 @@ msgstr ""
 msgid "Oil of Cleansing"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
-#, fuzzy
 msgid "Old Classlist Editor"
-msgstr "Editor de la lista de clases"
+msgstr ""
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
-#, fuzzy
 msgid "Old Hmwk Sets Editor"
-msgstr "Editor de tareas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
 msgid "One Column"
@@ -4624,13 +3907,10 @@ msgid ""
 "instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
-#, fuzzy
 msgid "Open"
-msgstr "tr: Open Date"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:780
@@ -4641,11 +3921,9 @@ msgstr "tr: Open Date"
 msgid "Open Date"
 msgstr "tr: Open Date"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
-#, fuzzy
 msgid "Open Problem Library"
-msgstr "Lista de problemas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
@@ -4657,38 +3935,28 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
-#, fuzzy
 msgid "Open, closes %1."
-msgstr "Abierta, se entrega"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
-#, fuzzy
 msgid "Open, complete by %1."
-msgstr "Abierta: completa por %1"
+msgstr ""
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
 msgid "Open, reduced scoring starts on %1."
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
-#, fuzzy
 msgid "Open:"
-msgstr "tr: Open Date"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
-#, fuzzy
 msgid "Opens"
-msgstr "tr: Open Date"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
@@ -4698,29 +3966,24 @@ msgstr ""
 msgid "Optional Modules"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
-#, fuzzy
 msgid "Order Problems Randomly"
-msgstr "Problemas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
-#, fuzzy
 msgid "Orig. Lib. Browser"
-msgstr "Explorador de bibliotecas"
+msgstr ""
 
+# Context is "7 Out Of 10"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
-#, fuzzy
 msgid "Over time, closed."
-msgstr "Tiempo terminado: cerrada."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
@@ -4731,6 +3994,7 @@ msgstr ""
 msgid "Overwrite existing files silently"
 msgstr ""
 
+# PG is a WeBWorK abreviation and should stay PG
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
@@ -4755,75 +4019,70 @@ msgstr ""
 msgid "PG warning messages"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
 msgid "PGInfo"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
 msgid "PGLab"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
 msgid "PGML"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
 msgid "POD"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
-#, fuzzy
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
-msgstr "SOLAMENTE PREVISUALIZACIÓN -- RESPUESTAS NO GUARDADAS"
+msgstr ""
 
+# Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
 msgid "PROB NUMBER"
 msgstr ""
 
+# Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
 msgid "PROB VALUE"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
 msgid "Pad Fields"
 msgstr "tr: Pad Fields"
 
-#
 #. (timestamp($self)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
-#, fuzzy
 msgid "Page generated at %1"
-msgstr "tr: Page generated at %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
-#, fuzzy
 msgid "Password"
-msgstr "tr: New Password"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:921
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
-#, fuzzy
 msgid "Password:"
-msgstr "tr: New Password"
+msgstr ""
 
-#
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
-#, fuzzy
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
 msgid "Percent"
@@ -4845,7 +4104,6 @@ msgid ""
 "number of attempts."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
@@ -4861,11 +4119,9 @@ msgstr ""
 msgid "Permission Level"
 msgstr "tr: Permission Level"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
-#, fuzzy
 msgid "Permissions"
-msgstr "tr: Permission Level"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
 msgid ""
@@ -4912,48 +4168,38 @@ msgstr ""
 msgid "Please enter in a value to match in the filter field."
 msgstr ""
 
-#
 #. (CGI::b($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
-#, fuzzy
 msgid "Please enter your username and password for %1 below:"
-msgstr "Lütfen %1 dersi için kullanici adi ve sifrenizi giriniz:"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
 msgid "Please provide a location name to delete."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
 msgid "Please select action to be performed."
 msgstr "tr: Please select action to be performed."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
-#, fuzzy
 msgid "Please select at least one set and try again."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
-#, fuzzy
 msgid "Please select at least one user and try again."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "tr: Please specify a file to save to."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
-#, fuzzy
 msgid "Points"
-msgstr "Mostrar ayuda"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
 msgid "Potion of Forgetfullness"
@@ -4963,47 +4209,34 @@ msgstr ""
 msgid "Preflight Log"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview Message"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
-#, fuzzy
 msgid "Preview My Answers"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
-#, fuzzy
 msgid "Preview Test"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview message"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
-#, fuzzy
 msgid "Preview set to:"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
 msgid "Previous Problem"
 msgstr "Problema anterior"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
-#, fuzzy
 msgid "Previous page"
-msgstr "Problema anterior"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "Primary sort"
@@ -5013,25 +4246,19 @@ msgstr ""
 msgid "Print Test"
 msgstr ""
 
-#
+# Short for Problem
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#, fuzzy
 msgid "Prob"
-msgstr "Problemas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
-#, fuzzy
 msgid "Problem"
-msgstr "Problemas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
-#, fuzzy
 msgid "Problem #"
-msgstr "tr: Problem"
+msgstr ""
 
-#
 #. ($prettyProblemID)
 #. (join('.',@seq)
 #. ($problemID)
@@ -5046,74 +4273,59 @@ msgstr "tr: Problem"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
-#, fuzzy
 msgid "Problem %1"
-msgstr "tr: Problem"
+msgstr ""
 
-#
 #. ($problemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
-#, fuzzy
 msgid "Problem %1."
-msgstr "tr: Problem"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
 msgid "Problem Editor"
 msgstr "Editor de problemas"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
-#, fuzzy
 msgid "Problem Editor2"
-msgstr "Editor de problemas"
+msgstr ""
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
-#, fuzzy
 msgid "Problem Editor3"
-msgstr "Editor de problemas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
 msgid "Problem List"
 msgstr "Lista de problemas"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
-#, fuzzy
 msgid "Problem Number"
-msgstr "tr: Problem Viewer"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
-#, fuzzy
 msgid "Problem Number "
-msgstr "tr: Problem Viewer"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
 msgid "Problem Techniques"
 msgstr "tr: Problem Techniques"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
-#, fuzzy
 msgid "Problem Viewer"
-msgstr "Editor de problemas"
+msgstr "tr: Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
@@ -5137,9 +4349,7 @@ msgstr ""
 msgid "Problems have been assigned to all current users."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
-#, fuzzy
 msgid "Proctor"
 msgstr "tr: Proctor"
 
@@ -5147,11 +4357,9 @@ msgstr "tr: Proctor"
 msgid "Proctor authorization required."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
-#, fuzzy
 msgid "Proctor password:"
-msgstr "tr: New Password"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
 msgid "Proctor username:"
@@ -5173,7 +4381,6 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
 msgid "Publish"
 msgstr "tr: Publish"
@@ -5191,7 +4398,6 @@ msgstr ""
 msgid "Really delete the items listed above?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
@@ -5214,7 +4420,6 @@ msgstr ""
 msgid "Recitation"
 msgstr "tr: Recitation"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
 msgid "Record Scores for Single Sets"
 msgstr "tr: Record Scores for Single Sets"
@@ -5223,43 +4428,34 @@ msgstr "tr: Record Scores for Single Sets"
 msgid "Reduced Scoring"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
-#, fuzzy
 msgid "Reduced Scoring Date"
-msgstr "tr: Reduced Credit Disabled"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Disabled"
-msgstr "tr: Reduced Credit Disabled"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Enabled"
-msgstr "tr: Reduced Credit Enabled"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
 msgid "Reduced Scoring Starts %1"
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr ""
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
 msgid "Reduced scoring started on %1."
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr ""
 
+# Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
 msgstr ""
@@ -5274,28 +4470,24 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Refresh Listing"
-msgstr "tr: Users List"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
 msgid "Relax IP restrictions when?"
 msgstr ""
 
-#
+# Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
-#, fuzzy
 msgid "Remaining"
-msgstr "Quedan"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
 msgid "Remember Me"
 msgstr "tr: Remember Me"
@@ -5304,35 +4496,29 @@ msgstr "tr: Remember Me"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
-#, fuzzy
 msgid "Rename"
-msgstr "tr: Filename"
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
 msgid "Rename %1 to %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
-#, fuzzy
 msgid "Rename Course"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
-#, fuzzy
 msgid "Rename file as:"
-msgstr "tr: header file"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render"
@@ -5342,17 +4528,13 @@ msgstr ""
 msgid "Render All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
-#, fuzzy
 msgid "Render Problem"
-msgstr "Problema siguiente"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
-#, fuzzy
 msgid "Renumber Problems"
-msgstr "Problemas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
@@ -5371,7 +4553,6 @@ msgstr ""
 msgid "Replace current problem: %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
 msgid "Replace which users?"
 msgstr "tr: Replace which users?"
@@ -5387,18 +4568,15 @@ msgstr ""
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
 msgid "Report bugs"
 msgstr "Reportar problemas (bugs)"
 
-#
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
-#, fuzzy
 msgid "Report for course %1:"
-msgstr "tr: Set Header for set %1"
+msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
@@ -5411,27 +4589,21 @@ msgstr ""
 msgid "Request New Version"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
-#, fuzzy
 msgid "Request information"
-msgstr "tr: Options Information"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
-#, fuzzy
 msgid "Request new version now."
-msgstr "tr: Options Information"
+msgstr ""
 
-#
 #. ($setName,$effectiveUserName)
 #. ($setName, $effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
-#, fuzzy
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -5456,33 +4628,25 @@ msgid ""
 "the problem sets listing page."
 msgstr ""
 
-#
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
-#, fuzzy
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
-#, fuzzy
 msgid "Requested set '%1' is not available yet."
-msgstr "Esta tarea aun no está abierta."
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
-#, fuzzy
 msgid "Requested set '%1' is not yet open."
-msgstr "Esta tarea aun no está abierta."
+msgstr ""
 
-#
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
-#, fuzzy
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
@@ -5518,67 +4682,54 @@ msgstr ""
 msgid "Restrict Access by IP"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
-#, fuzzy
 msgid "Restrict Locations"
-msgstr "tr: Recitation"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
 msgid "Restrict Problem Progression"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
-#, fuzzy
 msgid "Restrict To"
-msgstr "tr: Recitation"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Result"
 msgstr "Resultado"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
-#, fuzzy
 msgid "Result of last action performed"
-msgstr "tr: Results of last action performed"
+msgstr ""
 
-#
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
-#, fuzzy
 msgid "Result of last action performed: %1"
-msgstr "tr: Result of last action performed: %1"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
 msgid "Results for this submission"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
 msgid "Results of last action performed"
 msgstr "tr: Results of last action performed"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
-#, fuzzy
 msgid "Results of last action performed: "
-msgstr "tr: Results of last action performed"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
 msgid "Retitled"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
@@ -5586,13 +4737,11 @@ msgstr ""
 msgid "Revert"
 msgstr "tr: Revert"
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
-#, fuzzy
 msgid "Revert to %1"
-msgstr "tr: Revert"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
 msgid "Ring of Reduction"
@@ -5618,7 +4767,6 @@ msgstr ""
 msgid "STUDENT ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
@@ -5629,14 +4777,11 @@ msgstr ""
 msgid "Save"
 msgstr "tr: Save"
 
-#
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
-#, fuzzy
 msgid "Save %1"
-msgstr "tr: Save"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
@@ -5644,29 +4789,22 @@ msgstr "tr: Save"
 msgid "Save As"
 msgstr "tr: Save As [TMPL]/"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
-#, fuzzy
 msgid "Save Changes"
-msgstr "tr: Save changes"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
-#, fuzzy
 msgid "Save as"
 msgstr "tr: Save as"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
-#, fuzzy
 msgid "Save as Default"
-msgstr "tr: Use System Default"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
@@ -5679,30 +4817,24 @@ msgstr "tr: Use System Default"
 msgid "Save changes"
 msgstr "tr: Save changes"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
-#, fuzzy
 msgid "Save file to:"
-msgstr "tr: Save Edit"
+msgstr ""
 
-#
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
-#, fuzzy
 msgid "Save to %1 and View"
-msgstr "tr: Save %1 and View"
+msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
-#, fuzzy
 msgid "Saved to file '%1'"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
@@ -5716,7 +4848,6 @@ msgstr ""
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
@@ -5727,17 +4858,14 @@ msgstr ""
 msgid "Score"
 msgstr "Calificación"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Score (%)"
-msgstr "Calificación"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
 msgid "Score required for release"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
 msgid "Score selected set(s) and save to:"
 msgstr "tr: Score selected set(s) and save to:"
@@ -5746,32 +4874,23 @@ msgstr "tr: Score selected set(s) and save to:"
 msgid "Score summary for last submit:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
 msgid "Score which sets?"
 msgstr "tr: Score which sets?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
-#, fuzzy
 msgid "Scores"
-msgstr "Calificación"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
-#, fuzzy
 msgid "Scoring Download"
-msgstr "Herramientas para evaluar"
+msgstr "Bajar Calificaciones"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
-#, fuzzy
 msgid "Scoring Message"
-msgstr "Herramientas para evaluar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
-#, fuzzy
 msgid "Scoring Tools"
 msgstr "Herramientas para evaluar"
 
@@ -5790,7 +4909,6 @@ msgstr ""
 msgid "Secondary sort"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
@@ -5816,13 +4934,11 @@ msgstr ""
 msgid "Section"
 msgstr "tr: Section"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
-#, fuzzy
 msgid "Section:"
-msgstr "tr: Section"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
 msgid "Seed"
@@ -5834,21 +4950,17 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
-#, fuzzy
 msgid "Select a Problem Collection"
-msgstr "tr: Select action below"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
-#, fuzzy
 msgid "Select a course to delete."
-msgstr "tr: Select action below"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
 msgid ""
@@ -5857,72 +4969,55 @@ msgid ""
 "the course home page and can be any string."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
-#, fuzzy
 msgid "Select a course to unarchive."
-msgstr "tr: Select action below"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
-#, fuzzy
 msgid "Select a database layout below."
-msgstr "tr: Select action below"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
-#, fuzzy
 msgid "Select a listing format:"
-msgstr "tr: Select an action to perform"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
-#, fuzzy
 msgid "Select above then:"
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
-#, fuzzy
 msgid "Select all eligible courses"
-msgstr "tr: Select all users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
 msgid "Select all sets"
 msgstr "tr: Select all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
 msgid "Select all users"
 msgstr "tr: Select all users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
 msgid "Select an action to perform"
 msgstr "tr: Select an action to perform"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
-#, fuzzy
 msgid "Select an action to perform:"
-msgstr "tr: Select an action to perform"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
 msgid "Select course(s) to archive."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
-#, fuzzy
 msgid "Select course(s) to hide or unhide."
-msgstr "tr: Select action below"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
 msgid ""
@@ -5958,59 +5053,44 @@ msgid ""
 "choice."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
-#, fuzzy
 msgid "Selected students"
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
-#, fuzzy
 msgid "Send E-mail"
-msgstr "E-mail"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
-#, fuzzy
 msgid "Send Email"
-msgstr "E-mail"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
 msgid "Send to:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
 msgid "Set"
 msgstr "Tarea"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
-#, fuzzy
 msgid "Set %1 exists.  No set created"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr ""
 
-#
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
-#, fuzzy
 msgid "Set %1 has been created."
-msgstr "tr: Set %1 exists.  No set created"
+msgstr ""
 
-#
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
-#, fuzzy
 msgid "Set %1 was assigned to %2"
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
-#, fuzzy
 msgid "Set Assigner"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
@@ -6022,12 +5102,10 @@ msgstr ""
 msgid "Set Definition Files"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
-#, fuzzy
 msgid "Set Description"
-msgstr "tr: Show/Hide Site Description"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
@@ -6037,7 +5115,6 @@ msgstr ""
 msgid "Set Detail for set %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
@@ -6049,24 +5126,19 @@ msgstr ""
 msgid "Set Header"
 msgstr "tr: Set Header"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
-#, fuzzy
 msgid "Set ID"
-msgstr "tr: Student ID"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 msgid "Set Info"
 msgstr "tr: Set Info"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
 msgid "Set List"
 msgstr "tr: Set List"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:781
@@ -6075,7 +5147,6 @@ msgstr "tr: Set List"
 msgid "Set Name"
 msgstr "tr: Set Name"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1215
@@ -6088,9 +5159,8 @@ msgstr "tr: Set Name"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:699
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
-#, fuzzy
 msgid "Set Name "
-msgstr "tr: Set Name"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
@@ -6117,7 +5187,6 @@ msgid ""
 "version of their answer."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
@@ -6125,23 +5194,17 @@ msgstr ""
 msgid "Sets"
 msgstr "tr: Sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
-#, fuzzy
 msgid "Sets Assigned to User"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
-#, fuzzy
 msgid "Sets assigned to %1"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
-#, fuzzy
 msgid "Setting"
-msgstr "Cambio de opciones de usuario"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
 msgid "Shift dates so that the earliest is"
@@ -6160,24 +5223,18 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
-#, fuzzy
 msgid "Show Hints"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
-#, fuzzy
 msgid "Show Me Another"
-msgstr "tr: Show in another window"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
-#, fuzzy
 msgid "Show Past Answers"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:302
 msgid "Show Problems on Finished Tests"
@@ -6187,68 +5244,51 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
-#, fuzzy
 msgid "Show Solutions"
-msgstr "Mostrar soluciones"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:166
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
 msgid "Show Which Users?"
 msgstr "tr: Show Which Users?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
-#, fuzzy
 msgid "Show all paths"
-msgstr "tr: showing all sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
-#, fuzzy
 msgid "Show correct answers"
-msgstr "Mostrar las respuestas correctas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
-#, fuzzy
 msgid "Show me another"
-msgstr "tr: Show in another window"
+msgstr ""
 
-#
 #. ($exhausted)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
-#, fuzzy
 msgid "Show me another %1"
-msgstr "tr: Show in another window"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Show path ..."
-msgstr "tr: showing all sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
-#, fuzzy
 msgid "Show saved answers?"
-msgstr "Mostrar la respuesta anterior"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
 msgid "Show which sets?"
 msgstr "tr: Show which sets?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
@@ -6261,59 +5301,47 @@ msgstr "tr: Show/Hide Site Description"
 msgid "Show:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "Showing"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
-#, fuzzy
 msgid "Showing %1 out of %2 sets."
-msgstr "tr: Showing %1 out of %2 sets."
+msgstr ""
 
-#
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
-#, fuzzy
 msgid "Showing %1 out of %2 users"
-msgstr "tr: Showing %1 out of %2 users"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:391
 msgid "Simple"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:120
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:68
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:71
-#, fuzzy
 msgid "Site Information"
-msgstr "tr: Options Information"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid "Skip archiving this course"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
-#, fuzzy
 msgid "Solution:"
-msgstr "Mostrar soluciones"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
-#, fuzzy
 msgid "Solutions"
-msgstr "Mostrar soluciones"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
 msgid "Some answers will be graded later."
@@ -6342,33 +5370,26 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
-#, fuzzy
 msgid "Sort"
 msgstr "tr: Sort"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
 msgid "Sort by"
 msgstr "tr: Sort by"
 
-#
 #. ($names{$primary}, $names{$secondary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
-#, fuzzy
 msgid "Sort by %1 and then by %2"
-msgstr "tr: Sort by %1 and then by %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
-#, fuzzy
 msgid "Sort:"
-msgstr "tr: Sort"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
 msgid "Source File"
@@ -6395,7 +5416,6 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:107
@@ -6405,27 +5425,20 @@ msgstr ""
 msgid "Statistics"
 msgstr "Estadísticas"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
-#, fuzzy
 msgid "Statistics for"
-msgstr "Estadísticas"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
-#, fuzzy
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
-#, fuzzy
 msgid "Statistics for %1 student %2"
-msgstr "tr: View statistics by student"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
@@ -6437,28 +5450,21 @@ msgstr "tr: View statistics by student"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
-#, fuzzy
 msgid "Status"
-msgstr "Estatus"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Stop Acting"
 msgstr "Volver al usuario original"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
-#, fuzzy
 msgid "Stop Archiving"
-msgstr "Volver al usuario original"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
-#, fuzzy
 msgid "Stop archiving courses"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
@@ -6476,41 +5482,31 @@ msgstr "Cursos"
 msgid "Student ID"
 msgstr "tr: Student ID"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Student Name"
-msgstr "tr: Set Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:767
-#, fuzzy
 msgid "Student Progress"
-msgstr "tr: Student ID"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
-#, fuzzy
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr "Enviar respuestas por %1"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
-#, fuzzy
 msgid "Student Progress for %1 student %2"
-msgstr "Enviar respuestas por %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
-#, fuzzy
 msgid "Student answers"
-msgstr "Enviar respuestas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
@@ -6523,54 +5519,41 @@ msgstr ""
 msgid "Subject: "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
-#, fuzzy
 msgid "Submission time:"
-msgstr "Enviar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
-#, fuzzy
 msgid "Submit"
-msgstr "Enviar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
-#, fuzzy
 msgid "Submit Answers"
-msgstr "Enviar respuestas"
+msgstr ""
 
-#
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
-#, fuzzy
 msgid "Submit Answers for %1"
-msgstr "Enviar respuestas por %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "tr: Success"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
-#, fuzzy
 msgid "Success Index"
-msgstr "tr: Success"
+msgstr ""
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
 msgid "Successfully archived the course %1."
 msgstr ""
 
-#
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
-#, fuzzy
 msgid "Successfully created new achievement %1"
-msgstr "tr: selected sets"
+msgstr ""
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
@@ -6617,25 +5600,20 @@ msgstr ""
 msgid "Table is ok"
 msgstr ""
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:473
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
-#, fuzzy
 msgid "Take %1 test"
-msgstr "tr: Take %1 test"
+msgstr ""
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
-#, fuzzy
 msgid "Take %1 test."
-msgstr "tr: Take %1 test"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
@@ -6649,27 +5627,21 @@ msgstr "tr: Take %1 test"
 msgid "Take Action!"
 msgstr "tr: Take Action!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
-#, fuzzy
 msgid "Target Set:"
-msgstr "tr: Edit Set Data"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
 msgstr "tr: Test Date"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
 msgid "Test Score"
 msgstr "tr: Test Score"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
-#, fuzzy
 msgid "Test Time"
-msgstr "tr: Test Date"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
 msgid "Test Time Limit (min; 0=Close Date)"
@@ -6683,11 +5655,9 @@ msgstr ""
 msgid "Text chapter:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
-#, fuzzy
 msgid "Text section:"
-msgstr "tr: Take Action!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
 msgid "Textbook:"
@@ -6718,7 +5688,6 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
 msgid "The WeBWorK Project"
 msgstr "tr: The WeBWorK Project"
@@ -6744,23 +5713,17 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
-#, fuzzy
 msgid "The answer above is NOT correct."
-msgstr "La respuesta arriba no es %1 correcta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
-#, fuzzy
 msgid "The answer above is correct."
-msgstr "La respuesta arriba es correcta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
-#, fuzzy
 msgid "The answer will be graded later."
-msgstr "La respuesta arriba es correcta"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
 msgid ""
@@ -6784,11 +5747,9 @@ msgid ""
 "be erased.  This cannot be undone."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
-#, fuzzy
 msgid "The default display mode"
-msgstr "tr: Display Mode"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
 msgid ""
@@ -6819,12 +5780,10 @@ msgid ""
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
 
-#
 #. ($achievementName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
-#, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
@@ -6833,57 +5792,45 @@ msgid ""
 "saved"
 msgstr ""
 
-#
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
-#, fuzzy
 msgid "The file %1/%2 cannot be found."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr ""
 
 #. ($emailDirectory,$openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
-#, fuzzy
 msgid "The file '%1' cannot be found."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr ""
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
-#, fuzzy
 msgid "The file '%1' cannot be read!"
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid "The file '%1' is a blank problem!"
-msgstr "tr: The file '%1' is a blank problem!"
+msgstr ""
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
-#, fuzzy
 msgid "The file '%1' is a directory!"
-msgstr "tr: The file '%1' is a directory!"
+msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
-#, fuzzy
 msgid "The file '%1' is protected!"
-msgstr "tr: The file '%1' is protected!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
 msgid "The file does not appear to be a text file"
@@ -6914,14 +5861,12 @@ msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
-#
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
-#, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
-msgstr "Este problema no cuenta para la evaluación."
+msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
@@ -6930,13 +5875,11 @@ msgid ""
 "the weighted average of the problems: %1."
 msgstr ""
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
-#, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
@@ -6985,29 +5928,20 @@ msgstr ""
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
-#
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
-#, fuzzy
 msgid ""
 "The password you entered in the %1 field does not match your current "
 "password. Please retype your current password and try again."
 msgstr ""
-"La contraseña introducida en el campo %1 no corresponde a su contraseña "
-"actual. \tPor favor reescriba su contraseña actual e intente de nuevo."
 
-#
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
-#, fuzzy
 msgid ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 msgstr ""
-"La contraseña introducida en %1 y el campo %2 no coinciden. Por favor "
-"introduzca nuevamente su contraseña. "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
 msgid "The path to the original file should be absolute"
@@ -7025,19 +5959,15 @@ msgid ""
 "is in the 50% column."
 msgstr ""
 
-#
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
-#, fuzzy
 msgid "The recorded score for this test is  %1/%2."
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
-#, fuzzy
 msgid "The recorded score for this test is %1/%2."
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
@@ -7051,35 +5981,27 @@ msgid ""
 "The reduced scoring date should be between the open date and close date."
 msgstr ""
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
-#, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
-msgstr "Este problema no cuenta para la evaluación."
+msgstr ""
 
-#
 #. ($setName,$effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
-#, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
-msgstr "tr: The selected problem set (%1) is not a valid set for %2"
+msgstr ""
 
-#
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
-#, fuzzy
 msgid "The set %1 is assigned to %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
-#, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
@@ -7088,28 +6010,22 @@ msgid ""
 "like to start a new set."
 msgstr ""
 
-#
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
-#, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
 msgstr ""
 
-#
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
-#, fuzzy
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
@@ -7129,31 +6045,21 @@ msgid ""
 "created."
 msgstr ""
 
-#
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
-#, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
 
-#
 #. ($rename_newCourseID, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
-#, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
 
-#
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
-#, fuzzy
 msgid "The user %1 has been assigned %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #. ($enableReducedScoring)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
@@ -7207,7 +6113,7 @@ msgstr ""
 msgid "Theme (refresh page after saving changes to reveal new theme.)"
 msgstr ""
 
-#
+# Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
@@ -7388,23 +6294,17 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
-#, fuzzy
 msgid "This answer is NOT completely correct."
-msgstr "La respuesta arriba no es %1 correcta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
-#, fuzzy
 msgid "This answer is NOT correct."
-msgstr "La respuesta arriba no es %1 correcta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
-#, fuzzy
 msgid "This answer is correct."
-msgstr "La respuesta arriba es correcta"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
 msgid ""
@@ -7412,36 +6312,25 @@ msgid ""
 "guest."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
-#, fuzzy
 msgid "This homework set contains no problems."
-msgstr "Esta tarea no contiene problemas."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
-#, fuzzy
 msgid "This homework set is closed."
-msgstr "Esta tarea está cerrada"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
-#, fuzzy
 msgid "This homework set is not yet open."
-msgstr "Esta tarea aun no está abierta."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
-#, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
-"tr: This is a blank problem template file and can not be edited directly. "
-"Use the 'Save as' action below to create a local copy of the file and add it "
-"to the current problem set."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7517,25 +6406,21 @@ msgstr ""
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
-#, fuzzy
 msgid "This problem will not count towards your grade."
-msgstr "Este problema no cuenta para la evaluación."
+msgstr ""
 
 #. ($EMAIL)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
-#, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
-msgstr "Este problema no cuenta para la evaluación."
+msgstr ""
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -7545,20 +6430,16 @@ msgid ""
 "and the \"File Manager\" link in the left margin."
 msgstr ""
 
-#
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
-#, fuzzy
 msgid "This set %1 is assigned to %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
-#, fuzzy
 msgid "This set doesn't contain any problems yet."
-msgstr "Esta tarea no contiene problemas."
+msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
@@ -7573,13 +6454,12 @@ msgid ""
 "password below."
 msgstr ""
 
-#
+# Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
-#, fuzzy
 msgid "This set is %1"
-msgstr "tr: This set is %1"
+msgstr ""
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
@@ -7617,12 +6497,10 @@ msgstr ""
 msgid "This source file does not exist!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
-#, fuzzy
 msgid "This source file is a directory!"
-msgstr "tr: The file '%1' is a directory!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
@@ -7663,12 +6541,10 @@ msgid ""
 "problem page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
-#, fuzzy
 msgid "Time"
-msgstr "tr: Test Date"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
 msgid "Time Interval for New Test Versions (min; 0=infty)"
@@ -7729,33 +6605,23 @@ msgid ""
 "assigned sets."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
-#, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
-"tr: To edit this text you must first make a copy of this file using the "
-"'Save as' action below."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
 msgstr ""
-"tr: To edit this text you must use the 'Save AS' action below to save it to "
-"another file."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
-#, fuzzy
 msgid "To this Problem"
-msgstr "tr: Edit this problem"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
 msgid "To:"
@@ -7803,36 +6669,28 @@ msgstr ""
 msgid "URI"
 msgstr ""
 
-#
 #. ($achievementName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
-#, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr "tr: Unable to change the set header for set %1. Unknown error."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
-#, fuzzy
 msgid "Unable to write to '%1': %2"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
-#, fuzzy
 msgid "Unarchive"
-msgstr "Cursos"
+msgstr ""
 
-#
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
-#, fuzzy
 msgid "Unarchive %1 to course:"
-msgstr "Cursos"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
@@ -7841,24 +6699,18 @@ msgstr "Cursos"
 msgid "Unarchive Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
-#, fuzzy
 msgid "Unarchive Next Course"
-msgstr "Cursos"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
-#, fuzzy
 msgid "Unassign from All Users"
-msgstr "tr: unassigned problem file"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
-#, fuzzy
 msgid "Unassign selected sets from selected users"
-msgstr "tr: unassigned problem file"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
@@ -7866,30 +6718,24 @@ msgid ""
 "and click on the Unassign button."
 msgstr ""
 
-#
 #. ($unattempted,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
-#, fuzzy
 msgid "Unattempted: %1/%2"
-msgstr "tr: Unable to write to '%1': %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
-#, fuzzy
 msgid "Unclassified Problems"
-msgstr "tr: Edit Problems"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
 msgid "Ungraded"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
-#, fuzzy
 msgid "Unhide Courses"
-msgstr "Cursos"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
 msgid ""
@@ -7906,18 +6752,14 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
-#, fuzzy
 msgid "Unselect all courses"
-msgstr "tr: Unselect all users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
 msgid "Unselect all sets"
 msgstr "tr: Unselect all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
 msgid "Unselect all users"
 msgstr "tr: Unselect all users"
@@ -7948,26 +6790,22 @@ msgstr ""
 msgid "Updated location description."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
-#, fuzzy
 msgid "Upgrade"
-msgstr "Notas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
-#, fuzzy
 msgid "Upgrade Courses"
-msgstr "Cursos"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
 msgid "Upgrade process completed"
@@ -7995,7 +6833,6 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
 msgid "Use System Default"
 msgstr "tr: Use System Default"
@@ -8004,18 +6841,14 @@ msgstr "tr: Use System Default"
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
-#
 #. (CGI::b("$achievementID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
-#, fuzzy
 msgid "Use in achievement %1"
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
-#, fuzzy
 msgid "Use in new achievement:"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
 msgid "Use log base 10 instead of base <i>e</i>"
@@ -8050,24 +6883,18 @@ msgstr ""
 msgid "User ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
-#, fuzzy
 msgid "User Settings"
-msgstr "Cambio de opciones de usuario"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
-#, fuzzy
 msgid "User Values"
-msgstr "tr: Filename"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
-#, fuzzy
 msgid "User's name is:"
-msgstr "tr: Filename"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
 msgid "User's username is:"
@@ -8082,33 +6909,26 @@ msgid ""
 "database corruption."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
-#, fuzzy
 msgid "Username"
-msgstr "tr: Filename"
+msgstr ""
 
 #. ($user_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
 msgid "Username presented:  %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
-#, fuzzy
 msgid "Users"
-msgstr "Agregar usuarios"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
-#, fuzzy
 msgid "Users Assigned to Set %2"
-msgstr "tr: Edit Assigned Users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "Users List"
 msgstr "tr: Users List"
@@ -8126,12 +6946,10 @@ msgid ""
 "Normally guest users are not allowed to change their password."
 msgstr ""
 
-#
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
-#, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
-msgstr "tr: Users sorted by %1, then by %2, then by %3"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:306
 msgid ""
@@ -8152,12 +6970,10 @@ msgstr ""
 msgid "Using contents of the default message $default_msg_file instead."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
-#, fuzzy
 msgid "Using what display mode?: "
-msgstr "tr: Display Mode"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
@@ -8177,7 +6993,6 @@ msgstr ""
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
@@ -8187,65 +7002,52 @@ msgstr ""
 msgid "View"
 msgstr "tr: View"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:528
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:572
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
-#, fuzzy
 msgid "View Problems"
-msgstr "tr: Edit Problems"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
 msgid "View equations as"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
-#, fuzzy
 msgid "View it"
-msgstr "tr: View"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
 msgstr "tr: View statistics by set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
 msgid "View statistics by student"
 msgstr "tr: View statistics by student"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
 msgstr "tr: View student progress by set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
 msgstr "tr: View student progress by student"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
-#, fuzzy
 msgid "View/Edit"
-msgstr "tr: Edit"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
-#, fuzzy
 msgid "Viewing temporary file:"
-msgstr "Viendo archivo temporal"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:787
@@ -8254,33 +7056,25 @@ msgstr "Viendo archivo temporal"
 msgid "Visibility"
 msgstr "tr: Visibility"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
 msgid "Visible"
 msgstr "tr: Visible"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
-#, fuzzy
 msgid "Visible to Students"
-msgstr "tr: visible to students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
-#, fuzzy
 msgid "Warning"
-msgstr "Quedan"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
-#, fuzzy
 msgid "Warning messages"
-msgstr "Herramientas para evaluar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
@@ -8292,17 +7086,13 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
-#, fuzzy
 msgid "WeBWorK Error"
-msgstr "WeBWorK"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
-#, fuzzy
 msgid "WeBWorK Warnings"
-msgstr "WeBWorK"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
 msgid ""
@@ -8345,7 +7135,6 @@ msgstr ""
 msgid "Weight"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
 msgstr "Bienvenido a WeBWork!"
@@ -8354,7 +7143,6 @@ msgstr "Bienvenido a WeBWork!"
 msgid "What could be inside?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
 msgid "What field should filtered users match on?"
 msgstr "tr: What field should filtered users match on?"
@@ -8428,43 +7216,30 @@ msgid ""
 "you want to do before unchecking sets."
 msgstr ""
 
-#
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
-#, fuzzy
 msgid "Will open on %1."
-msgstr "Abrirá el %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
-#, fuzzy
 msgid "Worth"
-msgstr "Valor"
+msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
-"tr: Write permissions have not been enabled for '%1'.  Changes must be saved "
-"to another file for viewing."
 
-#
 #. ($self->shortPath($currentDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
-"tr: Write permissions have not been enabled in '%1'.  Changes must be saved "
-"to a different directory for viewing."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
@@ -8473,7 +7248,6 @@ msgstr ""
 "tr: Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
@@ -8509,53 +7283,42 @@ msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools"
-msgstr "tr: You are not authorized to access the instructor tools."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools."
-msgstr "tr: You are not authorized to access the instructor tools."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
 msgid "You are not authorized to access the instructor tools."
 msgstr "tr: You are not authorized to access the instructor tools."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
 msgid "You are not authorized to modify homework sets."
 msgstr "tr: You are not authorized to modify homework sets."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
 msgid "You are not authorized to modify problems."
 msgstr "tr: You are not authorized to modify problems."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
 msgid "You are not authorized to modify set definition files."
 msgstr "tr: You are not authorized to modify set definition files."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
-#, fuzzy
 msgid "You are not authorized to modify student data"
-msgstr "tr: You are not authorized to modify student data."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
 msgid "You are not authorized to perform this action."
@@ -8585,16 +7348,13 @@ msgstr ""
 msgid "You can also examine the following temporary files: "
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "En este problema puedes obtener crédito parcial."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
-#, fuzzy
 msgid "You can not specify an absolute path"
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
@@ -8628,11 +7388,9 @@ msgstr ""
 msgid "You can't download files of that type"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
-#, fuzzy
 msgid "You can't edit a directory"
-msgstr "tr: The file '%1' is a directory!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
 msgid "You can't view files of that type"
@@ -8642,13 +7400,10 @@ msgstr ""
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
-#, fuzzy
 msgid "You cannot delete the course you are currently using."
-msgstr "tr: You cannot delete yourself!"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
 msgid "You cannot delete yourself!"
 msgstr "tr: You cannot delete yourself!"
@@ -8659,52 +7414,40 @@ msgid ""
 "You must use Set Detail 2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
-#, fuzzy
 msgid "You did not specify a new set name."
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
 msgid "You didn't enter any message."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
 msgstr "Usted no tiene permiso para cambiar su dirección de correo."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
-#, fuzzy
 msgid "You do not have permission to change the hardcopy theme."
-msgstr "Usted no tiene permiso para cambiar su dirección de correo."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
 msgstr "Usted no tiene permiso para cambar su contraseña."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
-#, fuzzy
 msgid "You do not have permission to edit this file."
-msgstr "Usted no tiene permiso para ver los detalles de este error."
+msgstr ""
 
-#
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
-#, fuzzy
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr "Usted no tiene permiso para cambar su contraseña."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
-#, fuzzy
 msgid "You do not have permission to view the details of this error."
-msgstr "Usted no tiene permiso para ver los detalles de este error."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
@@ -8714,19 +7457,15 @@ msgstr ""
 msgid "You exceeded the allowed time."
 msgstr ""
 
-#
 #. ($numLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
-#, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
-msgstr " Te quedan %1 %2 intentos"
+msgstr ""
 
-#
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
-#, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr "Te quedan [negquant,_1,unlimited attempts,attempt,attempts]."
+msgstr ""
 
 #. ($attempts_before_rr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
@@ -8735,14 +7474,11 @@ msgid ""
 "requested."
 msgstr ""
 
-#
 #. ($attempts)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
-#, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
-msgstr "Tu has intentado este problema [quant,_1,vez,veces]."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
 msgid "You have been logged out of WeBWorK."
 msgstr "Has salido de WeBWork"
@@ -8781,34 +7517,27 @@ msgid ""
 "set."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
 msgid "You may not change your own password here!"
 msgstr "tr: You may not change your own password here!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
-#, fuzzy
 msgid "You may still check your answers."
-msgstr "tr: You may not change your own password here!"
+msgstr ""
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before Show Me Another "
 "is available."
-msgstr "Tu has intentado este problema [quant,_1,vez,veces]."
+msgstr ""
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
-msgstr "Tu has intentado este problema [quant,_1,vez,veces]."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
 msgid "You must confirm the password for the initial instructor."
@@ -8825,101 +7554,74 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
-#, fuzzy
 msgid "You must select a course to rename."
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
-#, fuzzy
 msgid "You must select at least one file for the archive"
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-#, fuzzy
 msgid "You must select one or more sets for scoring"
-msgstr "tr: No sets selected for scoring"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
-#, fuzzy
 msgid "You must specify a course ID."
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
-#, fuzzy
 msgid "You must specify a course name."
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
-#, fuzzy
 msgid "You must specify a file name"
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
-#, fuzzy
 msgid "You must specify a first name for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
-#, fuzzy
 msgid "You must specify a last name for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
-#, fuzzy
 msgid "You must specify a new institution for the course."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
-#, fuzzy
 msgid "You must specify a new name for the course."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
-#, fuzzy
 msgid "You must specify a new title for the course."
-msgstr "Debe especificar un ID de usuario."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
 msgid "You must specify a user ID."
 msgstr "Debe especificar un ID de usuario."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
-#, fuzzy
 msgid "You must specify an email address for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
-#, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "tr: You must specify an file name in order to save a new file."
 
@@ -8934,18 +7636,14 @@ msgstr ""
 msgid "You need to select a \"Target Set\" before you can edit it."
 msgstr ""
 
-#
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
-#, fuzzy
 msgid "You need to select a file to %1."
-msgstr "tr: Please specify a file to save to."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
-#, fuzzy
 msgid "You need to select a set definition file to view."
-msgstr "tr: You are not authorized to modify set definition files."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
@@ -8955,12 +7653,10 @@ msgstr ""
 msgid "You need to select a set to view."
 msgstr ""
 
-#
 #. (wwRound(0, $pg->{result}->{score} * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
-#, fuzzy
 msgid "You received a score of %1 for this attempt."
-msgstr "Tu has recibido una evaluación de %1 por este intento."
+msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
@@ -9028,13 +7724,10 @@ msgstr ""
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
-#, fuzzy
 msgid "Your display options have been saved."
-msgstr "Su dirección de correo ha sido cambiada."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
 msgid "Your email address has been changed."
 msgstr "Su dirección de correo ha sido cambiada."
@@ -9043,115 +7736,84 @@ msgstr "Su dirección de correo ha sido cambiada."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
-#
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
-#, fuzzy
 msgid "Your overall recorded score is %1.  %2"
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
-#, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
+# $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
-#, fuzzy
 msgid "Your score on this %1 WAS recorded."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
-#, fuzzy
 msgid "Your score on this %1 is %2/%3."
-msgstr "Tu calificación total es de %1.  %2."
+msgstr ""
 
-#
+# $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
-#, fuzzy
 msgid "Your score on this %1 was NOT recorded."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
-#
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
-#, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
-#, fuzzy
 msgid "Your score on this problem was recorded."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
-#, fuzzy
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr ""
-"Tu evaluación no fue registrada porque hubo una falla al almacenar la "
-"información en la base de datos."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
-#, fuzzy
 msgid "Your score was not recorded because this homework set is closed."
-msgstr "Tu evaluación no fue registrada porque esta tarea está cerrada."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
-#, fuzzy
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr ""
-"Tu calificación no fue registrada porque este problema no te fue asignado."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
-#, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
-"Tu calificación no fue registrada porque este problema no te fue asignado."
 
-#
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
-"Tu calificación no fue registrada porque este problema no te fue asignado."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
-"Tu calificación no fue registrada porque este problema no te fue asignado."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
-#, fuzzy
 msgid "Your score was not recorded."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
@@ -9159,11 +7821,9 @@ msgstr "Tu evaluación ha sido registrada."
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
-#, fuzzy
 msgid "Your score was recorded."
-msgstr "Tu evaluación ha sido registrada."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
@@ -9171,7 +7831,6 @@ msgstr "Tu evaluación ha sido registrada."
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr ""
@@ -9181,48 +7840,21 @@ msgstr ""
 msgid "Your systems are up to date!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
-#, fuzzy
 msgid "[Edit]"
-msgstr "~[editar~]"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
-#, fuzzy
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 msgstr ""
-"tr: This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
-#, fuzzy
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
-"tr: This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
@@ -9236,7 +7868,6 @@ msgstr ""
 "\"Take Action!\" button at the bottom of the form.  The bottom of the page "
 "contains a table containing the student usernames and their information."
 
-#
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
@@ -9244,7 +7875,6 @@ msgstr ""
 "%1 uses an external authentication system.  You've authenticated through "
 "that system, but aren't allowed to log in to this course."
 
-#
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
@@ -9252,7 +7882,6 @@ msgstr ""
 "tr: This course supports guest logins. Click %1 to log into this course as a "
 "guest."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
 msgstr ""
@@ -9267,7 +7896,6 @@ msgstr ""
 "the page contains a table displaying the sets and several pieces of relevant "
 "information."
 
-#
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
@@ -9283,7 +7911,6 @@ msgstr ""
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
 msgstr ""
@@ -9298,39 +7925,35 @@ msgstr ""
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
 
-#
+# Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
 msgstr "tr: a duplicate of the first selected set"
 
-#
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "tr: a new empty set"
 
+# Context is "Save to a new file named:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
 msgid "a new file named:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
 msgstr "tr: a single set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "active"
-msgstr "tr: Inactive"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
-#, fuzzy
 msgid "add problems"
-msgstr "tr: Add problem"
+msgstr ""
 
 #. ($setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
@@ -9341,6 +7964,7 @@ msgstr ""
 msgid "added missing permission level for user"
 msgstr ""
 
+# #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "admin"
 msgstr ""
@@ -9352,19 +7976,16 @@ msgstr ""
 msgid "all achievements"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
-#, fuzzy
 msgid "all current users"
-msgstr "tr: all users"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1319
@@ -9380,13 +8001,10 @@ msgstr ""
 msgid "all sets"
 msgstr "tr: all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
-#, fuzzy
 msgid "all students"
-msgstr "tr: all sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
@@ -9408,42 +8026,37 @@ msgstr ""
 msgid "alphabetically"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:661
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:672
-#, fuzzy
 msgid "answer"
-msgstr "tr: Answer Date"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
 msgid "any users"
 msgstr "tr: any users"
 
+# Context is "Create _____ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr ""
 
-#
+# Context is "Import achievements from ____ assigning the achievements to ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
 msgid "assigning the achievements to"
-msgstr "tr: Assign this set to which users?"
+msgstr ""
 
-#
+# Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
-#, fuzzy
 msgid "assigning this set to"
-msgstr "tr: Assign this set to which users?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
-#, fuzzy
 msgid "avg attempts"
-msgstr "intentos"
+msgstr ""
 
+# Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
 msgid "blank problem template(s) to end of homework set"
@@ -9455,33 +8068,27 @@ msgstr ""
 msgid "by last login date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "tr: changes abandoned"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "tr: changes saved"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "class list data"
-msgstr "Editor de la lista de clases"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
-#, fuzzy
 msgid "close"
-msgstr "tr: Closed"
+msgstr ""
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:685
 msgid "column"
@@ -9491,143 +8098,109 @@ msgstr ""
 msgid "columns:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
 msgid "correct"
 msgstr "correcto"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
-#, fuzzy
 msgid "course files"
-msgstr "Cursos"
+msgstr ""
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
-#, fuzzy
 msgid "deleted %1 sets"
-msgstr "tr: deleted %1 sets"
+msgstr ""
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
-#, fuzzy
 msgid "deleted %1 users"
-msgstr "tr: deleted %1 users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
-#, fuzzy
 msgid "editing all achievements"
-msgstr "tr: editing all sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
 msgid "editing all sets"
 msgstr "tr: editing all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
 msgid "editing all users"
 msgstr "tr: editing all users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
-#, fuzzy
 msgid "editing selected achievements"
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
 msgid "editing selected sets"
 msgstr "tr: editing selected sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing selected users"
 msgstr "tr: editing selected users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
 msgid "editing visible sets"
 msgstr "tr: editing visible sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing visible users"
 msgstr "tr: editing visible users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
-#, fuzzy
 msgid "email:"
-msgstr "E-mail"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
-#, fuzzy
 msgid "empty"
-msgstr "intento"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
 msgid "enter matching set IDs below"
 msgstr "tr: enter matching set IDs below"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
-#, fuzzy
 msgid "entry rows."
-msgstr "tr: Edit Problems"
+msgstr ""
 
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "tr: export abandoned"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
-#, fuzzy
 msgid "exporting all achievements"
-msgstr "tr: exporting all sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
 msgid "exporting all sets"
 msgstr "tr: exporting all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
-#, fuzzy
 msgid "exporting selected achievements"
-msgstr "tr: Export selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
 msgid "exporting selected sets"
 msgstr "tr: exporting selected sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
 msgid "exporting visible sets"
 msgstr "tr: exporting visible sets"
 
-#
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
@@ -9638,53 +8211,42 @@ msgstr ""
 msgid "for one <b>user</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
-#, fuzzy
 msgid "for students"
-msgstr "tr: hidden from students"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
 msgid "from"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
 msgid "giving new passwords to all users"
 msgstr "tr: giving new passwords to all users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to selected users"
 msgstr "tr: giving new passwords to selected users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to visible users"
 msgstr "tr: giving new passwords to visible users"
 
-#
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
-#, fuzzy
 msgid "global %1 for set %2 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
-#, fuzzy
 msgid "global set %1  not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
-#, fuzzy
 msgid "global set %1 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
@@ -9694,32 +8256,27 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
-#, fuzzy
 msgid "hidden"
-msgstr "tr: Hidden"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
-#, fuzzy
 msgid "hidden from"
-msgstr "oculta para"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "tr: hidden from students"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
 msgid "hidden sets"
 msgstr "tr: hidden sets"
 
+# doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
 #: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
@@ -9733,17 +8290,15 @@ msgstr ""
 msgid "illegal character in input: '/'"
 msgstr ""
 
+# Context is " Show users who match _____ in their _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
 msgid "in their"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "inactive"
-msgstr "tr: Inactive"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
 msgid "incorrect"
@@ -9762,80 +8317,61 @@ msgstr ""
 msgid "list of insertable macros"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
-#, fuzzy
 msgid "locations selected below"
-msgstr "tr: exporting selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
-#, fuzzy
 msgid "login"
-msgstr "tr: Login Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
-#, fuzzy
 msgid "login ID"
-msgstr "tr: Login Name"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
-#, fuzzy
 msgid "login/studentID:"
-msgstr "tr: Student ID"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "login_proctor"
 msgstr ""
 
-#
+# Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
-#, fuzzy
 msgid "made visible for"
-msgstr "visible para"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
 msgid "max"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
 msgid "multiple sets"
 msgstr "tr: multiple sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
-#, fuzzy
 msgid "new set:"
-msgstr "tr: no sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
-#, fuzzy
 msgid "new users"
-msgstr "tr: no users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
-#, fuzzy
 msgid "no achievements"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
 msgid "no achievements."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
-#, fuzzy
 msgid "no location"
-msgstr "Mostrar soluciones"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1073
@@ -9847,13 +8383,10 @@ msgstr "Mostrar soluciones"
 msgid "no sets"
 msgstr "tr: no sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
-#, fuzzy
 msgid "no students"
-msgstr "tr: no sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
@@ -9889,32 +8422,27 @@ msgstr ""
 msgid "one <b>user</b> (on one <b>set</b>)"
 msgstr ""
 
+# Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
 msgid "only"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
-#, fuzzy
 msgid "only best scores"
-msgstr "tr: Test Score"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
-#, fuzzy
 msgid "or"
-msgstr "tr: Sort"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
-#, fuzzy
 msgid "or Problems from"
-msgstr "Problemas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
@@ -9946,39 +8474,29 @@ msgstr ""
 msgid "pg warning"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
-#, fuzzy
 msgid "point"
-msgstr "Mostrar ayuda"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
-#, fuzzy
 msgid "points"
-msgstr "Mostrar ayuda"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
 msgid "preserve existing data"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
-#, fuzzy
 msgid "preview answers"
-msgstr "Previsualizar respuestas"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:667
-#, fuzzy
 msgid "problem"
-msgstr "tr: Problem"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
-#, fuzzy
 msgid "problems"
-msgstr "tr: Problem"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "professor"
@@ -9995,26 +8513,20 @@ msgstr ""
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
-#, fuzzy
 msgid "recitation #"
-msgstr "tr: Recitation"
+msgstr ""
 
-#
 #. ($studentName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
-#, fuzzy
 msgid "record for user %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
-#, fuzzy
 msgid "record for visible user %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr ""
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
@@ -10026,45 +8538,34 @@ msgstr ""
 msgid "row"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
-#, fuzzy
 msgid "section #"
-msgstr "tr: Section"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
-#, fuzzy
 msgid "section:"
-msgstr "tr: Section"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#, fuzzy
 msgid "selected <b>sets</b>"
-msgstr "tr: selected sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
-#, fuzzy
 msgid "selected achievements"
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
-#, fuzzy
 msgid "selected achievements."
-msgstr "tr: selected sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1321
@@ -10080,7 +8581,6 @@ msgstr "tr: selected sets"
 msgid "selected sets"
 msgstr "tr: selected sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
@@ -10095,136 +8595,101 @@ msgstr "tr: selected sets"
 msgid "selected users"
 msgstr "tr: selected users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
-#, fuzzy
 msgid "separate multiple IDs with commas"
-msgstr "tr: Match on what? (separate multiple IDs with commas)"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
-#, fuzzy
 msgid "set"
-msgstr "Tarea"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#, fuzzy
 msgid "sets"
-msgstr "tr: no sets"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
 msgid "sets checked below"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
-#, fuzzy
 msgid "sets hidden from students"
-msgstr "tr: hidden from students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
-#, fuzzy
 msgid "sets visible to students"
-msgstr "tr: visible to students"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
-#, fuzzy
 msgid "sets with matching set IDs:"
-msgstr "tr: enter matching set IDs below"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
 msgid "showing all sets"
 msgstr "tr: showing all sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
 msgid "showing all users"
 msgstr "tr: showing all users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
-#, fuzzy
 msgid "showing hidden sets"
-msgstr "tr: showing no sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
-#, fuzzy
 msgid "showing matching sets"
-msgstr "tr: showing matching users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing matching users"
 msgstr "tr: showing matching users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
 msgid "showing no sets"
 msgstr "tr: showing no sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing no users"
 msgstr "tr: showing no users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
 msgid "showing selected sets"
 msgstr "tr: showing selected sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing selected users"
 msgstr "tr: showing selected users"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
-#, fuzzy
 msgid "showing visible sets"
-msgstr "tr: exporting visible sets"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
-#, fuzzy
 msgid "still open"
-msgstr "Abrirá el %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
-#, fuzzy
 msgid "student"
-msgstr "tr: Student ID"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
-#, fuzzy
 msgid "students"
-msgstr "tr: Student ID"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "submission"
-msgstr "Enviar respuestas"
+msgstr ""
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "submission (test %1)"
-msgstr "Enviar respuestas"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "summary"
@@ -10234,30 +8699,22 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "test"
-msgstr "tr: %1 test"
+msgstr ""
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "test (%1)"
-msgstr "tr: %1 test"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
-#, fuzzy
 msgid "test date"
-msgstr "tr: Test Date"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
-#, fuzzy
 msgid "test time"
-msgstr "tr: %1 test"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
 msgid "the following file"
@@ -10267,41 +8724,35 @@ msgstr ""
 msgid "the following file(s)"
 msgstr ""
 
-#
 #. ($forcedSourceFile)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
-#, fuzzy
 msgid "the original path to the file is %1"
-msgstr "tr: the original path to the file is %1"
+msgstr ""
 
-#
+# Context is "Sort by ___ then by ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
-#, fuzzy
 msgid "then by"
-msgstr "tr: Then by"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
 msgid "then delete them"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
-#, fuzzy
 msgid "time"
-msgstr "tiempo"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
 msgid "time limit exceeded"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
-#, fuzzy
 msgid "times"
-msgstr "tiempos"
+msgstr ""
 
+# Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
 msgid "to"
 msgstr ""
@@ -10314,41 +8765,33 @@ msgstr ""
 msgid "to one <b>set</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
-#, fuzzy
 msgid "top score"
-msgstr "tr: Test Score"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
 msgid "total"
 msgstr ""
 
-#
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
-#, fuzzy
 msgid "unable to write to directory %1"
-msgstr "tr: Saved to file '%1'"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
-#, fuzzy
 msgid "unlimited"
-msgstr "ilimitado"
+msgstr ""
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
-#, fuzzy
 msgid "userID: %1 --"
-msgstr "tr: Replace %1"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
 msgid ""
@@ -10356,33 +8799,25 @@ msgid ""
 "score,"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "users"
-msgstr "tr: no users"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
 msgid "users who match on selected field"
 msgstr "tr: users who match on selected field"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
-#, fuzzy
 msgid "users who match:"
-msgstr "tr: users who match on selected field"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
-#, fuzzy
 msgid "visible"
-msgstr "tr: Visible"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1363
@@ -10391,13 +8826,11 @@ msgstr "tr: Visible"
 msgid "visible sets"
 msgstr "tr: visible sets"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "tr: visible to students"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
@@ -10418,481 +8851,453 @@ msgstr ""
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#, fuzzy
 msgid "your students"
-msgstr "tr: visible to students"
+msgstr ""
 
 #
+#, fuzzy
+msgid "Will open on %1"
+msgstr "Abrirá el %1"
+
+#
+#, fuzzy
+msgid "User ID:"
+msgstr "Agregar usuarios"
+
+#
+msgid "Viewing temporary file"
+msgstr "tr: Viewing temporary file"
+
+#
+#, fuzzy
+msgid "font-hidden"
+msgstr "tr: Hidden"
+
+#
+#, fuzzy
+msgid "set %1."
+msgstr "tr: Revert to %1"
+
+#
+#, fuzzy
+msgid "submitAnswers"
+msgstr "Enviar respuestas"
+
+#
+#, fuzzy
+msgid "Bad Nonce for user "
+msgstr "tr: Set Header for set %1"
+
+#
+#, fuzzy
+msgid "Can't write to file: %1"
+msgstr "tr: Saved to file '%1'"
+
+#
+#, fuzzy
+msgid "Change Display Options"
+msgstr "tr: Display Options"
+
+#
+msgid "navNext"
+msgstr "images_es/navNext"
+
+#
+msgid "navNextGrey"
+msgstr "images_es/navNextGrey"
+
+#
+msgid "navPrev"
+msgstr "images_es/navPrev"
+
+#
+msgid "navPrevGrey"
+msgstr "images_es/navPrevGrey"
+
+#
+msgid "navProbListGrey"
+msgstr "images_es/navProbListGrey"
+
+#
+msgid "navUp"
+msgstr "images_es/navUp"
+
+#
+#, fuzzy
+msgid "At least one of these answers is NOT completely correct."
+msgstr "Al menos una de las respuestas no es %1 correcta"
+
+#
+#, fuzzy
+msgid "[_1]: Problem [_2]"
+msgstr "tr: set %1/problem %2"
+
+#
+#, fuzzy
+msgid "Show me another [_1]"
+msgstr "tr: Show in another window"
+
+#
+#, fuzzy
+msgid "Assign "
+msgstr "tr: Edit Assigned Users"
+
+#
+msgid "Apply Options"
+msgstr "tr: Apply Options"
+
+#
+msgid "Disable"
+msgstr "tr: Disable"
+
+#
+msgid "Enable/Disable reduced scoring for selected sets"
+msgstr "tr: Enable/Disable reduced scoring for selected sets"
+
+#
+#, fuzzy
+msgid "Reduced Credit %1 for all sets"
+msgstr "tr: Reduced Credit %1 for all sets"
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_1"
+msgstr ""
+"tr: This assignment has a Reduced Credit Period that begins %1 and ends on "
+"the due date, %2.  During this period all additional work done counts %3% of "
+"the original."
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_2"
+msgstr ""
+"tr: This assignment had a Reduced Credit Period that began %1 and ended on "
+"the due date, %2.  During that period all additional work done counted %3% "
+"of the original."
+
+#
+msgid "completely"
+msgstr "tr: completely"
+
+#
+msgid "Course Information for course [_1]"
+msgstr "tr: Course Information for course %1"
+
+#
+msgid ""
+"Report bugs in a WeBWorK question/problem using this link. The very first "
+"time you do this you will need to register with an email address so that "
+"information on the bug fix can be reported back to you."
+msgstr ""
+"tr: Report bugs in a WeBWorK question/problem using this link. The very "
+"first time you do this you will need to register with an email address so "
+"that information on the bug fix can be reported back to you."
+
+#
+msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
+msgstr "tr: Unable to change the hardcopy header for set %1. Unknown error."
+
+#
+msgid "Unable to make '[_1]' the set header for [_2]"
+msgstr "tr: Unable to make '%1' the set header for %2"
+
+#
+msgid "Can't determine user of temporary edit file [_1]."
+msgstr "tr: Can't determine user of temporary edit file %1."
+
+#
+msgid "Top level of author information on the wiki."
+msgstr "tr: Top level of author information on the wiki."
+
+#
+msgid "Reverting to original file '[_1]'"
+msgstr "tr: Reverting to original file '%1'"
+
+#
+msgid "Wiki summary page for MathObjects"
+msgstr "tr: Wiki summary page for MathObjects"
+
+#
+msgid "Snippets of PG code illustrating specific techniques"
+msgstr "tr: Snippets of PG code illustrating specific techniques"
+
+#
+msgid "Error copying [_1] to [_2]"
+msgstr "tr: Error copying %1 to %2"
+
+#
+#, fuzzy
+msgid "This set is [_1] students."
+msgstr "Este conjunto es de %1 estudiantes"
+
+#
+msgid "blank problem"
+msgstr "tr: blank problem"
+
+#
+msgid ""
+"Note: this problem viewer is for viewing purposes only. As of right now, "
+"testing functionality is not possible."
+msgstr ""
+"tr: Note: this problem viewer is for viewing purposes only. As of right now, "
+"testing functionality is not possible."
+
+#
+msgid "webwork"
+msgstr "webwork"
+
+#
+#, fuzzy
+msgid "submit button clicked"
+msgstr "Botón enviar pulsado."
+
+#
+msgid ""
+"Test snippets of PG code in interactive lab.  Good way to learn PG language."
+msgstr ""
+"tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
+"language."
+
+#
+#, fuzzy
+msgid "Page generated at [_1] at [_2]"
+msgstr "tr: Page generated at %1"
+
+#
+msgid "View Using Seed Number"
+msgstr "tr: View Using Seed Number"
+
+#
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"tr: The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+
+#
+msgid ""
+"Documentation from source code for PG modules and macro files. Often the "
+"most up-to-date information."
+msgstr ""
+"tr: Documentation from source code for PG modules and macro files. Often the "
+"most up-to-date information."
+
+#
+msgid ""
+"PG mark down syntax used to format WeBWorK questions. This interactive lab "
+"can help you to learn the techniques."
+msgstr ""
+"tr: PG mark down syntax used to format WeBWorK questions. This interactive "
+"lab can help you to learn the techniques."
+
+#
+msgid ""
+"Error: This path is already in the temporary edit directory -- no new "
+"temporary file is created. path = [_1]"
+msgstr ""
+"tr: Error: This path is already in the temporary edit directory -- no new "
+"temporary file is created. path = %1"
+
+#
+msgid ""
+"Please use radio buttons to choose the method for saving this file. Can't "
+"recognize saveMode: |[_1]|."
+msgstr ""
+"tr: Please use radio buttons to choose the method for saving this file. "
+"Can't recognize saveMode: |%1|."
+
+#
+#, fuzzy
+msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
+msgstr ""
+"El problema seleccionado (%1) no es un problema válido para el conjunto %2."
+
+#
+msgid "Resources"
+msgstr "tr: Resources"
+
+#
+msgid "Duplicate"
+msgstr "tr: Duplicate"
+
+#
+msgid "This path |[_1]| is not the path to a temporary edit file."
+msgstr "tr: This path |%1| is not the path to a temporary edit file."
+
+#
+msgid ""
+"Unable to change the source file path for set [_1], problem [_2]. Unknown "
+"error."
+msgstr ""
+"tr: Unable to change the source file path for set %1, problem %2. Unknown "
+"error."
+
+#
+msgid "Options Information"
+msgstr "tr: Options Information"
+
+#
+msgid "Save as new independent problem"
+msgstr "tr: Save as new independent problem"
+
+#
+msgid "options information"
+msgstr "tr: options information"
+
+#
+msgid "The selected problem([_1]) is not a valid problem for set [_2]."
+msgstr ""
+"El problema seleccionado (%1) no es válido para el conjunto de problemas "
+"(%2). "
+
+#
+msgid "Unknown file type"
+msgstr "tr: Unknown file type"
+
+#
+msgid "Viewing temporary file:  "
+msgstr "Viendo el archivo temporal"
+
 #, fuzzy
 #~ msgid "answer "
 #~ msgstr "tr: Answer Date"
 
-#
-#, fuzzy
-#~ msgid "Will open on %1"
-#~ msgstr "Abrirá el %1"
-
-#
-#, fuzzy
-#~ msgid "User ID:"
-#~ msgstr "Agregar usuarios"
-
-#
-#~ msgid "Viewing temporary file"
-#~ msgstr "tr: Viewing temporary file"
-
-#
 #, fuzzy
 #~ msgid "You are not authorized to access instructor tools"
 #~ msgstr "tr: You are not authorized to access the instructor tools."
 
-#
 #, fuzzy
 #~ msgid "all current users."
 #~ msgstr "tr: all users"
 
-#
-#, fuzzy
-#~ msgid "font-hidden"
-#~ msgstr "tr: Hidden"
-
-#
 #, fuzzy
 #~ msgid "font-visible"
 #~ msgstr "tr: Visible"
 
-#
 #, fuzzy
 #~ msgid "no users."
 #~ msgstr "tr: no users"
 
-#
-#, fuzzy
-#~ msgid "set %1."
-#~ msgstr "tr: Revert to %1"
-
-#
-#, fuzzy
-#~ msgid "submitAnswers"
-#~ msgstr "Enviar respuestas"
-
-#
 #, fuzzy
 #~ msgid "All sets %1 all students"
-#~ msgstr "tr: All sets %1 all students"
+#~ msgstr "tr: Select all sets"
 
-#
-#, fuzzy
-#~ msgid "Bad Nonce for user "
-#~ msgstr "tr: Set Header for set %1"
-
-#
-#, fuzzy
-#~ msgid "Can't write to file: %1"
-#~ msgstr "tr: Saved to file '%1'"
-
-#
-#, fuzzy
-#~ msgid "Change Display Options"
-#~ msgstr "tr: Display Options"
-
-#
 #, fuzzy
 #~ msgid "Changes saved."
 #~ msgstr "tr: changes saved"
 
-#
 #, fuzzy
 #~ msgid "Comment: "
 #~ msgstr "tr: Comment"
 
-#
 #, fuzzy
 #~ msgid "Hardcopy Theme:"
 #~ msgstr "tr: Hardcopy Header"
 
-#
 #, fuzzy
 #~ msgid "No sets selected for scoring."
 #~ msgstr "tr: No sets selected for scoring"
 
-#
 #, fuzzy
 #~ msgid "Note: "
 #~ msgstr "tr: Note"
 
-#
 #, fuzzy
 #~ msgid "Recitation:"
 #~ msgstr "tr: Recitation"
 
-#
 #, fuzzy
 #~ msgid "Save as:"
 #~ msgstr "tr: Save as"
 
-#
 #, fuzzy
 #~ msgid "Log into"
 #~ msgstr "Salir"
 
-#
 #, fuzzy
 #~ msgid "Sets assigned to $userID"
 #~ msgstr "tr: Edit Assigned Users"
 
-#
-#~ msgid "navNext"
-#~ msgstr "images_es/navNext"
-
-#
-#~ msgid "navNextGrey"
-#~ msgstr "images_es/navNextGrey"
-
-#
-#~ msgid "navPrev"
-#~ msgstr "images_es/navPrev"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "images_es/navPrevGrey"
-
-#
+#, fuzzy
 #~ msgid "navProbList"
-#~ msgstr "images_es/navProbList"
+#~ msgstr "Lista de problemas"
 
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "images_es/navProbListGrey"
-
-#
-#~ msgid "navUp"
-#~ msgstr "images_es/navUp"
-
-#
+#, fuzzy
 #~ msgid "Problem [_1]"
-#~ msgstr "Problema %1"
+#~ msgstr "Problemas"
 
-#
 #, fuzzy
 #~ msgid "[_1]% correct"
-#~ msgstr "%1% correcto"
+#~ msgstr "correcto"
 
-#
-#, fuzzy
-#~ msgid "At least one of these answers is NOT completely correct."
-#~ msgstr "Al menos una de las respuestas no es %1 correcta"
-
-#
-#, fuzzy
-#~ msgid "[_1]: Problem [_2]"
-#~ msgstr "tr: set %1/problem %2"
-
-#
-#, fuzzy
-#~ msgid "Show me another [_1]"
-#~ msgstr "tr: Show in another window"
-
-#
 #, fuzzy
 #~ msgid "Edit "
 #~ msgstr "tr: Edit"
 
-#
-#, fuzzy
-#~ msgid "Assign "
-#~ msgstr "tr: Edit Assigned Users"
-
-#
 #, fuzzy
 #~ msgid "Delete "
 #~ msgstr "tr: Delete"
 
-#
 #, fuzzy
 #~ msgid "Export "
 #~ msgstr "tr: Export"
 
-#
 #, fuzzy
 #~ msgid "Add "
 #~ msgstr "Agregar usuarios"
 
-#
-#~ msgid "Apply Options"
-#~ msgstr "tr: Apply Options"
-
-#
-#~ msgid "Disable"
-#~ msgstr "tr: Disable"
-
-#
-#~ msgid "Enable/Disable reduced scoring for selected sets"
-#~ msgstr "tr: Enable/Disable reduced scoring for selected sets"
-
-#
 #, fuzzy
 #~ msgid ""
 #~ "No students shown.  Choose one of the options above to \n"
 #~ "\t              list the students in the course."
 #~ msgstr ""
-#~ "tr: No students shown.  Choose one of the options above to list the "
-#~ "students in the course."
+#~ "tr: No sets shown.  Choose one of the options above to list the sets in "
+#~ "the course."
 
-#
-#, fuzzy
-#~ msgid "Reduced Credit %1 for all sets"
-#~ msgstr "tr: Reduced Credit %1 for all sets"
-
-#
 #, fuzzy
 #~ msgid "Reduced Credit %1 for selected sets"
-#~ msgstr "tr: Reduced Credit %1 for selected sets"
+#~ msgstr "tr: editing selected sets"
 
-#
 #, fuzzy
 #~ msgid "Reduced Credit %1 for visable sets"
-#~ msgstr "tr: Reduced Credit %1 for visable sets"
+#~ msgstr "tr: Record Scores for Single Sets"
 
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "tr: This assignment has a Reduced Credit Period that begins %1 and ends "
-#~ "on the due date, %2.  During this period all additional work done counts "
-#~ "%3% of the original."
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "tr: This assignment had a Reduced Credit Period that began %1 and ended "
-#~ "on the due date, %2.  During that period all additional work done counted "
-#~ "%3% of the original."
-
-#
-#~ msgid "completely"
-#~ msgstr "tr: completely"
-
-#
-#~ msgid "Course Information for course [_1]"
-#~ msgstr "tr: Course Information for course %1"
-
-#
+#, fuzzy
 #~ msgid "Cancel Password"
-#~ msgstr "tr: Cancel Password"
+#~ msgstr "tr: New Password"
 
-#
+#, fuzzy
 #~ msgid "Hardcopy Header for set [_1]"
-#~ msgstr "tr: Hardcopy Header for set %1"
+#~ msgstr "tr: Hardcopy Header"
 
-#
-#~ msgid ""
-#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
-#~ "time you do this you will need to register with an email address so that "
-#~ "information on the bug fix can be reported back to you."
-#~ msgstr ""
-#~ "tr: Report bugs in a WeBWorK question/problem using this link. The very "
-#~ "first time you do this you will need to register with an email address so "
-#~ "that information on the bug fix can be reported back to you."
-
-#
+#, fuzzy
 #~ msgid "hardcopy header file"
-#~ msgstr "tr: hardcopy header file"
+#~ msgstr "tr: Hardcopy Header"
 
-#
 #, fuzzy
 #~ msgid "Unpublished"
-#~ msgstr "No publicado"
+#~ msgstr "tr: Publish"
 
-#
-#~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-#~ msgstr "tr: Unable to change the hardcopy header for set %1. Unknown error."
-
-#
-#~ msgid "Unable to make '[_1]' the set header for [_2]"
-#~ msgstr "tr: Unable to make '%1' the set header for %2"
-
-#
-#~ msgid "Can't determine user of temporary edit file [_1]."
-#~ msgstr "tr: Can't determine user of temporary edit file %1."
-
-#
-#~ msgid "Top level of author information on the wiki."
-#~ msgstr "tr: Top level of author information on the wiki."
-
-#
+#, fuzzy
 #~ msgid "Save Password"
-#~ msgstr "tr: Save Password"
+#~ msgstr "tr: New Password"
 
-#
-#~ msgid "Reverting to original file '[_1]'"
-#~ msgstr "tr: Reverting to original file '%1'"
-
-#
-#~ msgid "Wiki summary page for MathObjects"
-#~ msgstr "tr: Wiki summary page for MathObjects"
-
-#
+#, fuzzy
 #~ msgid "Password/Email"
-#~ msgstr "Contraseña/Email"
+#~ msgstr "tr: New Password"
 
-#
-#~ msgid "Snippets of PG code illustrating specific techniques"
-#~ msgstr "tr: Snippets of PG code illustrating specific techniques"
-
-#
-#~ msgid "Error copying [_1] to [_2]"
-#~ msgstr "tr: Error copying %1 to %2"
-
-#
 #, fuzzy
-#~ msgid "This set is [_1] students."
-#~ msgstr "Este conjunto es de %1 estudiantes"
-
-#
-#~ msgid "blank problem"
-#~ msgstr "tr: blank problem"
-
-#
-#~ msgid ""
-#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
-#~ "testing functionality is not possible."
-#~ msgstr ""
-#~ "tr: Note: this problem viewer is for viewing purposes only. As of right "
-#~ "now, testing functionality is not possible."
-
-#
 #~ msgid "Save Export"
-#~ msgstr "tr: Save Export"
+#~ msgstr "tr: Export"
 
-#
-#~ msgid "webwork"
-#~ msgstr "webwork"
-
-#
 #, fuzzy
-#~ msgid "submit button clicked"
-#~ msgstr "Botón enviar pulsado."
-
-#
 #~ msgid "Problem Source Code"
-#~ msgstr "tr: Problem Source Code"
+#~ msgstr "Editor de problemas"
 
-#
-#~ msgid ""
-#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-#~ msgstr ""
-#~ "tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-
-#
 #, fuzzy
-#~ msgid "Page generated at [_1] at [_2]"
-#~ msgstr "tr: Page generated at %1"
-
-#
-#~ msgid "View Using Seed Number"
-#~ msgstr "tr: View Using Seed Number"
-
-#
 #~ msgid "Published"
-#~ msgstr "Publicado"
+#~ msgstr "tr: Publish"
 
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "tr: The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-
-#
-#~ msgid ""
-#~ "Documentation from source code for PG modules and macro files. Often the "
-#~ "most up-to-date information."
-#~ msgstr ""
-#~ "tr: Documentation from source code for PG modules and macro files. Often "
-#~ "the most up-to-date information."
-
-#
-#~ msgid ""
-#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
-#~ "lab can help you to learn the techniques."
-#~ msgstr ""
-#~ "tr: PG mark down syntax used to format WeBWorK questions. This "
-#~ "interactive lab can help you to learn the techniques."
-
-#
-#~ msgid ""
-#~ "Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = [_1]"
-#~ msgstr ""
-#~ "tr: Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = %1"
-
-#
-#~ msgid ""
-#~ "Please use radio buttons to choose the method for saving this file. Can't "
-#~ "recognize saveMode: |[_1]|."
-#~ msgstr ""
-#~ "tr: Please use radio buttons to choose the method for saving this file. "
-#~ "Can't recognize saveMode: |%1|."
-
-#
 #, fuzzy
-#~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-#~ msgstr ""
-#~ "El problema seleccionado (%1) no es un problema válido para el conjunto "
-#~ "%2."
-
-#
-#~ msgid "Resources"
-#~ msgstr "tr: Resources"
-
-#
-#~ msgid "Duplicate"
-#~ msgstr "tr: Duplicate"
-
-#
-#~ msgid "This path |[_1]| is not the path to a temporary edit file."
-#~ msgstr "tr: This path |%1| is not the path to a temporary edit file."
-
-#
-#~ msgid ""
-#~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
-#~ "error."
-#~ msgstr ""
-#~ "tr: Unable to change the source file path for set %1, problem %2. Unknown "
-#~ "error."
-
-#
-#~ msgid "Options Information"
-#~ msgstr "tr: Options Information"
-
-#
-#~ msgid "Save as new independent problem"
-#~ msgstr "tr: Save as new independent problem"
-
-#
 #~ msgid "Cancel Export"
-#~ msgstr "tr: Cancel Export"
-
-#
-#~ msgid "options information"
-#~ msgstr "tr: options information"
-
-#
-#~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-#~ msgstr ""
-#~ "El problema seleccionado (%1) no es válido para el conjunto de problemas "
-#~ "(%2). "
-
-#
-#~ msgid "Unknown file type"
-#~ msgstr "tr: Unknown file type"
-
-#
-#~ msgid "Viewing temporary file:  "
-#~ msgstr "Viendo el archivo temporal"
+#~ msgstr "tr: Export"

--- a/lib/WeBWorK/Localize/es.po
+++ b/lib/WeBWorK/Localize/es.po
@@ -17,11 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "tr: Add how many students?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr ""
 
@@ -34,15 +39,15 @@ msgid "% correct with review"
 msgstr ""
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr ""
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -78,17 +83,17 @@ msgid "%1 students out of %2"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr ""
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -117,8 +122,8 @@ msgstr ""
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr ""
 
@@ -155,7 +160,7 @@ msgstr ""
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr ""
 
@@ -165,12 +170,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr ""
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -185,49 +190,49 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr ""
 
@@ -300,16 +305,30 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr ""
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
@@ -325,26 +344,26 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
@@ -384,37 +403,37 @@ msgid ""
 msgstr ""
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "tr: Abandon changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "tr: Abandon export"
@@ -424,12 +443,12 @@ msgid "Achievement"
 msgstr ""
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr ""
 
@@ -446,13 +465,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -468,12 +487,17 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "tr: giving new passwords to selected users"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr ""
 
@@ -493,17 +517,17 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr ""
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "tr: Active"
 
@@ -522,7 +546,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "tr: Add"
@@ -531,9 +555,9 @@ msgstr "tr: Add"
 msgid "Add All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr ""
 
@@ -545,7 +569,7 @@ msgstr ""
 msgid "Add Users"
 msgstr "Agregar usuarios"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -553,12 +577,12 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "tr: Add as what filetype?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "tr: Add how many students?"
 
@@ -566,41 +590,41 @@ msgstr "tr: Add how many students?"
 msgid "Add problems to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "tr: Add which new users?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr ""
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -609,52 +633,52 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -669,7 +693,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -682,7 +706,7 @@ msgid "After set answer date"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -695,15 +719,15 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -723,7 +747,7 @@ msgstr ""
 msgid "All sets made visible for all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -787,25 +811,25 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
@@ -823,8 +847,8 @@ msgstr "tr: Answer Date"
 msgid "Answer Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Previsualizar respuesta"
 
@@ -837,12 +861,12 @@ msgid "Answer:"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -864,8 +888,15 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr ""
+"tr: Any changes made below will be reflected in the set for ALL students."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
@@ -873,7 +904,7 @@ msgstr ""
 "tr: Any changes made below will be reflected in the set for ALL students."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -886,18 +917,18 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr ""
 
@@ -911,26 +942,26 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr ""
 
@@ -940,22 +971,26 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
+msgstr ""
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
@@ -980,17 +1015,17 @@ msgstr ""
 msgid "Assigned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr ""
 
@@ -998,7 +1033,13 @@ msgstr ""
 msgid "Assignment type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "tr: Edit Assigned Users"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr ""
 
@@ -1007,7 +1048,7 @@ msgstr ""
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1019,7 +1060,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr ""
 
@@ -1027,13 +1068,14 @@ msgstr ""
 msgid "Audit"
 msgstr "tr: Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "tr: Author Info"
 
@@ -1041,12 +1083,12 @@ msgstr "tr: Author Info"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1086,16 +1128,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1125,7 +1167,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1160,17 +1202,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr ""
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr ""
 
@@ -1179,7 +1221,7 @@ msgstr ""
 msgid "Can't rename file: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1188,11 +1230,11 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr ""
 
@@ -1203,7 +1245,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr ""
 
@@ -1216,8 +1258,8 @@ msgstr ""
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1237,11 +1279,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1255,7 +1297,7 @@ msgstr ""
 msgid "Change Email Address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1264,32 +1306,32 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr ""
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "tr: Changes in this file have not yet been permanently saved."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr ""
 
@@ -1304,26 +1346,26 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "tr: Checking additional error messages"
 
@@ -1338,7 +1380,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1377,8 +1419,8 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1393,7 +1435,7 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr ""
 
@@ -1431,7 +1473,7 @@ msgid "Closes"
 msgstr ""
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr ""
 
@@ -1440,39 +1482,39 @@ msgstr ""
 msgid "Closes:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "tr: Comment"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1480,7 +1522,7 @@ msgstr ""
 msgid "Completed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1490,7 +1532,7 @@ msgstr ""
 msgid "Confirm %1's New Password"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr ""
 
@@ -1504,8 +1546,8 @@ msgid "Continue"
 msgstr "tr: Continue"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr ""
 
@@ -1519,7 +1561,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1527,8 +1569,8 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Correcto"
@@ -1537,7 +1579,7 @@ msgstr "Correcto"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr ""
 
@@ -1554,17 +1596,17 @@ msgid "Correct answers"
 msgstr ""
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr ""
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1581,48 +1623,49 @@ msgid "Couldn't change your email address: %1"
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1632,13 +1675,13 @@ msgstr "Administración del curso"
 msgid "Course Configuration"
 msgstr "Configuración del curso"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr ""
 
@@ -1647,13 +1690,13 @@ msgstr ""
 msgid "Course Info"
 msgstr "Información del curso"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr ""
 
@@ -1661,15 +1704,15 @@ msgstr ""
 msgid "Course archived."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Cursos"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1687,7 +1730,7 @@ msgstr "tr: Create"
 msgid "Create CSV"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr ""
 
@@ -1695,7 +1738,7 @@ msgstr ""
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1703,12 +1746,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "tr: Create as what type of set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1721,34 +1764,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr ""
 
@@ -1760,7 +1803,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1785,77 +1828,77 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "tr: Delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "tr: Delete how many?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr ""
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr ""
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
 
@@ -1863,7 +1906,7 @@ msgstr ""
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 
@@ -1871,13 +1914,13 @@ msgstr ""
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -1895,53 +1938,57 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -1965,29 +2012,29 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr ""
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr ""
 
@@ -1996,17 +2043,17 @@ msgstr ""
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2036,8 +2083,8 @@ msgstr ""
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "tr: Download PDF or TeX Hardcopy for Current Set"
 
@@ -2057,6 +2104,16 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "tr: Drop"
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2078,7 +2135,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr ""
 
@@ -2096,7 +2153,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr ""
 
@@ -2104,25 +2161,25 @@ msgstr ""
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "tr: Edit"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr ""
 
@@ -2135,19 +2192,19 @@ msgstr "tr: Edit All Set Data"
 msgid "Edit Assigned Users"
 msgstr "tr: Edit Assigned Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr ""
 
@@ -2169,7 +2226,7 @@ msgstr "tr: Edit Set Data"
 msgid "Edit Target Set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "tr: Edit Which Users?"
 
@@ -2185,17 +2242,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2208,23 +2265,23 @@ msgid "Edit which sets?"
 msgstr "tr: Edit which sets?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr ""
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr ""
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr ""
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr ""
 
@@ -2234,44 +2291,44 @@ msgid "Editing achievement in file '%1'"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "E-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "tr: Email Address"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr ""
 
@@ -2279,29 +2336,29 @@ msgstr ""
 msgid "Email Instructor On Failed Attempt"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "E-mail del profesor"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2341,8 +2398,8 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr ""
 
@@ -2379,22 +2436,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "tr: Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "tr: Enrollment Status"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "tr: Enter filename below"
 
@@ -2408,8 +2465,8 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Enviado"
 
@@ -2439,7 +2496,7 @@ msgstr ""
 msgid "Error message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr ""
 
@@ -2461,7 +2518,7 @@ msgid ""
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr ""
@@ -2480,6 +2537,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2495,7 +2556,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2503,58 +2564,58 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "tr: Export"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr ""
 
@@ -2562,7 +2623,7 @@ msgstr ""
 msgid "Export selected sets"
 msgstr "tr: Export selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "tr: Export to what kind of file?"
 
@@ -2570,12 +2631,12 @@ msgstr "tr: Export to what kind of file?"
 msgid "Export which sets?"
 msgstr "tr: Export which sets?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "tr: Export which users?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr ""
 
@@ -2589,16 +2650,16 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr ""
 
@@ -2611,7 +2672,7 @@ msgstr ""
 msgid "Failed to create new set: no set name specified!"
 msgstr "tr: Failed to create new set: no set name specified!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
@@ -2642,10 +2703,10 @@ msgstr ""
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr ""
 
@@ -2655,11 +2716,11 @@ msgid "Failed to save: %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr ""
 
@@ -2671,35 +2732,35 @@ msgstr "Retroalimentación"
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
@@ -2746,7 +2807,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "tr: Filename"
 
@@ -2755,7 +2816,7 @@ msgstr "tr: Filename"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "tr: Filter by what text?"
 
@@ -2769,28 +2830,28 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "tr: First Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -2798,7 +2859,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -2806,6 +2867,10 @@ msgstr ""
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
@@ -2817,19 +2882,23 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+msgid "Found no directories containing problems"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr ""
 
@@ -2857,7 +2926,7 @@ msgid "General"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr ""
 
@@ -2877,11 +2946,16 @@ msgstr ""
 msgid "Get Target Set Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "tr: Give new password to which users?"
 
@@ -2908,7 +2982,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -2916,21 +2990,31 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr ""
 
@@ -2958,7 +3042,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "tr: Guest Login"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr ""
 
@@ -2985,12 +3069,16 @@ msgstr "tr: Hardcopy Header"
 msgid "Hardcopy Theme"
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "tr: Help"
 
@@ -3002,12 +3090,12 @@ msgstr ""
 msgid "Hidden"
 msgstr "tr: Hidden"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr ""
 
@@ -3019,8 +3107,8 @@ msgstr ""
 msgid "Hide Hints from Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr ""
 
@@ -3032,7 +3120,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr ""
 
@@ -3046,13 +3134,13 @@ msgstr ""
 msgid "Hmwk Sets Editor"
 msgstr "Editor de tareas"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Tareas"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr ""
 
@@ -3060,15 +3148,15 @@ msgstr ""
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3088,14 +3176,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3107,12 +3195,16 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3120,8 +3212,9 @@ msgstr ""
 msgid "Import"
 msgstr "tr: Import"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -3136,21 +3229,21 @@ msgstr "tr: Import how many sets?"
 msgid "Import sets with names"
 msgstr "tr: Import sets with names"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "tr: Import users from what file?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "tr: Inactive"
 
@@ -3158,17 +3251,17 @@ msgstr "tr: Inactive"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr ""
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr ""
 
@@ -3177,7 +3270,7 @@ msgstr ""
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr ""
 
@@ -3185,16 +3278,16 @@ msgstr ""
 msgid "Instructor Tools"
 msgstr "Herramientas del instructor"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3203,7 +3296,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3218,16 +3311,20 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr ""
 
@@ -3239,7 +3336,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3260,28 +3357,28 @@ msgstr ""
 msgid "Last Answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "tr: Last Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr ""
 
@@ -3308,18 +3405,18 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Explorador de bibliotecas"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr ""
@@ -3353,33 +3450,33 @@ msgstr ""
 msgid "Local Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr ""
 
@@ -3387,8 +3484,8 @@ msgstr ""
 msgid "Log In Again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Salir"
 
@@ -3396,20 +3493,20 @@ msgstr "Salir"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr ""
 
@@ -3421,23 +3518,23 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "tr: Login Name"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr ""
 
@@ -3445,7 +3542,7 @@ msgstr ""
 msgid "Logout"
 msgstr "Salir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Ana Menü"
 
@@ -3458,20 +3555,20 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr ""
@@ -3485,7 +3582,7 @@ msgid "Mark Correct"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr ""
 
@@ -3493,8 +3590,9 @@ msgstr ""
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "tr: Match on what? (separate multiple IDs with commas)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "tr: Math Objects"
 
@@ -3510,49 +3608,49 @@ msgstr ""
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr ""
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Mensajes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -3565,17 +3663,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3616,12 +3714,12 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "tr: New Password"
 
@@ -3633,13 +3731,13 @@ msgstr ""
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "tr: New passwords saved"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3647,15 +3745,17 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Problema siguiente"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3663,20 +3763,25 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "tr: No"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3695,7 +3800,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "tr: No change made to any set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3706,7 +3811,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr ""
 
@@ -3716,38 +3821,38 @@ msgstr ""
 msgid "No data exists for set %1 and problem %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3755,22 +3860,22 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr ""
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr ""
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -3783,7 +3888,7 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr "tr: No sets selected for scoring"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -3792,15 +3897,15 @@ msgstr ""
 "course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -3817,15 +3922,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -3839,26 +3948,32 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "No ha iniciado sesión"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "tr: Note"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "tr: Note"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr ""
 
@@ -3874,8 +3989,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -3907,7 +4022,7 @@ msgid ""
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr ""
 
@@ -3925,13 +4040,13 @@ msgstr "tr: Open Date"
 msgid "Open Problem Library"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -3945,9 +4060,9 @@ msgstr ""
 msgid "Open, complete by %1."
 msgstr ""
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -3970,12 +4085,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr ""
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -3999,70 +4114,73 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr ""
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "tr: Pad Fields"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr ""
 
@@ -4075,7 +4193,7 @@ msgstr ""
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr ""
 
@@ -4084,7 +4202,7 @@ msgstr ""
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4098,24 +4216,24 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "tr: Permission Level"
 
@@ -4123,7 +4241,7 @@ msgstr "tr: Permission Level"
 msgid "Permissions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4160,7 +4278,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4173,7 +4291,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4191,49 +4309,50 @@ msgstr ""
 msgid "Please select at least one user and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "tr: Please specify a file to save to."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Problema anterior"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr ""
@@ -4242,12 +4361,12 @@ msgstr ""
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr ""
 
@@ -4264,20 +4383,20 @@ msgstr ""
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr ""
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr ""
 
@@ -4295,8 +4414,8 @@ msgstr ""
 msgid "Problem Editor3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Lista de problemas"
 
@@ -4312,28 +4431,29 @@ msgstr ""
 msgid "Problem Number "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "tr: Problem Techniques"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "tr: Problem Viewer"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Problemas"
 
@@ -4381,11 +4501,11 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "tr: Publish"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -4399,28 +4519,28 @@ msgid "Really delete the items listed above?"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "tr: Recitation"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "tr: Record Scores for Single Sets"
 
@@ -4434,25 +4554,15 @@ msgid "Reduced Scoring Date"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
-msgstr ""
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr ""
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
 msgstr ""
 
 # Short for "Reduced Scoring:"
@@ -4470,12 +4580,12 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr ""
 
@@ -4484,7 +4594,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr ""
 
@@ -4496,7 +4606,7 @@ msgstr "tr: Remember Me"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4506,13 +4616,13 @@ msgid "Rename"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr ""
 
@@ -4520,19 +4630,19 @@ msgstr ""
 msgid "Rename file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr ""
 
@@ -4548,53 +4658,54 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "tr: Replace which users?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Reportar problemas (bugs)"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr ""
 
@@ -4657,8 +4768,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -4666,11 +4777,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4699,22 +4806,22 @@ msgstr ""
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Resultado"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr ""
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -4726,19 +4833,27 @@ msgstr "tr: Results of last action performed"
 msgid "Results of last action performed: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "tr: Revert"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr ""
@@ -4751,19 +4866,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -4772,86 +4887,86 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "tr: Save"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "tr: Save As [TMPL]/"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "tr: Save as"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "tr: Save changes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr ""
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -4866,11 +4981,11 @@ msgstr ""
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "tr: Score selected set(s) and save to:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -4895,14 +5010,14 @@ msgid "Scoring Tools"
 msgstr "Herramientas para evaluar"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -4912,24 +5027,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "tr: Section"
@@ -4944,11 +5059,16 @@ msgstr ""
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Tareas"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -4958,36 +5078,36 @@ msgstr ""
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr ""
 
@@ -4995,27 +5115,27 @@ msgstr ""
 msgid "Select all sets"
 msgstr "tr: Select all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "tr: Select all users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "tr: Select an action to perform"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr ""
 
@@ -5029,7 +5149,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5053,23 +5173,23 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Tarea"
 
@@ -5103,7 +5223,7 @@ msgid "Set Definition Files"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr ""
 
@@ -5116,7 +5236,7 @@ msgid "Set Detail for set %2"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5130,12 +5250,12 @@ msgstr "tr: Set Header"
 msgid "Set ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "tr: Set Info"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "tr: Set List"
 
@@ -5163,8 +5283,12 @@ msgid "Set Name "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -5190,7 +5314,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "tr: Sets"
 
@@ -5202,7 +5326,7 @@ msgstr ""
 msgid "Sets assigned to %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr ""
 
@@ -5211,11 +5335,11 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -5223,7 +5347,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr ""
 
@@ -5231,8 +5355,8 @@ msgstr ""
 msgid "Show Me Another"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr ""
 
@@ -5244,8 +5368,8 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr ""
 
@@ -5253,7 +5377,7 @@ msgstr ""
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "tr: Show Which Users?"
 
@@ -5262,17 +5386,17 @@ msgstr "tr: Show Which Users?"
 msgid "Show all paths"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr ""
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr ""
 
@@ -5281,7 +5405,7 @@ msgstr ""
 msgid "Show path ..."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr ""
 
@@ -5292,17 +5416,17 @@ msgstr "tr: Show which sets?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "tr: Show/Hide Site Description"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr ""
 
@@ -5312,7 +5436,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr ""
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr ""
 
@@ -5328,13 +5452,13 @@ msgstr ""
 msgid "Site Information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr ""
 
@@ -5343,7 +5467,7 @@ msgstr ""
 msgid "Solutions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -5352,6 +5476,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -5370,14 +5504,14 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "tr: Sort"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "tr: Sort by"
 
@@ -5406,7 +5540,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5439,46 +5573,46 @@ msgstr ""
 msgid "Statistics for %1 student %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Volver al usuario original"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "tr: Student ID"
 
@@ -5508,14 +5642,14 @@ msgstr ""
 msgid "Student answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -5527,31 +5661,35 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr ""
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "tr: Success"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr ""
 
@@ -5561,42 +5699,42 @@ msgid "Successfully created new set %1"
 msgstr ""
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -5614,16 +5752,16 @@ msgstr ""
 msgid "Take %1 test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "tr: Take Action!"
 
@@ -5688,11 +5826,11 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "tr: The WeBWorK Project"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -5713,15 +5851,15 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr ""
 
@@ -5734,14 +5872,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -5781,54 +5919,54 @@ msgid ""
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr ""
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr ""
 
@@ -5841,65 +5979,65 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -5918,13 +6056,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -5942,8 +6080,8 @@ msgid ""
 "your new password and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "tr: The path to the original file should be absolute"
 
@@ -5952,7 +6090,7 @@ msgstr "tr: The path to the original file should be absolute"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -5960,17 +6098,17 @@ msgid ""
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr ""
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr ""
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -5982,23 +6120,23 @@ msgid ""
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr ""
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr ""
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr ""
@@ -6012,7 +6150,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr ""
 
@@ -6021,16 +6159,25 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"tr: The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6046,64 +6193,66 @@ msgid ""
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr ""
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6115,8 +6264,8 @@ msgstr ""
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "tr: Then by"
 
@@ -6138,24 +6287,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6165,36 +6314,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -6215,11 +6364,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -6236,7 +6385,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6256,25 +6405,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6294,15 +6443,15 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr ""
 
@@ -6312,24 +6461,28 @@ msgid ""
 "guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
@@ -6388,35 +6541,39 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr ""
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
@@ -6432,17 +6589,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6456,13 +6613,13 @@ msgstr ""
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -6493,22 +6650,22 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -6532,7 +6689,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6541,8 +6698,8 @@ msgid ""
 "problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr ""
 
@@ -6551,7 +6708,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -6564,24 +6721,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -6593,27 +6750,27 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -6623,11 +6780,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -6644,7 +6801,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -6660,46 +6818,46 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr ""
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr ""
 
@@ -6719,7 +6877,7 @@ msgid ""
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr ""
 
@@ -6727,13 +6885,13 @@ msgstr ""
 msgid "Unclassified Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr ""
 
@@ -6752,7 +6910,7 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr ""
 
@@ -6760,12 +6918,12 @@ msgstr ""
 msgid "Unselect all sets"
 msgstr "tr: Unselect all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "tr: Unselect all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -6777,37 +6935,37 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -6821,11 +6979,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -6833,20 +6992,20 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "tr: Use System Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr ""
 
@@ -6864,7 +7023,7 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -6872,13 +7031,13 @@ msgid ""
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -6900,8 +7059,8 @@ msgstr ""
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -6919,7 +7078,7 @@ msgid "Username presented:  %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -6929,7 +7088,7 @@ msgstr ""
 msgid "Users Assigned to Set %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "tr: Users List"
 
@@ -6947,7 +7106,7 @@ msgid ""
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr ""
 
@@ -6966,17 +7125,18 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -6984,21 +7144,21 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "tr: View"
 
@@ -7011,7 +7171,7 @@ msgstr "tr: View"
 msgid "View Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr ""
 
@@ -7042,8 +7202,8 @@ msgstr "tr: View student progress by student"
 msgid "View/Edit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr ""
@@ -7066,17 +7226,17 @@ msgstr "tr: Visible"
 msgid "Visible to Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "tr: Warning: Deletion destroys all user-related data and is not undoable!"
@@ -7086,11 +7246,16 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr ""
 
@@ -7109,7 +7274,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7143,7 +7308,7 @@ msgstr "Bienvenido a WeBWork!"
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "tr: What field should filtered users match on?"
 
@@ -7222,25 +7387,25 @@ msgstr ""
 msgid "Will open on %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
@@ -7248,18 +7413,20 @@ msgstr ""
 "tr: Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "tr: Yes"
 
@@ -7287,15 +7454,15 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "tr: You are not authorized to access the instructor tools."
 
@@ -7305,7 +7472,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "tr: You are not authorized to modify homework sets."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "tr: You are not authorized to modify problems."
 
@@ -7314,13 +7481,13 @@ msgstr "tr: You are not authorized to modify problems."
 msgid "You are not authorized to modify set definition files."
 msgstr "tr: You are not authorized to modify set definition files."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "tr: You are not authorized to perform this action."
 
@@ -7340,7 +7507,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -7351,6 +7518,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "En este problema puedes obtener crédito parcial."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -7374,7 +7545,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -7396,15 +7567,15 @@ msgstr ""
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "tr: You cannot delete yourself!"
 
@@ -7418,7 +7589,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -7445,37 +7616,41 @@ msgstr ""
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr ""
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr ""
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr ""
 
@@ -7483,7 +7658,7 @@ msgstr ""
 msgid "You have been logged out of WeBWorK."
 msgstr "Has salido de WeBWork"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -7517,11 +7692,16 @@ msgid ""
 "set."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "tr: You may not change your own password here!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "tr: You may not change your own password here!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr ""
 
@@ -7533,13 +7713,13 @@ msgid ""
 msgstr ""
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -7554,7 +7734,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr ""
 
@@ -7566,20 +7746,27 @@ msgstr ""
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr ""
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+#, fuzzy
+msgid "You must select one or more sets for scoring!"
+msgstr "tr: No sets selected for scoring"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Debe especificar un ID de usuario."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr ""
 
@@ -7587,41 +7774,41 @@ msgstr ""
 msgid "You must specify a file name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Debe especificar un ID de usuario."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "tr: You must specify an file name in order to save a new file."
 
@@ -7654,19 +7841,19 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -7704,27 +7891,28 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr ""
 
@@ -7736,113 +7924,126 @@ msgstr "Su dirección de correo ha sido cambiada."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr ""
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr ""
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr ""
 "Tu sesión ha terminado debido a inactividad. Por favor reinicia sesión."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr ""
@@ -7855,7 +8056,7 @@ msgstr ""
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "tr: This is the classlist editor page, where you can view and edit the "
@@ -7906,12 +8107,12 @@ msgstr ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 "WebWork ha detectado un error de software al intentar procesar este "
@@ -7920,10 +8121,16 @@ msgstr ""
 "subsanado. Si usted es un profesor, por favor consulte la salida de error "
 "para obtener más información."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "tr: a duplicate of the first selected set"
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -7932,13 +8139,19 @@ msgid "a duplicate of the first selected set"
 msgstr "tr: a duplicate of the first selected set"
 
 # Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "tr: a new empty set"
+
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "tr: a new empty set"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -7947,7 +8160,7 @@ msgstr ""
 msgid "a single set"
 msgstr "tr: a single set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr ""
 
@@ -7956,11 +8169,11 @@ msgid "add problems"
 msgstr ""
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -7970,13 +8183,13 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -8005,14 +8218,14 @@ msgstr "tr: all sets"
 msgid "all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "tr: all users"
 
@@ -8020,30 +8233,36 @@ msgstr "tr: all users"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "tr: any users"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
 msgstr ""
 
 # Context is "Import set from ____ assigning this set to ____"
@@ -8058,22 +8277,22 @@ msgstr ""
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "tr: changes abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "tr: changes saved"
@@ -8090,17 +8309,17 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "correcto"
 
@@ -8114,7 +8333,7 @@ msgid "deleted %1 sets"
 msgstr ""
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr ""
 
@@ -8126,7 +8345,7 @@ msgstr ""
 msgid "editing all sets"
 msgstr "tr: editing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "tr: editing all users"
 
@@ -8138,7 +8357,7 @@ msgstr ""
 msgid "editing selected sets"
 msgstr "tr: editing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "tr: editing selected users"
 
@@ -8146,7 +8365,7 @@ msgstr "tr: editing selected users"
 msgid "editing visible sets"
 msgstr "tr: editing visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "tr: editing visible users"
 
@@ -8155,7 +8374,7 @@ msgstr "tr: editing visible users"
 msgid "email:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr ""
 
@@ -8168,16 +8387,16 @@ msgid "entry rows."
 msgstr ""
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "tr: export abandoned"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr ""
 
@@ -8185,7 +8404,7 @@ msgstr ""
 msgid "exporting all sets"
 msgstr "tr: exporting all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr ""
 
@@ -8219,15 +8438,15 @@ msgstr ""
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "tr: giving new passwords to all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "tr: giving new passwords to selected users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "tr: giving new passwords to visible users"
 
@@ -8256,9 +8475,9 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr ""
@@ -8267,7 +8486,7 @@ msgstr ""
 msgid "hidden from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "tr: hidden from students"
@@ -8279,45 +8498,49 @@ msgstr "tr: hidden sets"
 # doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "incorrecto"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr ""
 
@@ -8325,7 +8548,7 @@ msgstr ""
 msgid "login"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr ""
 
@@ -8360,15 +8583,15 @@ msgstr ""
 msgid "new users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr ""
 
@@ -8387,27 +8610,31 @@ msgstr "tr: no sets"
 msgid "no students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "tr: no users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -8432,7 +8659,7 @@ msgstr ""
 msgid "only best scores"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8444,53 +8671,57 @@ msgstr ""
 msgid "or Problems from"
 msgstr ""
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr ""
 
@@ -8508,8 +8739,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -8523,18 +8754,18 @@ msgid "record for user %1 not found"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr ""
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -8556,13 +8787,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr ""
 
@@ -8581,17 +8812,17 @@ msgstr ""
 msgid "selected sets"
 msgstr "tr: selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "tr: selected users"
 
@@ -8629,7 +8860,7 @@ msgstr ""
 msgid "showing all sets"
 msgstr "tr: showing all sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "tr: showing all users"
 
@@ -8644,7 +8875,7 @@ msgstr ""
 msgid "showing matching sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "tr: showing matching users"
 
@@ -8652,7 +8883,7 @@ msgstr "tr: showing matching users"
 msgid "showing no sets"
 msgstr "tr: showing no sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "tr: showing no users"
 
@@ -8660,12 +8891,16 @@ msgstr "tr: showing no users"
 msgid "showing selected sets"
 msgstr "tr: showing selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "tr: showing selected users"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -8682,16 +8917,16 @@ msgstr ""
 msgid "students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -8699,12 +8934,12 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr ""
 
@@ -8716,7 +8951,7 @@ msgstr ""
 msgid "test time"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -8725,14 +8960,14 @@ msgid "the following file(s)"
 msgstr ""
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr ""
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr ""
 
@@ -8740,7 +8975,11 @@ msgstr ""
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr ""
 
@@ -8748,43 +8987,40 @@ msgstr ""
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr ""
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr ""
 
@@ -8793,27 +9029,27 @@ msgstr ""
 msgid "userID: %1 --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "tr: users who match on selected field"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr ""
@@ -8826,20 +9062,25 @@ msgstr ""
 msgid "visible sets"
 msgstr "tr: visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "tr: visible to students"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "tr: visible users"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -8847,8 +9088,12 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
@@ -8857,306 +9102,295 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Will open on %1"
-msgstr "Abrirá el %1"
+#~ msgid "Will open on %1"
+#~ msgstr "Abrirá el %1"
 
 #
 #, fuzzy
-msgid "User ID:"
-msgstr "Agregar usuarios"
+#~ msgid "User ID:"
+#~ msgstr "Agregar usuarios"
 
 #
-msgid "Viewing temporary file"
-msgstr "tr: Viewing temporary file"
-
-#
-#, fuzzy
-msgid "font-hidden"
-msgstr "tr: Hidden"
+#~ msgid "Viewing temporary file"
+#~ msgstr "tr: Viewing temporary file"
 
 #
 #, fuzzy
-msgid "set %1."
-msgstr "tr: Revert to %1"
+#~ msgid "font-hidden"
+#~ msgstr "tr: Hidden"
 
 #
 #, fuzzy
-msgid "submitAnswers"
-msgstr "Enviar respuestas"
+#~ msgid "set %1."
+#~ msgstr "tr: Revert to %1"
 
 #
 #, fuzzy
-msgid "Bad Nonce for user "
-msgstr "tr: Set Header for set %1"
+#~ msgid "submitAnswers"
+#~ msgstr "Enviar respuestas"
 
 #
 #, fuzzy
-msgid "Can't write to file: %1"
-msgstr "tr: Saved to file '%1'"
+#~ msgid "Bad Nonce for user "
+#~ msgstr "tr: Set Header for set %1"
 
 #
 #, fuzzy
-msgid "Change Display Options"
-msgstr "tr: Display Options"
-
-#
-msgid "navNext"
-msgstr "images_es/navNext"
-
-#
-msgid "navNextGrey"
-msgstr "images_es/navNextGrey"
-
-#
-msgid "navPrev"
-msgstr "images_es/navPrev"
-
-#
-msgid "navPrevGrey"
-msgstr "images_es/navPrevGrey"
-
-#
-msgid "navProbListGrey"
-msgstr "images_es/navProbListGrey"
-
-#
-msgid "navUp"
-msgstr "images_es/navUp"
+#~ msgid "Can't write to file: %1"
+#~ msgstr "tr: Saved to file '%1'"
 
 #
 #, fuzzy
-msgid "At least one of these answers is NOT completely correct."
-msgstr "Al menos una de las respuestas no es %1 correcta"
+#~ msgid "Change Display Options"
+#~ msgstr "tr: Display Options"
+
+#
+#~ msgid "navNext"
+#~ msgstr "images_es/navNext"
+
+#
+#~ msgid "navNextGrey"
+#~ msgstr "images_es/navNextGrey"
+
+#
+#~ msgid "navPrev"
+#~ msgstr "images_es/navPrev"
+
+#
+#~ msgid "navPrevGrey"
+#~ msgstr "images_es/navPrevGrey"
+
+#
+#~ msgid "navProbListGrey"
+#~ msgstr "images_es/navProbListGrey"
+
+#
+#~ msgid "navUp"
+#~ msgstr "images_es/navUp"
 
 #
 #, fuzzy
-msgid "[_1]: Problem [_2]"
-msgstr "tr: set %1/problem %2"
+#~ msgid "At least one of these answers is NOT completely correct."
+#~ msgstr "Al menos una de las respuestas no es %1 correcta"
 
 #
 #, fuzzy
-msgid "Show me another [_1]"
-msgstr "tr: Show in another window"
+#~ msgid "[_1]: Problem [_2]"
+#~ msgstr "tr: set %1/problem %2"
 
 #
 #, fuzzy
-msgid "Assign "
-msgstr "tr: Edit Assigned Users"
+#~ msgid "Show me another [_1]"
+#~ msgstr "tr: Show in another window"
 
 #
-msgid "Apply Options"
-msgstr "tr: Apply Options"
+#~ msgid "Apply Options"
+#~ msgstr "tr: Apply Options"
 
 #
-msgid "Disable"
-msgstr "tr: Disable"
+#~ msgid "Disable"
+#~ msgstr "tr: Disable"
 
 #
-msgid "Enable/Disable reduced scoring for selected sets"
-msgstr "tr: Enable/Disable reduced scoring for selected sets"
-
-#
-#, fuzzy
-msgid "Reduced Credit %1 for all sets"
-msgstr "tr: Reduced Credit %1 for all sets"
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_1"
-msgstr ""
-"tr: This assignment has a Reduced Credit Period that begins %1 and ends on "
-"the due date, %2.  During this period all additional work done counts %3% of "
-"the original."
-
-#
-msgid "_REDUCED_CREDIT_MESSAGE_2"
-msgstr ""
-"tr: This assignment had a Reduced Credit Period that began %1 and ended on "
-"the due date, %2.  During that period all additional work done counted %3% "
-"of the original."
-
-#
-msgid "completely"
-msgstr "tr: completely"
-
-#
-msgid "Course Information for course [_1]"
-msgstr "tr: Course Information for course %1"
-
-#
-msgid ""
-"Report bugs in a WeBWorK question/problem using this link. The very first "
-"time you do this you will need to register with an email address so that "
-"information on the bug fix can be reported back to you."
-msgstr ""
-"tr: Report bugs in a WeBWorK question/problem using this link. The very "
-"first time you do this you will need to register with an email address so "
-"that information on the bug fix can be reported back to you."
-
-#
-msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-msgstr "tr: Unable to change the hardcopy header for set %1. Unknown error."
-
-#
-msgid "Unable to make '[_1]' the set header for [_2]"
-msgstr "tr: Unable to make '%1' the set header for %2"
-
-#
-msgid "Can't determine user of temporary edit file [_1]."
-msgstr "tr: Can't determine user of temporary edit file %1."
-
-#
-msgid "Top level of author information on the wiki."
-msgstr "tr: Top level of author information on the wiki."
-
-#
-msgid "Reverting to original file '[_1]'"
-msgstr "tr: Reverting to original file '%1'"
-
-#
-msgid "Wiki summary page for MathObjects"
-msgstr "tr: Wiki summary page for MathObjects"
-
-#
-msgid "Snippets of PG code illustrating specific techniques"
-msgstr "tr: Snippets of PG code illustrating specific techniques"
-
-#
-msgid "Error copying [_1] to [_2]"
-msgstr "tr: Error copying %1 to %2"
+#~ msgid "Enable/Disable reduced scoring for selected sets"
+#~ msgstr "tr: Enable/Disable reduced scoring for selected sets"
 
 #
 #, fuzzy
-msgid "This set is [_1] students."
-msgstr "Este conjunto es de %1 estudiantes"
+#~ msgid "Reduced Credit %1 for all sets"
+#~ msgstr "tr: Reduced Credit %1 for all sets"
 
 #
-msgid "blank problem"
-msgstr "tr: blank problem"
+#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
+#~ msgstr ""
+#~ "tr: This assignment has a Reduced Credit Period that begins %1 and ends "
+#~ "on the due date, %2.  During this period all additional work done counts "
+#~ "%3% of the original."
 
 #
-msgid ""
-"Note: this problem viewer is for viewing purposes only. As of right now, "
-"testing functionality is not possible."
-msgstr ""
-"tr: Note: this problem viewer is for viewing purposes only. As of right now, "
-"testing functionality is not possible."
+#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
+#~ msgstr ""
+#~ "tr: This assignment had a Reduced Credit Period that began %1 and ended "
+#~ "on the due date, %2.  During that period all additional work done counted "
+#~ "%3% of the original."
 
 #
-msgid "webwork"
-msgstr "webwork"
+#~ msgid "completely"
+#~ msgstr "tr: completely"
 
 #
-#, fuzzy
-msgid "submit button clicked"
-msgstr "Botón enviar pulsado."
+#~ msgid "Course Information for course [_1]"
+#~ msgstr "tr: Course Information for course %1"
 
 #
-msgid ""
-"Test snippets of PG code in interactive lab.  Good way to learn PG language."
-msgstr ""
-"tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
-"language."
+#~ msgid ""
+#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
+#~ "time you do this you will need to register with an email address so that "
+#~ "information on the bug fix can be reported back to you."
+#~ msgstr ""
+#~ "tr: Report bugs in a WeBWorK question/problem using this link. The very "
+#~ "first time you do this you will need to register with an email address so "
+#~ "that information on the bug fix can be reported back to you."
 
 #
-#, fuzzy
-msgid "Page generated at [_1] at [_2]"
-msgstr "tr: Page generated at %1"
+#~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
+#~ msgstr "tr: Unable to change the hardcopy header for set %1. Unknown error."
 
 #
-msgid "View Using Seed Number"
-msgstr "tr: View Using Seed Number"
+#~ msgid "Unable to make '[_1]' the set header for [_2]"
+#~ msgstr "tr: Unable to make '%1' the set header for %2"
 
 #
-msgid ""
-"The text box now contains the source of the original problem. You can "
-"recover lost edits by using the Back button on your browser."
-msgstr ""
-"tr: The text box now contains the source of the original problem. You can "
-"recover lost edits by using the Back button on your browser."
+#~ msgid "Can't determine user of temporary edit file [_1]."
+#~ msgstr "tr: Can't determine user of temporary edit file %1."
 
 #
-msgid ""
-"Documentation from source code for PG modules and macro files. Often the "
-"most up-to-date information."
-msgstr ""
-"tr: Documentation from source code for PG modules and macro files. Often the "
-"most up-to-date information."
+#~ msgid "Top level of author information on the wiki."
+#~ msgstr "tr: Top level of author information on the wiki."
 
 #
-msgid ""
-"PG mark down syntax used to format WeBWorK questions. This interactive lab "
-"can help you to learn the techniques."
-msgstr ""
-"tr: PG mark down syntax used to format WeBWorK questions. This interactive "
-"lab can help you to learn the techniques."
+#~ msgid "Reverting to original file '[_1]'"
+#~ msgstr "tr: Reverting to original file '%1'"
 
 #
-msgid ""
-"Error: This path is already in the temporary edit directory -- no new "
-"temporary file is created. path = [_1]"
-msgstr ""
-"tr: Error: This path is already in the temporary edit directory -- no new "
-"temporary file is created. path = %1"
+#~ msgid "Wiki summary page for MathObjects"
+#~ msgstr "tr: Wiki summary page for MathObjects"
 
 #
-msgid ""
-"Please use radio buttons to choose the method for saving this file. Can't "
-"recognize saveMode: |[_1]|."
-msgstr ""
-"tr: Please use radio buttons to choose the method for saving this file. "
-"Can't recognize saveMode: |%1|."
+#~ msgid "Snippets of PG code illustrating specific techniques"
+#~ msgstr "tr: Snippets of PG code illustrating specific techniques"
+
+#
+#~ msgid "Error copying [_1] to [_2]"
+#~ msgstr "tr: Error copying %1 to %2"
 
 #
 #, fuzzy
-msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-msgstr ""
-"El problema seleccionado (%1) no es un problema válido para el conjunto %2."
+#~ msgid "This set is [_1] students."
+#~ msgstr "Este conjunto es de %1 estudiantes"
 
 #
-msgid "Resources"
-msgstr "tr: Resources"
+#~ msgid "blank problem"
+#~ msgstr "tr: blank problem"
 
 #
-msgid "Duplicate"
-msgstr "tr: Duplicate"
+#~ msgid ""
+#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
+#~ "testing functionality is not possible."
+#~ msgstr ""
+#~ "tr: Note: this problem viewer is for viewing purposes only. As of right "
+#~ "now, testing functionality is not possible."
 
 #
-msgid "This path |[_1]| is not the path to a temporary edit file."
-msgstr "tr: This path |%1| is not the path to a temporary edit file."
+#~ msgid "webwork"
+#~ msgstr "webwork"
 
 #
-msgid ""
-"Unable to change the source file path for set [_1], problem [_2]. Unknown "
-"error."
-msgstr ""
-"tr: Unable to change the source file path for set %1, problem %2. Unknown "
-"error."
+#, fuzzy
+#~ msgid "submit button clicked"
+#~ msgstr "Botón enviar pulsado."
 
 #
-msgid "Options Information"
-msgstr "tr: Options Information"
+#~ msgid ""
+#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
+#~ "language."
+#~ msgstr ""
+#~ "tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
+#~ "language."
 
 #
-msgid "Save as new independent problem"
-msgstr "tr: Save as new independent problem"
+#, fuzzy
+#~ msgid "Page generated at [_1] at [_2]"
+#~ msgstr "tr: Page generated at %1"
 
 #
-msgid "options information"
-msgstr "tr: options information"
+#~ msgid "View Using Seed Number"
+#~ msgstr "tr: View Using Seed Number"
 
 #
-msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-msgstr ""
-"El problema seleccionado (%1) no es válido para el conjunto de problemas "
-"(%2). "
+#~ msgid ""
+#~ "Documentation from source code for PG modules and macro files. Often the "
+#~ "most up-to-date information."
+#~ msgstr ""
+#~ "tr: Documentation from source code for PG modules and macro files. Often "
+#~ "the most up-to-date information."
 
 #
-msgid "Unknown file type"
-msgstr "tr: Unknown file type"
+#~ msgid ""
+#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
+#~ "lab can help you to learn the techniques."
+#~ msgstr ""
+#~ "tr: PG mark down syntax used to format WeBWorK questions. This "
+#~ "interactive lab can help you to learn the techniques."
 
 #
-msgid "Viewing temporary file:  "
-msgstr "Viendo el archivo temporal"
+#~ msgid ""
+#~ "Error: This path is already in the temporary edit directory -- no new "
+#~ "temporary file is created. path = [_1]"
+#~ msgstr ""
+#~ "tr: Error: This path is already in the temporary edit directory -- no new "
+#~ "temporary file is created. path = %1"
+
+#
+#~ msgid ""
+#~ "Please use radio buttons to choose the method for saving this file. Can't "
+#~ "recognize saveMode: |[_1]|."
+#~ msgstr ""
+#~ "tr: Please use radio buttons to choose the method for saving this file. "
+#~ "Can't recognize saveMode: |%1|."
+
+#
+#, fuzzy
+#~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
+#~ msgstr ""
+#~ "El problema seleccionado (%1) no es un problema válido para el conjunto "
+#~ "%2."
+
+#
+#~ msgid "Resources"
+#~ msgstr "tr: Resources"
+
+#
+#~ msgid "Duplicate"
+#~ msgstr "tr: Duplicate"
+
+#
+#~ msgid "This path |[_1]| is not the path to a temporary edit file."
+#~ msgstr "tr: This path |%1| is not the path to a temporary edit file."
+
+#
+#~ msgid ""
+#~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
+#~ "error."
+#~ msgstr ""
+#~ "tr: Unable to change the source file path for set %1, problem %2. Unknown "
+#~ "error."
+
+#
+#~ msgid "Options Information"
+#~ msgstr "tr: Options Information"
+
+#
+#~ msgid "Save as new independent problem"
+#~ msgstr "tr: Save as new independent problem"
+
+#
+#~ msgid "options information"
+#~ msgstr "tr: options information"
+
+#
+#~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
+#~ msgstr ""
+#~ "El problema seleccionado (%1) no es válido para el conjunto de problemas "
+#~ "(%2). "
+
+#
+#~ msgid "Unknown file type"
+#~ msgstr "tr: Unknown file type"
+
+#
+#~ msgid "Viewing temporary file:  "
+#~ msgstr "Viendo el archivo temporal"
 
 #, fuzzy
 #~ msgid "answer "
@@ -9197,10 +9431,6 @@ msgstr "Viendo el archivo temporal"
 #, fuzzy
 #~ msgid "No sets selected for scoring."
 #~ msgstr "tr: No sets selected for scoring"
-
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "tr: Note"
 
 #, fuzzy
 #~ msgid "Recitation:"

--- a/lib/WeBWorK/Localize/fr.po
+++ b/lib/WeBWorK/Localize/fr.po
@@ -13,14 +13,19 @@ msgstr ""
 "fichier n'a été créé. Chemin = %1\n"
 "X-Generator: Poedit 1.6.10\n"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "Étudiants sélectionnés"
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 #, fuzzy
 msgid "#corr"
 msgstr "correct"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 #, fuzzy
 msgid "#incorr"
 msgstr "erroné"
@@ -35,16 +40,16 @@ msgstr "%1% correct"
 msgid "% correct with review"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 #, fuzzy
 msgid "% students"
 msgstr "étudiant"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -90,20 +95,20 @@ msgid "%1 students out of %2"
 msgstr "étudiant"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 #, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 usagers ont été exportés dans le fichier %2/%3"
 
 #
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 #, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
@@ -138,8 +143,8 @@ msgstr "complet."
 #
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 #, fuzzy
 msgid "%1% correct"
 msgstr "%1% correct"
@@ -190,7 +195,7 @@ msgstr "Le mot de passe de l'usager %1 a été modifié."
 #
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: Problème %2."
 
@@ -202,13 +207,13 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1: Problème %2."
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 #, fuzzy
 msgid "%1: The directory for the course not found."
 msgstr "Enregistrement pour l'utilisateur %1 introuvable"
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -224,54 +229,54 @@ msgstr ""
 
 #
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 #, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "%1 restent sans réponse."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 #, fuzzy
 msgid "%score"
 msgstr "Résultat"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr "(Les modification non sauvegardées seront perdus)"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(Ce problème ne sera pas noté.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 #
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 #, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "Votre résultat final est : %1.  %2"
 
 #
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 #, fuzzy
 msgid "(Your score on this %1 is not available.)"
 msgstr "Votre résultat final est : %1.  %2"
@@ -378,17 +383,31 @@ msgstr ""
 #
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 #, fuzzy
 msgid "A course with ID %1 already exists."
 msgstr "Impossible de dupliquer le devoir : le devoir %1 existe déjà!"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #
@@ -406,14 +425,14 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -421,14 +440,14 @@ msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 #, fuzzy
 msgid "A new file has been created at '%1'"
 msgstr "Le devoir %1 existe déjà.  Aucun devoir créé"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 #, fuzzy
 msgid ""
@@ -469,49 +488,49 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 #, fuzzy
 msgid "ANSWERS NOT RECORDED"
 msgstr "APERÇU SEULEMENT --  LES RÉPONSES NE SERONT PAS ENREGISTRÉES"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 #, fuzzy
 msgid "ANSWERS NOT RECORDED --"
 msgstr "APERÇU SEULEMENT --  LES RÉPONSES NE SERONT PAS ENREGISTRÉES"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 #, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr ""
 "LES RÉPONSES ONT ÉTÉ VÉRIFIÉES -- MAIS ELLES N'ONT PAS ÉTÉ ENREGISTRÉES"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr ""
 "LES RÉPONSES ONT ÉTÉ VÉRIFIÉES -- MAIS ELLES N'ONT PAS ÉTÉ ENREGISTRÉES"
 
 #
 # avant: msgstr "Abandonner les changements"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "Ne pas enregistrer les modifications"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Annuler l'exportation"
@@ -522,13 +541,13 @@ msgid "Achievement"
 msgstr "Activer les objectifs des cours"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 #, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "Le devoir %1 existe déjà.  Aucun devoir créé"
@@ -547,13 +566,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -572,12 +591,17 @@ msgstr "Points de réussite par problème"
 msgid "Achievement has been assigned to all users."
 msgstr "L'utilisateur %1 a été assigné %2."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "L'utilisateur %1 a été assigné %2."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 #, fuzzy
 msgid "Achievement scores saved to %1"
 msgstr "Points de réussite par problème"
@@ -601,7 +625,7 @@ msgstr "Est:"
 
 #
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 #, fuzzy
 msgid "Acting as %1."
 msgstr "Dans le rôle de %1."
@@ -609,13 +633,13 @@ msgstr "Dans le rôle de %1."
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList3.pm
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 #, fuzzy
 msgid "Action %1 not found"
 msgstr "L'action % n'a pas été trouvé."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Actif"
 
@@ -637,7 +661,7 @@ msgstr ""
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Ajouter"
@@ -647,9 +671,9 @@ msgid "Add All"
 msgstr "Ajouter tous"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 #, fuzzy
 msgid "Add Course"
 msgstr "Cours"
@@ -664,7 +688,7 @@ msgstr "étudiant"
 msgid "Add Users"
 msgstr "Ajouter des usagers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -673,14 +697,14 @@ msgid "Add a new test for which Gateway?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 #, fuzzy
 msgid "Add as what filetype?"
 msgstr "Spécifier le type du fichier"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Ajouter combien d'étudiants?"
 
@@ -691,47 +715,47 @@ msgstr "Additionner des problèmes à "
 
 #
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 #, fuzzy
 msgid "Add to what set?"
 msgstr "Ajouter à quel devoir?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Ajouter quels nouveaux usagers?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr "Ajouté %1 à %2 en problème %3"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 #, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "Ajout de '%1' à %2 en tant que nouvel entête"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 #, fuzzy
 msgid "Added '%1' to %2 as new set header"
 msgstr "Ajout de '%1' à %2 en tant que nouvel entête"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -740,54 +764,54 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr "Autres adresses pour recevoir les commentaires par e-mail."
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Addresses"
 msgstr "Adresse courriel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -802,7 +826,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -818,7 +842,7 @@ msgid "After set answer date"
 msgstr "Date de disponibilité des réponses"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -831,18 +855,18 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 #, fuzzy
 msgid "All of the answers above are correct."
 msgstr "Tous les %1 réponses si-dessus sont correctes."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 #, fuzzy
 msgid "All of the gradeable answers above are correct."
 msgstr "Les réponses ci-dessus sont toutes correctes."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -868,7 +892,7 @@ msgstr "devoirs cachés aux étudiants"
 msgid "All sets made visible for all students"
 msgstr "devoirs visible pour les étudiants"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr "Tous les étudiants dans le cours"
 
@@ -942,26 +966,26 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 #, fuzzy
 msgid "An error occured while archiving the course %1:"
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 #, fuzzy
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "Réussite de la création du nouveau devoir %1"
@@ -985,8 +1009,8 @@ msgid "Answer Log"
 msgstr "Remise des réponses"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Aperçu des réponses"
 
@@ -1000,11 +1024,11 @@ msgstr ""
 msgid "Answer:"
 msgstr "Remise des réponses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -1031,8 +1055,17 @@ msgid "Answers cannot be made available until on or after the close date!"
 msgstr "Les réponses ne peuvent pas être disponibles avant date de remise!"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr ""
+"Les changements effectués ci-bas affecteront les devoirs de TOUS les "
+"étudiants"
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
@@ -1041,7 +1074,7 @@ msgstr ""
 "étudiants"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -1060,20 +1093,20 @@ msgstr ""
 "supprimé, il manquera un numéro dans la série sauf si la case si-contre est "
 "cochée."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 #, fuzzy
 msgid "Append to end of %1 set"
 msgstr "Ajouter à la fin du devoir %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 #, fuzzy
 msgid "Archive"
 msgstr "Archiver"
@@ -1089,30 +1122,30 @@ msgstr "Archive '%1' créé avec succès (%2 fichier%3)"
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 #, fuzzy
 msgid "Archive Course"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 #, fuzzy
 msgid "Archive Courses"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 #, fuzzy
 msgid "Archive next course"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 #, fuzzy
 msgid "Archive this Course"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 #, fuzzy
 msgid "Archived Courses"
 msgstr "De ce cours"
@@ -1123,24 +1156,28 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 #, fuzzy
 msgid "Assign"
 msgstr "Assigné à "
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1172,18 +1209,18 @@ msgid "Assigned"
 msgstr "Assigné à "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Devoirs assignés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 #, fuzzy
 msgid "Assigned achievements to users"
 msgstr "attribuer ce devoir à"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 #, fuzzy
 msgid "Assigned to"
 msgstr "Assigné à "
@@ -1194,7 +1231,13 @@ msgid "Assignment type"
 msgstr "Type de devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "Type de devoir"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 #, fuzzy
 msgid "At least one of the answers above is NOT correct."
 msgstr "Au moins une des réponses ci-dessus N'EST PAS %1 correcte."
@@ -1203,7 +1246,7 @@ msgstr "Au moins une des réponses ci-dessus N'EST PAS %1 correcte."
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1218,7 +1261,7 @@ msgstr "Essais"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Essais"
 
@@ -1228,15 +1271,16 @@ msgstr "Essais"
 msgid "Audit"
 msgstr "Audit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 #, fuzzy
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr "Votre vérification OAuth LTI a échoué."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "À propos de l'auteur"
 
@@ -1244,12 +1288,12 @@ msgstr "À propos de l'auteur"
 msgid "Automatic"
 msgstr "Automatique"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1295,16 +1339,16 @@ msgstr ""
 "à toutes les adresses spécifiées dans ce vide. Séparer les adresses e-mail "
 "par des virgules."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1336,7 +1380,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1380,19 +1424,19 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "Impossible d'accéder au mot de passe pour l'usager '%1': %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 #, fuzzy
 msgid "Can't open %1"
 msgstr "Impossible d'ouvrir le fichier %1"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 #, fuzzy
 msgid "Can't open file %1"
 msgstr "Impossible d'ouvrir le fichier %1"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 #, fuzzy
 msgid "Can't read merge file %1. No message sent"
 msgstr "Impossible d'ouvrir le fichier %1"
@@ -1403,7 +1447,7 @@ msgstr "Impossible d'ouvrir le fichier %1"
 msgid "Can't rename file: %1"
 msgstr "Impossible d'ouvrir le fichier %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 #, fuzzy
 msgid "Can't rename to the same name."
 msgstr "Crée un nouveau devoir nommé:"
@@ -1413,11 +1457,11 @@ msgstr "Crée un nouveau devoir nommé:"
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 #, fuzzy
 msgid "Can't write to file %1"
 msgstr "Impossible d'écrire dans le fichier %1"
@@ -1432,7 +1476,7 @@ msgid "Cancel"
 msgstr "Annuler la modification"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 #, fuzzy
 msgid "Cancel E-mail"
 msgstr "Annuler"
@@ -1447,8 +1491,8 @@ msgstr "Impossible d'ouvrir le fichier %1"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1468,11 +1512,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1489,7 +1533,7 @@ msgstr "Options d'affichage"
 msgid "Change Email Address"
 msgstr "Changer l'adresse courriel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1500,37 +1544,37 @@ msgid "Change Password"
 msgstr "Changer le mot de passe"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 #, fuzzy
 msgid "Change User Settings"
 msgstr "Changer les options d'usager"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "Les modifications n'ont pas été sauvegardées"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Les modifications dans ce fichier n'ont pas été sauvegardées."
 
 # msgstr "Les modifications ont été annulées"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "Les modifications ont été sauvegardées"
 
@@ -1546,29 +1590,29 @@ msgid "Chapter:"
 msgstr "Chapitre:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "Vérifier les réponses"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 #, fuzzy
 msgid "Check Test"
 msgstr "Vérifier les réponses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "Vérification des messages d'erreur additionnels"
 
@@ -1583,7 +1627,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1628,8 +1672,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1647,7 +1691,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 #, fuzzy
 msgid "Close"
 msgstr "Fermé"
@@ -1699,7 +1743,7 @@ msgstr "Fermé"
 
 #
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 #, fuzzy
 msgid "Closes %1"
 msgstr "Retourner à %1"
@@ -1711,11 +1755,11 @@ msgstr "Retourner à %1"
 msgid "Closes:"
 msgstr "Fermé"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
@@ -1724,28 +1768,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Commenter"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1755,7 +1799,7 @@ msgstr ""
 msgid "Completed."
 msgstr "complet."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1768,7 +1812,7 @@ msgid "Confirm %1's New Password"
 msgstr "Confirmer le nouveau mot de passe de %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 #, fuzzy
 msgid "Confirm Password:"
 msgstr "Confirmer le nouveau mot de passe de %1"
@@ -1785,8 +1829,8 @@ msgstr "Continuer"
 
 #
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 #, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "Les fichiers auxiliaires de %1 ont été copiés dans %2"
@@ -1801,7 +1845,7 @@ msgstr "Copier"
 msgid "Copy file as:"
 msgstr "Copier le fichier vers\t:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1812,8 +1856,8 @@ msgid "Copy this Problem"
 msgstr "Éditer ce problème"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Correct"
@@ -1823,7 +1867,7 @@ msgid "Correct Adjusted Status"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 #, fuzzy
 msgid "Correct Answer"
 msgstr "Bonnes réponses"
@@ -1847,20 +1891,20 @@ msgstr "Bonnes réponses"
 
 #
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 #, fuzzy
 msgid "Correct: %1/%2"
 msgstr "devoir %1/problème %2"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 #, fuzzy
 msgid "CorrectAnswers"
 msgstr "Bonnes réponses"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 #, fuzzy
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
@@ -1885,51 +1929,52 @@ msgid "Couldn't change your email address: %1"
 msgstr "Il n'a pas été possible de modifier votre adresse de courriel : %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 #, fuzzy
 msgid "Couldn't save your display options: %1"
 msgstr "Il n'a pas été possible de modifier votre adresse de courriel : %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1940,14 +1985,14 @@ msgstr "Administration du cours"
 msgid "Course Configuration"
 msgstr "Configuration du cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 #, fuzzy
 msgid "Course ID:"
 msgstr "Informations sur le cours"
@@ -1959,15 +2004,15 @@ msgid "Course Info"
 msgstr "Informations sur le cours"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 #, fuzzy
 msgid "Course Name:"
 msgstr "Prénom"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 #, fuzzy
 msgid "Course Title:"
 msgstr "Cours"
@@ -1979,15 +2024,15 @@ msgid "Course archived."
 msgstr "Prénom"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -2009,7 +2054,7 @@ msgid "Create CSV"
 msgstr "Créer"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 #, fuzzy
 msgid "Create Location:"
 msgstr "Récitation"
@@ -2018,7 +2063,7 @@ msgstr "Récitation"
 msgid "Create a New Set in This Course:"
 msgstr "Créer un nouveau devoir dans ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -2027,13 +2072,13 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "Créer en tant que quel type de devoir?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 #, fuzzy
 msgid "Create unattached problem"
 msgstr "Il n'y a pas de problèmes de Webwork correspondant"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -2046,36 +2091,36 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr "Données"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
 # avant: msgstr "tr: enter matching set IDs below"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 #, fuzzy
 msgid "Database:"
 msgstr "exportation annulée"
@@ -2091,7 +2136,7 @@ msgstr "Date d'ouverture"
 msgid "Debug"
 msgstr "pg debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 #, fuzzy
@@ -2125,82 +2170,82 @@ msgid "Default Time that the Assignment is Due"
 msgstr "Temps où le devoir est due"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Supprimer"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 #, fuzzy
 msgid "Delete Course"
 msgstr "Supprimer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 #, fuzzy
 msgid "Delete course:"
 msgstr "Supprimer"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "En supprimer combien?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr "Supprimer?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 #, fuzzy
 msgid "Delete location:"
 msgstr "Supprimer"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 #, fuzzy
 msgid "Deleted %quant(%1,achievement)"
 msgstr "devoirs sélectionnés"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 #, fuzzy
 msgid "Deleting temp file at %1"
 msgstr "Suppression du fichier temporaire %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 #, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
@@ -2209,7 +2254,7 @@ msgstr ""
 "La suppression détruit toutes les données liées au devoir et n'est pas "
 "annulable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 #, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
@@ -2222,7 +2267,7 @@ msgstr ""
 "La suppression détruit toutes les données liées au devoir et n'est pas "
 "annulable!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "La suppression détruit toutes les données utilisateur connexes et n'est pas "
@@ -2232,14 +2277,14 @@ msgstr ""
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 #, fuzzy
 msgid "Description"
 msgstr "Description du devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -2259,49 +2304,49 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 #, fuzzy
 msgid "Directory structure"
 msgstr "Superviseur"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr "Mode d'affichage:"
@@ -2312,6 +2357,12 @@ msgstr "Mode d'affichage:"
 #, fuzzy
 msgid "Display Past Answers"
 msgstr "Afficher les réponses précédentes"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+#, fuzzy
+msgid "Display of scores for this set is not allowed."
+msgstr "Votre résultat final est : %1.  %2"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -2336,38 +2387,38 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 #, fuzzy
 msgid "Don't Archive"
 msgstr "Archiver"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 #, fuzzy
 msgid "Don't Unarchive"
 msgstr "Archiver"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 #, fuzzy
 msgid "Don't Upgrade"
 msgstr "Supprimer"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #, fuzzy
 msgid "Don't delete"
 msgstr "Supprimer"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 #, fuzzy
 msgid "Don't make changes"
 msgstr "Sauvegarder les modifications"
 
 #
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 #, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "Méthode d'enregistrement inconnue |%1|. Erreur inconnue."
@@ -2378,18 +2429,18 @@ msgstr "Méthode d'enregistrement inconnue |%1|. Erreur inconnue."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr "Ne reconnais pas les statistiques de type d'affichage: |% 1 |"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 #, fuzzy
 msgid "Don't use in an achievement"
 msgstr "Archiver"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2427,8 +2478,8 @@ msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Télécharger une copie de : $1 devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Télécharger une copie PDF ou TeX pour le devoir en cours"
 
@@ -2454,6 +2505,16 @@ msgstr "Télécharger"
 #, fuzzy
 msgid "Drop"
 msgstr "Déposer"
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
@@ -2488,7 +2549,7 @@ msgstr ""
 
 # avant: msgstr "Options. Les bonnes réponses et les solutions ne sont disponibles qu'après la date de remise."
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "Envoyer un courriel à l'enseignant"
 
@@ -2511,7 +2572,7 @@ msgstr "Niveau de verbose pour les emails"
 
 # avant: msgstr "Nom d'utilisateur" cohérence
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 #, fuzzy
 msgid "E-mail:"
 msgstr "Courriel"
@@ -2521,25 +2582,25 @@ msgid "Earned"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Editer"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 #, fuzzy
 msgid "Edit %1 of set %2."
 msgstr "Modification %1 du devoir %1."
@@ -2555,24 +2616,24 @@ msgstr "Editer les données de tous les devoirs"
 msgid "Edit Assigned Users"
 msgstr "Éditer les usagers assignés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 #, fuzzy
 msgid "Edit Header"
 msgstr "Entête du devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 #, fuzzy
 msgid "Edit Location:"
 msgstr "Récitation"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #, fuzzy
 msgid "Edit Problem"
 msgstr "Éditer les problèmes"
@@ -2598,7 +2659,7 @@ msgid "Edit Target Set"
 msgstr "Modifier ce devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Éditer quels usagers?"
 
@@ -2617,19 +2678,19 @@ msgstr "Modifier"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 #, fuzzy
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr "Modification du devoir pour TOUS les étidiants assignés à ce devoir.%1"
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 #, fuzzy
 msgid "Edit set %1 for this user."
 msgstr "Modiication du devoir %1 pour cet utilisateur."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2642,23 +2703,23 @@ msgstr ""
 msgid "Edit which sets?"
 msgstr "Éditer quels devoirs?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr "Modifier1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr "Modifier2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr "Modifier3"
 
 # avant: msgstr "Le problème choisi (%1) n'est pas valide pour l'ensemble %2."
 #
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 #, fuzzy
 msgid "Editing %1 in file '%2'"
 msgstr "Modification de %1 du fichier '%2'"
@@ -2674,26 +2735,26 @@ msgstr "Modification de %1 du fichier '%2'"
 # avant: msgstr "tr: Set Header for set %1"
 #
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 #, fuzzy
 msgid "Editing location %1"
 msgstr "Statistiques pour %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 #, fuzzy
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr "Modification du devoir %1 pour ces étudiants: %2"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 #, fuzzy
 msgid "Editor"
 msgstr "Editer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 #, fuzzy
 msgid "Editor rows:"
 msgstr "Lignes de l'éditeur"
@@ -2701,26 +2762,26 @@ msgstr "Lignes de l'éditeur"
 # avant: msgstr "Nom d'utilisateur" cohérence
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "Courriel"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "Adresse courriel"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 #, fuzzy
 msgid "Email Body:"
 msgstr "Corps du message :"
@@ -2734,33 +2795,33 @@ msgstr "Envoyer un courriel à l'enseignant"
 
 # avant: msgstr "Nom d'utilisateur" cohérence
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 #, fuzzy
 msgid "Email Link"
 msgstr "Courriel"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 #, fuzzy
 msgid "Email address"
 msgstr "Adresse courriel"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "Envoyer un courriel à l'enseignant"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2807,8 +2868,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 #, fuzzy
 msgid "Enabled"
 msgstr "Activer"
@@ -2847,25 +2908,25 @@ msgstr ""
 msgid "Enrolled"
 msgstr "Inscrit"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Statut d'inscription"
 
 # avant: msgstr "Statut d'étudiant"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Entrer le nom du fichier ci-bas"
 
@@ -2881,8 +2942,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Saisi"
 
@@ -2922,7 +2983,7 @@ msgstr "Messages"
 
 # vérifier le contexte ...msgstr "tr: Match on what? (separate multiple IDs with commas)"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 #, fuzzy
 msgid "Error messages"
 msgstr "Messages"
@@ -2953,7 +3014,7 @@ msgstr ""
 
 #
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 #, fuzzy
 msgid "Error: The original file %1 cannot be read."
@@ -2979,6 +3040,10 @@ msgstr ""
 "Erreur: la date d'ouverture ne peut pas dépasser 10 ans après la date "
 "d'aujourd'hui dans le devoir %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2997,7 +3062,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -3005,61 +3070,61 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 #, fuzzy
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr "Le fichier existant %1 n'a pas pu être sauvegardée et a été perdu."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Exporter"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 #, fuzzy
 msgid "Export selected achievements."
 msgstr "Exporter les devoirs sélectionnés"
@@ -3070,7 +3135,7 @@ msgid "Export selected sets"
 msgstr "Exporter les devoirs sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Exporter sous quel type de fichier?"
 
@@ -3081,13 +3146,13 @@ msgid "Export which sets?"
 msgstr "Exporter quels devoirs?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Exporter quels usagers?"
 
 #
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 #, fuzzy
 msgid "Exported achievements to %1"
 msgstr "Exporter les devoirs sélectionnés"
@@ -3102,19 +3167,19 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 #, fuzzy
 msgid "Failed to create new achievement: %1"
 msgstr "Impossible de créer le nouveau devoir : %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 #, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "Impossible de créer le nouveau devoir : aucun nom n'a été spécifié!"
@@ -3132,7 +3197,7 @@ msgid "Failed to create new set: no set name specified!"
 msgstr "Impossible de créer le nouveau devoir : aucun nom n'a été spécifié!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 #, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
@@ -3176,10 +3241,10 @@ msgstr "Impossible de créer le nouveau devoir : %1"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 #, fuzzy
 msgid "Failed to open %1"
 msgstr "Échec d'ouverture pour %1"
@@ -3191,12 +3256,12 @@ msgid "Failed to save: %1"
 msgstr "Échec d'ouverture pour %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid "Feature exhausted for this problem"
 msgstr "signaler une erreur pour ce problème"
@@ -3212,37 +3277,37 @@ msgid "Feedback by Section."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 #, fuzzy
 msgid "FeedbackMessage"
 msgstr "Commentaires"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 #, fuzzy
 msgid ""
@@ -3302,7 +3367,7 @@ msgid "File successfully renamed"
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Nom de fichier"
 
@@ -3312,7 +3377,7 @@ msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "Filtrer avec quelle chaîne de caractères?"
 
@@ -3331,30 +3396,30 @@ msgid "First"
 msgstr "Prénom"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "Prénom"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 #, fuzzy
 msgid "First name"
 msgstr "Prénom"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3363,7 +3428,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 #, fuzzy
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
@@ -3379,6 +3444,12 @@ msgstr ""
 "Forcer les problèmes à être numérotées par un (toujours fait lors de la "
 "renumérotation des problèmes)"
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+#, fuzzy
+msgid "Format"
+msgstr "Format :"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
 msgstr "Format pour la ligne sujet dans les e-mails de feedback"
@@ -3390,21 +3461,27 @@ msgstr "Format pour la ligne sujet dans les e-mails de feedback"
 msgid "Format:"
 msgstr "Format :"
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "Ce devoir ne contient aucun problème."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 #, fuzzy
 msgid "From field must contain one valid email address."
 msgstr "Autorisés à modifier leur adresse e-mail"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "De :"
 
@@ -3434,7 +3511,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr "Information Générale"
 
@@ -3461,12 +3538,19 @@ msgstr "Problème suivant"
 msgid "Get Target Set Problems"
 msgstr "Modifier ce devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+#, fuzzy
+msgid "Get a new version of this problem"
+msgstr "signaler une erreur pour ce problème"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr "Donne le nouveau mot de passe à"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Donner un nouveau mot de passe à quels usagers?"
 
@@ -3494,7 +3578,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "Problème global %1 pour le devoir %2 n'a pas été trouvé."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 "Les données globals vont être affichés au lieu de ceux spécifique à "
@@ -3504,30 +3588,40 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
 # avant:  msgstr "tr: View Using Seed Number" suggestion svp
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 #, fuzzy
 msgid "Grade"
 msgstr "Résultats"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 #, fuzzy
 msgid "Grade Problem"
 msgstr "Problème suivant"
 
 # avant:  msgstr "tr: View Using Seed Number" suggestion svp
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 #, fuzzy
 msgid "Grade Test"
 msgstr "Résultats"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/ProblemSet.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr "Étudiant"
 
@@ -3559,7 +3653,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "Invité"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 #, fuzzy
 msgid "HTTP Headers"
 msgstr "Entêtes"
@@ -3592,13 +3686,17 @@ msgstr "Entête d'impression"
 msgid "Hardcopy Theme"
 msgstr "Entête d'impression"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr "Entêtes"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Aide"
 
@@ -3612,13 +3710,13 @@ msgstr ""
 msgid "Hidden"
 msgstr "Caché"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 #, fuzzy
 msgid "Hide All"
 msgstr "Ajouter tous"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Hide Courses"
 msgstr "De ce cours"
@@ -3635,8 +3733,8 @@ msgstr "Cacher les indices"
 msgid "Hide Hints from Students"
 msgstr "Cacher les indices aux étudiants"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 #, fuzzy
 msgid "Hide Inactive Courses"
 msgstr "De ce cours"
@@ -3652,7 +3750,7 @@ msgid "Hide path:"
 msgstr "Cacher les indices"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 #, fuzzy
 msgid "Hint:"
 msgstr "Indices"
@@ -3669,14 +3767,14 @@ msgid "Hmwk Sets Editor"
 msgstr "Éditeur de devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 #, fuzzy
 msgid "Homework Totals"
 msgstr "Devoirs"
@@ -3685,17 +3783,17 @@ msgstr "Devoirs"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 #, fuzzy
 msgid "Icon File"
 msgstr "Fichier source"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3714,14 +3812,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3733,6 +3831,10 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
@@ -3740,7 +3842,7 @@ msgstr ""
 msgid "Illegal file '%1' specified"
 msgstr "Le fichier '%1' est protégé."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr "Fichier illégal contient '..'"
 
@@ -3749,10 +3851,11 @@ msgstr "Fichier illégal contient '..'"
 msgid "Import"
 msgstr "Importer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
 #, fuzzy
-msgid "Import achievements from"
-msgstr "Activer les objectifs des cours"
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "attribuer ce devoir à"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -3770,23 +3873,23 @@ msgid "Import sets with names"
 msgstr "Importer les devoirs avec le nom"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Importer les usagers à partir de quel fichier?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 #, fuzzy
 msgid "Imported %quant(%1,achievement)"
 msgstr "Activer les objectifs des cours"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Inactif"
 
@@ -3795,13 +3898,13 @@ msgid "Inactivity time before a user is required to login again"
 msgstr "Temps d'inactivité avant que l'utilisateur doit se connecter à nouveau"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 #, fuzzy
 msgid "Include Success Index"
 msgstr "Inclure l'index"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 #, fuzzy
 msgid "Incorrect"
@@ -3809,7 +3912,7 @@ msgstr "erroné"
 
 #
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 #, fuzzy
 msgid "Incorrect: %1/%2"
 msgstr "erroné"
@@ -3818,7 +3921,7 @@ msgstr "erroné"
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 #, fuzzy
 msgid "Institution:"
 msgstr "Récitation:"
@@ -3828,16 +3931,16 @@ msgstr "Récitation:"
 msgid "Instructor Tools"
 msgstr "Outils pour l'enseignant"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3846,7 +3949,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 #, fuzzy
 msgid "Invalid headerType %1"
 msgstr "Type d'entête invalide %1"
@@ -3865,19 +3968,23 @@ msgstr ""
 "C'est avant la date d'ouverture. Vous voulez probablement renuméroter les "
 "problèmes si vous en effacer quelques-uns dans le milieu."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 #, fuzzy
 msgid "Jump to Page:"
 msgstr "Problème suivant"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 #, fuzzy
 msgid "Jump to Problem:"
 msgstr "Problème suivant"
@@ -3891,7 +3998,7 @@ msgstr "Paramètres passerelle"
 msgid "Keywords:"
 msgstr "Mots clés:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3922,30 +4029,30 @@ msgstr "Afficher les réponses précédentes"
 
 # avant: msgstr "Code d'usager ou mot de passe invalides"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Nom de famille"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
 # avant: msgstr "Code d'usager ou mot de passe invalides"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 #, fuzzy
 msgid "Last name"
 msgstr "Nom de famille"
@@ -3980,20 +4087,20 @@ msgid "Level:"
 msgstr "Niveau:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Choisir des problèmes"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Choisir des problèmes 2"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr "Navigateur des librairies 3"
@@ -4036,14 +4143,14 @@ msgid "Local Problems"
 msgstr "Problèmes locaux"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Location"
 msgstr "Récitation"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -4051,23 +4158,23 @@ msgstr ""
 
 #
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 #, fuzzy
 msgid "Location %1 has been created, with addresses %2."
 msgstr "Le devoir %1 existe déjà.  Aucun devoir créé"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 #, fuzzy
 msgid "Location description:"
 msgstr "Description du devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 #, fuzzy
 msgid "Location name:"
 msgstr "aucune action"
@@ -4078,8 +4185,8 @@ msgid "Log In Again"
 msgstr "Se connecter à nouveau"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Se déconnecter"
 
@@ -4087,23 +4194,23 @@ msgstr "Se déconnecter"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 #, fuzzy
 msgid "Logged in as %1."
 msgstr "Connecté sous le nom %1."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 #, fuzzy
 msgid "Login"
 msgstr "Nom d'usager"
@@ -4118,24 +4225,24 @@ msgstr "Paramètres du compte"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Nom d'usager"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Statut d'accès"
 
@@ -4146,7 +4253,7 @@ msgstr "Déconnexion"
 
 # msgstr "Statut"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -4160,22 +4267,22 @@ msgid "Make Archive"
 msgstr "Archiver"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 #, fuzzy
 msgid "Make changes"
 msgstr "Sauvegarder les modifications"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/ProblemSet.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 #, fuzzy
 msgid "Manual Grader"
@@ -4191,7 +4298,7 @@ msgid "Mark Correct"
 msgstr "Marquer correct?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr "Marquer correct?"
 
@@ -4203,8 +4310,9 @@ msgstr ""
 "virgules)"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Math Objects"
 
@@ -4222,59 +4330,59 @@ msgstr " Max. affiché:"
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 #, fuzzy
 msgid "Merge file:"
 msgstr "Fichier de fusion"
 
 # vérifier le contexte ...msgstr "tr: Match on what? (separate multiple IDs with commas)"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 #, fuzzy
 msgid "Message"
 msgstr "Messages"
 
 # /home/francois/ExtractStrings/SendMail.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 #, fuzzy
 msgid "Message file:"
 msgstr "Fichier de message: "
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
 # vérifier le contexte ...msgstr "tr: Match on what? (separate multiple IDs with commas)"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 #, fuzzy
 msgid "Message:"
 msgstr "Messages"
 
 # vérifier le contexte ...msgstr "tr: Match on what? (separate multiple IDs with commas)"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Messages"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -4288,18 +4396,18 @@ msgstr "Problèmes"
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -4346,14 +4454,14 @@ msgstr "Nouveau dossier"
 
 # msgstr "tr: Set List"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 #, fuzzy
 msgid "New Name:"
 msgstr "Nom du devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "Nouveau mot de passe"
 
@@ -4366,12 +4474,12 @@ msgid "New folder name:"
 msgstr "Nom du nouveau dossier:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "Nouveaux mots de passe sauvegardés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -4380,16 +4488,18 @@ msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Problème suivant"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr "Page suivante"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4397,21 +4507,27 @@ msgstr "Page suivante"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "Non"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 #, fuzzy
 msgid "No Description"
 msgstr "Description du devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "L'utilisateur %1 a été assigné %2."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -4435,7 +4551,7 @@ msgstr "Aucune méthode d'authentification trouvé pour votre demande.  "
 msgid "No change made to any set"
 msgstr "Aucun changement effectué à aucun devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -4447,7 +4563,7 @@ msgid "No changes were saved!"
 msgstr "Aucun changement n'a été sauvegardé!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 #, fuzzy
 msgid "No course id defined"
 msgstr "Cours"
@@ -4459,39 +4575,39 @@ msgstr "Cours"
 msgid "No data exists for set %1 and problem %2"
 msgstr "Aucune données exite pour le devoir %1 et le problème %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 #, fuzzy
 msgid "No merge data file"
 msgstr "Fichier de fusion"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -4499,25 +4615,25 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 #, fuzzy
 msgid "No record for global set %1."
 msgstr "Aucun enregistrement pout le devoir global %1"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 #, fuzzy
 msgid "No record for user %1."
 msgstr "Aucun enregistrement pour l'utilisateur %1"
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 #, fuzzy
 msgid "No record found for problem %1."
 msgstr "Aucun enregistrement trouvé pour le problème %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr "Aucun enregistrement trouvé."
 
@@ -4534,7 +4650,7 @@ msgstr "Aucun devoir sélectionné pour la notation"
 
 # avant: msgstr "Aucun devoir sélectionné pour évaluation." (cohérence avec traduction préc.)
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -4543,16 +4659,16 @@ msgstr ""
 "devoirs de ce cours."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr "Aucun chemin de fichier source n'a été spécifié"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 #, fuzzy
 msgid "No source_file for problem in .def file"
 msgstr "Ce fichier source n'est pas un fichier!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -4574,15 +4690,19 @@ msgid "No user specific data exists for user %1"
 msgstr "Aucune données spécifiques existe pour l'utilisateur %1"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -4596,30 +4716,37 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 #, fuzzy
 msgid "None of the selected users are assigned to this set: %1"
 msgstr "Aucun des utilisateurs ne sont assignés à ce devoir: %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Non connecté."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Note"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "Note"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 #, fuzzy
 msgid "Number"
 msgstr "Voir le problème"
@@ -4636,8 +4763,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -4675,7 +4802,7 @@ msgstr ""
 "Seul ce niveau d'autorisation et supérieur peuvent voir le bouton pour "
 "l'envoi d'e-mail à l'instructeur."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -4695,13 +4822,13 @@ msgstr "Date d'ouverture"
 msgid "Open Problem Library"
 msgstr "Librairie de problèmes nationale"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -4719,12 +4846,10 @@ msgstr "Disponible, date de remise : "
 msgid "Open, complete by %1."
 msgstr "Disponible : date de remise : %1"
 
-#
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
-msgid "Open, reduced scoring starts on %1."
-msgstr "Points partiels débutent: %1"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 #, fuzzy
@@ -4749,11 +4874,11 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr "Réordonner les problèmes seulement"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr "Navig. orig. lib."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4778,69 +4903,72 @@ msgstr "Écraser les fichier existant en silence"
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr "Messages de debug PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr "Erreur internes PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr "Le rendu de la question PG a échoué"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr "Traîtement des messages d'erreur de la question PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr "Messages d'avertissement PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "APERÇU SEULEMENT --  LES RÉPONSES NE SERONT PAS ENREGISTRÉES"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
 # avant: msgstr "Signaler un bogue ou encore poser une question à WeBWorK en suivant ce lien. À la première utilisation, il sera nécessaire de s'enregistrer en fournissant une adresse courriel valide, de telle sorte d'assurer un suivi sur les correctifs."
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Remplir les champs"
 
 # avant: msgstr "Visualiser seulement  --  SANS ENREGISTRER LES RÉPONSES"
 #
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 #, fuzzy
 msgid "Page generated at %1"
 msgstr "Page génerée à %1"
@@ -4856,7 +4984,7 @@ msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 #, fuzzy
 msgid "Password:"
 msgstr "Mot de passe"
@@ -4868,7 +4996,7 @@ msgstr "Mot de passe"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "Le problème %1 a été ajouté à %2 en tant que problème %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4882,25 +5010,25 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Niveau de permission"
 
@@ -4910,7 +5038,7 @@ msgstr "Niveau de permission"
 msgid "Permissions"
 msgstr "Niveau de permission"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4947,7 +5075,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4962,7 +5090,7 @@ msgid "Please enter your username and password for %1 below:"
 msgstr ""
 "Veuillez écrire votre nom d'usager et votre mot de passe pour %1 ci-dessous:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4987,57 +5115,58 @@ msgid "Please select at least one user and try again."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Prière d’attribuer un nom au fichier pour permettre l’enregistrement."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #, fuzzy
 msgid "Points"
 msgstr "Indices"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview Message"
 msgstr "Prévisualiser le message"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 #, fuzzy
 msgid "Preview My Answers"
 msgstr "Visualiser les réponses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 #, fuzzy
 msgid "Preview Test"
 msgstr "Prévisualiser le message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr "Prévisualiser le message"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 #, fuzzy
 msgid "Preview set to:"
 msgstr "Aperçu du devoir à: "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Problème précédent"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr "Page précédente"
@@ -5046,12 +5175,12 @@ msgstr "Page précédente"
 msgid "Primary sort"
 msgstr "Tri primaire"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #, fuzzy
 msgid "Prob"
 msgstr "Problèmes"
@@ -5074,22 +5203,22 @@ msgstr "Problème %1"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 #, fuzzy
 msgid "Problem %1"
 msgstr "Problème %1"
 
 #
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 #, fuzzy
 msgid "Problem %1."
 msgstr "Problème %1"
@@ -5112,8 +5241,8 @@ msgid "Problem Editor3"
 msgstr "Éditeur de problèmes"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Liste des problèmes"
 
@@ -5134,31 +5263,32 @@ msgid "Problem Number "
 msgstr "Voir le problème"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Techniques de problèmes"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 #, fuzzy
 msgid "Problem Viewer"
 msgstr "Éditeur de problèmes"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr "La source d'un problèm est tiré d'un groupe de devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Problèmes"
 
@@ -5214,11 +5344,11 @@ msgstr ""
 "étudiants pour commencer en examen."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Publier"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -5234,30 +5364,30 @@ msgstr "Vous voulez vraiment supprimer les éléments énumérés ci-dessus?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 #, fuzzy
 msgid "Recitation"
 msgstr "Récitation"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Ajouter les résultats de chaque devoir"
 
@@ -5274,7 +5404,7 @@ msgstr "Points partiels désactivés"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Disabled"
 msgstr "Points partiels désactivés"
@@ -5283,24 +5413,10 @@ msgstr "Points partiels désactivés"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Enabled"
 msgstr "Points partiels activés"
-
-#
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
-msgid "Reduced Scoring Starts %1"
-msgstr "Points partiels débutent: %1"
-
-#
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
-msgid "Reduced scoring started on %1."
-msgstr "Points partiels débutent: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
@@ -5318,12 +5434,12 @@ msgid "Refresh Display"
 msgstr "Rafraîchir la page"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Refresh Listing"
 msgstr "Rafraîchir la page"
@@ -5333,7 +5449,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 # avant: msgstr "Points partiels débute: %1"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Nombre d'essais restant"
 
@@ -5346,7 +5462,7 @@ msgstr "Rester connecté"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -5356,13 +5472,13 @@ msgid "Rename"
 msgstr "Renommer"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 #, fuzzy
 msgid "Rename Course"
 msgstr "Renommer"
@@ -5371,21 +5487,21 @@ msgstr "Renommer"
 msgid "Rename file as:"
 msgstr "Renommer le fichier en:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 #, fuzzy
 msgid "Render Problem"
 msgstr "Problème suivant"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 #, fuzzy
 msgid "Renumber Problems"
 msgstr "Voir les problèmes"
@@ -5402,60 +5518,61 @@ msgid "Reorder problems only"
 msgstr "Réordonner les problèmes seulement"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Remplacer quels usagers?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 #, fuzzy
 msgid "Reply-To:"
 msgstr "Répondre à: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Signaler un bogue"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 #, fuzzy
 msgid "Report for course %1:"
 msgstr "Aucun enregistrement pour l'utilisateur %1"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 #, fuzzy
 msgid "Request information"
 msgstr "information sur le cours"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 #, fuzzy
 msgid "Request new version now."
 msgstr "information sur le cours"
@@ -5528,8 +5645,8 @@ msgid "Reset"
 msgstr "Réinitialiser"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr "Réinitialiser le formulaire"
 
@@ -5537,11 +5654,7 @@ msgstr "Réinitialiser le formulaire"
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -5575,25 +5688,25 @@ msgid "Restrict release by set(s)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Résultat"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr "Résultat de la dernière action effectuée"
 
 #
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 #, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "Résultat de la dernière action effectuée: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -5608,22 +5721,30 @@ msgstr "Résultats de la dernière action effectuée"
 msgid "Results of last action performed: "
 msgstr "Résultats de la dernière action effectuée"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 #, fuzzy
 msgid "Revert"
 msgstr "Revenir"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 #, fuzzy
 msgid "Revert to %1"
@@ -5637,19 +5758,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -5659,59 +5780,59 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "Enregistrer"
 
 #
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 #, fuzzy
 msgid "Save %1"
 msgstr "Enregistrer"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Enregistrer sous [TMPL]/"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr "Sauvegarder les modifications"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "Enregistrer sous"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr "Enregistrer par défaut"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "Sauvegarder les modifications"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 #, fuzzy
 msgid "Save file to:"
 msgstr "Enregistrer vers: "
@@ -5719,38 +5840,38 @@ msgstr "Enregistrer vers: "
 # avant: msgstr "Les droit d'écriture n'ont pas été activés pour le répertoire templates. Aucune modification ne peut être effectuée."
 #
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 #, fuzzy
 msgid "Save to %1 and View"
 msgstr "Sauvegarder %1 et visualiser"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 #, fuzzy
 msgid "Saved to file '%1'"
 msgstr "Fichier  '%1' enregistré"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5769,11 +5890,11 @@ msgstr ""
 
 # avant: msgstr "tr: Top level of author information on the wiki." vérif contexte
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Sauvegarder les résultats sélectionnés sous:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -5804,7 +5925,7 @@ msgid "Scoring Tools"
 msgstr "Outils d'évaluation"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
@@ -5813,7 +5934,7 @@ msgstr ""
 "pas être substitués pour pour un étudiant individuel."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5824,24 +5945,24 @@ msgstr "Tri secondaire"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Section"
@@ -5858,11 +5979,17 @@ msgstr "Section"
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr "Selectionner"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Devoirs"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
@@ -5876,12 +6003,12 @@ msgid "Select a Set from this Course"
 msgstr "Créer un nouveau devoir dans ce cours"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 #, fuzzy
 msgid "Select a course to delete."
 msgstr "Sélectionner une action ci-bas"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5889,32 +6016,32 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 #, fuzzy
 msgid "Select a course to unarchive."
 msgstr "Sélectionner une action ci-bas"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 #, fuzzy
 msgid "Select a database layout below."
 msgstr "Sélectionner une action ci-bas"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 #, fuzzy
 msgid "Select a listing format:"
 msgstr "Sélectionner une action à effectuer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 #, fuzzy
 msgid "Select above then:"
 msgstr "Étudiants sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 #, fuzzy
 msgid "Select all eligible courses"
 msgstr "Sélectionner tous les usagers"
@@ -5925,30 +6052,30 @@ msgid "Select all sets"
 msgstr "Sélectionner tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Sélectionner tous les usagers"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Sélectionner une action à effectuer"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr "Sélectionner une action à effectuer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 #, fuzzy
 msgid "Select course(s) to hide or unhide."
 msgstr "Sélectionner une action ci-bas"
@@ -5963,7 +6090,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5990,26 +6117,26 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr "Étudiants sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 #, fuzzy
 msgid "Send E-mail"
 msgstr "Envoyer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr "Envoyer"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr "Envoyer à:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Devoirs"
 
@@ -6049,7 +6176,7 @@ msgid "Set Definition Files"
 msgstr "Fichier de définition devoirs"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr "Description du devoir"
 
@@ -6067,7 +6194,7 @@ msgstr "fixer l'entête d'impression du devoir %1"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -6085,15 +6212,15 @@ msgstr "Numéro de l'étudiant"
 
 # msgstr "En-tête"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 #, fuzzy
 msgid "Set Info"
 msgstr "Informations sur le devoir"
 
 # msgstr "tr: Set Info"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 #, fuzzy
 msgid "Set List"
 msgstr "Liste des devoirs"
@@ -6128,11 +6255,15 @@ msgid "Set Name "
 msgstr "Nom du devoir"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
 msgstr ""
 "Les entêtes de devoir ne sont pas utilisés pour affichée les tests "
 "passerelle."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
@@ -6163,7 +6294,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Devoirs"
 
@@ -6180,7 +6311,7 @@ msgid "Sets assigned to %1"
 msgstr "Éditer les usagers assignés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #, fuzzy
 msgid "Setting"
 msgstr "Changer les options d'usager"
@@ -6190,11 +6321,11 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr "Afficher"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -6203,7 +6334,7 @@ msgid "Show Date & Size"
 msgstr "Voir la date et la taille"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "Afficher les indices"
 
@@ -6215,8 +6346,8 @@ msgstr "Afficher dans une autre fenêtre"
 
 # avant: msgstr "Recourir à des indices"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Afficher les réponses précédentes"
 
@@ -6229,8 +6360,8 @@ msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "Afficher les solutions"
 
@@ -6239,7 +6370,7 @@ msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Afficher quels usagers?"
 
@@ -6251,20 +6382,20 @@ msgid "Show all paths"
 msgstr "affichage de tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Afficher les bonnes réponses"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 #, fuzzy
 msgid "Show me another"
 msgstr "Afficher dans une autre fenêtre"
 
 #
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 #, fuzzy
 msgid "Show me another %1"
 msgstr "Afficher dans une autre fenêtre"
@@ -6276,7 +6407,7 @@ msgstr "Afficher dans une autre fenêtre"
 msgid "Show path ..."
 msgstr "affichage de tous les devoirs"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr "Montrer les réponses enregistrés ?"
 
@@ -6289,18 +6420,18 @@ msgstr "Afficher quels devoirs?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Afficher/masquer la description du site web"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Afficher : "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr "Présentation"
 
@@ -6313,7 +6444,7 @@ msgstr "%1 devoirs affichés sur un total de %2."
 
 #
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 #, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "%1 usagers affichés sur un total de %2."
@@ -6333,15 +6464,15 @@ msgstr "EditionSimple"
 msgid "Site Information"
 msgstr "Informations sur le site"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
 # avant: msgstr "tr: Drop"
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 #, fuzzy
 msgid "Solution:"
 msgstr "Solutions"
@@ -6353,7 +6484,7 @@ msgstr "Solutions"
 msgid "Solutions"
 msgstr "Solutions"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 #, fuzzy
 msgid "Some answers will be graded later."
 msgstr "La réponde va être corrigée plus tard."
@@ -6367,6 +6498,16 @@ msgstr ""
 "Certains de ces fichiers sont des répertoires. Supprimer seulement des "
 "répertoires si vous savez vraiment ce que vous faites. Vous pouvez "
 "endommager sérieusement votre cours si vous supprimez la mauvaise chose."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 #, fuzzy
@@ -6393,8 +6534,8 @@ msgid ""
 msgstr "Quelque chose n'a pas bien été avec vos paramètres LTI."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 #, fuzzy
 msgid "Sort"
 msgstr "Trier"
@@ -6402,8 +6543,8 @@ msgstr "Trier"
 # msgstr "tr: Site Information"
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "Trier selon"
 
@@ -6439,7 +6580,7 @@ msgstr ""
 "Le chemin de fichier source ne peut pas inclure .. ou commencer par /: le "
 "chemin a été modifié."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -6480,51 +6621,51 @@ msgid "Statistics for %1 student %2"
 msgstr "Statistiques par étudiant"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Statut"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Cesser de jouer le rôle"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 #, fuzzy
 msgid "Stop Archiving"
 msgstr "Cesser de jouer le rôle"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 #, fuzzy
 msgid "Stop archiving courses"
 msgstr "De ce cours"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "Numéro de l'étudiant"
 
@@ -6566,14 +6707,14 @@ msgstr "Progrès des étudiants pour %1"
 msgid "Student answers"
 msgstr "Réponses de l'étudiant"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr "Sujet:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 #, fuzzy
 msgid "Subject: "
 msgstr "Sujet:  "
@@ -6593,17 +6734,21 @@ msgstr "Soumettre les réponses"
 
 # avant: msgstr "ID de l'étudiant"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "Soumettre les réponses"
 
 # avant: msgstr "Soumettre ses réponses"
 #
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 #, fuzzy
 msgid "Submit Answers for %1"
 msgstr "Soumettre les réponses pour %1"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 # avant: msgstr "Soumettre ses réponses de %1"
 #
@@ -6613,20 +6758,20 @@ msgstr "Succès"
 
 # avant: msgstr "Soumettre ses réponses de %1"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 #, fuzzy
 msgid "Success Index"
 msgstr "Succès"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 #, fuzzy
 msgid "Successfully archived the course %1."
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 #, fuzzy
 msgid "Successfully created new achievement %1"
 msgstr "Réussite de la création du nouveau devoir %1"
@@ -6638,46 +6783,46 @@ msgid "Successfully created new set %1"
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 #, fuzzy
 msgid "Successfully created the course %1"
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 #, fuzzy
 msgid "Successfully deleted the course %1."
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 #, fuzzy
 msgid "Successfully renamed the course %1 to %2"
 msgstr "Réussite de la création du nouveau devoir %1"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 #, fuzzy
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "Réussite de la création du nouveau devoir %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -6700,16 +6845,16 @@ msgid "Take %1 test."
 msgstr "Faire le test %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "Effectuer l'action!"
 
@@ -6780,11 +6925,11 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "Le projet WeBWorK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6813,17 +6958,17 @@ msgstr ""
 "date est fixée."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 #, fuzzy
 msgid "The answer above is NOT correct."
 msgstr "La réponse ci-dessus N'EST PAS %1correcte."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "La réponse ci-dessus est correcte."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr "La réponde va être corrigée plus tard."
 
@@ -6836,7 +6981,7 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
@@ -6846,7 +6991,7 @@ msgstr ""
 "soit à jour."
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6888,13 +7033,13 @@ msgstr ""
 
 #
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 #, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "L'entête pour le devoir %1 a été renommé par '%2'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
@@ -6902,52 +7047,52 @@ msgstr ""
 
 #
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 #, fuzzy
 msgid "The file %1/%2 cannot be found."
 msgstr "Impossible de trouver le fichier '%1'"
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 #, fuzzy
 msgid "The file '%1' cannot be found."
 msgstr "Impossible de trouver le fichier '%1'"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 #, fuzzy
 msgid "The file '%1' cannot be read!"
 msgstr "Impossible de trouver le fichier '%1'"
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid "The file '%1' is a blank problem!"
 msgstr "Le fichier '%1' est un problème vierge!"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 #, fuzzy
 msgid "The file '%1' is a directory!"
 msgstr "Le fichier '%1' est un dossier!"
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 #, fuzzy
 msgid "The file '%1' is protected!"
 msgstr "Le fichier '%1' est protégé."
@@ -6961,22 +7106,22 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 #, fuzzy
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
@@ -6986,7 +7131,7 @@ msgstr ""
 
 #
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 #, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
@@ -6994,7 +7139,7 @@ msgid ""
 msgstr "Ce problème ne sera pas noté."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -7002,31 +7147,31 @@ msgstr ""
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 #, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "L'entête d'impression du devoir %1 a été renommé '%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -7049,7 +7194,7 @@ msgstr ""
 "des devoirs."
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 #, fuzzy
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
@@ -7058,7 +7203,7 @@ msgstr ""
 "La date d'ouverture: %1, la date d'échéance: 2%, et la date de remise des "
 "éponse: 3% doivent être définies et être dans l'ordre chronologique."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -7085,8 +7230,8 @@ msgstr ""
 "essayer de nouveau"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "Le chemin du fichier original devrait être décrit de manière absolue"
 
@@ -7095,7 +7240,7 @@ msgstr "Le chemin du fichier original devrait être décrit de manière absolue"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -7104,20 +7249,20 @@ msgstr ""
 
 #
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 #, fuzzy
 msgid "The recorded score for this test is  %1/%2."
 msgstr "Votre résultat final est : %1.  %2"
 
 #
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #, fuzzy
 msgid "The recorded score for this test is %1/%2."
 msgstr "Votre résultat final est : %1.  %2"
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 #, fuzzy
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
@@ -7134,7 +7279,7 @@ msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 #, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "Ce problème ne sera pas noté."
@@ -7142,21 +7287,21 @@ msgstr "Ce problème ne sera pas noté."
 # avant: msgstr "Les mots de passe saisis dans les champs %1 et %2 sont différents. Veuillez essayer à nouveau" * cohérent avec prec.
 #
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 #, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "Le devoir sélectionné (%1) n'est pas un devoir valide pour %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 #, fuzzy
 msgid "The set %1 is assigned to %2."
 msgstr "Le devoir %1 est assigné à %2."
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 #, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
@@ -7171,7 +7316,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 #, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "Le set-version (%1, version %2) n'est pas assigné à l'utilisateur %3."
@@ -7183,7 +7328,7 @@ msgstr ""
 # avant: msgstr "Exporter les résultats" pas certaine que c'est ok
 #
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 #, fuzzy
 msgid ""
@@ -7192,9 +7337,19 @@ msgstr ""
 "Le fichier source du 'devoir %1 / problème %2' a été changé de %3 à '%4'."
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"La boîte de saisie contient actuellement le code source du problème "
+"original. Les modifications perdues peuvent être récupérées en utilisant le "
+"bouton Précédent du navigateur web."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -7216,7 +7371,7 @@ msgstr ""
 # avant: msgstr "Exporter les résultats" pas certaine que c'est ok
 #
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 #, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
@@ -7225,7 +7380,7 @@ msgstr ""
 # avant: msgstr "Exporter les résultats" pas certaine que c'est ok
 #
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 #, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr ""
@@ -7233,13 +7388,13 @@ msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 #, fuzzy
 msgid "The user %1 has been assigned %2."
 msgstr "L'utilisateur %1 a été assigné %2."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 #, fuzzy
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
@@ -7249,7 +7404,7 @@ msgstr ""
 "'N'."
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 #, fuzzy
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
@@ -7259,7 +7414,9 @@ msgstr ""
 "par '0'."
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 #, fuzzy
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
@@ -7269,7 +7426,7 @@ msgstr ""
 "'N'."
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 #, fuzzy
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
@@ -7279,7 +7436,7 @@ msgstr ""
 "'N'."
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 #, fuzzy
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
@@ -7289,7 +7446,7 @@ msgstr ""
 "remplacé par 'No'."
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 #, fuzzy
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
@@ -7298,7 +7455,7 @@ msgstr ""
 "La valeur %1 de l'option restrictIP n'est pas valide, elle sera remplacé par "
 "'No'."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -7312,8 +7469,8 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "Ensuite selon"
 
@@ -7340,24 +7497,24 @@ msgstr ""
 "math2 et dgage. Le thème spécifie une apparence unifiée pour les pages web "
 "de cours de Webwork."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -7367,36 +7524,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr "Il n'y a pas de problèmes de Webwork correspondant"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -7423,11 +7580,11 @@ msgstr ""
 "L'annulation n'es pas possibler pour la suppression de fichiers ou de "
 "répertoires!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -7444,7 +7601,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -7466,25 +7623,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -7507,19 +7664,19 @@ msgid "This action will not overwrite existing users."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 #, fuzzy
 msgid "This answer is NOT completely correct."
 msgstr "La réponse ci-dessus N'EST PAS %1correcte."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 #, fuzzy
 msgid "This answer is NOT correct."
 msgstr "La réponse ci-dessus N'EST PAS %1correcte."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 #, fuzzy
 msgid "This answer is correct."
 msgstr "La réponse ci-dessus est correcte."
@@ -7531,24 +7688,24 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "Ce devoir ne contient aucun problème."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "Ce devoir n'est plus disponible."
 
 # avant: msgstr "Ce devoir est échu."
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "Ce devoir n'est pas encore disponible."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 #, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
@@ -7558,6 +7715,10 @@ msgstr ""
 "Ceci est un fichier modèle d'un problème vierge et on ne peut le modifier "
 "directement. Utiliser la fonction \"Enregistrer sous\" pour créer une copie "
 "locale du fichier et l'ajouter au devoir courant."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7617,38 +7778,42 @@ msgstr ""
 "Ceci est le nombre de points pour les objectifs donnés à chaque utilisateur "
 "pour avoir rempli un problème."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 #, fuzzy
 msgid "This problem uses the same source file as number %1."
 msgstr "Ce problème utilise le même fichier source que le problème numéro %1."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "Ce problème ne sera pas noté."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 #, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
@@ -7665,18 +7830,18 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 #, fuzzy
 msgid "This set %1 is assigned to %2."
 msgstr "Ce devoir %1 est assigné à %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr "Ce devoir ne contient pas encore de problème."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -7691,14 +7856,14 @@ msgstr ""
 # avant: msgstr "Ce problème n'est pas noté."
 #
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 #, fuzzy
 msgid "This set is %1"
 msgstr "Ce devoir est %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -7743,22 +7908,22 @@ msgstr ""
 "élèves personnalisées si elles sont écrites de façon appropriée. </p>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr "Ce fichier source n'existe pas!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr "Ce fichier source est un dossier!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr "Ce fichier source n'est pas un fichier!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr "Impossible de lire ce fichier source!"
 
@@ -7782,7 +7947,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -7792,8 +7957,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 #, fuzzy
 msgid "Time"
 msgstr "Date du test"
@@ -7803,7 +7968,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -7816,24 +7981,24 @@ msgid "Timezone for the course"
 msgstr "Fuseau horaire pour le cours"
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7845,13 +8010,13 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
@@ -7860,8 +8025,8 @@ msgstr ""
 "(tous) ses devoirs assignés."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 #, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
@@ -7871,8 +8036,8 @@ msgstr ""
 "fonction \"Enregistrer sous\"."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
@@ -7887,11 +8052,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "Éditer ce problème"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -7908,7 +8073,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -7925,52 +8091,52 @@ msgstr ""
 msgid "Two Columns"
 msgstr " colonnes: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 #, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "Impossible de modifier l'entête du devoir %1. Erreur inconnue."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr "Incapable d'obtenir un message d'erreur de la question PG."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 #, fuzzy
 msgid "Unable to write to '%1': %2"
 msgstr "Impossible d'écrire dans le fichier %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 #, fuzzy
 msgid "Unarchive"
 msgstr "Archiver"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 #, fuzzy
 msgid "Unarchive %1 to course:"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 #, fuzzy
 msgid "Unarchive Course"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 #, fuzzy
 msgid "Unarchive Next Course"
 msgstr "De ce cours"
@@ -7998,7 +8164,7 @@ msgstr ""
 
 #
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 #, fuzzy
 msgid "Unattempted: %1/%2"
 msgstr "Impossible d'écrire dans  '%1': %2"
@@ -8009,13 +8175,13 @@ msgid "Unclassified Problems"
 msgstr "Voir les problèmes"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Problem.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr "Mise à jour réussie"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 #, fuzzy
 msgid "Unhide Courses"
 msgstr "De ce cours"
@@ -8037,7 +8203,7 @@ msgstr "Décompresser les archives automatiquement"
 
 # avant: msgstr "Dessélectionner tous les devoirs"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 #, fuzzy
 msgid "Unselect all courses"
 msgstr "Désélectionner tous les usagers"
@@ -8049,12 +8215,12 @@ msgstr "Désélectionner tous les devoirs"
 
 # avant: msgstr "Dessélectionner tous les devoirs"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Désélectionner tous les usagers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 #, fuzzy
 msgid "Update"
 msgstr "MAJ des menus"
@@ -8069,40 +8235,40 @@ msgstr "Rafraîchir la page"
 msgid "Update Menus"
 msgstr "MAJ des menus"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr "Mise à jour des paramètres et rafraîchir la page"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Problem.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 #, fuzzy
 msgid "Upgrade"
 msgstr "Mise à jour réussie"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 #, fuzzy
 msgid "Upgrade Courses"
 msgstr "De ce cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -8116,11 +8282,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr "Utiliser le fichier d'entête par défaut"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -8130,22 +8297,22 @@ msgstr ""
 
 # avant: msgstr "Dessélectionner pour les usagers"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Utiliser les paramètres par défaut"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 #, fuzzy
 msgid "Use in achievement %1"
 msgstr "Activer les objectifs des cours"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 #, fuzzy
 msgid "Use in new achievement:"
 msgstr "devoirs sélectionnés"
@@ -8165,7 +8332,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -8176,13 +8343,13 @@ msgstr ""
 "additionnelles sur l'état du système utilisé accompagneront votre message."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 #, fuzzy
 msgid "User ID"
@@ -8210,8 +8377,8 @@ msgstr "Nom d'usager"
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 #, fuzzy
@@ -8235,7 +8402,7 @@ msgid "Username presented:  %1"
 msgstr "Nom d'utilisateur présenté:  "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -8248,7 +8415,7 @@ msgid "Users Assigned to Set %2"
 msgstr "Éditer les usagers assignés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Liste d'usagers"
 
@@ -8274,7 +8441,7 @@ msgstr ""
 
 #
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 #, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "Usagers triés selon %1, ensuite selon %2 et ensuite selon %3"
@@ -8303,18 +8470,19 @@ msgstr ""
 "dessous. Pour envoyer SEULEMENT aux adresses énumérées ci-après, régler le "
 "niveau de permission à \"personne\"."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 #, fuzzy
 msgid "Using what display mode?: "
 msgstr "Le mode d'affichage par défaut"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -8324,13 +8492,13 @@ msgid "Value of work done in Reduced Scoring Period"
 msgstr "Valeur du travail effectué durant la période de crédit réduite"
 
 # /home/francois/ExtractStrings/defaults.config
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 #, fuzzy
 msgid "Variable Documentation:"
 msgstr "Documentation variable:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 "La version d'un devoir peut seulement être modifier par un seul utilisateur "
@@ -8340,10 +8508,10 @@ msgstr ""
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "Voir"
 
@@ -8358,7 +8526,7 @@ msgstr "Voir les problèmes"
 
 # avant: msgstr "Les étudiants voient ce devoir."
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "Afficher les équations à l'aide de"
 
@@ -8396,8 +8564,8 @@ msgstr "Voir"
 
 # avant: msgstr "Affichage du fichier temporaire"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 #, fuzzy
 msgid "Viewing temporary file:"
@@ -8425,20 +8593,20 @@ msgstr "Visible"
 msgid "Visible to Students"
 msgstr "Visible aux étudiants"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 #, fuzzy
 msgid "Warning"
 msgstr "Attention:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 #, fuzzy
 msgid "Warning messages"
 msgstr "Messages d'avertissement PG"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "Avertissement: la suppression détruit toutes les données relatives aux "
@@ -8449,14 +8617,19 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 #, fuzzy
 msgid "WeBWorK Error"
 msgstr "WeBWorK"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 #, fuzzy
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK"
@@ -8478,7 +8651,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -8515,7 +8688,7 @@ msgid "What could be inside?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "Sélectionner les usagers selon quel champs d'information?"
 
@@ -8614,13 +8787,13 @@ msgstr "sera disponible le %1"
 
 # avant : msgstr "tr: What field should filtered users match on?"  *** vérif contexte... sélectionner les usagers selon quel champs d'information
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Pondération"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
@@ -8631,7 +8804,7 @@ msgstr ""
 
 #
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
@@ -8642,7 +8815,7 @@ msgstr ""
 
 # avant: msgstr "tr: hardcopy header file" voir contexte
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
@@ -8651,18 +8824,20 @@ msgstr ""
 "Aucune modification ne peut être effectuée."
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Oui"
 
@@ -8691,16 +8866,16 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr "Vous n'êtes pas autorisé à accéder aux outils de l'enseignant."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr "Vous n'êtes pas autorisé à accéder aux outils de l'enseignant."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "Vous n'êtes pas autorisé à accéder aux outils de l'enseignant."
 
@@ -8712,7 +8887,7 @@ msgstr "Vous n'êtes pas autorisé à modifier les devoirs."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "Vous n'êtes pas autorisé à modifier des problèmes."
 
@@ -8723,14 +8898,14 @@ msgid "You are not authorized to modify set definition files."
 msgstr "Vous n'êtes pas autorisé à modifier les fichiers de définition."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "Vous n'êtes pas autorisé à modifier les données des étudiants."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "Vous n'êtes pas autorisé à effectuer cette action."
 
@@ -8750,7 +8925,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -8762,6 +8937,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "Vous pouvez obtenir une partie des points pour ce problème."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
@@ -8787,7 +8966,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -8810,18 +8989,18 @@ msgstr "Ce fichier source est un dossier!"
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 #, fuzzy
 msgid "You cannot delete the course you are currently using."
 msgstr "Vous ne pouvez pas vous supprimer vous-même!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "Vous ne pouvez pas vous supprimer vous-même!"
 
@@ -8837,7 +9016,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "Spécifier le numéro d'usager."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -8877,35 +9056,39 @@ msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "Vos droits ne vous permettent pas de modifier votre mot de passe."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr ""
 "Les droits qui vous sont assignés ne permettent pas de voir les détails de "
 "cette erreur."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 #, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "Vous avez essayer ce problème %1 fois."
 
 #
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 #, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "Il reste %1 essais."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
@@ -8913,7 +9096,7 @@ msgstr ""
 
 #
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 #, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Vous avez essayé ce problème à %1 reprises."
@@ -8923,7 +9106,7 @@ msgstr "Vous avez essayé ce problème à %1 reprises."
 msgid "You have been logged out of WeBWorK."
 msgstr "Vous êtes déconnecté de WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -8963,12 +9146,18 @@ msgstr ""
 "réponses du devoir."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Vous ne pouvez pas modifier votre propre mot de passe ici!"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "Vous ne pouvez pas modifier votre propre mot de passe ici!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 #, fuzzy
 msgid "You may still check your answers."
 msgstr "Vous ne pouvez pas modifier votre propre mot de passe ici!"
@@ -8984,14 +9173,14 @@ msgstr "Vous avez essayé ce problème à %1 reprises."
 
 #
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "Vous avez essayé ce problème à %1 reprises."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -9007,7 +9196,7 @@ msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 #, fuzzy
 msgid "You must select a course to rename."
 msgstr "Spécifier le numéro d'usager."
@@ -9023,24 +9212,31 @@ msgid "You must select at least one file to delete"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
 #, fuzzy
-msgid "You must select one or more sets for scoring"
+msgid "You must select one or more sets for scoring!"
 msgstr "Aucun devoir sélectionné pour la notation"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Spécifier le numéro d'usager."
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 #, fuzzy
 msgid "You must specify a course ID."
 msgstr "Spécifier le numéro d'usager."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 #, fuzzy
 msgid "You must specify a course name."
 msgstr "Spécifier le numéro d'usager."
@@ -9052,54 +9248,54 @@ msgid "You must specify a file name"
 msgstr "Spécifier le numéro d'usager."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 #, fuzzy
 msgid "You must specify a first name for the initial instructor."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 #, fuzzy
 msgid "You must specify a last name for the initial instructor."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 #, fuzzy
 msgid "You must specify a new institution for the course."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 #, fuzzy
 msgid "You must specify a new name for the course."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 #, fuzzy
 msgid "You must specify a new title for the course."
 msgstr "Spécifier le numéro d'usager."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Spécifier le numéro d'usager."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 #, fuzzy
 msgid "You must specify an email address for the initial instructor."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 #, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "Attribuer un nom au fichier afin de pouvoir l'enregistrer."
@@ -9139,20 +9335,20 @@ msgstr ""
 # avant: msgstr "Spécifier le code d'usager."  pour cohérence
 #
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 #, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "Résultat pour cette tentative : %1."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -9194,28 +9390,29 @@ msgid ""
 "instructor if you need help."
 msgstr "Votre authentification a échoué. S'il vous plaît essayer de nouveau."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 #, fuzzy
 msgid "Your display options have been saved."
 msgstr "Votre adresse courriel a été modifiée."
@@ -9229,59 +9426,73 @@ msgstr "Votre adresse courriel a été modifiée."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+#, fuzzy
+msgid "Your file name is not valid! "
+msgstr "Impossible de lire ce fichier source!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 #, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Votre résultat final est : %1.  %2"
 
 #
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 #, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "Votre résultat final est : %1.  %2"
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 #, fuzzy
 msgid "Your score on this %1 WAS recorded."
 msgstr "Votre résultat a été enregistré"
 
 #
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 #, fuzzy
 msgid "Your score on this %1 is %2/%3."
 msgstr "Votre résultat final est : %1.  %2"
 
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 #, fuzzy
 msgid "Your score on this %1 was NOT recorded."
 msgstr "Votre résultat a été enregistré"
 
 #
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 #, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "Votre résultat a été enregistré"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 #, fuzzy
 msgid "Your score on this problem was recorded."
 msgstr "Votre résultat a été enregistré"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -9290,13 +9501,13 @@ msgstr ""
 "processus d'enregistrement dans la base de données."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr ""
 "Votre résultat n'a pas été enregistré car la date de remise est passée."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
@@ -9305,7 +9516,7 @@ msgstr ""
 "assigné."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 #, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
@@ -9315,7 +9526,7 @@ msgstr ""
 
 #
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
@@ -9325,7 +9536,7 @@ msgstr ""
 "assigné."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
@@ -9335,36 +9546,36 @@ msgstr ""
 "assigné."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 #, fuzzy
 msgid "Your score was not recorded."
 msgstr "Votre résultat a été enregistré"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Votre résultat a été enregistré"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
 # avant: msgstr "Le résultat final est : %1.  %2"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Votre session est échue. Veuillez vous reconnecter"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
@@ -9372,7 +9583,7 @@ msgstr ""
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 #, fuzzy
 msgid "[Edit]"
@@ -9413,7 +9624,7 @@ msgstr ""
 "informations correspondantes."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "Ceci est la page d’édition de la liste de classe, où vous pouvez voir et "
@@ -9474,13 +9685,13 @@ msgstr ""
 "contrôle direct. Utilisez cette fonctionnalité que pour les ordinateurs de "
 "confiance."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 "WebWork a rencontré une erreur logicielle lors de la manipulation de ce "
@@ -9488,10 +9699,16 @@ msgstr ""
 "Si vous êtes un étudiant, mentionner l'erreur aux responsables du cours. Si "
 "vous avez les droits, alors vous pouvez voir le rapport d'erreur suivant."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "une copie du premier devoir sélectionné"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -9500,12 +9717,18 @@ msgid "a duplicate of the first selected set"
 msgstr "une copie du premier devoir sélectionné"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "un nouveau devoir vide"
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "un nouveau devoir vide"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr "un nouveau fichier nommé:"
 
@@ -9515,7 +9738,7 @@ msgstr "un nouveau fichier nommé:"
 msgid "a single set"
 msgstr "un seul devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr "Actif"
 
@@ -9526,13 +9749,13 @@ msgid "add problems"
 msgstr "Ajouter un problème"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 #, fuzzy
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr "addGlobalSet %1 dans ProblemSetList: %2"
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr "le niveau d'autorisation manquant pour l'utilisateur a été ajouté"
 
@@ -9541,14 +9764,14 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 #, fuzzy
 msgid "all achievements"
 msgstr "Activer les objectifs des cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -9581,14 +9804,14 @@ msgid "all students"
 msgstr "tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "tous les usagers"
 
@@ -9596,34 +9819,40 @@ msgstr "tous les usagers"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
+msgstr ""
+
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
 msgstr ""
 
 #
 # vérifier le contexte: Je vois "answers due" et "answer available", mais pas answer date
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 #, fuzzy
 msgid "answer"
 msgstr "Date de disponibilité des réponses"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "n'importe quel usager"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr "tel"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
-msgid "assigning the achievements to"
-msgstr "attribuer ce devoir à"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 msgid "assigning this set to"
@@ -9636,25 +9865,25 @@ msgid "avg attempts"
 msgstr "Essais maximum"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr "Problème(s) modèle(s) vide(s) à la fin du devoir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "Les modifications n'ont pas été sauvegardées"
 
 # avant: msgstr "modificiations annulées"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "modifications sauvegardées"
@@ -9675,20 +9904,20 @@ msgstr ""
 msgid "close"
 msgstr "Fermé"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 #, fuzzy
 msgid "column"
 msgstr " colonnes: "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 #, fuzzy
 msgid "columns:"
 msgstr " colonnes: "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "correct"
 
@@ -9707,7 +9936,7 @@ msgstr "suppression de %1 devoirs"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 #, fuzzy
 msgid "deleted %1 users"
 msgstr "suppression de %1 usagers"
@@ -9723,7 +9952,7 @@ msgid "editing all sets"
 msgstr "modification de tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "modification de tous les usagers"
 
@@ -9739,7 +9968,7 @@ msgid "editing selected sets"
 msgstr "modification des devoirs sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "modification des usagers sélectionnés"
 
@@ -9749,7 +9978,7 @@ msgid "editing visible sets"
 msgstr "modifications des devoirs visibles"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "modification des usagers visibles"
 
@@ -9762,7 +9991,7 @@ msgid "email:"
 msgstr "Courriel"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 #, fuzzy
 msgid "empty"
 msgstr "essai"
@@ -9779,7 +10008,7 @@ msgid "entry rows."
 msgstr "Lignes de l'éditeur"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 #, fuzzy
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
@@ -9787,13 +10016,13 @@ msgstr ""
 
 # avant: msgstr "tr: enter matching set IDs below"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "exportation annulée"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 #, fuzzy
 msgid "exporting all achievements"
 msgstr "exportation de tous les devoirs"
@@ -9804,7 +10033,7 @@ msgid "exporting all sets"
 msgstr "exportation de tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 #, fuzzy
 msgid "exporting selected achievements"
 msgstr "Exporter les devoirs sélectionnés"
@@ -9843,17 +10072,17 @@ msgid "from"
 msgstr "de"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "assignation de nouveaux mots de passe à tous les usagers"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "assignation de nouveaux mots de passe aux usagers sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "assignation de nouveaux mots de passe aux usagers visibles"
 
@@ -9887,9 +10116,9 @@ msgid "guest"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "caché"
@@ -9901,7 +10130,7 @@ msgid "hidden from"
 msgstr "invisible pour"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "caché pour les étudiants"
@@ -9913,47 +10142,51 @@ msgstr "devoirs cachés"
 
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr "caractère illégal : '/'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr "dans leurs"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr "innactif"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "erroné"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 #, fuzzy
 msgid "input set location %1 already exists for set %2."
 msgstr "l'entrée du lieu %1 existe déjà pour le devoir %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 #, fuzzy
 msgid "locations selected below"
 msgstr "exportation des devoirs sélectionnés"
@@ -9965,7 +10198,7 @@ msgid "login"
 msgstr "Nom d'usager"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 #, fuzzy
 msgid "login ID"
 msgstr "Nom d'usager"
@@ -10007,19 +10240,19 @@ msgstr "aucun devoir"
 msgid "new users"
 msgstr "aucun usager"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 #, fuzzy
 msgid "no achievements"
 msgstr "Activer les objectifs des cours"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 #, fuzzy
 msgid "no achievements."
 msgstr "Activer les objectifs des cours"
 
 # avant: msgstr "tr: Drop"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 #, fuzzy
 msgid "no location"
 msgstr "Solutions"
@@ -10042,29 +10275,33 @@ msgid "no students"
 msgstr "pour les étudiants"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "aucun usager"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
 # /home/francois/ExtractStrings/lib/WeBWorK/ContentGenerator/Instructor/UserList3.pm
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
 msgstr "Le nombre d'étudiants n'est pas définie"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
@@ -10090,7 +10327,7 @@ msgid "only best scores"
 msgstr "Résultat du test"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -10105,61 +10342,65 @@ msgstr "Trier"
 msgid "or Problems from"
 msgstr "Problèmes %1 : "
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr "hors de"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 #, fuzzy
 msgid "permissions for %1 not defined"
 msgstr "les permissions pour %1 se sont pas définies"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr "pg debug"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr "pg erreur interne"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr "pg avertissement"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 #, fuzzy
 msgid "point"
 msgstr "Indices"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 #, fuzzy
 msgid "points"
 msgstr "Indices"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 #, fuzzy
 msgid "preview answers"
 msgstr "Visualiser les réponses"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 #, fuzzy
 msgid "problem"
 msgstr "Problème %1"
@@ -10180,8 +10421,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 #, fuzzy
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr "Erreur readSetDef, impossible de lire la ligne ||%1||"
@@ -10199,21 +10440,21 @@ msgid "record for user %1 not found"
 msgstr "Enregistrement pour l'utilisateur %1 introuvable"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 #, fuzzy
 msgid "record for visible user %1 not found"
 msgstr "enregistrement pour l'utilisateur visible %1 est introuvable"
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 #, fuzzy
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 "restriction de lieu %1 n'existe pas. Les restrictions IP ont été ignorées."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 #, fuzzy
 msgid "row"
 msgstr "Naviguer "
@@ -10243,15 +10484,15 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 #, fuzzy
 msgid "selected achievements"
 msgstr "devoirs sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 #, fuzzy
 msgid "selected achievements."
 msgstr "devoirs sélectionnés"
@@ -10273,17 +10514,17 @@ msgid "selected sets"
 msgstr "devoirs sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "usagers sélectionnés"
 
@@ -10324,7 +10565,7 @@ msgid "showing all sets"
 msgstr "affichage de tous les devoirs"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "affichage de tous les usagers"
 
@@ -10344,7 +10585,7 @@ msgid "showing matching sets"
 msgstr "affichage des usagers correspondant"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "affichage des usagers correspondant"
 
@@ -10354,7 +10595,7 @@ msgid "showing no sets"
 msgstr "affichage d'aucun devoir"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "affichage d'aucun usager"
 
@@ -10364,7 +10605,7 @@ msgid "showing selected sets"
 msgstr "affichage des devoirs sélectionnés"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "affichage des usagers sélectionnés"
 
@@ -10373,6 +10614,10 @@ msgstr "affichage des usagers sélectionnés"
 #, fuzzy
 msgid "showing visible sets"
 msgstr "exportation des devoirs visibles"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -10392,19 +10637,19 @@ msgid "students"
 msgstr "étudiant"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "submission"
 msgstr "Soumettre les réponses"
 
 #
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "submission (test %1)"
 msgstr "Soumettre les réponses"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -10415,7 +10660,7 @@ msgstr "Données"
 
 #
 # pourquoi tr :?
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "test"
 msgstr "tr: %1 test"
@@ -10423,7 +10668,7 @@ msgstr "tr: %1 test"
 #
 # pourquoi tr :?
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "test (%1)"
 msgstr "tr: %1 test"
@@ -10441,7 +10686,7 @@ msgstr "Date du test"
 msgid "test time"
 msgstr "tr: %1 test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 #, fuzzy
 msgid "the following file"
 msgstr "les fichiers suivants"
@@ -10452,14 +10697,14 @@ msgstr "les fichiers suivants"
 
 #
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 #, fuzzy
 msgid "the original path to the file is %1"
 msgstr "Le chemin original de ce fichier est %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr "puis par"
 
@@ -10467,9 +10712,13 @@ msgstr "puis par"
 msgid "then delete them"
 msgstr "et les effacer ensuite"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
 # avant: msgstr "Soumettre ses réponses"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "reprise"
 
@@ -10478,46 +10727,43 @@ msgid "time limit exceeded"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "reprises"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
 msgstr "à"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
-msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 #, fuzzy
 msgid "top score"
 msgstr "Résultat du test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 #, fuzzy
 msgid "unable to write to directory %1"
 msgstr "Impossible d'écrire dans le fichier %1"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "illimité"
 
@@ -10528,30 +10774,30 @@ msgstr "illimité"
 msgid "userID: %1 --"
 msgstr "Remplacer %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr "utlisateur"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "usagers qui correspondent aux champs sélectionnés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr "Utilisateurs correspondants:"
 
 # avant: msgstr "usagers qui correspondent pour les champs sélectionnés"
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "visible"
@@ -10566,21 +10812,26 @@ msgid "visible sets"
 msgstr "devoirs visibles"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "visible pour les étudiants"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "usagers visibles"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -10588,15 +10839,38 @@ msgstr "avec le nom des devoirs:"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 #, fuzzy
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr "incapable de lire le fichier %1 /%2: Existe-t-il? Est-il lisible?"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #, fuzzy
 msgid "your students"
 msgstr "pour les étudiants"
+
+#, fuzzy
+#~ msgid "Import achievements from"
+#~ msgstr "Activer les objectifs des cours"
+
+#
+#, fuzzy
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "Points partiels débutent: %1"
+
+#
+#, fuzzy
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "Points partiels débutent: %1"
+
+#
+#, fuzzy
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "Points partiels débutent: %1"
 
 #
 # vérifier le contexte: Je vois "answers due" et "answer available", mais pas answer date
@@ -10695,11 +10969,6 @@ msgstr "pour les étudiants"
 #
 #~ msgid "No sets selected for scoring."
 #~ msgstr "Aucun devoir sélectionné pour la notation."
-
-#
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "Note"
 
 #~ msgid "Recitation:"
 #~ msgstr "Récitation:"
@@ -11040,15 +11309,6 @@ msgstr "pour les étudiants"
 #
 #~ msgid "Published"
 #~ msgstr "Publié"
-
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "La boîte de saisie contient actuellement le code source du problème "
-#~ "original. Les modifications perdues peuvent être récupérées en utilisant "
-#~ "le bouton Précédent du navigateur web."
 
 #
 #~ msgid ""

--- a/lib/WeBWorK/Localize/heb.po
+++ b/lib/WeBWorK/Localize/heb.po
@@ -1,119 +1,103 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+# Translators:
+# Michael Oren Perlstein <michaelore@campus.technion.ac.il>, 2018
+# Nathan Wallach <tani@mathnet.technion.ac.il>, 2018
+# Ran Kiri <rankiri@campus.technion.ac.il>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: WeBWorK Online Homework System\n"
+"Project-Id-Version: webwork2\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2016-03-21 14:37-0500\n"
-"Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: WeBWorK language team <gage@math.rochester.edu>\n"
-"Language: he_IL\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Michael Oren Perlstein <michaelore@campus.technion.ac.il>\n"
+"Language-Team: Hebrew (http://www.transifex.com/webwork/webwork2/language/"
+"he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
-#, fuzzy
 msgid "#corr"
-msgstr "נכון"
+msgstr "# נכון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
-#, fuzzy
 msgid "#incorr"
-msgstr "לא נכון"
+msgstr "#שגוי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
-#, fuzzy
 msgid "% correct"
-msgstr "נכון [1_]%"
+msgstr "% נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
 msgid "% correct with review"
-msgstr ""
+msgstr "% נכון עם ביקורת"
 
-#
+# Percent students
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
-#, fuzzy
 msgid "% students"
-msgstr "tr: visible to students"
+msgstr "% תלמידים"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
 msgid "%1 (old editor)"
-msgstr ""
+msgstr "%1 (עורך ישן)"
 
-#
+# Gateway (test 3)
 #. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
-#, fuzzy
 msgid "%1 (test %2)"
-msgstr "tr: %1 (test %2)"
+msgstr "%1 (מבחן %2)"
 
-#
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
-#, fuzzy
 msgid "%1 Points:"
-msgstr "הראה רמזים"
+msgstr "%1 נקודות:"
 
-#
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
-#, fuzzy
 msgid "%1 Problems:"
-msgstr "בעיות"
+msgstr "%1 שאלות:"
 
-#
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
-#, fuzzy
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr "tr: %1 sets exported, %2 sets skipped. Skipped sets: (%3)"
+msgstr "%1 גליונות נוספו, %2 גליונות שעליהם דילגו. הגליונות שעליהם דילגו: (%3)"
 
-#
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
-#, fuzzy
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
-msgstr "tr: %1 sets exported, %2 sets skipped. Skipped sets: (%3)"
+msgstr "%1 גליונות יוצאו, %2 גליונות שעליהם דילגו. הגליונות שעליהם דילגו: (%3)"
 
-#
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
-#, fuzzy
 msgid "%1 students out of %2"
-msgstr "tr: visible to students"
+msgstr "%1 תלמידים מתוך %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
-msgstr ""
+msgstr "%1 כותרת ומוסד שונו מ%2 ל%3 ומ%4 ל%5"
 
-#
 #. (scalar @userIDsToExport, $dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
-#, fuzzy
 msgid "%1 users exported to file %2/%3"
-msgstr "tr: %1 users exported to file %2/%3"
+msgstr "%1 משתמשים יוצאו לקובץ %2/%3"
 
-#
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
-#, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
-"tr: %1 users replaced, %2 users added, %3 users skipped.  Skipped users: (%4)"
+"%1 משתמשים הוחלפו, %2 משתמשים הוספו, על %3 משתמשים דילגו. המשתמשים שעליהם "
+"דילגו: (%4) "
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
@@ -123,191 +107,160 @@ msgid ""
 "Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
 "again."
 msgstr ""
+"%1 משתמש במערכת אימות חיצונית (כגון Oncourse, CAS, Blackboard, Moodle, "
+"Canvas, וכו'.) בבקשה חזור למערכת בה השתמשת ונסה שוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:97
 msgid ""
 "%1 uses an external authentication system.  You've authenticated through "
 "that system, but aren't allowed to log in to this course."
 msgstr ""
+"%1 משתמש במערכת אימות חיצונית. אומתת במערכת החיצונית, אבל אתה לא רשאי להתחבר "
+"לקורס הזה."
 
-#
 #. ($levelpercentage)
 #. ($percentage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
-#, fuzzy
 msgid "%1% Complete"
-msgstr "tr: completely"
+msgstr "%1% הושלמו"
 
-#
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
-#, fuzzy
 msgid "%1% correct"
-msgstr "נכון [1_]%"
+msgstr "%1% נכון"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
-#, fuzzy
 msgid "%1's Current Address"
-msgstr "%1 için Mevcut Adres"
+msgstr "הכתובת הנוכחית של %1"
 
-#
 #. ($user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
-#, fuzzy
 msgid "%1's Current Password"
-msgstr "%1 için Mevcut Şifre"
+msgstr "הסיסמה הנוכחית של %1"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
-#, fuzzy
 msgid "%1's New Address"
-msgstr "%1 için Yeni Adres"
+msgstr "הכתובת החדשה של %1"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
-#, fuzzy
 msgid "%1's New Password"
-msgstr "%1 için Yeni Şifre"
+msgstr "הסיסמה החדשה של %1"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
-#, fuzzy
 msgid "%1's new password cannot be blank."
-msgstr "%1 için yeni şifre boş bırakılamaz."
+msgstr "הסיסמה החדשה של %1 לא יכולה להיות ריקה"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
-#, fuzzy
 msgid "%1's password has been changed."
-msgstr "%1 adlı kullanıcının şifresi değiştirildi."
+msgstr "הסיסמה של %1 שונתה"
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
-#, fuzzy
 msgid "%1: Problem %2"
-msgstr "בעיה [2_[1_]"
+msgstr "%1: שאלה %2"
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
-#, fuzzy
 msgid "%1: Problem %2 Show Me Another"
-msgstr "בעיה [2_[1_]"
+msgstr "%1: שאלה %2 תראה לי עוד אחת"
 
-#
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
-#, fuzzy
 msgid "%1: The directory for the course not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr "%1: התקיה של הקורס לא נמצאה."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
 msgid "%quant(%1,course was, courses were) successfully unhidden."
-msgstr ""
+msgstr "%quant(%1,קורס נהפך לגלוי, קורסים נהפכו לגלויים) בהצלחה."
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:297
 msgid "%quant(%1,error) occured while generating hardcopy:"
-msgstr ""
+msgstr "%quant(%1,שגיאה קרתה, שגיאות קרו) בזמן ההכנה להדפסה:"
 
 #. ($n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:802
 msgid "%quant(%1,file) unpacked successfully"
-msgstr ""
+msgstr "%quant(%1,קובץ נפרק,קבצים נפרקו) נפרק בהצלחה"
 
 #. ($numBlanks)
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
-msgstr ""
+msgstr "%quant(%1, מהשאלות לא נענתה, מהשאלות לא נענו)."
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
 msgid "%quant_1( course was, courses were) successfully hidden."
-msgstr ""
+msgstr "%quant_1(הקורס הוחבא, הקורסים הוחבאו) בהצלחה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
-#, fuzzy
 msgid "%score"
-msgstr "ניקוד"
+msgstr "מתוך 100"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
 msgid "(Any unsaved changes will be lost.)"
-msgstr ""
+msgstr "(כל שינויים שלא נשמרו ימחקו)"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
-msgstr ""
+msgstr "(צפייה ברמז למדריך: הראה לתלמיד את הרמז לאחר מספר זה של נסיונות:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
 msgid "(This problem will not count towards your grade.)"
-msgstr "(Bu soru notunuzu etkilemeyecektir.)"
+msgstr "(שאלה זו לא תחשב בחישוב הציון לגליון.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
-msgstr ""
+msgstr "(מבחן זה הוגש באיחור מכיוון שהוא לא הוגש בזמן המוגדר.)"
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
-#, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "(הניקוד שלך על זה %1 לא זמין עד %2.)"
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
-#, fuzzy
 msgid "(Your score on this %1 is not available.)"
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "(הניקוד שלך על זה  %1 לא זמין.)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
-#, fuzzy
 msgid "(correct)"
-msgstr "נכון"
+msgstr "(נכון)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
 msgid "(gw/quiz) After version answer date"
-msgstr ""
+msgstr "(מחסום/בוחן) אחרי תאריך התשובות של הגירסה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
-#, fuzzy
 msgid "(incorrect)"
-msgstr "לא נכון"
+msgstr "(לא נכון)"
 
-#
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
-#, fuzzy
 msgid "(score %1)"
-msgstr "ניקוד"
+msgstr "(ניקוד %1)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
-#, fuzzy
 msgid "1 student"
-msgstr "tr: Student ID"
+msgstr "1 תלמיד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
 msgid ""
@@ -323,7 +276,17 @@ msgid ""
 "std_problem_grader (the all or nothing grader). It will work with custom "
 "graders if they are written appropriately.</p>"
 msgstr ""
+"<p>לאחר תאריך הניקוד המופחת כל ,תשובות נוספות של התלמיד יקבלו ערך מופחת. כאן "
+"ניתן למלא את הערך המופת באחוזים. לדוגמה, אם הערך הוא 50% ותלמיד צופה בבעיה "
+"בזמן תקופת הניקוד המופחת, הוא יראה את ההודעה \"אתה בתקופת ניקוד מופחת: כל "
+"הגשה נוספת תחשב כ-50% מהניקוד המקורי.\"</p><p>כדי להשתמש אפשרות זאת, יש גם "
+"לאפשר ניקוד מופחת ולבחור תאריך ניקוד מופחת לכל מטלה בנפרד, על-ידי עריכתו של "
+"הנתונים של האוסף בעזרת עורך אוספי שיעורי הבית.</p><p>זה עובד עם "
+"avg_problem_grader (שהוא המנקד לפי ברירת המחדל) ועם std_problem_grader "
+"( מנקד לפי הכל או כלום). זה יעבוד גם עם מנקדים שנכתבו על-ידי המשתמשים, אם הם "
+"נכתבו כנדרש.</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
@@ -337,7 +300,17 @@ msgid ""
 "least one display mode. If you select only one, then the options box will "
 "not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
+"<p>בזמן צפייה בשאלה משתמשים יכולים לבחור שיטות שונות לכתיבת נוסחאות באמצעות "
+"קופסאת האפשריות שנמצאת בפאנל השמאלי. כאן, ניתן להתאים את האפשרויות התצוגה "
+"שיוצגו.</p><p>אפשרויות תצוגה מסוימות דורשות תוכנות נוספות שצריכות להיות "
+"מתקנות על השרת. כדאי לודא שכל האפשרויות שנבחרו עובדות מהשרת שלך.</"
+"p><p>אפשרויות התצוגה הן<ul><li>טקסט רגיל: מראה את מחרוזות ה-LaTeX הגולמיות "
+"עבור נוסחאות.<li>תמונות: מיצר תמונות בעזרת התוכנות החיצוניות LaTeX ו-dvipng. "
+"<li>MathJax: יורשו של jsMath, משתמש ב-javascript על מנת להציג משוואות.</ul></"
+"p></p>חובה להשתמש בלפחות אפשרות תצוגה אחת. אם נבחרה רק אחת, אז קופסאת "
+"האפשרויות לא תתן לבחור אפשרות תצוגה(בגלל שרק אחת תהיה פעילה)</p>"
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
 msgid ""
 "<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
@@ -352,15 +325,23 @@ msgid ""
 "unless you check at least one of these options - the students would simply "
 "see a new version that they can not attempt or learn from.</p>"
 msgstr ""
+"<ul><li><b>תלע\"א-בדוק תשובות</b>: מפעיל את כפתור בדיקת התשובות<i>עבור השאלה "
+"החדשה</i> כשנלחץ כפתור \"תראה לי עוד אחת\" </li> <li><b>תלע\"א-תראה פתרונות</"
+"b>: מראה פתרון כולל דרך<i>עבור השעלה החדשה</i> כשנלחץ כפתור \"תראה לי עוד אחת"
+"\" ראשית מתבצעת בדיקה שמודא שקיים פתרון </li><li><b>תלע\"א-תראה נכונות</b>: "
+"נתן לצפות בפתרונות נכונים עבור <i>השאלה החדשה</i> כשכפתור \"תראה לי עוד אחת"
+"\" נלחץ; שים לב שיש להפעיל את <b>תלע\"א-בדוק תשובות</b> באותו הזמן</"
+"li><li><b>תלע\"א-תראה רמזים</b>: מראה רמזים <i>עבור השאלה החדשה</i>(בהנחה "
+"שקיימים)</li></ul> שים לב: אין ממש סיבה להפעיל את הכפתור אלא עם כן מופעלות "
+"לפחות אחת מאפשרויות אלו - התלמידים פשוט יראו גרסה חדשה שהם לא יכולים לפתור "
+"או ללמוד ממנה.</p>"
 
-#
 #. ($add_courseID)
 #. ($rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
-#, fuzzy
 msgid "A course with ID %1 already exists."
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr "קורס עם מזהה %1 כבר קיים."
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
@@ -368,13 +349,12 @@ msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
+"תקייה עם השם %1 כבר קיימת. יש למחוק את הקורס הזה לפני שניתן להוציאו מהארכיון."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
-#, fuzzy
 msgid "A file with that name already exists"
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr "כבר קיים קובץ עם שם זה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
@@ -382,13 +362,15 @@ msgid ""
 "check that no problems are missing and that they are all legible. If not, "
 "please inform your instructor."
 msgstr ""
+"הוכן קובץ להדפסה, אבל הוא עשוי להיות חלקי או שגוי. אנא בדוק ששום שאלות אינן "
+"חסרות וכולן קריאות. אם לא, אנא פנה למדריך שלך."
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
-msgstr ""
+msgstr "קבר קיים מיקום בשם %1 במסד הנתונים. האם התכוונת לערוך אותו?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
@@ -396,25 +378,21 @@ msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
+"הודעה עם הנושא \"%1\" נשלחה ל-%quant(%2, נמען) בכיתה %3.  לא היה נתן לשלוח "
+"%4 הודעה/ות."
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
-#, fuzzy
 msgid "A new file has been created at '%1'"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr "נוצר קובץ חדש ב-'%1'"
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
-#, fuzzy
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
-msgstr ""
-"tr: A new file has been created at '%1' with the contents below. No changes "
-"have been made to set %2."
+msgstr "נוצר קובץ חדש ב-'%1' עם התוכן שמפורט למטה. לא נעשו שינויים באוסף %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -422,7 +400,10 @@ msgid ""
 "to 100 indicates the grade earned. The number on the second line gives the "
 "number of incorrect attempts."
 msgstr ""
+"נוקדה (.) מסמל שהשאלה לא נוסתה, והמספר מ-0 ל-100 מראה את הניקוד. המספר בשורה "
+"השנייה הוא מספר הניסיונות הלא נכונים."
 
+# Leave symbol codes in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
 msgid ""
 "A switch to govern the use of a Progress Bar for the student; this also "
@@ -430,6 +411,9 @@ msgid ""
 "and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
 "(&#x2717;), or unattempted (no symbol)."
 msgstr ""
+"מתג ששולט בשימוש במד ההתקדמות עבור התלמיד; המתג גם מפעיל/מכבה את הדגשת השעלה "
+"הנוכחית בסרגל הצד, והאם היא נכונה (&#x2713;), מתבצעת (&hellip;), שגויה "
+"(&#x2717;), או לא נוסתה כלל (ללא סימון)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:101
 msgid ""
@@ -446,36 +430,37 @@ msgid ""
 "Clicking the links in the entries in the assigned sets columns will take you "
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
+"טבלה שמראה את כל המשתמשים העשיויים ובנוסף מס' נתונים על המשתמשים. הנתונים "
+"מימין לשמאל: שם משתמש, מצב התחברות, אוספים שהוקצאו, שם פרטי, שם משפחה, כתובת "
+"דוא\"ל, מס' תלמיד, מצב לימודים, קבוצה, תרגול, תגובות, והרשאות. לחיצה על "
+"הקישורים בראש העמוד תמhין את הטבלה לפי הנתון המתאים. תאי שם המשתמשים מכילים "
+"ריבועים לסימון בחירת המשתמש. לחיצה על הקישור שבשם עצמו יאפשר פהתחזות לאותו "
+"משתמש. יהיה גם תמונת קישור לאחר השם שיוביל לעמוד בו ניתן את פרטי אותו "
+"המשתמש. לחיצה על דוא\"ל תאפשר שליחת דוא\"ל לאותו המשתמש. הקישורים בעמודת "
+"האוספים שהוקצאו מובילים לעמוד בו ניתן לראות ולהקצות אוספים עבור אותו משתשמש."
 
+# Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
 msgid "ADJ STATUS"
-msgstr ""
+msgstr "סטטוס מותאם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
-#, fuzzy
 msgid "ANSWERS NOT RECORDED"
-msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
+msgstr "תשובות לא נשמרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
-#, fuzzy
 msgid "ANSWERS NOT RECORDED --"
-msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
+msgstr "תשובות לא נשמרו --"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
-#, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
-msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
+msgstr "תשובות רק נבדקו --"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
-msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
+msgstr "התשובות נבדקו בלבד --  תשובות לא נשמרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
@@ -483,122 +468,108 @@ msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
 msgid "Abandon changes"
-msgstr "tr: Abandon changes"
+msgstr "בטל שינויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
-msgstr "tr: Abandon export"
+msgstr "בטל יצוא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
-#, fuzzy
 msgid "Achievement"
-msgstr "tr: selected sets"
+msgstr "הישג"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
 msgid "Achievement %1 created with evaluator '%2'."
-msgstr ""
+msgstr "הישג %1 נוצר עם מעריך '%2'."
 
-#
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
-#, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr "הישג %1 קיים. לא נוצר הישג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
 msgid "Achievement Editor"
-msgstr ""
+msgstr "עורך הישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:726
 msgid "Achievement Evaluator Editor"
-msgstr ""
+msgstr "עורך מעריכי הישגים"
 
 #. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:173
 msgid "Achievement Evaluator for achievement %1"
-msgstr ""
+msgstr "מעריך הישגים עבור הישג %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 msgid "Achievement ID"
-msgstr ""
+msgstr "מזהה הישג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
-msgstr ""
+msgstr "מזהה הישג כבר קיים! לא נוצר הישג חדש. קובץ לא נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:202
 msgid "Achievement Points Per Problem"
-msgstr ""
+msgstr "נקודות הישג עבור כל שאלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:736
 msgid "Achievement User Editor"
-msgstr ""
+msgstr "עורך משתמש יעידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
-#, fuzzy
 msgid "Achievement has been assigned to all users."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "ההישג הוקצה לכל המשתמשים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
-msgstr ""
+msgstr "ההישג הוסר לכל המשתמשים."
 
-#
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
-#, fuzzy
 msgid "Achievement scores saved to %1"
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "נקודות הישגים נשמרו ל-%1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
-#, fuzzy
 msgid "Achievements"
-msgstr "tr: selected sets"
+msgstr "הישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "Act as"
-msgstr ""
+msgstr "התחזה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:161
 msgid "Act as:"
-msgstr ""
+msgstr "מתחזה ל-:"
 
-#
 #. (HTML::Entities::encode_entities($eUserID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
-#, fuzzy
 msgid "Acting as %1."
-msgstr "%1 gibi davranılıyor."
+msgstr "מתחזה ל%1."
 
-#
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
-#, fuzzy
 msgid "Action %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr "פעולה %1 לא נמצאה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Active"
-msgstr "tr: Active"
+msgstr "פעיל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:198
 msgid ""
 "Activiating this will enable Mathchievements for webwork.  Mathchievements "
 "can be managed by using the Achievement Editor link."
 msgstr ""
+"מאפשר הישגי מתמטיקה עבור webwork. הישגי מתמטיקה ניתנים לשינוי בעזרת הקישור "
+"לעורך היעדים. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:208
 msgid ""
@@ -606,79 +577,64 @@ msgid ""
 "students who earn achievements with items that allow them to affect their "
 "homework in a limited way."
 msgstr ""
+"מאפשר חפצי הישגים. כלי זה מזכה תלמידים שזכו בהישגים בחפצים שיאפשרו להם "
+"להשפיע על שיעורי הבית שלהם באופן מוגבל."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
-msgstr "tr: Add"
+msgstr "הוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:942
 msgid "Add All"
-msgstr ""
+msgstr "הוסף הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
-#, fuzzy
 msgid "Add Course"
-msgstr "קורסים"
+msgstr "הוסף קורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
-#, fuzzy
 msgid "Add Students"
-msgstr "tr: visible to students"
+msgstr "הוסף תלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
-#, fuzzy
 msgid "Add Users"
 msgstr "הוסף משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid "Add WeBWorK administrators to new course"
-msgstr ""
+msgstr "הוסף מנהלי WeBWorK לקורס חדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1384
 msgid "Add a new test for which Gateway?"
-msgstr ""
+msgstr "הוסף מבחן חדש לאיזה בוחן מחסום?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
-#, fuzzy
 msgid "Add as what filetype?"
-msgstr "tr: Add as what filetype?"
+msgstr "איזה סוג קובץ להוסיף?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
 msgid "Add how many students?"
-msgstr "tr: Add how many students?"
+msgstr "כמה סטודנטים להוסיף?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
-#, fuzzy
 msgid "Add problems to"
-msgstr "tr: Add problem"
+msgstr "הוסף שאלות ל-"
 
-#
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
-#, fuzzy
 msgid "Add to what set?"
-msgstr "tr: Add to which set?"
+msgstr "הוסף לאיזה אוסף?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
 msgid "Add which new users?"
-msgstr "tr: Add which new users?"
+msgstr "איזה משתמשים להוסיף?"
 
-#
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_path, $setID, $targetProblemNumber)
@@ -688,34 +644,29 @@ msgstr "tr: Add which new users?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
-#, fuzzy
 msgid "Added %1 to %2 as problem %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr "נוסף %1 ל%2 בתור שאלה %3"
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
-#, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
-msgstr "tr: Added '%1' to %2 as new set header"
+msgstr "נוסף '%1' ל%2 בתור קידומת הדפסה חדשה"
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
-#, fuzzy
 msgid "Added '%1' to %2 as new set header"
-msgstr "tr: Added '%1' to %2 as new set header"
+msgstr "נוסף '%1' ל%2 בתור קידומת אוסף חדשה"
 
 #. (join(', ', @toAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
 msgid "Added addresses %1 to location %2."
-msgstr ""
+msgstr "נוספו כתובות %1 למיקום %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:409
 msgid "Additional addresses for receiving feedback e-mail."
-msgstr ""
+msgstr "כתובות נוספות לקבלת משוב בדוא\"ל."
 
 #. ($badLocAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
@@ -723,20 +674,22 @@ msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
+"כתובת(/ות) %1 כבר קיימת במסד הנתונים. זה לא אמור לקרות! אנא בדוק שנית את "
+"אמינות מסד הנתונים של WeBWorK לפני שאתה ממשיך."
 
 #. (join(', ', @noAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
-msgstr ""
+msgstr "הכתובת(/ות) %1 שברשימת ההוספה כבר במיקום %2, ולכן דולגה(/ו)."
 
 #. (join(', ', @noDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
-msgstr ""
+msgstr "הכתובת(/ות) %1 שברשימת המחיקה לא במיקום %2, ולכן דולגה(/ו)."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
@@ -744,6 +697,7 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
+"הכתובת(ות) %1 היא(/הן) לא בצורה מזוהה. אנא בדוק את הנתונים שהוזנו ושלח שוב."
 
 #. ($badAddr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
@@ -751,12 +705,11 @@ msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
+"הכתובת(ות) %1 היא(/הן) לא בצורה מזוהה. אנא בדוק את הנתונים שהוזנו ונסה שוב."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Addresses"
-msgstr "tr: Email Address"
+msgstr "כתובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
 msgid ""
@@ -764,6 +717,9 @@ msgid ""
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"כתובות למיקום חדש. הכנס אחת בכל שורה, בתור כתובת IP יחידה, לדוגמה "
+"192.168.1.101), מסכת כתובת (לדוגמה 192.168.1.0/24), או טווח IP (לדוגמה "
+"192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid ""
@@ -771,186 +727,158 @@ msgid ""
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
 "ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
+"כתובות להוספה למיקום. הכנס אחת בכל שורה, בתור כתובת IP יחידה, (לדוגמה "
+"192.168.1.101), מסכת כתובת (לדוגמה 192.168.1.0/24), או טווח IP (לדוגמה "
+"192.168.1.101-192.168.1.150)):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:190
 msgid "Adds 24 hours to the close date of a homework."
-msgstr ""
+msgstr "הוסף 24 שעות לתאריך סגירת שיעורי הבית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:273
 msgid "Adds 48 hours to the close date of a homework."
-msgstr ""
+msgstr "הוסף 48 שעות לתאריך סגירת שיעורי הבית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 msgid "Adjusted Status"
-msgstr ""
+msgstr "סטטוס מותאם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:595
 msgid "Advanced Search"
-msgstr ""
+msgstr "חיפוש מתקדם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
-#, fuzzy
 msgid "After set answer date"
-msgstr "tr: Answer Date"
+msgstr "לאחר תאריך התשובות של האוסף"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
-msgstr ""
+msgstr "לאחר תחילת תקופת הניקוד המופחת, כל ניקוד נספר כ-%1% מערכו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715
 msgid "All Selected Constraints Joined by \"And\""
-msgstr ""
+msgstr "כל ההגלות שנבחרו יחוברו על ידי \"ו-\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:52
 msgid "All assignments were made successfully."
-msgstr ""
+msgstr "כל המטלות בוצעו בהצלחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
-#, fuzzy
 msgid "All of the answers above are correct."
-msgstr "Yanıtların tümü doğru"
+msgstr "כל התשובות לעיל הם נכונות."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
-#, fuzzy
 msgid "All of the gradeable answers above are correct."
-msgstr "Yanıtların tümü doğru"
+msgstr "כל התשבות לעיל שניתנות לניקוד הן נכונותם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "All of these files will also be made available for mail merge."
-msgstr ""
+msgstr "כל הקבצים הללו יהיו נגשים לאיחוד דואר."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
-#, fuzzy
 msgid "All selected sets hidden from all students"
-msgstr "tr: All selected sets %1 all students"
+msgstr "כל האוספים שנבחרו הם מוחבאים מכל התלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
-#, fuzzy
 msgid "All selected sets made visible for all students"
-msgstr "tr: All selected sets %1 all students"
+msgstr "כל האוספים שנבחרו הם ניתנים לצפייה לכל התלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
-#, fuzzy
 msgid "All sets hidden from all students"
-msgstr "tr: hidden from students"
+msgstr "כל האוספים הם מוחבאים מכל התלמדים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
-#, fuzzy
 msgid "All sets made visible for all students"
-msgstr "tr: visible to students"
+msgstr "כל האוספים הם ניתנים לצפייה לכל התלמידים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "All students in course"
-msgstr ""
+msgstr "כל התלמידים בקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:57
 msgid "All unassignments were made successfully."
-msgstr ""
+msgstr "כל ביטולי ההקצאות בוצעו בהצלחה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
-#, fuzzy
 msgid "All visible hidden from all students"
-msgstr "tr: All visible sets %1 all students"
+msgstr "כל הנראים כאן הם מוחבאים מכל התלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
-#, fuzzy
 msgid "All visible sets made visible for all students"
-msgstr "tr: All visible sets %1 all students"
+msgstr "כל האוספים הנראים כאן הם ניתנים לצפייה לכל התלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
-#, fuzzy
 msgid "Allow unassign"
-msgstr "tr: Edit Assigned Users"
+msgstr "אפשר לבטל הקצאה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
 msgid "Allowed error, as a percentage, for numerical comparisons"
-msgstr ""
+msgstr "שגיאה מותרת, באחוזים, להשוואה מספרית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
-#, fuzzy
 msgid "Allowed to <em>act as</em> another user"
-msgstr "הראה תשובות"
+msgstr "מורשה <em>להתחזות</em> למשתמש אחר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
-#, fuzzy
 msgid "Allowed to change their e-mail address"
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr "מורשה לשנות כתובת דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
-#, fuzzy
 msgid "Allowed to change their password"
-msgstr "%1 adlı kullanıcının şifresi değiştirilemedi: %2"
+msgstr "מורשה לשנות סיסמה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
-#, fuzzy
 msgid "Allowed to login to the course"
-msgstr "הראה תשובות"
+msgstr "מורשה להתחבר לקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
 msgid "Allowed to see solutions before the answer date"
-msgstr ""
+msgstr "מורשה לראות תשובות לפני תאריך התשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:324
 msgid "Allowed to see the correct answers before the answer date"
-msgstr ""
+msgstr "מורשה לראות תשובות נכונות לפני תאריך התשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
-#, fuzzy
 msgid "Allowed to view past answers"
-msgstr "הראה תשובות"
+msgstr "מורשה לראות תשובות מהעבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
 msgid "Allowed to view problems in sets which are not open yet"
-msgstr ""
+msgstr "מורש לצפות בשאלו באוספים שעדיין לא נפתחו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1441
 msgid "Amulet of Extension"
-msgstr ""
+msgstr "תליון ההארכה"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
 msgid "An error occured while archiving the course %1:"
-msgstr ""
+msgstr "שגיאה ארעה בזמן הוספת הקורס %1 לארכיון:"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
 msgid "An error occured while changing the title of the course %1."
-msgstr ""
+msgstr "שגיאה ארעה בזמן שינוי כותרתו של הקורס %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
 msgid "An error occured while deleting the course %1:"
-msgstr ""
+msgstr "שגיאה ארעה בזמן מחיקת הקורס %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
 msgid "An error occured while renaming the course %1 to %2:"
-msgstr ""
+msgstr "שגיאה ארעה בזמן שינוי השם של הקורס %1 ל-%2:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:782
@@ -959,15 +887,12 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:805
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:828
 msgid "Answer Date"
-msgstr "tr: Answer Date"
+msgstr "תאריך תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
-#, fuzzy
 msgid "Answer Log"
-msgstr "בדוק תשובות"
+msgstr "רשימת תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Answer Preview"
@@ -975,62 +900,53 @@ msgstr "תצוגה מקדימה של תשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1268
 msgid "Answer(s) submitted:"
-msgstr ""
+msgstr "תשובה/ות שנשלחו:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
-#, fuzzy
 msgid "Answer:"
-msgstr "בדוק תשובות"
+msgstr "תשובה:"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
 msgid "AnswerGroupInfo"
-msgstr ""
+msgstr "מידע קבוצת תשובות"
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
 msgid "AnswerHashInfo"
-msgstr ""
+msgstr "מידע גיבוב תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
-#, fuzzy
 msgid "Answers"
-msgstr "בדוק תשובות"
+msgstr "תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
-#, fuzzy
 msgid "Answers Available"
-msgstr "סגור, תשובות זמינות"
+msgstr "תשובות זמינות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
 msgid "Answers cannot be due until on or after the open date!"
-msgstr ""
+msgstr "תאריך התשובות לא יכול להיות לפני או בזמן תאריך הפתיחה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1050
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1123
 msgid "Answers cannot be made available until on or after the close date!"
-msgstr ""
+msgstr "תשובות לא יכולות להפוך לזמינות עד זמן או לאחר תאריך הסגירה!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
-msgstr ""
-"tr: Any changes made below will be reflected in the set for ALL students."
+msgstr "כל שינוי שנעשה למטה יוחל על האוסף עבור כל התלמידים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
-#, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
-msgstr ""
-"tr: Any changes made below will be reflected in the set for ALL students."
+msgstr "כל שינוי שנעשה למטה יופיע באוסף רק עבור התלמיד/ים למעלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -1038,71 +954,62 @@ msgid ""
 "be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
+"כל פעם שמשנים שמספרי שאלות, השאלות תמיד ימוספרו באופן עוקב מהמספר אחד. "
+"כשמוחקים שאלות, ישארו רווחים במספור אלא עם כן סומנה האפשרות למעלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
 msgid "Append"
-msgstr ""
+msgstr "צרף"
 
-#
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
-#, fuzzy
 msgid "Append to end of %1 set"
-msgstr "tr: Append to end of set %1"
+msgstr "צרף בסופו של האוסף %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
-#, fuzzy
 msgid "Archive"
-msgstr "קורסים"
+msgstr "הוסף לארכיון"
 
 #. ($archive, $n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
 msgid "Archive '%1' created successfully (%quant( %2, file))"
-msgstr ""
+msgstr "ארכיון '%1\" נוצר בהצלחה  (%quant( %2, קובץ))"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:938
 msgid "Archive '%1' deleted"
-msgstr ""
+msgstr "ארכיון '%1' נמחק"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Archive Course"
-msgstr ""
+msgstr "הוסף קורס לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
-#, fuzzy
 msgid "Archive Courses"
-msgstr "קורסים"
+msgstr "הוסף קורסים לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
-#, fuzzy
 msgid "Archive next course"
-msgstr "קורסים"
+msgstr "הוסף את הקורס הבא לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
-#, fuzzy
 msgid "Archive this Course"
-msgstr "קורסים"
+msgstr "הוסף את הקורס הזה לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
-#, fuzzy
 msgid "Archived Courses"
-msgstr "קורסים"
+msgstr "קרוסים בארכיון"
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
 msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
+"מוסיף את הקורס לארכיון בתור %1.tar.gz. רענן את מנהל הקבצים כדי לראות אותו."
 
 #. (CGI::b($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
@@ -1110,6 +1017,7 @@ msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
+"אתה בטוח שאתה רוצה למחוק את הקורס %1 אחרי שהוא נוסף לארכיון? זה בלתי הפיך!"
 
 #. (CGI::b($delete_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
@@ -1117,88 +1025,71 @@ msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
+"אתה בטוח שאתה למחוק את הקורס %1? כל המידע והקבצים של הקורס ימחקו. זה בלתי "
+"הפיך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
-#, fuzzy
 msgid "Assign"
-msgstr "tr: Edit Assigned Users"
+msgstr "הקצה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
-msgstr ""
+msgstr "הקצה את כל האוספים למשתמש הנוכחי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
-#, fuzzy
 msgid "Assign selected sets to selected users"
-msgstr "tr: Assign this set to which users?"
+msgstr "הקצה את האוספים שנבחרו לתלמידים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
-msgstr "tr: Assign this set to which users?"
+msgstr "לאיזה משתמשים להקצות אוסף זה?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "Assign to All Current Users"
-msgstr ""
+msgstr "הקצה לכל המשתמשים הנוכחיים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Assigned"
-msgstr "tr: Edit Assigned Users"
+msgstr "הוקצה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
-#, fuzzy
 msgid "Assigned Sets"
-msgstr "tr: Edit Assigned Users"
+msgstr "אוספים שהוקצו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
-#, fuzzy
 msgid "Assigned achievements to users"
-msgstr "tr: Assign this set to which users?"
+msgstr "הקצה הישגים למשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
-#, fuzzy
 msgid "Assigned to"
-msgstr "tr: Edit Assigned Users"
+msgstr "הקצה ל-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
-#, fuzzy
 msgid "Assignment type"
-msgstr "tr: Edit Assigned Users"
+msgstr "סוג מטלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
-#, fuzzy
 msgid "At least one of the answers above is NOT correct."
-msgstr "Yanıtların en az bir tanesi %1doğru değil."
+msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
 
+# Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
 msgid "Att. to Open Children"
-msgstr ""
+msgstr "נסיונות לפתיחת תתי-שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
 msgid "Attempt to upgrade directories"
-msgstr ""
+msgstr "נסה לשדרג תקיות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
-#, fuzzy
 msgid "Attempted"
-msgstr "ניסיונות"
+msgstr "בוצע נסיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
@@ -1207,55 +1098,53 @@ msgstr "ניסיונות"
 msgid "Attempts"
 msgstr "ניסיונות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Audit"
-msgstr "tr: Enrolled"
+msgstr "צופה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
 msgid "Authentication failed.  Please speak to your instructor."
-msgstr ""
+msgstr "האימות נכשל. אנא פנה למדריך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
 msgid "Author Info"
-msgstr "tr: Author Info"
+msgstr "מידע על הכותב"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Automatic"
-msgstr ""
+msgstr "אוטומטי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
 msgid "Automatically render problems on page load"
-msgstr ""
+msgstr "הצג שאלות ישירוצ לאחר טעינת העמוד"
 
 #. ($emailDirectory,$old_default_msg_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
 msgid "Backup file <code>%1/%2</code> created."
-msgstr ""
+msgstr "גיבוי לקובץ <code>%1/%2</code> נוצר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:745
 msgid "Basic Search"
-msgstr ""
+msgstr "חיפוש בסיסי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Binary"
-msgstr ""
+msgstr "בינארי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1163
 msgid "Box of Transmogrification"
-msgstr ""
+msgstr "כופסת החליפין"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:885
 msgid "Browse"
-msgstr ""
+msgstr "עיין"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:455
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:812
 msgid "Browse from:"
-msgstr ""
+msgstr "עיין מתוך:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
 msgid ""
@@ -1264,6 +1153,9 @@ msgid ""
 "have the same section as the user initiating the feedback.  I.E.  Feedback "
 "will only be sent to section leaders."
 msgstr ""
+"כברירת מחדל, המשוב תמיד נשלח לכל המשתמשים שנבחרו לקבלת משוב. משתנה זה גורם "
+"למערכת לשלוח דוא\"ל משוב רק למשתמשים חברי אותה הקבוצה כמו המשתמש ששולח את "
+"המשוב. ז\"א משוב ישלח רק למנהיגי הקבוצה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:410
 msgid ""
@@ -1271,367 +1163,310 @@ msgid ""
 "receive feedback. Feedback is also sent to any addresses specified in this "
 "blank. Separate email address entries by commas."
 msgstr ""
+"כברירת מחדל, משוב נשלח לכל המשתמשים לעיל שיש להם רשות לקבל משוב. המשוב נשלח "
+"לכל כתובת שמפורטת פה. הפרד כתובות דוא\"ל באמצעות פסיק."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
 msgid "CLOSE DATE"
-msgstr ""
+msgstr "תאריך הסגירה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
 msgid "CLOSE TIME"
-msgstr ""
+msgstr "זמן הגשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
 msgid "Cake of Enlargment"
-msgstr ""
+msgstr "עוגת התפיחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
-#, fuzzy
 msgid "Can e-mail instructor"
-msgstr "מדריך דוא"
+msgstr "יכול לשלוח דוא\"ל למדריך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
-#, fuzzy
 msgid "Can report bugs"
-msgstr "דווח על וירוסים"
+msgstr "יכול לדווח על באגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
-#, fuzzy
 msgid "Can show old answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr "יכול לראות תשובות מהעבר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
-#, fuzzy
 msgid "Can submit answers for a student"
-msgstr "שלח תשובות של [1_]"
+msgstr "יכול לשלוח תשבות בשם תלמיד"
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
-#, fuzzy
 msgid "Can't copy file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לההעתיק את הקובץ: %1"
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
 msgid "Can't create archive '%1': command returned %2"
-msgstr ""
+msgstr "לא יכול ליצור את הארכיון '%1': פקודה החזירה %2"
 
 #. ($courseID,  $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
 msgid "Can't create course environment for %1 because %2"
-msgstr ""
+msgstr "לא יכול ליצור סביבת קורס עבור %1 בגלל ש%2"
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
-#, fuzzy
 msgid "Can't create directory: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול ליצור תקייה: %1"
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
-#, fuzzy
 msgid "Can't create file '%1': %2"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לצור את הקובץ '%1': %2"
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
-#, fuzzy
 msgid "Can't create file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול ליצור קובץ: %1"
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
-#, fuzzy
 msgid "Can't delete archive '%1': %2"
-msgstr "Can't get password record for user '%1': %2"
+msgstr "לא יכול למחוק את הארכיון '%1': %2"
 
-#
 #. ($eUserID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
-#, fuzzy
 msgid "Can't get password record for effective user '%1': %2"
-msgstr "Can't get password record for effective user '%1': %2"
+msgstr "לא יכול להשיג היסטורית סיסמאות עבור המשתמש בפועל '%1': %2"
 
-#
 #. ($userID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
-#, fuzzy
 msgid "Can't get password record for user '%1': %2"
-msgstr "Can't get password record for user '%1': %2"
+msgstr "לא יכול להשיג היסטורית סיסמאות עבור המשתמש '%1': %2"
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
-#, fuzzy
 msgid "Can't open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לפתוח את %1"
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
-#, fuzzy
 msgid "Can't open file %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לפתוח את הקובץ %1"
 
-#
 #. ($merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
-#, fuzzy
 msgid "Can't read merge file %1. No message sent"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לקרוא את קובץ האיחוד %1. לא נשלחה שום הודעה"
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
-#, fuzzy
 msgid "Can't rename file: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לשנות את שם הקובץ: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
 msgid "Can't rename to the same name."
-msgstr ""
+msgstr "לא יכול לשנות שם לאותו השם."
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:805
 msgid "Can't unpack '%1': command returned %2"
-msgstr ""
+msgstr "לא יכול לפרוק '%1': פקודה החזירה %2"
 
-#
 #. ($!)
 #. ($fullPath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
-#, fuzzy
 msgid "Can't write to file %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לכתוב בקובץ %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
-#, fuzzy
 msgid "Cancel"
-msgstr "tr: Cancel Edit"
+msgstr "ביטול"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
-#, fuzzy
 msgid "Cancel E-mail"
-msgstr "tr: Cancel Edit"
+msgstr "ביטול דוא\"ל"
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
-#, fuzzy
 msgid "Cannot open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא יכול לפתוח %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
 msgid "Cap Test Time at Set Close Date?"
-msgstr ""
+msgstr "הגבל את זמן המבחן לזמן הסגירה?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
 msgid "Category"
-msgstr ""
+msgstr "קטגוריה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:451
 msgid ""
 "Cause the selected homework set to count for twice as many points as it "
 "normally would."
-msgstr ""
+msgstr "גרום לשעורי הבית שנבחרו להניב פי-2 יותר נקודות מהערך הרגיל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1164
 msgid ""
 "Causes a homework problem to become a clone of another problem from the same "
 "set."
-msgstr ""
+msgstr "גרום לשאלת שיעורי בית להפוך להעתק של בעיה אחרת באותו האוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
 msgid "Causes a single homework problem to be worth twice as much."
-msgstr ""
+msgstr "גרום לשאלת שיעורי בית אחת להיות שווה פי-2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
 msgid "Change Course Title to:"
-msgstr ""
+msgstr "שנה כותרת קורס ל-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
 msgid "Change CourseID to:"
-msgstr ""
+msgstr "שנה מזהה קורס ל-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
-#, fuzzy
 msgid "Change Display Settings"
-msgstr "tr: Display Options"
+msgstr "שנה אפשרויות תצוגה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
 msgid "Change Email Address"
-msgstr "E-posta Adresi Değiştir"
+msgstr "שנה כתובת דוא\"ל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
 msgid "Change Institution to:"
-msgstr ""
+msgstr "שנה מוסד ל-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
 msgid "Change Password"
-msgstr "Şifre Değiştir"
+msgstr "שנה סיסמה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
-#, fuzzy
 msgid "Change User Settings"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr "שנה הגדרות משתמש"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
 msgid "Change course institution from %1 to %2"
-msgstr ""
+msgstr "שנה את מוסד הקורס מ%1 ל%2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
 msgid "Change title from %1 to %2"
-msgstr ""
+msgstr "שנה את כתרת הקורס מ%1 ל%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
-#, fuzzy
 msgid "Changes abandoned"
-msgstr "tr: changes abandoned"
+msgstr "שינויים בוטלו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
 msgid "Changes in this file have not yet been permanently saved."
-msgstr "tr: Changes in this file have not yet been permanently saved."
+msgstr "שינויי בקובץ זה עוד לא נשמרו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
-#, fuzzy
 msgid "Changes saved"
-msgstr "tr: changes saved"
+msgstr "שינויים נשמרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1354
 msgid ""
 "Changing the problem seed for display, but there are no problems showing."
-msgstr ""
+msgstr "משנה את גרעין השאלות עבור התצוגה, אבל לא מוצגות שום שאלות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:598
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:727
 msgid "Chapter:"
-msgstr ""
+msgstr "פרק:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
 msgid "Check Answers"
 msgstr "בדוק תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
-#, fuzzy
 msgid "Check Test"
-msgstr "בדוק תשובות"
+msgstr "בדוק מבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
 msgid "Check that it's permissions are set correctly."
-msgstr ""
+msgstr "בדוק שההרשאות מוגדרות כנדרש"
 
 #. ($emailDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
-msgstr ""
+msgstr "בדוק אם קיים והאם התקייה %1 ניתנת לקריאה על ידי השרת."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
 msgid "Checking additional error messages"
-msgstr "tr: Checking additional error messages"
+msgstr "בודק הודעות שגיאה נוספות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:477
 msgid "Choose the set which you would like to be worth twice as much."
-msgstr ""
+msgstr "בחר את האוסף שתרצה שיחשב פי-2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:386
 msgid "Choose the set which you would like to enable partial credit for."
-msgstr ""
+msgstr "בחר את האוסף עבורו תרצה להפעיל ניקו חלקי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
 msgid "Choose the set which you would like to ressurect."
-msgstr ""
+msgstr "בחר את האוסף שתרצה לשחזר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
 msgid "Choose the set whose close date you would like to extend."
-msgstr ""
+msgstr "בחר את האוסף שתרצה להאריך את תאריך הסגירה שלו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
-msgstr "tr: Choose visibility of the sets to be affected"
+msgstr "בחר את האופן בו האוספים שנבחרו יהיו ניתנים לצפייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
 msgid "Choose which sets to be affected"
-msgstr "tr: Choose which sets to be affected"
+msgstr "בחר אילו אוספים יושפעו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:523
 msgid "Class values"
-msgstr ""
+msgstr "ערכי כיתה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
 msgid "Classlist Editor"
 msgstr "עורך רשימות כיתה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
 msgid "Clear"
-msgstr "tr: Clear"
+msgstr "רוקן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
-#, fuzzy
 msgid "Clear Problem Display"
-msgstr "רשימת בעיות"
+msgstr "רוקן את תצוגת השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
 msgid ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 msgstr ""
+"לחץ על שמו של תלמיד על מנת לראות את גירסתו של אוסף שיעורי הבית. לחץ על "
+"הכותרות כדי למיין את הטבלה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
-#, fuzzy
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
-"tr: Click on the login name to edit individual problem set data, (e.g. due "
-"dates) for these students."
+"לחץ על שם המשתמש כדי לערוך מידע של אוסף שאלות ספציפי, (למשל תאריך הגשה) עבור "
+"תלמידים אלו."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
@@ -1641,14 +1476,13 @@ msgid ""
 "associated with the restriction.  Contact your professor to have this "
 "problem resolved."
 msgstr ""
+"כתובת ה-IP של הלקוח  %1 לא מאושרת לעבודה על מטלה זו, מכיוון שלמטלה יש הגבלות "
+"כתובת IP ואין מיקומים מותרים לפי הגבלה זו. פנה למרצה כדי לפתור בעיה זו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
-#, fuzzy
 msgid "Close"
-msgstr "tr: Closed"
+msgstr "סגור"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:781
@@ -1657,65 +1491,49 @@ msgstr "tr: Closed"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:804
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Close Date"
-msgstr "tr: Due Date"
+msgstr "תאריך סגירה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
-#, fuzzy
 msgid "Closed, answers available."
-msgstr "סגור, תשובות זמינות"
+msgstr "סגור, תשובות זמינות."
 
-#
 #. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
-#, fuzzy
 msgid "Closed, answers on %1."
-msgstr "סגור, תשובות ב-[1_],"
+msgstr "סגור, תשובות ב%1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
-#, fuzzy
 msgid "Closed, answers recently available."
-msgstr "סגור, תשובות זמינות אחרונות"
+msgstr "סגור, תשובות זמינות לאחרונה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
-#, fuzzy
 msgid "Closed."
-msgstr "tr: Closed"
+msgstr "סגור."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
-#, fuzzy
 msgid "Closes"
-msgstr "tr: Closed"
+msgstr "סוגר"
 
-#
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
-#, fuzzy
 msgid "Closes %1"
-msgstr "tr: Revert to %1"
+msgstr "סוגר את  %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
-#, fuzzy
 msgid "Closes:"
-msgstr "tr: Closed"
+msgstr "סוגר את:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
 msgid "Collapse"
-msgstr ""
+msgstr "הסתר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
 msgid "Collapse All"
-msgstr ""
+msgstr "הסתר הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
@@ -1733,80 +1551,68 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Comment"
-msgstr "tr: Comment"
+msgstr "הגב"
 
 #. ($self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
 msgid "Completed results for this assignment are not available until %1"
-msgstr ""
+msgstr "תוצאות עבור מטלה זו לא זמינות עד %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Completed results for this assignment are not available."
-msgstr ""
+msgstr "תוצאות עבור מטלה זו לא זמינות."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
-#, fuzzy
 msgid "Completed."
-msgstr "tr: completely"
+msgstr "הושלם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "Confirm"
-msgstr ""
+msgstr "אישור"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
-#, fuzzy
 msgid "Confirm %1's New Password"
-msgstr "%1 için Şifre Onayı"
+msgstr "אשר אתה הסיסמה החדשה של %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
-#, fuzzy
 msgid "Confirm Password:"
-msgstr "%1 için Şifre Onayı"
+msgstr "אשר סיסמה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
 msgid "Congratulations, you earned a new level!"
-msgstr ""
+msgstr "מזל טוב, עלית דרגה!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
 msgid "Continue"
-msgstr "tr: Continue"
+msgstr "המשך"
 
-#
 #. ($sourceDirectory, $outputDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
-#, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
-msgstr "tr: Copied auxiliary files from %1 to  new location at %2"
+msgstr "הועתקו קבצים משניים מ%1 למיקום חדש ב%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy"
-msgstr ""
+msgstr "העתק"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
 msgid "Copy file as:"
-msgstr ""
+msgstr "העתק קובץ בשם:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
 msgid "Copy templates from:"
-msgstr ""
+msgstr "העתק תבנית מ-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
-#, fuzzy
 msgid "Copy this Problem"
-msgstr "tr: Edit this problem"
+msgstr "העתק שאלה זו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
@@ -1815,119 +1621,99 @@ msgstr "נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:644
 msgid "Correct Adjusted Status"
-msgstr ""
+msgstr "תקן סטטוס מותאם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
-#, fuzzy
 msgid "Correct Answer"
-msgstr "בדוק תשובות"
+msgstr "תשובה נכונה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
-#, fuzzy
 msgid "Correct Answers:"
-msgstr "בדוק תשובות"
+msgstr "תשובות נכונות:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
-#, fuzzy
 msgid "Correct Status"
-msgstr "נכון"
+msgstr "תקן סטטוס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
-#, fuzzy
 msgid "Correct answers"
-msgstr "Doğru yanıtları göster"
+msgstr "תשובות נכונות"
 
-#
 #. ($total_correct,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
-#, fuzzy
 msgid "Correct: %1/%2"
-msgstr "tr: set %1/problem %2"
+msgstr "נכון: %1/%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
-#, fuzzy
 msgid "CorrectAnswers"
-msgstr "בדוק תשובות"
+msgstr "תשובות נכונות"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
-msgstr ""
+msgstr "לא יכל להוסיף %1 שאלות לאוסף זה. המספר חייב להיות בין %1 ל%2"
 
-#
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
-#, fuzzy
 msgid "Couldn't change %1's password: %2"
-msgstr "%1 adlı kullanıcının şifresi değiştirilemedi: %2"
+msgstr "לא היה ניתן לשנות את הסיסמה של %1: %2"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
-#, fuzzy
 msgid "Couldn't change your email address: %1"
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr "לא היה ניתן לשנות את כתובת הדוא\"ל שלך: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
 msgid "Couldn't find OPL Branch %1 in remote %2"
-msgstr ""
+msgstr "לא היה ניתן למצוא את ענף ספריית השאלות הפתוחה %1 ב-remote בשם %2"
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
 msgid "Couldn't find PG Branch %1 in remote %2"
-msgstr ""
+msgstr "לא היה ניתן למצוא את ענף ה-PG ששמו %1 ב-remote בשם %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
-msgstr ""
+msgstr "לא היה ניתן למצוא את ענף ה-WeBWork ששמו %1 ב-remote בשם %2"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
-#, fuzzy
 msgid "Couldn't save your display options: %1"
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr "לא היה ניתן לשמור את אפשרויות התצוגה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
-msgstr ""
+msgstr "כמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
 msgid "Counts for Parent"
-msgstr ""
+msgstr "נספר למכיל"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
 msgid "Course %1 database is in order"
-msgstr ""
+msgstr "מסד הנתונים של הקורס %1 עובד כשורה"
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
 msgid "Course %1 databases must be updated before renaming this course."
-msgstr ""
+msgstr "יש לעדכן את מסד הנתונים של הקורס %1 לפני שמשנים את שמו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
-msgstr "אדמיניסטרצית קורס"
+msgstr "ניהול הקורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
 msgid "Course Configuration"
 msgstr "תצורת קורס"
@@ -1935,42 +1721,32 @@ msgstr "תצורת קורס"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
-msgstr ""
+msgstr "מזהה הקורס יכול להכיל רק אותיות, מספרים, מקפים, וקוים תחתונים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
-#, fuzzy
 msgid "Course ID:"
-msgstr "מידע על הקורס"
+msgstr "מזהה קורס:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "Course Info"
 msgstr "מידע על הקורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
-#, fuzzy
 msgid "Course Name:"
-msgstr "tr: First Name"
+msgstr "שם קורס:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
-#, fuzzy
 msgid "Course Title:"
-msgstr "קורסים"
+msgstr "כותרת קורס:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
-#, fuzzy
 msgid "Course archived."
-msgstr "tr: First Name"
+msgstr "הקורס הוכנס לארכיון."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
@@ -1987,42 +1763,40 @@ msgid ""
 "Course_Name (status :: date/time of most recent login) where status is "
 "\"hidden\" or \"visible\"."
 msgstr ""
+"הקורסים מסודרים לפי סדר אלפבתי או לפי זמן התחברות אחרונה (מאוחר למוקדם). כדי "
+"לשנון את הסדר בחר את אופן הסידור המועדף, ולחץ \"רענן רשימה\". הפורמט הוא: "
+"שם_קורס (סטטוס :: זמן של התחברות אחרונה) כש\"סטטוס\" הוא \"מוחבא\" או \"ניתן "
+"לצפייה\"."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "Create"
-msgstr "tr: Create"
+msgstr "צור"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
-#, fuzzy
 msgid "Create CSV"
-msgstr "tr: Create"
+msgstr "צור CSV"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
-#, fuzzy
 msgid "Create Location:"
-msgstr "tr: Recitation"
+msgstr "צור מיקום:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
-msgstr ""
+msgstr "צור אוסף חדש בקו0רס הזה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
 msgid "Create a new achievement with ID"
-msgstr ""
+msgstr "צור הישג חדש עם מזהה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
-msgstr "tr: Create as what type of set?"
+msgstr "איזה סוג של אוסף ליצור?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
-msgstr ""
+msgstr "צור שאלה ללא שיכות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
 msgid ""
@@ -2032,80 +1806,79 @@ msgid ""
 "is only available for mysql databases. It depends on the mysqldump "
 "application."
 msgstr ""
+"יוצר קובץ ארכיון gzipped tar (סיומת tar.gz)  של הקורס בתקיית הקורסים של "
+"WeBWork. לפני יצירת הקורס, מסד הנתונים של הקורס מועבר לתת-תקייה של תקיית ה-"
+"DATA של הקורס. כרגע אמצעי הארכיון ניתן לשימוש רק למסדי נתונים מסוג mysql. זה "
+"תלוי באפליקציית ה-mysqldump."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:648
 msgid "Cupcake of Enlargement"
-msgstr ""
+msgstr "מאפין התפיחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 msgid "Current"
-msgstr ""
+msgstr "נוכחי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
 msgid "Currently defined locations are listed below."
-msgstr ""
+msgstr "המיקמים שמוגדרים כרגע מפורטים למטה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
 msgid "Data"
-msgstr ""
+msgstr "מידע"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
 msgid "Database tables are ok"
-msgstr ""
+msgstr "טבלאות מסד הנתנים הם תקינים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables need updating."
-msgstr ""
+msgstr "טבלאות מסד הנתונים מתעדכנות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
 msgid "Database tables ok"
-msgstr ""
+msgstr "טבלאות מסד נתונים תקינים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
-#, fuzzy
 msgid "Database:"
-msgstr "tr: export abandoned"
+msgstr "מסד נתונים:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
-#, fuzzy
 msgid "Date"
-msgstr "tr: Open Date"
+msgstr "תאריך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
 msgid "Debug"
-msgstr ""
+msgstr "דיבאג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
-msgstr ""
+msgstr "ברירת מחדל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:189
 msgid ""
 "Default Amount of Time (in minutes) after Due Date that Answers are Open"
-msgstr ""
+msgstr "זמן ברירת המחדל (בדקות) לאחר תאריך ההגשה שהשאולות ישארו פתוחות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:183
 msgid ""
 "Default Amount of Time (in minutes) before Due Date that the Assignment is "
 "Open"
-msgstr ""
+msgstr "זמן ברירת המחדל (בדקות) לפני תאריך ההגשה שהמטלה פתוחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:247
 msgid "Default Length of Reduced Scoring Period in minutes"
-msgstr ""
+msgstr "זמן ברירת המחדל (בדקות) של תקופת הניקוד המופחת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:177
 msgid "Default Time that the Assignment is Due"
-msgstr ""
+msgstr "זמן ברירת המחדל שבו יש להגיש את המטלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
@@ -2113,149 +1886,118 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
 msgid "Delete"
-msgstr "tr: Delete"
+msgstr "מחק"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
-#, fuzzy
 msgid "Delete Course"
-msgstr "tr: Delete"
+msgstr "מחק קורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
 msgid "Delete all existing addresses"
-msgstr ""
+msgstr "מחק את כל הכתובות הקיימות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
 msgid "Delete course after archiving. Caution there is no undo!"
-msgstr ""
+msgstr "מחק את הקורס לאחר הכנסתו לארכיון. זהירות אין אפשרות לחזור בך!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
-#, fuzzy
 msgid "Delete course:"
-msgstr "tr: Delete"
+msgstr "מחק קורס:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
 msgid "Delete how many?"
-msgstr "tr: Delete how many?"
+msgstr "כמה למחוק?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
-#, fuzzy
 msgid "Delete it?"
-msgstr "tr: Delete"
+msgstr "למחוק?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
-#, fuzzy
 msgid "Delete location:"
-msgstr "tr: Delete"
+msgstr "מחק מיקום:"
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
-#, fuzzy
 msgid "Deleted %quant(%1,achievement)"
-msgstr "tr: selected sets"
+msgstr "%quant(%1, נמחק הישג, נמחקו הישגים)"
 
 #. (join(', ', @delLocations)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Deleted Location(s): %1"
-msgstr ""
+msgstr "נמחקו מקום/ות: %1"
 
 #. (join(', ', @toDel)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
 msgid "Deleted addresses %1 from location."
-msgstr ""
+msgstr "נמחקו הכתובות %1 מהמיקום."
 
-#
 #. ($self->shortPath($self->{tempFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
-#, fuzzy
 msgid "Deleting temp file at %1"
-msgstr "tr: Deleting temp file at %1"
+msgstr "מוחק קובץ זמני ב%1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
-#, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
-msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "המחיקה תמחוק את כל מידע המיקום וכתובות שקשורות עליו, והיא בלתי הפיך!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
-#, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
-msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "מחיקה הורסת את כל המידע שקשור להישג והיא בלתי הפיכה!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
-#, fuzzy
 msgid "Deletion destroys all set-related data and is not undoable!"
-msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "מחיקה הורסת את כל המידע הקשור לאוסף והיא לא הפיכה!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
-#, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
-msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "מחיקה הורסת את כת המידע הקשור למשתמש והיא בלתי הפיכה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
 msgid "Deny From"
-msgstr ""
+msgstr "תמנע מ-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
-#, fuzzy
 msgid "Description"
-msgstr "tr: Recitation"
+msgstr "תיאור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
 msgid "Didn't recognize action"
-msgstr ""
+msgstr "פעולה לא זוהתה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
-#, fuzzy
 msgid "Directory"
-msgstr "tr: Proctor"
+msgstr "תיקייה"
 
 #. ($file, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
 msgid "Directory '%1' not removed: %2"
-msgstr ""
+msgstr "התקייה '%1' לא הוסרה: %2"
 
 #. ($file, $removed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:678
 msgid "Directory '%1' removed (items deleted: %2)"
-msgstr ""
+msgstr "התיקייה '%1' הוסרה (פריטים שנמחקו: %2)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "Directory permission errors "
-msgstr ""
+msgstr "שגיאות התרי תיקייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
-#, fuzzy
 msgid "Directory structure"
-msgstr "tr: Proctor"
+msgstr "מבנה תיקייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
@@ -2264,125 +2006,104 @@ msgstr "tr: Proctor"
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
-msgstr ""
+msgstr "למבנה התיקייה חסרים תיקייות או שלשרת הרשת אין את היתרים הנדרשים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
 msgid "Directory structure is ok"
-msgstr ""
+msgstr "מבנה התקייה הוא תקין"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
 msgid "Directory structure needs to be repaired manually before archiving."
-msgstr ""
+msgstr "יש לתקן את מבנה התיקייה באופן ידני לפני הכנסה לארכיון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
 msgid "Directory structure needs to be repaired manually before renaming."
-msgstr ""
+msgstr "יש לתקן את מבנה התיקייה באופן ידני לפני שנוי השם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
 msgid "Directory structure or permissions need to be repaired. "
-msgstr ""
+msgstr "יש לתקן את מבנה התיקייה או את ההיתרים. "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
-#, fuzzy
 msgid "Display Mode:"
-msgstr "tr: Display Mode"
+msgstr "מצב תצוגה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
-#, fuzzy
 msgid "Display Past Answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr "הראה תשובות מהעבר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
-#, fuzzy
 msgid "Display options: Show"
-msgstr "tr: Display Options"
+msgstr "אפשריות תצוגה: הראה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
-#, fuzzy
 msgid "Display the evaluated student answer"
-msgstr "Önceki Yanıtları Göster"
+msgstr "הצג את התשובה הבדוקה של התלמיד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
-msgstr ""
+msgstr "אל תבטל את ההקצאה של תלמידים אלא אם אתה יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:274
 msgid "Do not uncheck a set unless you know what you are doing."
-msgstr ""
+msgstr "אל תבטל אוסף אם אתה לא יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
 msgid "Do not uncheck students, unless you know what you are doing."
-msgstr ""
+msgstr "אל תבטל הקצאת תלמידים אם אתה לא יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Don't Archive"
-msgstr ""
+msgstr "אל תוסיף לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
-#, fuzzy
 msgid "Don't Unarchive"
-msgstr "tr: Save changes"
+msgstr "אל תסיר מהארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
-#, fuzzy
 msgid "Don't Upgrade"
-msgstr "tr: Delete"
+msgstr "אל תשדרג"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
-#, fuzzy
 msgid "Don't delete"
-msgstr "tr: Delete"
+msgstr "אל תמחק"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
-#, fuzzy
 msgid "Don't make changes"
-msgstr "tr: Save changes"
+msgstr "אל תעשה שינויים"
 
-#
 #. ($saveMode)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
-#, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
-msgstr "tr: Unrecognized saveMode: |%1|. Unknown error."
+msgstr "לא מזהה את מצב השמירה: |%1|. שגיאה לא ידוע."
 
 #. ($type)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
 msgid "Don't recognize statistics display type: |%1|"
-msgstr ""
+msgstr "לא מזהה את סוג תצוגת הסטטיסטיקה: |%1|."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
 msgid "Don't rename"
-msgstr ""
+msgstr "אל תשנה שם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
-#, fuzzy
 msgid "Don't use in an achievement"
-msgstr "tr: Save changes"
+msgstr "אל תשתמש הישג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
 msgid "Done"
-msgstr ""
+msgstr "בוצע"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:158
@@ -2390,63 +2111,50 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:69
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
-#, fuzzy
 msgid "Download"
-msgstr "הורדת ניקוד"
+msgstr "הורד"
 
-#
 #. ($set->set_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
-#, fuzzy
 msgid "Download %1"
-msgstr "הורדת ניקוד"
+msgstr "הורד %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:267
 msgid "Download Hardcopy"
-msgstr ""
+msgstr "הורד קובץ להדפסה"
 
-#
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
-#, fuzzy
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr "Seçili Setleri Yazdır: [plural,_1,Set,Sets]"
+msgstr "הורד קובץ להדפסה עבור האוספים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
 msgid "Download PDF or TeX Hardcopy for Current Set"
-msgstr "tr: Download PDF or TeX Hardcopy for Current Set"
+msgstr "הורד גרסת הדפסה כ-PDF או TeX של האוסף הנוכחי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
-msgstr "tr: Download PDF or TeX Hardcopy for Selected Sets"
+msgstr "הורד גרסת הדפסה כ-PDF או TeX של האוספים שנבחרו"
 
-#
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
-#, fuzzy
 msgid "Download hardcopy of set %1 for %2?"
-msgstr "Bu soru grubunu basılı halde indirin."
+msgstr "הורד קובץ להדפסה של אוסף %1 עבור %2?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
-#, fuzzy
 msgid "Download:"
-msgstr "הורדת ניקוד"
+msgstr "הורדה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
-msgstr "tr: Drop"
+msgstr "עזוב"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
-msgstr "tr: Duplicate this set and name it"
+msgstr "שכפל את האוסף הזה ותן לו שם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:371
 msgid ""
@@ -2459,42 +2167,43 @@ msgid ""
 "will be used by default, and choosing <i>true</i> means that the old answer "
 "checkers will be used by default."
 msgstr ""
+"במהלך קיץ 2005, גרסה חדשה יותר של בודקי התשובות הוספה עבור תשובות שהן "
+"פונקציות או מספרים. הבודקים החדשים מאפשרים יותר פוונקציות בתשובות התלמידים, "
+"ומתפקדות טוב יותר במקרים מסויימים. חלק מהשאלות בנויות במיוחד עבור בודקי "
+"התשובות החדשים (או הישנים). אבל עבור רוב השאלות, אתה יכול לבחור מה תהיה "
+"ברירת המחדל. <p> בחירת <i> לא נכון</i> כאן אומר שהבודקים החדשים יהיו ברירת "
+"המחדל, ולבחור <i>נכון</i> אומר שהבודקים הישנים יהיו ברירת המחדל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
 msgid "E-Mail"
-msgstr ""
+msgstr "דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
-#, fuzzy
 msgid "E-mail Instructor"
-msgstr "מדריך דוא"
+msgstr "שלח דוא\"ל למדריך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:399
 msgid "E-mail addresses which can receive e-mail from a pg problem"
-msgstr ""
+msgstr "כתובות דוא\"ל שיכולות לקבל הודעה משאלת PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:404
 msgid ""
 "E-mail feedback from students automatically sent to this permission level "
 "and higher:"
-msgstr ""
+msgstr "דוא\"ל משוב מתלמידים נשלח אוטומטית לדרגת היתרים זו ומעלה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:389
 msgid "E-mail verbosity level"
-msgstr ""
+msgstr "אורך פורמט הדוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
-#, fuzzy
 msgid "E-mail:"
-msgstr "דואל אלקטרוני"
+msgstr "דוא\"ל:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Earned"
-msgstr ""
+msgstr "הושג"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
@@ -2509,101 +2218,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
 msgid "Edit"
-msgstr "tr: Edit"
+msgstr "ערוך"
 
-#
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
-#, fuzzy
 msgid "Edit %1 of set %2."
-msgstr "tr: Editing %1 in file '%2'"
+msgstr "ערוך %1 מהאוסף %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
-msgstr "tr: Edit All Set Data"
+msgstr "ערוך את כל המידע של האוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
-msgstr "tr: Edit Assigned Users"
+msgstr "ערוך משתמשים שהוקצאו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
 msgid "Edit Evaluator"
-msgstr ""
+msgstr "ערוך מעריך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#, fuzzy
 msgid "Edit Header"
-msgstr "tr: Set Header"
+msgstr "ערוך קידומת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
-#, fuzzy
 msgid "Edit Location:"
-msgstr "tr: Recitation"
+msgstr "ערוך מיקום:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
-#, fuzzy
 msgid "Edit Problem"
-msgstr "tr: Edit Problems"
+msgstr "ערוך שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
 msgid "Edit Problems"
-msgstr "tr: Edit Problems"
+msgstr "ערוך שאלות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
-#, fuzzy
 msgid "Edit Set"
-msgstr "tr: Edit Set Data"
+msgstr "ערוך אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
-msgstr "tr: Edit Set Data"
+msgstr "ערוך את מידע האוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
-#, fuzzy
 msgid "Edit Target Set"
-msgstr "tr: Edit Set Data"
+msgstr "ערוך את האוסף הנבחר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
 msgid "Edit Which Users?"
-msgstr "tr: Edit Which Users?"
+msgstr "ערוך איזה משתמשים?"
 
 #. ($user)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:199
 msgid "Edit data for %1"
-msgstr ""
+msgstr "ערוך את המידע של &1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
-#, fuzzy
 msgid "Edit it"
-msgstr "tr: Edit"
+msgstr "ערוך"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
 msgid "Edit set %1 data for ALL students assigned to this set."
-msgstr ""
+msgstr "ערוך את המידע של האוסף %1 עבור כל התלמידים שלהם שהוקצעו לאוסף הזה."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "Edit set %1 for this user."
-msgstr ""
+msgstr "ערוך את האוסף %1 עבור המשתמש הזה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
 msgid ""
@@ -2612,77 +2302,66 @@ msgid ""
 "make all of your changes.  Or, click \"Manage Locations\" above to make no "
 "changes and return to the Manage Locations page."
 msgstr ""
+"ערוך את הערך הנוכחי של תיאור המיקום, אם אתה רוצה, ואז תוסיף כתובות למחיקה, "
+"ואז לחץ על כפתור \"בצע פעולה\" כדי לבצע את כל השינויים. או, לחץ \"נהל מיקומים"
+"\" למעלה כדי לא לבצע שינויים ולחזור למנהל המיקומים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
 msgid "Edit which sets?"
-msgstr "tr: Edit which sets?"
+msgstr "איזה אוספים לערוך?"
 
-#
+# Edit with a number 1 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
-#, fuzzy
 msgid "Edit1"
-msgstr "tr: Edit"
+msgstr "עריכה1"
 
-#
+# Edit with a number 2 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
-#, fuzzy
 msgid "Edit2"
-msgstr "tr: Edit"
+msgstr "עריכה2"
 
-#
+# Edit with a number 3 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
-#, fuzzy
 msgid "Edit3"
-msgstr "tr: Edit"
+msgstr "עריכה3"
 
-#
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
-#, fuzzy
 msgid "Editing %1 in file '%2'"
-msgstr "tr: Editing %1 in file '%2'"
+msgstr "עורך %1 בקובץ '%2'"
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
-#, fuzzy
 msgid "Editing achievement in file '%1'"
-msgstr "tr: Editing %1 in file '%2'"
+msgstr "עורך את ההישג בקובץ '%1'"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
 msgid "Editing location %1"
-msgstr ""
+msgstr "עורך את המיקום %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Editing problem set %1 data for these individual students: %2"
-msgstr ""
+msgstr "עורך את המידע של אוסף השאלות %1 עבור התלמידים הספציפים האלה: %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
-#, fuzzy
 msgid "Editor"
-msgstr "tr: Edit"
+msgstr "עורך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
-#, fuzzy
 msgid "Editor rows:"
-msgstr "tr: Edit Problems"
+msgstr "עורך שורות:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
-msgstr "דואל אלקטרוני"
+msgstr "דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
@@ -2693,39 +2372,29 @@ msgstr "דואל אלקטרוני"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
 msgid "Email Address"
-msgstr "tr: Email Address"
+msgstr "כתובת דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
-#, fuzzy
 msgid "Email Body:"
-msgstr "דואל אלקטרוני"
+msgstr "גוף הדוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
-#, fuzzy
 msgid "Email Instructor On Failed Attempt"
-msgstr "מדריך דוא"
+msgstr "שלח דוא\"ל למדריך בכל נסיון כושל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
-#, fuzzy
 msgid "Email Link"
-msgstr "דואל אלקטרוני"
+msgstr "קישור דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
-#, fuzzy
 msgid "Email address"
-msgstr "tr: Email Address"
+msgstr "כתובת דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
-#, fuzzy
 msgid "Email instructor"
-msgstr "מדריך דוא"
+msgstr "שלח דוא\"ל למדריך"
 
 #. (scalar(@{$self->{ra_send_to}})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
@@ -2734,61 +2403,55 @@ msgid ""
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
+"שולח דוא\"ל ל%quant(%1,נמען, נמענים). תקבל הודעה כאשר המשימה תושלם. זה עשוי "
+"לקחת כמה דקות אם הכיתה גדולה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 msgid "Emails to be sent to the following:"
-msgstr ""
+msgstr "דוא\"ל נשלח ל-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
-#, fuzzy
 msgid "Enable Achievement Items"
-msgstr "tr: selected sets"
+msgstr "הפעל חפצי הישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Enable Conditional Release"
-msgstr ""
+msgstr "הפעל פרסום מותנה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
-#, fuzzy
 msgid "Enable Course Achievements"
-msgstr "tr: selected sets"
+msgstr "הפעל הישגי קורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
 msgid "Enable Progress Bar and current problem highlighting"
-msgstr ""
+msgstr "הפעל סרגל התקדמות והדגשת הבעיה הנוכחית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
-#, fuzzy
 msgid "Enable Reduced Scoring"
-msgstr "tr: Enable Reduced Credit"
+msgstr "הפעל ניקוד מופחת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
-#, fuzzy
 msgid "Enable Show Me Another button"
-msgstr "tr: Show in another window"
+msgstr "הפעל את כפתור \"תראה לי עוד אחת\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
 msgid "Enable periodic re-randomization of problems"
-msgstr ""
+msgstr "הפעל רנדומיזציה מחדש של שאלות מדי לסרוגין."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:358
 msgid ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
+"אפשר ניקוד מופחת עבור מחבן שיעורי בית. יאפשר לשלוח תשובות עבור ניקוד חלקי 24 "
+"שעות לאחר תאריך הסגירה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
-#, fuzzy
 msgid "Enabled"
-msgstr "tr: Enable"
+msgstr "מופעל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
 msgid ""
@@ -2796,6 +2459,9 @@ msgid ""
 "attempts. Student would have to click Request New Version to obtain new "
 "version of the problem and to continue working on the problem"
 msgstr ""
+"הפעל רנדומיזציה מחדש של שאלות מדי לסרוגין לאחר מספר מסויים של נסיונות. "
+"התלמידילחץ על \"בקש גרסה חדשה\" כדי לקבל גרסה חדשה של השאלה ולהמשיך לעבוד על "
+"השאלה "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:213
 msgid ""
@@ -2805,12 +2471,17 @@ msgid ""
 "homework set until they have achieved the minimum score on all of the listed "
 "sets."
 msgstr ""
+"הפעל את השימוש במערכת הפרסום המותנה. כדי להשתמש בפרסום מותנה צריך לפרט רשימה "
+"של שמות בדף פרטי אוסף השאלות, ולפרט ציון מינימלי. לתלמידים לא יהיה גישה "
+"לאוסף הזה עד שהגיעו לציון המינימלי בכל האוספים שנרשמו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
 msgid ""
 "Enables the use of the date picker on the Homework Sets Editor 2 page and "
 "the Problem Set Detail page"
 msgstr ""
+"מפעיל את השימוש בבורר התאריך על אוספי שיעורי הבית דף עורך 2 ודף פרטי אוסף "
+"השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:253
 msgid ""
@@ -2818,17 +2489,17 @@ msgid ""
 "seeded version of the current problem, complete with solution (if it exists "
 "for that problem)."
 msgstr ""
+"הפעל את השימוש בכפתור \"תראה לי עוד אחת\", שנותן לתלמיד גרסה עם מספרים שונים "
+"של אותה השאלה, ביחד עם פתרון מתאים (אם קיים לשאלה)."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Enrolled"
-msgstr "tr: Enrolled"
+msgstr "רשום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
 msgid "Enrolled, Drop, etc."
-msgstr ""
+msgstr "רשום, פרש, וכו'."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
@@ -2838,45 +2509,42 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "Enrollment Status"
-msgstr "tr: Enrollment Status"
+msgstr "סטטוס רישום"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
 msgid "Enter filename below"
-msgstr "tr: Enter filename below"
+msgstr "הכנס שם קובץ כאן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
 msgid "Enter filenames below"
-msgstr "tr: Enter filenames below"
+msgstr "הכנס שמות קבצים כאן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:132
 msgid ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 msgstr ""
+"הכנס מידע כאן לגבי התלמידים שאתה רוצה להוסיף כל סיסמה של תלמיד תהיה מזהה "
+"התלמיד שלו בהתחלה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
 msgid "Entered"
-msgstr "נכנסו"
+msgstr "הוכנס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
-#, fuzzy
 msgid "Entered student:"
-msgstr "tr: selected sets"
+msgstr "תלמיד שהוכנס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
 msgid "Equation Display"
-msgstr ""
+msgstr "תצוגת משוואה"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1442
 msgid "Error adding set-level proctor: %1"
-msgstr ""
+msgstr "שגיאה בהוספת משגיח אוסף: %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1344
@@ -2884,29 +2552,25 @@ msgstr ""
 msgid ""
 "Error getting old set-proctor password from the database: %1.  No update to "
 "the password was done."
-msgstr ""
+msgstr "שגיאה בהשגת סיסמת משגיח אוסף ישנה ממסד הנתונים: %1. לא שונתה הסיסמה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
-#, fuzzy
 msgid "Error message:"
-msgstr "הודעות"
+msgstr "הודעת שגיאה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
-#, fuzzy
 msgid "Error messages"
-msgstr "הודעות"
+msgstr "הודעות שגיאה"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
 msgid "Error: Answer date must come after close date in set %1"
-msgstr ""
+msgstr "שגיאה: תאריך תשובות חייב לבוא אחרי תאריך הסגירה באווסף %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1534
 msgid "Error: Close date must come after open date in set %1"
-msgstr ""
+msgstr "שגיאה: תאריך הסגירה חייב לבוא אחרי תאריך הפתיחה באוסף %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1551
@@ -2914,35 +2578,34 @@ msgid ""
 "Error: Reduced scoring date must come between the open date and close date "
 "in set %1"
 msgstr ""
+"שגיאה: תאריך ניקוד מופחת חייב לבוא בין תאריך הפתיחה לתאריך הסגירה באוסף %1"
 
-#
 #. ($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
-#, fuzzy
 msgid "Error: The original file %1 cannot be read."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr "שגיאה: אי אפשר לקרוא את הקובץ המקורי %1."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1528
 msgid "Error: answer date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "שגיאה: תאריך תשובות לא יכולל להיות יותר מ-10 שנים מעכשיו באוסף %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1082
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1526
 msgid "Error: close date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "שיגאה: תאריך סגירה לא יכול להיות יותר מ-10 שנים מהיום באוסף %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
 msgid "Error: open date cannot be more than 10 years from now in set %1"
-msgstr ""
+msgstr "שגיאה: תאריך פתיחה לא יכול להיות יותר מ-10 שנים מהיום באוסף %1"
 
 #. ($problem_desc, $problem_name, CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1230
@@ -2950,6 +2613,7 @@ msgid ""
 "Errors encountered while processing %1. This %2 has been omitted from the "
 "hardcopy. Error text: %3"
 msgstr ""
+"אירעו שגיאות בזמן עיבוד %1. שאלה %2 לא נכנסה לקובץ ההדפסה. טקסט שגיאה: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
@@ -2958,6 +2622,8 @@ msgid ""
 "create the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"אירעו שגיאות זמן החבאת הקורסים שנרשמו למטה בזמן הנסיון ליצור את הקובץ  "
+"hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרים של תיקיית הקורס, %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
@@ -2966,163 +2632,143 @@ msgid ""
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
+"שגיאות אירעו בזמן הפיכת הקורסים שנרשמו למטה לגלויים בזמן הניסיון למחוק את "
+"הקובץ hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרית של תיקיית "
+"הקורס, %11"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 msgid "Evaluator"
-msgstr ""
+msgstr "מעריך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
 msgid "Evaluator File"
-msgstr ""
+msgstr "קובץ מעריך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
-msgstr ""
+msgstr "חוץ מאולי השגיאות לעיל, כל הקורסים שנבחרו בם כר מוחבאים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
-msgstr ""
+msgstr "חוץ מאולי השגיאות לעיל, כל הקורסים שנבחרו בם כר גלויים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
+"ברשימה למטה מורטים כתובות קיימות עבור המיקום . בחר כתובות מהרשימה כדי למחוק "
+"אותם:"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
 msgid "Existing file %1 could not be backed up and was lost."
-msgstr ""
+msgstr "לא היה אפשרות לשמור את הקובץ %1 ולכן הוא נמחק."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
 msgid "Expand"
-msgstr ""
+msgstr "פתח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
 msgid "Expand All"
-msgstr ""
+msgstr "פתח הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
 msgid "Export"
-msgstr "tr: Export"
+msgstr "יצא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
-#, fuzzy
 msgid "Export selected achievements."
-msgstr "tr: Export selected sets"
+msgstr "יצא הישגים שנבחרו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
 msgid "Export selected sets"
-msgstr "tr: Export selected sets"
+msgstr "יצא את האוספים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
 msgid "Export to what kind of file?"
-msgstr "tr: Export to what kind of file?"
+msgstr "איזה סוג קובץ ליצא?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
 msgid "Export which sets?"
-msgstr "tr: Export which sets?"
+msgstr "איזה אוספים ליצא?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
 msgid "Export which users?"
-msgstr "tr: Export which users?"
+msgstr "איזה משתמשים ליצא?"
 
-#
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
-#, fuzzy
 msgid "Exported achievements to %1"
-msgstr "tr: Export selected sets"
+msgstr "הישגים יוצאו ל-%1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
 msgid "Extend the close date for which Gateway?"
-msgstr ""
+msgstr "הארך את תאריך הסגירה של איזה בוחן מחסום?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1442
 msgid ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 msgstr ""
+"מאריך את תאריך הסגירה של בוחן מחסום ב-24 שעות. שים לב: הבוחן חייב להיות פתוח "
+"כדי שזה יעבוד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "FIRST NAME"
-msgstr ""
+msgstr "שם פרטי"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
-#, fuzzy
 msgid "Failed to create new achievement: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr "יצירת הישג חדש נכשלה: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
-#, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
-msgstr "tr: Failed to create new set: no set name specified!"
+msgstr "יצירת הישג חדש נכשלה: לא פורט מזהה הישג!"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
-#, fuzzy
 msgid "Failed to create new set: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr "יצירת אוסף חדש נכשלה: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
-msgstr "tr: Failed to create new set: no set name specified!"
+msgstr "יצירת אוסף חדש נכשלה: לא הוכנס שם לאוסף!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
-#, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
-msgstr "tr: Failed to duplicate set: no set selected for duplication!"
+msgstr "שכפול ההישג נכשל: לא נבחר הישג לשכפול! "
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
-#, fuzzy
 msgid "Failed to duplicate set: %1"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr "שכפול אוסף נכשל: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
-msgstr "tr: Failed to duplicate set: no set name specified!"
+msgstr "שיכפול אוסף נכשל: לא הוכנס שם לאוסף!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
-msgstr "tr: Failed to duplicate set: no set selected for duplication!"
+msgstr "שכפול אוסף נכשל: לא נבחר אוסף לשכפול!"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
-#, fuzzy
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr "tr: Failed to duplicate set: set %1 already exists!"
+msgstr "שכפול האוסף נכשל: אוסף %1 כבר קיים!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
-#, fuzzy
 msgid "Failed to enter student:"
-msgstr "tr: Failed to duplicate set: %1"
+msgstr "הוספת תלמיד נכשלה:"
 
-#
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
@@ -3130,155 +2776,131 @@ msgstr "tr: Failed to duplicate set: %1"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
-#, fuzzy
 msgid "Failed to open %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "פתיחת %1 נכשלה"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
-#, fuzzy
 msgid "Failed to save: %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "השמירה נכשלה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "False"
-msgstr ""
+msgstr " לא נכון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid "Feature exhausted for this problem"
-msgstr "tr: report bugs in this problem"
+msgstr "האפשרותת כבר נוצלה עד תומה עבור שאלה זו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
-#, fuzzy
 msgid "Feedback"
 msgstr "משוב"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:414
 msgid "Feedback by Section."
-msgstr ""
+msgstr "משוב לפי קבוצה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
-#, fuzzy
 msgid "FeedbackMessage"
-msgstr "משוב"
+msgstr "הודעת משוב"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Field is ok"
-msgstr ""
+msgstr "השדה תקין"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
 msgid "Field missing in database"
-msgstr ""
+msgstr "שדה חסר במסד הנתונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Field missing in schema"
-msgstr ""
+msgstr "שדה חסר בתבנית"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
 msgid "File '%1' exists.  File not saved.  No changes have been made."
-msgstr ""
+msgstr "הקובץ '%1' קיים. הקובץ לא נשמר. לא בוצעו ציונים."
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
-#, fuzzy
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
-"tr: File '%1' exists. File not saved. No changes have been made. You can "
-"change the file path for this problem manually from the 'Hmwk Sets Editor' "
-"page"
+"הקובץ '%1' קיים. הקובץ לא נשמר. לא בוצעו שינויים. אתה יכול לשנות את מיקום "
+"הקובץ של שאלה זו באופן ידני מדף 'עורך אוסף שיעורי בית'."
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
 msgid "File '%1' not removed: %2"
-msgstr ""
+msgstr "הקובץ '%1' לא הוסר: %2"
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:681
 msgid "File '%1' successfully removed"
-msgstr ""
+msgstr "הקובץ '%1' הוסר בהצלחה"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:935
 msgid "File '%2' uploaded successfully"
-msgstr ""
+msgstr "הקובץ '%2' הועלה בהצלחה"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
-msgstr ""
+msgstr "קובץ <b>%1</b> כבר קיים.  שמור עליו, או שנה את שמו ל-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
-#, fuzzy
 msgid "File Compare"
-msgstr "tr: Filename"
+msgstr "השווה קבצים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
 msgid "File Manager"
 msgstr "מנהל קבצים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
-#, fuzzy
 msgid "File saved"
-msgstr "tr: Filename"
+msgstr "הקובץ נשמר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
 msgid "File successfully copied"
-msgstr ""
+msgstr "הקובץ הועתק בהצלחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:644
 msgid "File successfully renamed"
-msgstr ""
+msgstr "שם הקובץ שונה בהצלחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
 msgid "Filename"
-msgstr "tr: Filename"
+msgstr "שם קובץ"
 
 #. ($extension,$location)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1168
 msgid "Files with extension '.%1' usually belong in '%2'"
-msgstr ""
+msgstr "קבצים עם הסיומת '.%1' בדרכ כלל שייכים ל-'%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
 msgid "Filter by what text?"
-msgstr "tr: Filter by what text?"
+msgstr "לפי אזה טקסט לסנן?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
-#, fuzzy
 msgid "Filter:"
-msgstr "tr: Filter"
+msgstr "סינון:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#, fuzzy
 msgid "First"
-msgstr "tr: First Name"
+msgstr "ראשון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
@@ -3294,13 +2916,11 @@ msgstr "tr: First Name"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
 msgid "First Name"
-msgstr "tr: First Name"
+msgstr "שם פרטי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
-#, fuzzy
 msgid "First name"
-msgstr "tr: First Name"
+msgstr "שם פרטי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
 msgid ""
@@ -3309,215 +2929,184 @@ msgid ""
 "Please specify a different file or move the needed file to the email "
 "directory"
 msgstr ""
+"מתוך שיכולי אבטחה, את הלא יכול לבחור קובץ מתקייה גבוהה יותר מתיקיית הדוא\"ל "
+"(אתה לא יכול להתשתמש ב .../blah/blah למשל). אנא בחר קובץ אחר או העבר את "
+"הקובץ הדרוש לתיקיית הדוא\"ל "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
 msgid "Force problems to be numbered consecutively from one"
-msgstr ""
+msgstr "אלץ מספור עוקב של של השאלות החל ממספר אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2303
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+"אלץ מספור עוקב של של השאלות החל ממספר אחד ( זה תמיד נעשה כשמסדרים בעיות מחדש)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
-msgstr ""
+msgstr "פורמט עבור נשורת נושא בדוא\"ל משוב."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
-#, fuzzy
 msgid "Format:"
-msgstr "tr: Hardcopy Header"
+msgstr "פורמט:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
-msgstr ""
+msgstr "מהקורס הזה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
-#, fuzzy
 msgid "From field must contain one valid email address."
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr "שדה הנמען חייב להכיל לפחות כתובת דוא\"ל תקינה אחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
 msgid "From:"
-msgstr ""
+msgstr "שולח:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1075
 msgid "GLOBAL Usage"
-msgstr ""
+msgstr "שימוש גלובאלי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
-#, fuzzy
 msgid "Gateway Name "
-msgstr "tr: Last Name"
+msgstr "שם בוחן מחסום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
 msgid "Gateway Quiz %2"
-msgstr ""
+msgstr "בוחן מחסום %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:808
 msgid "Gateway parameters"
-msgstr ""
+msgstr "הפאראמטרים של בוחן המחסום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:120
 msgid "General"
-msgstr ""
+msgstr "כללי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
-#, fuzzy
 msgid "General Information"
-msgstr "tr: Site Information"
+msgstr "מידע כללי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate Hardcopy"
-msgstr ""
+msgstr "תיצור קובץ להדפסה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate hardcopy for selected sets and selected users"
-msgstr ""
+msgstr "צור קובץ להדפסה עבור האוספים והמשתמשים שנבחרו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
-#, fuzzy
 msgid "Get Library Set Problems"
-msgstr "בעיה הבאה"
+msgstr "השג שאלות מאוסף סיפרייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
-#, fuzzy
 msgid "Get Target Set Problems"
-msgstr "tr: Edit Set Data"
+msgstr "השג את שאלות האוסף הנבחר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
-#, fuzzy
 msgid "Give new password to"
-msgstr "tr: Give new password to which users?"
+msgstr "תן סיסמה חדשה ל-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
 msgid "Give new password to which users?"
-msgstr "tr: Give new password to which users?"
+msgstr "לאיזה משתמשים לתת סיסמה חדשה?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:968
 msgid "Gives full credit on a single homework problem."
-msgstr ""
+msgstr "תן ניקוד מלא על שאלת שיעורי בית אחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1079
 msgid "Gives full credit on every problem in a set."
-msgstr ""
+msgstr "תן ניקוד מלא על כל שאלה באוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:762
 msgid "Gives half credit on a single homework problem."
-msgstr ""
+msgstr "תן חצי ניקוד על שאלה אחת משעורי הבית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:878
 msgid "Gives half credit on every problem in a set."
-msgstr ""
+msgstr "תן חצי ניקוד על כל שאלה מאוסף."
 
-#
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
-#, fuzzy
 msgid "Global problem %1 for set %2 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr "שאלה גלובאלית %1 עבור אוסף %2 לא נמצאה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "Global set data will be shown instead of user specific data"
-msgstr ""
+msgstr "מידע אוסף גלובאלי יופיע במקום מידע משתמש ספציפי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:155
 msgid "Go"
-msgstr ""
+msgstr "התחל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#, fuzzy
 msgid "Grade"
-msgstr "ציונים"
+msgstr "נקד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
-#, fuzzy
 msgid "Grade Problem"
-msgstr "בעיה הבאה"
+msgstr "נקד שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
-#, fuzzy
 msgid "Grade Test"
-msgstr "ציונים"
+msgstr "נקד מבחן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
-#, fuzzy
 msgid "Grader"
-msgstr "ציונים"
+msgstr "מנקד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
-#, fuzzy
 msgid "Grades"
 msgstr "ציונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:97
 msgid "Grades have been saved for all current users."
-msgstr ""
+msgstr "הציונים נשמרו עבור על כל המתמשים הנוכחיים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:229
 msgid "Grading assignment:"
-msgstr ""
+msgstr "מנקד מטלה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:967
 msgid "Greater Rod of Revelation"
-msgstr ""
+msgstr "מטה הגילוי הגדול"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1078
 msgid "Greater Tome of Enlightenment"
-msgstr ""
+msgstr "כרך ההארה הגדול"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
 msgid "Guest Login"
-msgstr "tr: Guest Login"
+msgstr "כניסת אורח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
-#, fuzzy
 msgid "HTTP Headers"
-msgstr "tr: Set Header"
+msgstr "קידומות HTTP"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
-#, fuzzy
 msgid "Hardcopy Format:"
-msgstr "tr: Hardcopy Header"
+msgstr "פורמט קובץ להדפסה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
-#, fuzzy
 msgid "Hardcopy Generator"
-msgstr "tr: Hardcopy Header"
+msgstr "יוצר הקבצים להדפסה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:763
@@ -3525,127 +3114,101 @@ msgstr "tr: Hardcopy Header"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:783
 msgid "Hardcopy Header"
-msgstr "tr: Hardcopy Header"
+msgstr "קידומת גירסת הדפסה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
-#, fuzzy
 msgid "Hardcopy Theme"
-msgstr "tr: Hardcopy Header"
+msgstr "עיצוב גרסת הדפסה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
-#, fuzzy
 msgid "Headers"
-msgstr "tr: Set Header"
+msgstr "קידומות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
 msgid "Help"
-msgstr "tr: Help"
+msgstr "עזרה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:479
 msgid "Here is a new version of your problem."
-msgstr ""
+msgstr "הנה גרסה חדשה של השאלה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
 msgid "Hidden"
-msgstr "tr: Hidden"
+msgstr "מוחבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
 msgid "Hide All"
-msgstr ""
+msgstr "החבא הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Hide Courses"
-msgstr "קורסים"
+msgstr "החבא קורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
-#, fuzzy
 msgid "Hide Hints"
-msgstr "הראה רמזים"
+msgstr "החבא רמזים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
-#, fuzzy
 msgid "Hide Hints from Students"
-msgstr "tr: hidden from students"
+msgstr "החבא רמזים מהתלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
-#, fuzzy
 msgid "Hide Inactive Courses"
-msgstr "קורסים"
+msgstr "החבא קורסים לא פעילים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
 msgid "Hide all paths"
-msgstr ""
+msgstr "החבא את כל הכתובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Hide path:"
-msgstr "הראה רמזים"
+msgstr "החבא כתובת:"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
-#, fuzzy
 msgid "Hint:"
-msgstr "הראה רמזים"
+msgstr "רמז:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
-#, fuzzy
 msgid "Hints"
-msgstr "הראה רמזים"
+msgstr "רמזים"
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
 msgid "Hmwk Sets Editor"
 msgstr "עורך שיעורי בית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
-msgstr "שיעורי בית"
+msgstr "אוסף שיעורי בית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
-#, fuzzy
 msgid "Homework Totals"
-msgstr "שיעורי בית"
+msgstr "סך הכל שיעורי בית"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
-msgstr ""
+msgstr "לא יכול למצוא את הקובץ  [ACHEVDIR]/surprise_message.txt"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
 msgid "Icon"
-msgstr ""
+msgstr "אייקון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
 msgid "Icon File"
-msgstr ""
+msgstr "קוץ אייקון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
-msgstr ""
-"tr: If a password field is left blank, the student's current password will "
-"be maintained."
+msgstr "אם משארים את שדה הסיסמה ריק, סיסמת התלמיד לא תשתנה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:454
 msgid ""
@@ -3654,6 +3217,9 @@ msgid ""
 "of the problem's status and the weighted average of the status of its child "
 "problems which have this flag enabled."
 msgstr ""
+"כשזה נבחר, שאלה זו תחשב לניקוד השאלה המכילה. בכללי הסטאטוס המותאם של שאלה "
+"הוא הסטאטוס הגדול יותר מסטאטוס השאלה והממוצע המותאם של הסטאטוס של השאלות "
+"המוכלות שעבורם אפשרות זו נבחרה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
 msgid ""
@@ -3661,6 +3227,8 @@ msgid ""
 "emails will be notified whenever a student runs out of attempts on a problem "
 "and its children without receiving an adjusted status of 100%"
 msgstr ""
+"אם זה מופעל אז מדריכים שיכולים לקבל משוב יקבלו הודע בכל פעם שלתלמיד נגמר "
+"הנסיונות על שאלה והשאלות המוכלות בלי לקבל סטאטוס מותאם של 100%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
@@ -3668,6 +3236,8 @@ msgid ""
 "they have completed all of the previous problems, and their child problems "
 "if necessary"
 msgstr ""
+"אם זה מופעל אז תלמידים לא יוכלו לנסות שאלה עד שהשלימו את כל השאלות הקודמות, "
+"והאשלות המוכלות במידת הצורך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
 msgid ""
@@ -3677,112 +3247,96 @@ msgid ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 msgstr ""
+"אם אתה בוחר את %1 פרטי ההתחברות שלך ישמרו על ידי הדפדפן שלך, מה שיאפשר לך "
+"לבקר בדפי WeBWorK בלי להקליד שם משתמש וסיסמה (עד שפג תוקף הביקור). אפשרות זו "
+"לא בטוחה עבור מקומות עובודה ציבוריים, מחשבים לא בטוחים, ומחשבים שבהם אתה לא "
+"שולט באופן ישיר."
 
-#
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
-#, fuzzy
 msgid "Illegal file '%1' specified"
-msgstr "tr: The file '%1' is protected!"
+msgstr "נבחר קובץ לא חוקי '%1' "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
 msgid "Illegal filename contains '..'"
-msgstr ""
+msgstr "שם קובץ לא חוקי, מכיל '..'"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
 msgid "Import"
-msgstr "tr: Import"
+msgstr "יבא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-#, fuzzy
 msgid "Import achievements from"
-msgstr "tr: Export selected sets"
+msgstr "יבא הישגים מ-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
-msgstr "tr: Import from where?"
+msgstr "מאיפה ליבא?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
 msgid "Import how many sets?"
-msgstr "tr: Import how many sets?"
+msgstr "כמה אוספים ליבא?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
 msgid "Import sets with names"
-msgstr "tr: Import sets with names"
+msgstr "יבא אוספים עם שמות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
 msgid "Import users from what file?"
-msgstr "tr: Import users from what file?"
+msgstr "מאיזה קובץ ליבא משתמשים?"
 
-#
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
-#, fuzzy
 msgid "Imported %quant(%1,achievement)"
-msgstr "tr: Export selected sets"
+msgstr "יבא Imported %quant(%1,הישג, הישגים)"
 
 #. ($total_inprogress, $num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "In progress: %1/%2"
-msgstr ""
+msgstr "בתהליך: %1/%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Inactive"
-msgstr "tr: Inactive"
+msgstr "לא פעיל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:141
 msgid "Inactivity time before a user is required to login again"
-msgstr ""
+msgstr "זמן אי-פעילות לפני שהמשתמש נדרש להתחבר שוב"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
-#, fuzzy
 msgid "Include Success Index"
-msgstr "tr: Include Index"
+msgstr "הוסף תיבת הצלחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
-#, fuzzy
 msgid "Incorrect"
 msgstr "לא נכון"
 
-#
 #. ($total_incorrect,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
-#, fuzzy
 msgid "Incorrect: %1/%2"
-msgstr "לא נכון"
+msgstr "לא נכון: %1/%2"
 
+# Short for Initial
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
 msgid "Init"
-msgstr ""
+msgstr "התחל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
-#, fuzzy
 msgid "Institution:"
-msgstr "tr: Recitation"
+msgstr "מוסד:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
 msgid "Instructor Tools"
-msgstr "כלי מנחה"
+msgstr "כלי מדריך"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
 msgid "Instructor solution preview: show the student solution after due date."
-msgstr ""
+msgstr "הצגת פתרון למדריך: הראה לתלמיד פתרון לאחר מועד ההגשה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "Invalid Reply-to address."
-msgstr ""
+msgstr "כתובת משוב לא תקינה."
 
 #. ($output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
@@ -3791,76 +3345,69 @@ msgid ""
 "All email file names must end in the extension \".msg\" choose a file name "
 "with a \".msg\" extension. The message was not saved."
 msgstr ""
+"שם קובץ לא תקין. שם הקובץ \"%1\" לא מסתיים ב-\".msg\" כל קבצי הדוא\"ל חייבים "
+"להסתיים בסיומת זו. בחר שם קובץ עם הסיומת \".msg\". ההודעה לא נשמרה."
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
 msgid "Invalid headerType %1"
-msgstr ""
+msgstr "סוג קידומת לא תקין %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
 msgid "Invalid user ID or password."
-msgstr "Yanlış kullanıcı adı ya da şifre."
+msgstr "מזהה משתמש או סיסמה לא תקינים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2306
 msgid ""
 "It is before the open date.  You probably want to renumber the problems if "
 "you are deleting some from the middle."
 msgstr ""
+"זה לפני תאריך הפתיחה. כנראה תרצה למספר מחדש את השאלות אם אתה מוחק מהאמצע."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
-msgstr ""
+msgstr "חפצים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
-#, fuzzy
 msgid "Jump to Page:"
-msgstr "בעיה הבאה"
+msgstr "קפוץ לעמוד:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
-#, fuzzy
 msgid "Jump to Problem:"
-msgstr "בעיה הבאה"
+msgstr "קפוץ לשאלה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
 msgid "Just-In-Time parameters"
-msgstr ""
+msgstr "פאראמטרים \"בדיוק בזמן\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:772
 msgid "Keywords:"
-msgstr ""
+msgstr "מילות מפתח:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "LAST NAME"
-msgstr ""
+msgstr "שם משפחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1089
 msgid "LOCAL Usage"
-msgstr ""
+msgstr "שימוש מקומי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:135
 msgid "Language (refresh page after saving changes to reveal new language.)"
-msgstr ""
+msgstr "שפה (רענן דף לאחר שמירת שינויים כדי להציג את השפה החדשה.)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
-#, fuzzy
 msgid "Last"
-msgstr "tr: Last Name"
+msgstr "אחרון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
-#, fuzzy
 msgid "Last Answer"
-msgstr "Önceki Yanıtları Göster"
+msgstr "תשובה אחרונה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
@@ -3876,23 +3423,19 @@ msgstr "Önceki Yanıtları Göster"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
 msgid "Last Name"
-msgstr "tr: Last Name"
+msgstr "שם משפחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "Last column of merge file"
-msgstr ""
+msgstr "עמודה אחרונה של קובץ האיחוד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
-#, fuzzy
 msgid "Last name"
-msgstr "tr: Last Name"
+msgstr "שם משפחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Latest Answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr "תשובות אחרונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
 msgid ""
@@ -3900,49 +3443,44 @@ msgid ""
 "to login again.<p> This value should be entered as a number, so as 3600 "
 "instead of 60*60 for one hour"
 msgstr ""
+"פסק זמן, בשניות, שבו המשתמש יכול להיות לא פעיל לפני שהוא נדרש להתחבר שוב. "
+"<p>הערך הזה צריך להכתב כמספר, למשל 3600 במקום 60*60 עבור שעה אחת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:761
 msgid "Lesser Rod of Revelation"
-msgstr ""
+msgstr "מטה הגילוי הקטן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:877
 msgid "Lesser Tome of Enlightenment"
-msgstr ""
+msgstr "כרך ההארה הקטן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:768
 msgid "Level:"
-msgstr ""
+msgstr "שלב:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "דפדפן ספרייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
-#, fuzzy
 msgid "Library Browser 2"
-msgstr "דפדפן ספרייה"
+msgstr "דפדפן ספרייה 2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
-#, fuzzy
 msgid "Library Browser 3"
-msgstr "דפדפן ספרייה"
+msgstr "דפדפן ספרייה 3"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
-#, fuzzy
 msgid "Library Browser no js"
-msgstr "דפדפן ספרייה"
+msgstr "דפדפן ספרייה ללא js"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
 msgid "List of display modes made available to students"
-msgstr ""
+msgstr "רשימת מצבי התצוגה המופיעים לתלמידים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
 msgid ""
@@ -3950,30 +3488,27 @@ msgid ""
 "Professors need to be added to this list if questionaires are used, or other "
 "WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
+" רשימת כתובות דוא\"ל שאליהן שאלה תוכל לשלוח הודעה. צריך להוסיף מרצים אם "
+"משתמשים בשאלונים, או שאלות WeBWorK אחרות ששולחות דוא\"ל כחלק ממנגנות התשובות "
+"שלהן."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
-#, fuzzy
 msgid "List of options for Show Me Another button"
-msgstr "tr: Show in another window"
+msgstr "רשימת אפשרויות עבור כפתור \"תראה לי עוד אחת\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
 msgid "Local"
-msgstr ""
+msgstr "מקומי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
-#, fuzzy
 msgid "Local Problems"
-msgstr "בעיות"
+msgstr "שאלות מקומיות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Location"
-msgstr "tr: Recitation"
+msgstr "מיקום"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
@@ -3982,41 +3517,35 @@ msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
+"מיקום %1 לא קיים במסד הנתונים של WeBWorK. אנא בדוק את הקלט (אולי אתה צריך "
+"לטעון מחדש את דף ניהול המיקומים?)."
 
-#
 #. ($locationID, join(', ', @addresses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
-#, fuzzy
 msgid "Location %1 has been created, with addresses %2."
-msgstr "tr: Set %1 exists.  No set created"
+msgstr "מיקום %1 נוצר, עם כתובת %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
 msgid "Location deletion requires confirmation."
-msgstr ""
+msgstr "מחיקת מיקום דורשת אישור."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
-#, fuzzy
 msgid "Location description:"
-msgstr "tr: Show/Hide Site Description"
+msgstr "תיאור מיקום:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
-#, fuzzy
 msgid "Location name:"
-msgstr "tr: no action"
+msgstr "שם מיקום:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
 msgid "Log In Again"
-msgstr "Tekrar giriş yap"
+msgstr "התחבר שוב"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Log Out"
-msgstr "יציאה"
+msgstr "התנתק"
 
 #. ($add_courseID)
 #. ($rename_oldCourseID)
@@ -4027,29 +3556,23 @@ msgstr "יציאה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
 msgid "Log into %1"
-msgstr ""
+msgstr "התחבר ל-%1"
 
-#
 #. (HTML::Entities::encode_entities($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
-#, fuzzy
 msgid "Logged in as %1."
-msgstr "היכנס כ-[1_]."
+msgstr "מחובר בתור %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
-#, fuzzy
 msgid "Login"
-msgstr "כניסה"
+msgstr "התחבר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
 msgid "Login Info"
-msgstr "tr: Login Info"
+msgstr "נתוני התחברות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
@@ -4066,128 +3589,105 @@ msgstr "tr: Login Info"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
-msgstr "tr: Login Name"
+msgstr "שם התחברות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
-#, fuzzy
 msgid "Login Status"
-msgstr "Durumu"
+msgstr "סטטוס התחברות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
 msgid "Logout"
-msgstr "יציאה"
+msgstr "התנתק"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
 msgid "Main Menu"
 msgstr "תפריט ראשי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:859
 msgid "Make"
-msgstr ""
+msgstr "צור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:162
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:354
 msgid "Make Archive"
-msgstr ""
+msgstr " צור ארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
-#, fuzzy
 msgid "Make changes"
-msgstr "tr: Save changes"
+msgstr "בצע שינויים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
 msgid "Make these changes in  course:"
-msgstr ""
+msgstr "בצע את השינויים הבאים בקורס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Manage Locations"
-msgstr ""
+msgstr "נהל מיקומים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
-#, fuzzy
 msgid "Manual Grader"
-msgstr "ציונים"
+msgstr "מנקד אוטומטי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
 msgid "Mark All"
-msgstr ""
+msgstr "סמן הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Mark Correct"
-msgstr "נכון"
+msgstr "סמן כנכון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
-#, fuzzy
 msgid "Mark Correct?"
-msgstr "נכון"
+msgstr "סמן כנכון?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
 msgid "Match on what? (separate multiple IDs with commas)"
-msgstr "tr: Match on what? (separate multiple IDs with commas)"
+msgstr "התאמה לפי מה? (הפרד מספר מזהים שונים באמצעות פסיק)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
 msgid "Math Objects"
-msgstr "tr: Math Objects"
+msgstr "אובייקטים מתמטיים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
-#, fuzzy
 msgid "Max attempts"
-msgstr "ניסיונות"
+msgstr "מספר מקסימאלי של נסיונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
 msgid "Max. Shown:"
-msgstr ""
+msgstr "מקסימום שיוצגו:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
+"מספר מקסימאלי של פעמים שניתן להשתמש בכפתור \"תראה לי עוד אחת\" עבור כל בעיה "
+"(1- => לא מוגבל)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
-#, fuzzy
 msgid "Merge file:"
-msgstr "tr: header file"
+msgstr "קובץ איחוד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
-#, fuzzy
 msgid "Message"
-msgstr "הודעות"
+msgstr "הודעה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
-#, fuzzy
 msgid "Message file:"
-msgstr "tr: header file"
+msgstr "קובץ הודעה:"
 
 #. ($emailDirectory, $output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
 msgid "Message saved to file <code>%1/%2</code>."
-msgstr ""
+msgstr "הודעה נשמרה לקובץ <code>%1/%2</code>."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
-#, fuzzy
 msgid "Message:"
-msgstr "הודעות"
+msgstr "הודעה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
 msgid "Messages"
 msgstr "הודעות"
@@ -4195,38 +3695,37 @@ msgstr "הודעות"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid "Method"
-msgstr ""
+msgstr "Method"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
-msgstr ""
+msgstr "חסר קלט הכרחי. אנא ודא שמלאת את כל שדות יצירת המיקום ושלח שוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
 msgid "Move"
-msgstr ""
+msgstr "הזז"
 
+# Msg is short for message
 #. ($recipient, $ur->email_address)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
 msgid "Msg sent to %1 at %2."
-msgstr ""
+msgstr "הודעה נשלח ל%2 ב%2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
-#, fuzzy
 msgid "My Problems"
-msgstr "בעיות"
+msgstr "השאלות שלי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
 msgid "Mysterious Package (with Ribbons)"
-msgstr ""
+msgstr "חבילה מסתורית (עם סרט אדום)"
 
+# Short for Number of Fields
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
 msgid "NO OF FIELDS"
-msgstr ""
+msgstr "מספר הסדות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
@@ -4239,95 +3738,81 @@ msgstr ""
 msgid "Name"
 msgstr "שם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
-#, fuzzy
 msgid "Name for new set here"
-msgstr "tr: Name the new set"
+msgstr "שם לאוסף חדש "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
-#, fuzzy
 msgid "Name of course information file"
-msgstr "tr: course information"
+msgstr "שם של  קובץ מידע של הקורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
-msgstr "tr: Name the new set"
+msgstr "תן שם לאוסף החדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1552
 msgid "Necromancers Charm"
-msgstr ""
+msgstr "מדליון בעל האוב"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
-#, fuzzy
 msgid "Never"
-msgstr "tr: Revert"
+msgstr "אף פעם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
 msgid "New File"
-msgstr ""
+msgstr "קובץ חדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New Folder"
-msgstr ""
+msgstr "תיקייה חדשה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
-#, fuzzy
 msgid "New Name:"
-msgstr "tr: Set Name"
+msgstr "שם חדש:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
 msgid "New Password"
-msgstr "tr: New Password"
+msgstr "סיסמה חדשה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
-#, fuzzy
 msgid "New file name:"
-msgstr "tr: Filename"
+msgstr "שם קובץ חדש:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New folder name:"
-msgstr ""
+msgstr "שם תיקייה חדש:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
 msgid "New passwords saved"
-msgstr "tr: New passwords saved"
+msgstr "סיסמאות חדשות נשמרו"
 
+# No space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "NewVersion"
-msgstr ""
+msgstr "גרסה חדשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1852
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
-msgstr ""
+msgstr "יש ליבא קבצי .def של אוסף שאלות חדש בעזרת עורך אוספי שיעורי בית 2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
 msgid "Next Problem"
-msgstr "בעיה הבאה"
+msgstr "שאלה הבאה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
-msgstr ""
+msgstr "הדף הבא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4342,183 +3827,159 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "No"
-msgstr "tr: No"
+msgstr "לא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
-#, fuzzy
 msgid "No Description"
-msgstr "tr: Show/Hide Site Description"
+msgstr "אין תיאור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
 msgid "No achievements shown.  Create an achievement!"
-msgstr ""
+msgstr "לא מוצגים הישגים. צור הישג!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
-#, fuzzy
 msgid "No action taken"
-msgstr "tr: no action"
+msgstr "לא נעשת פעולה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
 msgid ""
 "No authentication method found for your request.  If this recurs, please "
 "speak with your instructor."
 msgstr ""
+"לא נמצאה שיטת אימות לבקשה שלך. אם בעיה זו חוזרת על עצמה, אנא פנה למדריך שלך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
-msgstr "tr: No change made to any set"
+msgstr "לא בוצע שום שינוי לשום אוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
 msgstr ""
+"לא פורטו שינויים. יש לבחור את הדברים שברצונך לשנות ולהכניס את פרטי השינוי."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
-#, fuzzy
 msgid "No changes were saved!"
-msgstr "tr: changes saved"
+msgstr "לא נשמרו שינויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
-#, fuzzy
 msgid "No course id defined"
-msgstr "קורסים"
+msgstr "לא הוגדר מזהה קורס"
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
-#, fuzzy
 msgid "No data exists for set %1 and problem %2"
-msgstr "tr: set %1/problem %2"
+msgstr "לא קיימים נתונים עבור אוסף %1 ושאלה %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
 msgid "No filename was specified for saving!  The message was not saved."
-msgstr ""
+msgstr "לא פורט שם קובץ לשמירה! ההודעה לא נשמרה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
 msgid "No guest logins are available. Please try again in a few minutes."
-msgstr ""
+msgstr "אין חשבונות אורחים זמינים. אנא נסה מאוחר יותר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
 msgid "No location specified to edit?! Please check your input data."
-msgstr ""
+msgstr "לא פורט מיקום לערוך?! אנה בדוק את הנתונים שהקלדת."
 
 #. ($badID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
 msgid "No location with name %1 exists in the database"
-msgstr ""
+msgstr "לא קיים מיקום עם השם %1 במסד הנתונים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
-#, fuzzy
 msgid "No merge data file"
-msgstr "tr: header file"
+msgstr "לא קיים קובץ נתוני איחוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
-msgstr ""
+msgstr "לא פורט מזהה הישג חדש. לא נוצר הישג חדש. קובץ לא נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
 msgid "No problems matched the given parameters."
-msgstr ""
+msgstr "לא נמצאו שאלות שתואמות לפאראמטרים שנתנו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
-msgstr ""
+msgstr "לא נבחרו נמענים. אנא בחר נמען אחד או יותר מהרשימה."
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
-#, fuzzy
 msgid "No record for global set %1."
-msgstr "tr: Set Header for set %1"
+msgstr "אין רישום לאוסף הגלובאלי %1."
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
-#, fuzzy
 msgid "No record for user %1."
-msgstr "tr: Set Header for set %1"
+msgstr "אין רישום למשתמש %1."
 
-#
 #. ($prob)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
-#, fuzzy
 msgid "No record found for problem %1."
-msgstr "tr: Set Header for set %1"
+msgstr "לא נמצא רישום עבור שאלה %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
 msgid "No record found."
-msgstr ""
+msgstr "לא נמצא רישום."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:48
 msgid "No sets in this course yet"
-msgstr ""
+msgstr "עדיין לא קיימים אוספים בקורס זה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
 msgid "No sets selected for scoring"
-msgstr "tr: No sets selected for scoring"
+msgstr "לא נבחרו אוספים לנקד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr ""
-"tr: No sets shown.  Choose one of the options above to list the sets in the "
-"course."
+"לא מוצגים אוספים. בחר את אחת האפשרויות לעיל כדי להציג את האוספים בקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
 msgid "No source filePath specified"
-msgstr ""
+msgstr "לא פורט מסלול קובץ מקור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
 msgid "No source_file for problem in .def file"
-msgstr ""
+msgstr "אין קובץ מקור לשאלה בקובץ ה-def."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
-#, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
-"tr: No sets shown.  Choose one of the options above to list the sets in the "
-"course."
+"לא מוצגים תלמידים. אנא בחר את אחד  מהאפשרויות לעיל כדי לראות את התלמידים "
+"בקורס."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
-#, fuzzy
 msgid "No tests taken."
-msgstr "tr: no action"
+msgstr "לא נעשו מבחנים."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:625
 msgid "No user specific data exists for user %1"
-msgstr ""
+msgstr "לא קיימים נתוניי משתמש עבור משתמש %1"
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
 msgid "No valid changes submitted for location %1."
-msgstr ""
+msgstr "לא נשלחו שינויים תקפים עבור מיקום %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
@@ -4526,7 +3987,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
 msgid "None"
-msgstr ""
+msgstr "כלום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:120
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:130
@@ -4534,92 +3995,82 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:180
 msgid "None Specified"
-msgstr ""
+msgstr "לא נבחרו פריטים"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
 msgid "None of the selected users are assigned to this set: %1"
-msgstr ""
+msgstr "לאף אחד מהמשתמשים הנבחרים לא הוקצה האוסף הזה: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
 msgid "Not logged in."
-msgstr "לא רשום ב."
+msgstr "לא מחובר."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
 msgid "Note"
-msgstr "tr: Note"
+msgstr "פתק"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
-msgstr ""
+msgstr "שים לב: ניקוד המבחן מנקד את כל השאלות, לא רק מהדף הזה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
-#, fuzzy
 msgid "Number"
-msgstr "tr: Problem Viewer"
+msgstr "מספר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
 msgid "Number of Graded Submissions per Test (0=infty)"
-msgstr ""
+msgstr "מספר ההגשות שנוקדו עבור כל מבחן (0=אינסוף)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:287
 msgid "Number of Problems per Page (0=all)"
-msgstr ""
+msgstr "מספר שאלות בכל דף (0=הכל)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:270
 msgid "Number of Tests per Time Interval (0=infty)"
-msgstr ""
+msgstr "מספר מבחנים עבור פסק זמן (0=אינסוף)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
 msgid "OK"
-msgstr ""
+msgstr "אישור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1340
 msgid "Oil of Cleansing"
-msgstr ""
+msgstr "שמן הטיהור"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
-#, fuzzy
 msgid "Old Classlist Editor"
-msgstr "עורך רשימות כיתה"
+msgstr "עורך רשימת כיתה ישן"
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
-#, fuzzy
 msgid "Old Hmwk Sets Editor"
-msgstr "עורך שיעורי בית"
+msgstr "עורך אוספי שיעורי בית ישן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
 msgid "One Column"
-msgstr ""
+msgstr "עמודה אחת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:306
 msgid "Only after set answer date"
-msgstr ""
+msgstr "רק לאחר תאריך התשובות של האוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:296
 msgid ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
-msgstr ""
+msgstr "רק רמת ההיתר הזאת ומעלה מקבלים גישה לכפתור לשליחת דוא\"ל למדריך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
-#, fuzzy
 msgid "Open"
-msgstr "tr: Open Date"
+msgstr "פתח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:780
@@ -4628,211 +4079,195 @@ msgstr "tr: Open Date"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:803
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:826
 msgid "Open Date"
-msgstr "tr: Open Date"
+msgstr "תאריך פתיחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
-#, fuzzy
 msgid "Open Problem Library"
-msgstr "רשימת בעיות"
+msgstr "ספריית שאלות פתוחות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "Open in New Window"
-msgstr ""
+msgstr "פתח בחלון חדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
 msgid "Open in new window"
-msgstr ""
+msgstr "פתח בחלון חדש"
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
-#, fuzzy
 msgid "Open, closes %1."
-msgstr "פתח עכשיו מכיוון ש"
+msgstr "פתח, נסגר ב-%1."
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
-#, fuzzy
 msgid "Open, complete by %1."
-msgstr "tr: completely"
+msgstr "פתח, השלם עד %1."
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
 msgid "Open, reduced scoring starts on %1."
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr "פתח, ניקוד מופלת מתחיל ב-%1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
-#, fuzzy
 msgid "Open:"
-msgstr "tr: Open Date"
+msgstr "פתח:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
-#, fuzzy
 msgid "Opens"
-msgstr "tr: Open Date"
+msgstr "פותח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
-msgstr ""
+msgstr "פותח אוסף שחעורח בית ל-24 שעות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:195
 msgid "Optional Modules"
-msgstr ""
+msgstr "מערכות אפשריות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
-#, fuzzy
 msgid "Order Problems Randomly"
-msgstr "בעיות"
+msgstr "סדר שאלות באופן אקראי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
-#, fuzzy
 msgid "Orig. Lib. Browser"
-msgstr "דפדפן ספרייה"
+msgstr "דפדפן ספרייה מקורית"
 
+# Context is "7 Out Of 10"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
-msgstr ""
+msgstr "אזל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
-#, fuzzy
 msgid "Over time, closed."
-msgstr "תם הזמן: סגור"
+msgstr "הזמן חלף, סגור."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Overwrite"
-msgstr ""
+msgstr "דרוס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:382
 msgid "Overwrite existing files silently"
-msgstr ""
+msgstr "דרוס קבצים קיימים באופן שקט"
 
+# PG is a WeBWorK abreviation and should stay PG
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
 msgid "PG - Problem Display/Answer Checking"
-msgstr ""
+msgstr "PG - הצגת שאלה/בדיקת תשובה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
 msgid "PG debug messages"
-msgstr ""
+msgstr "הודעות דיבאג של PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "PG internal errors"
-msgstr ""
+msgstr "שגיאות PG פנימיות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
 msgid "PG question failed to render"
-msgstr ""
+msgstr "רינדור שאלת PG נכשל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
 msgid "PG question processing error messages"
-msgstr ""
+msgstr "הודעות שגיאות עיבוד של שאלת PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG warning messages"
-msgstr ""
+msgstr "הודעות הזהרה של PG"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
 msgid "PGInfo"
-msgstr ""
+msgstr "מידע PG"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
 msgid "PGLab"
-msgstr ""
+msgstr "מעבדת PG"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
 msgid "PGML"
-msgstr ""
+msgstr "PGML"
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
 msgid "POD"
-msgstr ""
+msgstr "POD"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
-msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
+msgstr "תצוגה מקדימה בלבד -- התשובות לא נשמרות"
 
+# Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
 msgid "PROB NUMBER"
-msgstr ""
+msgstr "מספר שאלה"
 
+# Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
 msgid "PROB VALUE"
-msgstr ""
+msgstr "ערך שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
 msgid "Pad Fields"
-msgstr "tr: Pad Fields"
+msgstr "רפד שדות"
 
-#
 #. (timestamp($self)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
-#, fuzzy
 msgid "Page generated at %1"
-msgstr "tr: Page generated at %1"
+msgstr "דף נוצר ב-%1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
 msgid "Password"
-msgstr "סיסמא"
+msgstr "סיסמה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:921
 msgid "Password (Leave blank for regular proctoring)"
-msgstr ""
+msgstr "סיסמה (השאר ריק עבור משגיח רגיל)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
-#, fuzzy
 msgid "Password:"
-msgstr "סיסמא"
+msgstr "סיסמה:"
 
-#
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
-#, fuzzy
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr "תשובות מהעבר עבור %1, אוסף %2, שאלה %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
 msgid "Percent"
-msgstr ""
+msgstr "אחוז"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:574
 msgid "Percentage of Active Students with Correct Answers"
-msgstr ""
+msgstr "אחוז התלמידים הפעילים עם תשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:570
 msgid ""
 "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
 "median number of attempts"
 msgstr ""
+"אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. <br/>עמודת ה-50% מראה את "
+"החציון של מספר הניסיונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
+"אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. עמודת ה-50% מראה את "
+"החציון של מספר הניסיונות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
@@ -4846,13 +4281,11 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 msgid "Permission Level"
-msgstr "tr: Permission Level"
+msgstr "רמת הרשאה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
-#, fuzzy
 msgid "Permissions"
-msgstr "tr: Permission Level"
+msgstr "היתרים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
 msgid ""
@@ -4860,165 +4293,140 @@ msgid ""
 "will not show up in the courses list on the WeBWorK home page. It will still "
 "appear in the Course Administration listing."
 msgstr ""
+"צור תיקייה בשם \"hide_directory\" בקורס או בתיקייה אחרת והיא לא תופיע ברשימת "
+"הקורסים בעמוד הבית של WeBWorK. היא כן תופיע ברישום הנהלת הקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1016
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given full credit."
-msgstr ""
+msgstr "אנא בחר שם אוסף ומספר מספר שאלה של השאלה שיש לתת לה  ניקוד מלא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:811
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given half credit."
-msgstr ""
+msgstr "אנא בחר שם אוסף ומספר מספר שאלה של השאלה שיש לתת לה חצי ניקוד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:587
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its incorrect attempt count reset."
 msgstr ""
+"אנא בחר שם אוסף ומספר מספר שאלה של השאלה שלה יש לאפס את ספירת הניסיונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:698
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its weight doubled."
-msgstr ""
+msgstr "אנא בחר את שם האוסף ומספר השאלה של השאלה שאת משקלה יש להכפיל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1214
 msgid ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 msgstr ""
+"אנא בחר את האוסף, השאלה שתרצה להעתיק, ואת השאלה אליה תרציה להעתיק אותה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
 msgid "Please correct the following errors and try again:"
-msgstr ""
+msgstr "אנא תקן את השגיאות הבאות ונסה שוב:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:706
 msgid "Please enter in a value to match in the filter field."
-msgstr ""
+msgstr "אנה הכנס ערך תואם בשדה הסינון."
 
-#
 #. (CGI::b($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
-#, fuzzy
 msgid "Please enter your username and password for %1 below:"
-msgstr "הכנס שם משתמש וסיסמא ב-[1_]"
+msgstr "אנה הכנס את שם המשתמש והסיסמה שלךעבור %1 למטה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
 msgid "Please provide a location name to delete."
-msgstr ""
+msgstr "אנא בחר שם מיקום למחיקה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
 msgid "Please select action to be performed."
-msgstr "tr: Please select action to be performed."
+msgstr "אנא בחר פעולה לבצע"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
-#, fuzzy
 msgid "Please select at least one set and try again."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אנא בחר לפחות אוסף אחד ונסה שוב."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
-#, fuzzy
 msgid "Please select at least one user and try again."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אנא בחר לפחות משתמש אחד ונסה שוב."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
-msgstr "tr: Please specify a file to save to."
+msgstr "אנא בחר קובץ לשמירה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
-#, fuzzy
 msgid "Points"
-msgstr "הראה רמזים"
+msgstr "נקודות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
 msgid "Potion of Forgetfullness"
-msgstr ""
+msgstr "שיקוי השכחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
-msgstr ""
+msgstr "פרטי בדיקה מקדימה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview Message"
-msgstr "הראה תשובות"
+msgstr "צפייה מוקדמת בהודעה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
-#, fuzzy
 msgid "Preview My Answers"
-msgstr "הראה תשובות"
+msgstr "צפייה מוקדמת בתשובות שלי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
-#, fuzzy
 msgid "Preview Test"
-msgstr "הראה תשובות"
+msgstr "צפייה מוקדמת במבחן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview message"
-msgstr "הראה תשובות"
+msgstr "צפייה מוקדמת בהודעה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
-#, fuzzy
 msgid "Preview set to:"
-msgstr "הראה תשובות"
+msgstr "הצג אוסף עבור:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
 msgid "Previous Problem"
-msgstr "בעיה קודמת"
+msgstr "שאלה קודמת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
-#, fuzzy
 msgid "Previous page"
-msgstr "בעיה קודמת"
+msgstr "עמוד קודם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "Primary sort"
-msgstr ""
+msgstr "מיון ראשי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
 msgid "Print Test"
-msgstr ""
+msgstr "הדפס מבחן"
 
-#
+# Short for Problem
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#, fuzzy
 msgid "Prob"
-msgstr "בעיות"
+msgstr "שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
-#, fuzzy
 msgid "Problem"
-msgstr "בעיות"
+msgstr "שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
-#, fuzzy
 msgid "Problem #"
-msgstr "tr: Problem"
+msgstr "שאלה #"
 
-#
 #. ($prettyProblemID)
 #. (join('.',@seq)
 #. ($problemID)
@@ -5033,74 +4441,59 @@ msgstr "tr: Problem"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
-#, fuzzy
 msgid "Problem %1"
-msgstr "tr: Problem"
+msgstr "שאלה %1"
 
-#
 #. ($problemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
-#, fuzzy
 msgid "Problem %1."
-msgstr "tr: Problem"
+msgstr "שאלה %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
 msgid "Problem Editor"
-msgstr "עורך בעיות"
+msgstr "עורך שאלות"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
-#, fuzzy
 msgid "Problem Editor2"
-msgstr "עורך בעיות"
+msgstr "עורך שאלות2"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
-#, fuzzy
 msgid "Problem Editor3"
-msgstr "עורך בעיות"
+msgstr "עורך שאלות3"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
 msgid "Problem List"
-msgstr "רשימת בעיות"
+msgstr "רשימת שאלות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
-#, fuzzy
 msgid "Problem Number"
-msgstr "tr: Problem Viewer"
+msgstr "מספר שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
-#, fuzzy
 msgid "Problem Number "
-msgstr "tr: Problem Viewer"
+msgstr "מספר שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
 msgid "Problem Techniques"
-msgstr "tr: Problem Techniques"
+msgstr "טכניקות שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
-#, fuzzy
 msgid "Problem Viewer"
-msgstr "עורך בעיות"
+msgstr "מציג השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
 msgid "Problem source is drawn from a grouping set"
-msgstr ""
+msgstr "השאלה נבחרת באופן אקראי מתוך קבוצת שאלות ייעודיות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
@@ -5110,47 +4503,43 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
 msgid "Problems"
-msgstr "בעיות"
+msgstr "שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:62
 msgid "Problems for all students have been unassigned."
-msgstr ""
+msgstr "הוקצאו שאלות לכל התלמידים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:65
 msgid "Problems for selected students have been reassigned."
-msgstr ""
+msgstr "הוקצאו שאלות לתלמידים הנבחרים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:57
 msgid "Problems have been assigned to all current users."
-msgstr ""
+msgstr "שאלות הוקצאו לכל המשתמשים הנוכחיים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
-#, fuzzy
 msgid "Proctor"
-msgstr "tr: Proctor"
+msgstr "משגיח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:203
 msgid "Proctor authorization required."
-msgstr ""
+msgstr "נדרשת הרשאת משגיח."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
-#, fuzzy
 msgid "Proctor password:"
-msgstr "סיסמא"
+msgstr "סיסמת משגיח:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
 msgid "Proctor username:"
-msgstr ""
+msgstr "שם משתמש משגיח:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:259
 msgid "Proctored Gateway Quiz %2"
-msgstr ""
+msgstr "השגיח על בוחן מחסום %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:268
 msgid "Proctored Gateway Quiz %2 Proctor Login"
-msgstr ""
+msgstr "השגיח על מבחן מחסום %2 התחברות משגיח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:841
@@ -5159,26 +4548,26 @@ msgid ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 msgstr ""
+"כדי להתחיל ולנקד מבחן עם משגיח צריך הרשאת משגיח. תן סיסמה כדי שיהיה סיסמה "
+"אחת שכל התלמידים יוכלו להתחיל בעזרתה מבחן עם משגיח."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
 msgid "Publish"
-msgstr "tr: Publish"
+msgstr "פרסם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "RECITATION"
-msgstr ""
+msgstr "תרגול"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
 msgid "Read only"
-msgstr ""
+msgstr "קריאה בלבד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:735
 msgid "Really delete the items listed above?"
-msgstr ""
+msgstr "אתה באמת רוצה למחוק את הפריטים לעיל?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
@@ -5199,146 +4588,123 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Recitation"
-msgstr "tr: Recitation"
+msgstr "תרגול"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
 msgid "Record Scores for Single Sets"
-msgstr "tr: Record Scores for Single Sets"
+msgstr "שמור ניקוד לאוספים בודדים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:477
 msgid "Reduced Scoring"
-msgstr ""
+msgstr "ניקוד מופחת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
-#, fuzzy
 msgid "Reduced Scoring Date"
-msgstr "tr: Reduced Credit Disabled"
+msgstr "תאריך ניקוד מופחת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Disabled"
-msgstr "tr: Reduced Credit Disabled"
+msgstr "ביטול ניקוד מופחת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Enabled"
-msgstr "tr: Reduced Credit Enabled"
+msgstr "הפעלת ניקוד מופחת"
 
-#
 #. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
 msgid "Reduced Scoring Starts %1"
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr "נתוני ניקוד מופחת %1"
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
 msgid "Reduced scoring started on %1."
-msgstr "tr: Reduced Credit Starts: %1"
+msgstr "ניקוד מופחת מצחיל ב-%1."
 
+# Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
-msgstr ""
+msgstr "מופחת:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:358
 msgid "Refresh"
-msgstr ""
+msgstr "רענן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2031
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2156
 msgid "Refresh Display"
-msgstr ""
+msgstr "רענן תצוגה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Refresh Listing"
-msgstr "tr: Users List"
+msgstr "רענן רשימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
 msgid "Relax IP restrictions when?"
-msgstr ""
+msgstr "הרגע הגבלות IP מתי?"
 
-#
+# Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 msgid "Remaining"
-msgstr "נשאר"
+msgstr "נותר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
 msgid "Remember Me"
-msgstr "tr: Remember Me"
+msgstr "זכור אותי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:480
 msgid "Remember to return to your original problem when you're finished here!"
-msgstr ""
+msgstr "זכור לחזור לשאלה המקורית כשסיימת כאן!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
-#, fuzzy
 msgid "Rename"
-msgstr "tr: Filename"
+msgstr "שנה שם"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
 msgid "Rename %1 to %2"
-msgstr ""
+msgstr "שנה את שם %1 ל-%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
-#, fuzzy
 msgid "Rename Course"
-msgstr "קורסים"
+msgstr "שנה שם לקורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
-#, fuzzy
 msgid "Rename file as:"
-msgstr "tr: header file"
+msgstr "שנה שם קובץ ל-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render"
-msgstr ""
+msgstr "הצג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
 msgid "Render All"
-msgstr ""
+msgstr "הצג הכל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
-#, fuzzy
 msgid "Render Problem"
-msgstr "בעיה הבאה"
+msgstr "הצג שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
-#, fuzzy
 msgid "Renumber Problems"
-msgstr "בעיות"
+msgstr "מספר שאלות מחדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
@@ -5346,78 +4712,70 @@ msgid ""
 "a test even if the close date has past. This item does not allow you to take "
 "additional versions of the test."
 msgstr ""
+"פותח מחדש בוחן מחסום ל-24 שעות נוספות. דבר זה מאפשר לך לבצע אותו אפילו עם "
+"עבר תאריך הסגירה. חפץ זה לא מאפשר לך לבצע גרסאות אחרות של הבוחן הזה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2326
 msgid "Reorder problems only"
-msgstr ""
+msgstr "סדר מחדש שאלות בלבד"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
-msgstr ""
+msgstr "החלףשאלה נוכחית: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
 msgid "Replace which users?"
-msgstr "tr: Replace which users?"
+msgstr "איזה משתמשים להחליף?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
 msgid "Reply-To:"
-msgstr ""
+msgstr "השב ל-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
 msgid "Report Bugs in this Problem"
-msgstr ""
+msgstr "דווח על באגים בשאלה הזו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
 msgid "Report bugs"
-msgstr "דווח על וירוסים"
+msgstr "דווח על באגים"
 
-#
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
-#, fuzzy
 msgid "Report for course %1:"
-msgstr "tr: Set Header for set %1"
+msgstr "דווח עבור קורס %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
 msgid "Report on database structure for course %1:"
-msgstr ""
+msgstr "דווח מבנה מסד נתונים עבור קורס %1:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
 msgid "Request New Version"
-msgstr ""
+msgstr "בקש גרסה חדשה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
-#, fuzzy
 msgid "Request information"
-msgstr "tr: Site Information"
+msgstr "בקש מידע"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
-#, fuzzy
 msgid "Request new version now."
-msgstr "tr: Site Information"
+msgstr "בקש גרסה חדשה כעת"
 
-#
 #. ($setName,$effectiveUserName)
 #. ($setName, $effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
-#, fuzzy
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "לא נמצא האוסף שבוקש '%1'  במסד הנתונים עבור משתמש %2."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -5426,13 +4784,15 @@ msgid ""
 "generator %2 was called.  Try re-entering the set from the problem sets "
 "listing page."
 msgstr ""
+"האוסף שבוקש '%1' הוא מטלת שיעורי בית אבל יוצר התכנים של בוחן המחסום/בוחן %2 "
+"נקרא.  נסה  להכניס מחדש את האוסף מעמוד רישום אוספי השאלות."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
 msgid ""
 "Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
 "authorization has been obtained."
-msgstr ""
+msgstr "האוסף שבוקש '%1' הוא מטלת בבוחן מוגנת, אבל לא הושג אימות משגיח תקין."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
@@ -5441,56 +4801,50 @@ msgid ""
 "assignment content generator %2 was called.  Try re-entering the set from "
 "the problem sets listing page."
 msgstr ""
+"האוסף שבוקש '%1' הוא מטלת בוחן/מבחן אבל יוצר התכנים של מטלות שיעורי הבית %2 "
+"נקרא. נסה להכניס מחדש את האוסף מעמוד רישום אוספי השאלות."
 
-#
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
-#, fuzzy
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "האוסף שבוקש '%1' לא הוקצה למשמתמש %2."
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
-#, fuzzy
 msgid "Requested set '%1' is not available yet."
-msgstr "Bu soru grubu henüz açık değil."
+msgstr "האוסף שבוקש '%1' עדיין לא זמין"
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
-#, fuzzy
 msgid "Requested set '%1' is not yet open."
-msgstr "Bu soru grubu henüz açık değil."
+msgstr "האוסף שבוקש '%1' עדיין לא נפתח."
 
-#
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
-#, fuzzy
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "הגרסה שבוקשה (%1) של האוסף '%2' לא הוקצאה למשתמש %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
-msgstr ""
+msgstr "בצע רנדומיזציה מחדש אחרי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:734
 msgid "Reset"
-msgstr ""
+msgstr "אתחל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Reset Form"
-msgstr ""
+msgstr "אתחל טופס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:538
 msgid "Resets the number of incorrect attempts on a single homework problem."
-msgstr ""
+msgstr "מאתחל את מספר הניסיונות הלא נכונים על שאלת שיעורי בית אחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
 msgid "Ressurect which Gateway?"
-msgstr ""
+msgstr "החזר איזה בוחן מחסום?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
 msgid ""
@@ -5499,112 +4853,99 @@ msgid ""
 "directory. Currently the archive facility is only available for mysql "
 "databases. It depends on the mysqldump application."
 msgstr ""
+"משחזר קורס מארכיון gzippe tar (סיומת .tar.gz). אחרי הסרה מהארכיון, מסד נתוני "
+"הקורס משוחזר מתת-תיקייה של תיקיית ה-DATA של הקורס. כרגע מתקן הארכיון ניתן "
+"לשימוש רק עם מסד נתונים מסוג mysql. זה תלוי באפליקציית mysqldump."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:202
 msgid "Restrict Access by IP"
-msgstr ""
+msgstr "הגבל גישה לפי  IP"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
-#, fuzzy
 msgid "Restrict Locations"
-msgstr "tr: Recitation"
+msgstr "הגבל מיקומים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
 msgid "Restrict Problem Progression"
-msgstr ""
+msgstr "הגבל התקדמות שאלות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
-#, fuzzy
 msgid "Restrict To"
-msgstr "tr: Recitation"
+msgstr "הגבל ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
 msgid "Restrict release by set(s)"
-msgstr ""
+msgstr "הגבל פרסום לפי אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Result"
 msgstr "תוצאות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
-#, fuzzy
 msgid "Result of last action performed"
-msgstr "tr: Results of last action performed"
+msgstr "התוצאה של הפעולה האחרונה שבוצעה"
 
-#
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
-#, fuzzy
 msgid "Result of last action performed: %1"
-msgstr "tr: Result of last action performed: %1"
+msgstr "התוצאה של הפעולה האחרונה שבוצעה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
 msgid "Results for this submission"
-msgstr ""
+msgstr "תוצאות של הגשה זו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
 msgid "Results of last action performed"
-msgstr "tr: Results of last action performed"
+msgstr "התוצאות של הפעולה האחרונה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
-#, fuzzy
 msgid "Results of last action performed: "
-msgstr "tr: Results of last action performed"
+msgstr "התוצאות של הפעולה האחרונה שבוצעה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
 msgid "Retitled"
-msgstr ""
+msgstr "כותרת שונתה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "Revert"
-msgstr "tr: Revert"
+msgstr "שחזר"
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
-#, fuzzy
 msgid "Revert to %1"
-msgstr "tr: Revert"
+msgstr "שחזר ל-%1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
 msgid "Ring of Reduction"
-msgstr ""
+msgstr "טבעת ההפחתה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:272
 msgid "Robe of Longevity"
-msgstr ""
+msgstr "חלוק אריכות הימים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "SECTION"
-msgstr ""
+msgstr "קבוצה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
 msgid "SET NAME"
-msgstr ""
+msgstr "שם אוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
 msgid "STATUS"
-msgstr ""
+msgstr "סטאטוס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
 msgid "STUDENT ID"
-msgstr ""
+msgstr "מזהה תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
@@ -5613,46 +4954,36 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
-msgstr "tr: Save"
+msgstr "שמור"
 
-#
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
-#, fuzzy
 msgid "Save %1"
-msgstr "tr: Save"
+msgstr "שמור %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
-msgstr "tr: Save As [TMPL]/"
+msgstr "שמור בשם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
-#, fuzzy
 msgid "Save Changes"
-msgstr "tr: Save changes"
+msgstr "שמור שינויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
-#, fuzzy
 msgid "Save as"
-msgstr "tr: Save as"
+msgstr "שמור בשם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
-#, fuzzy
 msgid "Save as Default"
-msgstr "tr: Use System Default"
+msgstr "שמור כברירת מחדל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
@@ -5663,46 +4994,39 @@ msgstr "tr: Use System Default"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
 msgid "Save changes"
-msgstr "tr: Save changes"
+msgstr "שמור שינויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
-#, fuzzy
 msgid "Save file to:"
-msgstr "tr: Save Edit"
+msgstr "שמור קובץ ב-:"
 
-#
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
-#, fuzzy
 msgid "Save to %1 and View"
-msgstr "tr: Save %1 and View"
+msgstr "שמור ל-%1 וצפה"
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
-#, fuzzy
 msgid "Saved to file '%1'"
-msgstr "tr: Saved to file '%1'"
+msgstr "שמור לקובץ '%1'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Schema and database field definitions do not agree"
-msgstr ""
+msgstr "הגדרות שדה של הסכמה ומסד הנתונים לא מתאימות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
 msgid "Schema and database table definitions do not agree"
-msgstr ""
+msgstr "הגדרות טבלה של הסכמה ומסד הנתונים לא מתאימות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
@@ -5713,51 +5037,39 @@ msgstr ""
 msgid "Score"
 msgstr "ניקוד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Score (%)"
-msgstr "ניקוד"
+msgstr "ציון (%)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
 msgid "Score required for release"
-msgstr ""
+msgstr "ציון שנדרש עבור פרסום"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
 msgid "Score selected set(s) and save to:"
-msgstr "tr: Score selected set(s) and save to:"
+msgstr "נקד את האוספים שנבחרו ושמור ב-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
 msgid "Score summary for last submit:"
-msgstr ""
+msgstr "סיכום ניקוד עבור שליחה אחרונה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
 msgid "Score which sets?"
-msgstr "tr: Score which sets?"
+msgstr "איזה אוספים לנקד?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
-#, fuzzy
 msgid "Scores"
-msgstr "ניקוד"
+msgstr "ציונים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
-#, fuzzy
 msgid "Scoring Download"
-msgstr "כלי ניקוד"
+msgstr "הורדת ציונים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
-#, fuzzy
 msgid "Scoring Message"
-msgstr "כלי ניקוד"
+msgstr "הודעת ציון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
-#, fuzzy
 msgid "Scoring Tools"
 msgstr "כלי ניקוד"
 
@@ -5767,16 +5079,16 @@ msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
+"מידע קידומת גרסת הדפסה או מסך של אוסף לא יכול להשתנות עבור תלמיד ספציפי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
 msgid "Scroll of Ressurection"
-msgstr ""
+msgstr "מגילת התחייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
-msgstr ""
+msgstr "מיון משני"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
@@ -5800,41 +5112,35 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
-msgstr "tr: Section"
+msgstr "קבוצה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
-#, fuzzy
 msgid "Section:"
-msgstr "tr: Section"
+msgstr "קבוצה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
 msgid "Seed"
-msgstr ""
+msgstr "זרע"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
 msgid "Select"
-msgstr ""
+msgstr "בחר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
-#, fuzzy
 msgid "Select a Problem Collection"
-msgstr "tr: Select action below"
+msgstr "בחר מקבץ שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
-msgstr ""
+msgstr "בחר אוסף מהקורס הזה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
-#, fuzzy
 msgid "Select a course to delete."
-msgstr "tr: Select action below"
+msgstr "בחר קורס למחיקה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
 msgid ""
@@ -5842,83 +5148,71 @@ msgid ""
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
+"בחר קורס שתרצה לשנות את שמו. מזהה הקורס  יהיה חלק מ-URL ויכול להכיל רק "
+"מספרים אותיות וקוים תחתונים. כותרת הקורס מופיע בדף הבית של הקורס ויוכלה "
+"להיות כל מחרוזת."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
-#, fuzzy
 msgid "Select a course to unarchive."
-msgstr "tr: Select action below"
+msgstr "בחר קורס להוציא מהארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
-#, fuzzy
 msgid "Select a database layout below."
-msgstr "tr: Select action below"
+msgstr "בחר מתכונת מסד נתונים למטה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
-#, fuzzy
 msgid "Select a listing format:"
-msgstr "tr: Select an action to perform"
+msgstr "בחר פורמט רשימה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
-#, fuzzy
 msgid "Select above then:"
-msgstr "tr: selected sets"
+msgstr "אז בחר לעיל:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
-#, fuzzy
 msgid "Select all eligible courses"
-msgstr "tr: Select all users"
+msgstr "בחר את כל הקורסים המתאימים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
 msgid "Select all sets"
-msgstr "tr: Select all sets"
+msgstr "בחר את כל האוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
 msgid "Select all users"
-msgstr "tr: Select all users"
+msgstr "בחר את כל המשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
 msgid "Select an action to perform"
-msgstr "tr: Select an action to perform"
+msgstr "בחר בפעולה לבצע"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
-#, fuzzy
 msgid "Select an action to perform:"
-msgstr "tr: Select an action to perform"
+msgstr "בחר פעולה שתרצה לבצע:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
 msgid "Select course(s) to archive."
-msgstr ""
+msgstr "בחור קורס/ים להוסיף לארכיון."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
-#, fuzzy
 msgid "Select course(s) to hide or unhide."
-msgstr "tr: Select action below"
+msgstr "בחר קורס/ים להחביא או להפוך לגלוי/ם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
 msgid ""
 "Select one or more sets and one or more users below to assign/unassign each "
 "selected set to/from all selected users."
 msgstr ""
+"בחר אוסף אחד או יותר ומשתמש אחד או יותר כדי להקצות/לבטל הקצאת כל אוסף שנבחר "
+"לכל המשתמש שנבחר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
 msgid "Select sets below to assign them to the newly-created users."
-msgstr ""
+msgstr "בחר אוספים למטה כדי להקצות אותם למשתמשים החדשים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
 msgid ""
@@ -5930,6 +5224,11 @@ msgid ""
 "opening page.  To access the course, an instructor or student must know the "
 "full URL address for the course."
 msgstr ""
+"בחר קורס/ים שתרצה להחביא (או להפוך לגלוי/ים) ולחץ על \"החבא קורסים\" (או "
+"\"הפוך קורסים לגלויים\"). החבאת קורס שהוא כבר חבוי לא עושה כלום. באותו אופן "
+"הפיכת קורס גלוי לגלוי גם לא עושה כלום. קורסים מוחבאים הם עדיין פעילים אבל לא "
+"רשומים ברשימת הקורסים של WeBWorK בדף השער. כדי לגשת לקורס, מדריך או תלמיד "
+"חייבים לדעת את כתובת ה-URL המלאה של הקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:489
 msgid ""
@@ -5937,93 +5236,77 @@ msgid ""
 "also select multiple users from the users list. You will receive hardcopy "
 "for each (set, user) pair."
 msgstr ""
+"בחר אוסף שיעורי בית עבורו תרצה ליצור גרסת הדפסה. אתה גם יכול לבחור מספר "
+"משתמשים מרשימת המשתמשים. אתה תקבל גרסת הדפסה עבור כל זוג (אוסף, תלמיד)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
 msgid ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
-msgstr ""
+msgstr "בחר משתמש/ים ו/או אוסף/ים ולחץ על כפתור הפעולה לפי בחירתך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
-#, fuzzy
 msgid "Selected students"
-msgstr "tr: selected sets"
+msgstr "תלמידים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
-#, fuzzy
 msgid "Send E-mail"
-msgstr "דואל אלקטרוני"
+msgstr "שלח דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
-#, fuzzy
 msgid "Send Email"
-msgstr "דואל אלקטרוני"
+msgstr "שלח דוא\"ל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
 msgid "Send to:"
-msgstr ""
+msgstr "שלח ל-:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
 msgid "Set"
-msgstr "סט"
+msgstr "אוסף"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
-#, fuzzy
 msgid "Set %1 exists.  No set created"
-msgstr "tr: Set %1 exists.  No set created"
+msgstr "אוסף %1 קיים. לא נוצר אוסף"
 
-#
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
-#, fuzzy
 msgid "Set %1 has been created."
-msgstr "tr: Set %1 exists.  No set created"
+msgstr "אוסף %1 נוצר"
 
-#
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
-#, fuzzy
 msgid "Set %1 was assigned to %2"
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "אוסף %1 הוקצה ל%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
-#, fuzzy
 msgid "Set Assigner"
-msgstr "tr: Edit Assigned Users"
+msgstr "מקצה האוספים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
 msgid "Set Definition Filename"
-msgstr ""
+msgstr "שם קובץ הגדרת אוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
 msgid "Set Definition Files"
-msgstr ""
+msgstr "קבצי הגדרת אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
-#, fuzzy
 msgid "Set Description"
-msgstr "tr: Show/Hide Site Description"
+msgstr "תיאור אוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
-msgstr ""
+msgstr "פרטי אוסף 2 עבור אוסף %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:423
 msgid "Set Detail for set %2"
-msgstr ""
+msgstr "פרטי אוסף עבור אוסף %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
@@ -6033,35 +5316,29 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
 msgid "Set Header"
-msgstr "tr: Set Header"
+msgstr "קידומת אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
-#, fuzzy
 msgid "Set ID"
-msgstr "tr: Student ID"
+msgstr "מזהה אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 msgid "Set Info"
-msgstr "tr: Set Info"
+msgstr "נתוני אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
 msgid "Set List"
-msgstr "tr: Set List"
+msgstr "רשימת אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:781
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:802
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:825
 msgid "Set Name"
-msgstr "tr: Set Name"
+msgstr "שם אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1215
@@ -6074,25 +5351,26 @@ msgstr "tr: Set Name"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:699
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
-#, fuzzy
 msgid "Set Name "
-msgstr "tr: Set Name"
+msgstr "שם אוסף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
 msgid "Set headers are not used in display of gateway tests."
-msgstr ""
+msgstr "קידומות אוספים  לא משומשות בהצגת בחני מחסום."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
 "Set to true for log to mean base 10 log and false for log to mean natural "
 "logarithm"
 msgstr ""
+"בחר \"נכון\" כדי ש-log יסמל לוגריתם בבסיס 10 ו\"לא נכון\"  עבור לוגרית טבעי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:355
 msgid ""
 "Set to true to display MathView equation editor icon next to each answer box"
 msgstr ""
+"בחר \"נכון\" כדי להציג את סמל עורך המשוואות MathView לצד כל קופסת תשובה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:360
 msgid ""
@@ -6102,76 +5380,68 @@ msgid ""
 "see their evaluated answer by hovering the mouse pointer over the typeset "
 "version of their answer."
 msgstr ""
+"בחר \"נכון\" כדי להציג את עמודת \"הוכנס\" שמציגה את התשובה המוערכת של "
+"התלמיד, לדוגמה 1 אם התלמיד כתב sin(pi/2). אם בחרת \"לא נכון\", לדוגמה כדי "
+"לשמור מקום באיזור התגובה, התלמיד עדיין יכול לראות את התשובה המוערכת שלו על "
+"ידי להניח את הסמן על התשובה שהכניס."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
 msgid "Sets"
-msgstr "tr: Sets"
+msgstr "אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
-#, fuzzy
 msgid "Sets Assigned to User"
-msgstr "tr: Edit Assigned Users"
+msgstr "האוספים שהוקצאו למשתמש"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
-#, fuzzy
 msgid "Sets assigned to %1"
-msgstr "tr: Edit Assigned Users"
+msgstr "האוספים שהוקצאו ל-%1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
-#, fuzzy
 msgid "Setting"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr "הגדרה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
 msgid "Shift dates so that the earliest is"
-msgstr ""
+msgstr "הזז תאריכים כך שהמוקדם ביותר הוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
 msgid "Show"
-msgstr ""
+msgstr "הצג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
 msgid "Show Auxiliary Resources"
-msgstr ""
+msgstr "הצג מקורות מישניים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:323
 msgid "Show Date & Size"
-msgstr ""
+msgstr "הצג תאריך וגודל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
 msgid "Show Hints"
 msgstr "הראה רמזים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
-#, fuzzy
 msgid "Show Me Another"
-msgstr "tr: Show in another window"
+msgstr "תראה לי עוד אחת"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
 msgid "Show Past Answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr "הראה תשובות מהעבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:302
 msgid "Show Problems on Finished Tests"
-msgstr ""
+msgstr "הראה שאלות במבחנים שבוצעו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:295
 msgid "Show Scores on Finished Assignments?"
-msgstr ""
+msgstr "הראה ציונים על מטלות שבוצעו?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
 msgid "Show Solutions"
@@ -6179,127 +5449,101 @@ msgstr "הראה פתרונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:166
 msgid "Show Total Homework Grade on Grades Page"
-msgstr ""
+msgstr "הראה ציון בסך כל שיעורי הבית בעמוד הציונים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
 msgid "Show Which Users?"
-msgstr "tr: Show Which Users?"
+msgstr "אזה משתמשים להציג?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
-#, fuzzy
 msgid "Show all paths"
-msgstr "tr: showing all sets"
+msgstr "הראה את כל המסלולים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
-#, fuzzy
 msgid "Show correct answers"
-msgstr "Doğru yanıtları göster"
+msgstr "הראה תשובות נכונות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
-#, fuzzy
 msgid "Show me another"
-msgstr "tr: Show in another window"
+msgstr "הראה לי עוד אחת"
 
-#
 #. ($exhausted)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
-#, fuzzy
 msgid "Show me another %1"
-msgstr "tr: Show in another window"
+msgstr "הראה לי עוד אחת %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Show path ..."
-msgstr "tr: showing all sets"
+msgstr "הראה מסלול ..."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
-#, fuzzy
 msgid "Show saved answers?"
-msgstr "Önceki Yanıtları Göster"
+msgstr "הראה תשובות שנשמרו?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
 msgid "Show which sets?"
-msgstr "tr: Show which sets?"
+msgstr "איזה אוספים להציג?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
 msgid "Show/Hide Site Description"
-msgstr "tr: Show/Hide Site Description"
+msgstr "הצג/החבא תיאור אתר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
 msgid "Show:"
-msgstr ""
+msgstr "הראה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "Showing"
-msgstr "הראה רמזים"
+msgstr "מראה"
 
-#
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
-#, fuzzy
 msgid "Showing %1 out of %2 sets."
-msgstr "tr: Showing %1 out of %2 sets."
+msgstr "מראה %1 מתוך %2 אוספים."
 
-#
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
-#, fuzzy
 msgid "Showing %1 out of %2 users"
-msgstr "tr: Showing %1 out of %2 users"
+msgstr "מראה %1 מתוך %2 אוספים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:391
 msgid "Simple"
-msgstr ""
+msgstr "פשוט"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:120
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:68
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:71
 msgid "Site Information"
-msgstr "tr: Site Information"
+msgstr "תיאור אתר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid "Skip archiving this course"
-msgstr ""
+msgstr "דלג על הוספת קורס זה לארכיון"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
-#, fuzzy
 msgid "Solution:"
-msgstr "הראה פתרונות"
+msgstr "פתרון:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
-#, fuzzy
 msgid "Solutions"
-msgstr "הראה פתרונות"
+msgstr "פתרונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
 msgid "Some answers will be graded later."
-msgstr ""
+msgstr "חלק מהתשובות ינוקדו מאוחר יותר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:733
 msgid ""
@@ -6307,6 +5551,8 @@ msgid ""
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
 msgstr ""
+"חלק מקבצים אלה הם תיקיות. מחק תיקיות רק אם אתה בטוח שאתה יודעה מה אתה עושה. "
+"אתה יכול לעשות נזק רציני לקורס אם אתה מוחק את הדבר הלא נכון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -6317,44 +5563,44 @@ msgid ""
 "\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
 "List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 msgstr ""
+"ישנם שרתים המוסגלים להתמודד עם קורסים שפועלים באזורי זמן שונים. אם קורס זה "
+"לא מראה את איזור הזמן הנכון, הכנס את הערך הנכון כאן. הפורמט הוא בזמני unix, "
+"כגון \"America/New_York\",\"America/Chicago\", \"America/Denver\", \"America/"
+"Phoenix\" or \"America/Los_Angeles\".  לרשימה המלאה <a href=\"http://en."
+"wikipedia.org/wiki/List_of_zoneinfo_time_zones\">קבצי אזורי זמן</a>."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:484
 msgid ""
 "Something was wrong with your LTI parameters.  If this recurs, please speak "
 "with your instructor"
 msgstr ""
+"משהו לא כשורה עם הפאראמטרים של ה-LTI שלך. אם בעיה זו חוזרת על עצמה, אנא פנה "
+"למדריך שלך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
-#, fuzzy
 msgid "Sort"
-msgstr "tr: Sort"
+msgstr "מיין"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
 msgid "Sort by"
-msgstr "tr: Sort by"
+msgstr "מיין לפי"
 
-#
 #. ($names{$primary}, $names{$secondary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
-#, fuzzy
 msgid "Sort by %1 and then by %2"
-msgstr "tr: Sort by %1 and then by %2"
+msgstr "מיין לפי %1 ואז לפי %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
-#, fuzzy
 msgid "Sort:"
-msgstr "tr: Sort"
+msgstr "מיין:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
 msgid "Source File"
-msgstr ""
+msgstr "קובץ קוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1439
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1465
@@ -6365,19 +5611,20 @@ msgstr ""
 msgid ""
 "Source file paths cannot include .. or start with /: your source file path "
 "was modified."
-msgstr ""
+msgstr "מסלולי קבצי קוד לא יכולים לכלול .. או להתחיל ב- /: המסלול שהזנת שונה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
 msgstr ""
+"פרט מזהה, כותרת, ומוסד עבור הקורס החדש. מזהה הקורס יכול להכיל רק אותיות, "
+"מספרים, מקפים, וקוים תחתונים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:392
 msgid "Standard"
-msgstr ""
+msgstr "סטנדרטי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:107
@@ -6387,27 +5634,20 @@ msgstr ""
 msgid "Statistics"
 msgstr "סטטיסטיקות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
-#, fuzzy
 msgid "Statistics for"
-msgstr "tr: Statistics for %1"
+msgstr "סטטיסטיקה עבור"
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
-#, fuzzy
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr "tr: Added %1 to %2 as problem %3"
+msgstr "סטטיסטיקה עבור %1 אוסף %2.  נסגר ב-%3"
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
-#, fuzzy
 msgid "Statistics for %1 student %2"
-msgstr "tr: View statistics by student"
+msgstr "סטטיסטיקה עבור %1 סטודנט %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
@@ -6420,26 +5660,20 @@ msgstr "tr: View statistics by student"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
-msgstr "Durumu"
+msgstr "סטטוס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Stop Acting"
-msgstr "Rol Yapmayı bırak"
+msgstr "עצור התחזות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
-#, fuzzy
 msgid "Stop Archiving"
-msgstr "Rol Yapmayı bırak"
+msgstr "הפסק להוסיף לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
-#, fuzzy
 msgid "Stop archiving courses"
-msgstr "קורסים"
+msgstr "הפסק להוסיף קורסים לארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
@@ -6455,166 +5689,140 @@ msgstr "קורסים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 msgid "Student ID"
-msgstr "tr: Student ID"
+msgstr "מזהה תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Student Name"
-msgstr "tr: Set Name"
+msgstr "שם תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:767
 msgid "Student Progress"
-msgstr "tr: Student Progress"
+msgstr "התקדמות תלמיד"
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
-#, fuzzy
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr "tr: Student Progress for %1"
+msgstr "התקדמות התלמיד עבור %1 אוסף %2.  נסגר ב-%3"
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
-#, fuzzy
 msgid "Student Progress for %1 student %2"
-msgstr "tr: Student Progress for %1"
+msgstr "התקדמות התלמיד עבור %1 תלמיד %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
-#, fuzzy
 msgid "Student answers"
-msgstr "שלח תשובות"
+msgstr "תשובות התלמידים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
-msgstr ""
+msgstr "נושא:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
 msgid "Subject: "
-msgstr ""
+msgstr "נושא:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
-#, fuzzy
 msgid "Submission time:"
-msgstr "שלח תשובות"
+msgstr "זמן הגשה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
-#, fuzzy
 msgid "Submit"
-msgstr "שלח תשובות"
+msgstr "שלח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
 msgid "Submit Answers"
 msgstr "שלח תשובות"
 
-#
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
-#, fuzzy
 msgid "Submit Answers for %1"
-msgstr "שלח תשובות של [1_]"
+msgstr "שלח תשובות עבור %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
-msgstr "tr: Success"
+msgstr "הצלחה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
-#, fuzzy
 msgid "Success Index"
-msgstr "tr: Success"
+msgstr "מדד הצלחה"
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
 msgid "Successfully archived the course %1."
-msgstr ""
+msgstr "הקורס %1 הוכנס לארכיון בהצלחה."
 
-#
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
-#, fuzzy
 msgid "Successfully created new achievement %1"
-msgstr "tr: selected sets"
+msgstr "ההישג החדש %1 נוצר בהצלחה"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
 msgid "Successfully created new set %1"
-msgstr ""
+msgstr "האוסף החדש %1 נוצר בהצלחה"
 
 #. ($add_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
 msgid "Successfully created the course %1"
-msgstr ""
+msgstr "הקורס %1 נוצר בהצלחה"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
 msgid "Successfully deleted the course %1."
-msgstr ""
+msgstr "הקורס %1 נמחק בהצלחה."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
 msgid "Successfully renamed the course %1 to %2"
-msgstr ""
+msgstr "שם הקורס שונה בהצלחה מ-%1 ל-%2"
 
 #. ($unarchive_courseID, $new_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
 msgid "Successfully unarchived %1 to the course %2"
-msgstr ""
+msgstr "%1 הוסר בהצלחה מהארכיון עבור קורס %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
 msgid "Table defined in database but missing in schema"
-msgstr ""
+msgstr "טבלה מוגדרת במסד הנתונים אך חסרה בסכמה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
 msgid "Table defined in schema but missing in database"
-msgstr ""
+msgstr "טבלה מוגדרת בסכמה אך חסרה במסד הנתונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
 msgid "Table is ok"
-msgstr ""
+msgstr "הטבלה תקינה"
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:473
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
-#, fuzzy
 msgid "Take %1 test"
-msgstr "tr: Take %1 test"
+msgstr "בצע את מבחן %1"
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
-#, fuzzy
 msgid "Take %1 test."
-msgstr "tr: Take %1 test"
+msgstr "בצע את מבחן %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
@@ -6626,56 +5834,48 @@ msgstr "tr: Take %1 test"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
 msgid "Take Action!"
-msgstr "tr: Take Action!"
+msgstr "בצע פעולה!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
-#, fuzzy
 msgid "Target Set:"
-msgstr "tr: Edit Set Data"
+msgstr "האוסף שנבחר:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
-msgstr "tr: Test Date"
+msgstr "תאריך מבחן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
 msgid "Test Score"
-msgstr "tr: Test Score"
+msgstr "ציון מבחן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
-#, fuzzy
 msgid "Test Time"
-msgstr "tr: Test Date"
+msgstr "זמן המבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
 msgid "Test Time Limit (min; 0=Close Date)"
-msgstr ""
+msgstr "הגבלת הזמן של המבחן (דק'; 0=תאריך הסגירה)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
 msgid "Text"
-msgstr ""
+msgstr "טקסט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:752
 msgid "Text chapter:"
-msgstr ""
+msgstr "פרק טקסט:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
-#, fuzzy
 msgid "Text section:"
-msgstr "tr: Take Action!"
+msgstr "קטע טקסט:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
 msgid "Textbook:"
-msgstr ""
+msgstr "ספר לימוד:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1000
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:433
 msgid "That symbolic link takes you outside your course directory"
-msgstr ""
+msgstr "הקישור הסימלי הזה מוציא אותך מתיקיית הקורס שלך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:258
 msgid ""
@@ -6683,6 +5883,8 @@ msgid ""
 "student. If set to -1 then there is no limit to the number of times that "
 "Show Me Another can be used."
 msgstr ""
+"המספר המקסימלי של הפעמים שתלמיד יכול להשתמש ב-\"תראה לי עוד אחת\" עבור כל "
+"שאלה. אם הוכנס -1 אז אין גבול למספר הפעמים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:248
 msgid ""
@@ -6696,11 +5898,17 @@ msgid ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
+"תקופת הניקוד המופחת היא התקופה בברירת המחדל לפני תאריך ההגשה בה כל התקדמות "
+"שמבצע התלמיד נספרת בערך ניקו מופחת. כשנבחרת אפשרות הניקוד מופחת עבור אוסף "
+"תאריך הניקוד המופחת יהיה תאריך ההגשה פחות המספר הזה בתור ברירת מחדל. לאחר "
+"מכן, ניתן לשנות את תאריך הניקוד המופחת. אם אפשרות זו נבחרת ואם תאריך הניקוד "
+"זה עבר, אבל לא עבר תאריך ההגשה, תופיעה הודעה כגון \"למטלה זו יש תקופת ניקוד "
+"מופחת שמתחילה ב-08/11/2009 בשעה 18:17 ונגמרת בתאריך ההגשה, 10/11/2009 בשעה "
+"18:17. בתקופה זו כל עבודה תשובות נוספות נספרות כ-50% מערכם המקורי\"."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
 msgid "The WeBWorK Project"
-msgstr "tr: The WeBWorK Project"
+msgstr "פרוייקט WeBWorK"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
@@ -6708,6 +5916,8 @@ msgid ""
 "the weighted average of the status of those problems which count towards the "
 "parent grade."
 msgstr ""
+"הסטטוס המותאם של שאלה הוא הגדול מבין הסטטוס של השאלה הממוצה המתואם של הסטטוס "
+"של השאלות שנספרות לניקוד שאלה המכילה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:190
 msgid ""
@@ -6715,6 +5925,9 @@ msgid ""
 "available to student to view.  You can change this for individual homework, "
 "but WeBWorK will use this value when a set is created."
 msgstr ""
+"כמה זמן (בדקות) אחרי תאריך ההגשה שהתשובות יהיו זמינות לתלמיד לצפייה. אתה "
+"יכול לשנות את זה עבור אוסף שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה "
+"כשהאוסף נוצר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
 msgid ""
@@ -6722,23 +5935,20 @@ msgid ""
 "opened.  You can change this for individual homework, but WeBWorK will use "
 "this value when a set is created. "
 msgstr ""
+"כמה זמן (בדקות) לפני תאריך ההגשה שבו נפתחת המטלה. אה יכול לשנות את זה עבור "
+"אוסף שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה כשהאוסף נוצר."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
-#, fuzzy
 msgid "The answer above is NOT correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr "התשובה לעיל היא לא נכונה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
 msgid "The answer above is correct."
-msgstr "Yukarıdaki yanıt doğru."
+msgstr "התשובה למעלה נכונה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
-#, fuzzy
 msgid "The answer will be graded later."
-msgstr "Yukarıdaki yanıt doğru."
+msgstr "התשובה תנוקד מאוחר יותר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
 msgid ""
@@ -6748,12 +5958,18 @@ msgid ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 msgstr ""
+"השאלות המוכלות עבור שאלה זו יהפכו לגלויות עבור התלמיד כשהם ביצעו יותר "
+"ניסיונות שגויים מאשר מפורט כאן, או כשנגמר להם הניסיונות, הקודום מבינהם. אם "
+"נבחר כאן \"מקסימום\"  אז שאלות מוכלות יהיו זמינות רק לאחר שלתמיד נגמרו "
+"הניסיונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
+"מערכת ההתאמה לא מצאה את המידע שהיא צריכה כדי לתפקד. פנה למנהל האתר כדי "
+"שיבדוק שהקובץ constants.pm מעודכן."
 
 #. ($archive_courseID, $archive_path)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
@@ -6761,32 +5977,33 @@ msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
 msgstr ""
+"הקורס '%1' כבר הוכנס לארכיון ב-'%2'. הרישום המוקדם יותר ימחק. זה בילתי הפיך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
-#, fuzzy
 msgid "The default display mode"
-msgstr "tr: Display Mode"
+msgstr "ברירי ת המחדל של מצב התצוגה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
 msgid ""
 "The default number of attempts before the problem is re-randomized. ( 0 => "
 "never )"
 msgstr ""
+"ברירת המחדל למספר הנסיונות לפני שהשאלה עוברת רמדומיזציה מחדש. ( 0 => אף פעם )"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:275
 msgid ""
 "The default number of attempts between re-randomization of the problems ( 0 "
 "=> never)"
 msgstr ""
+"ברירת המחדל למספר הנסיונות בין רנדומיזציות מחדש של השאלה ( 0 => אף פעם )"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:249
 msgid "The directory you specified doesn't exist"
-msgstr ""
+msgstr "התיקייה שציינת  לא קיימת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1361
 msgid "The display was already cleared."
-msgstr ""
+msgstr "התצוגה כבר היתה ריקה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:390
 msgid ""
@@ -6796,110 +6013,99 @@ msgid ""
 "as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
+"אורך פורמט הדוא\"ל קובע כמה מידע יכנס באופן אוטומטי לדוא\"ל משוב. הרמות הן "
+"<ol><li value=\"Simple\"> פשוט: שלח רק את תגובת המשוב וקישור של ההקשר <li "
+"value=\"Standard\"> סטנדרטי: כמו בפשוט, רק בתוספת משתמש, אוסף, שאלה, ונתוני "
+"PG. <li value=\"Debug\"> דיבאג: כמו סטנדרטי, רק בתוספת סביבת השאלה (נתונים "
+"לדיבאג) </ol>"
 
-#
 #. ($achievementName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
-#, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr "שם המעריך עבור %1 שונה ל-'%2'."
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
-msgstr ""
+msgstr "הקובץ %1/%2 כבר קיים ולא ניתן לדרוס אותו. ההודע לא נשמרה"
 
-#
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
-#, fuzzy
 msgid "The file %1/%2 cannot be found."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr "הקובץ %1/%2 לא נמצא."
 
 #. ($emailDirectory,$openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
 msgid "The file %1/%2 is not readable by the webserver."
-msgstr ""
+msgstr "הקובץ %1/%2 לא ניתן לקריאה על ידי שרת הרשת."
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
-#, fuzzy
 msgid "The file '%1' cannot be found."
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr "לא היה אפשר למצוא את הקובץ '%1'."
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
-#, fuzzy
 msgid "The file '%1' cannot be read!"
-msgstr "tr: Error: The original file %1 cannot be read."
+msgstr "אי אפשר לקרוא את הקובץ '%1'!"
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid "The file '%1' is a blank problem!"
-msgstr "tr: The file '%1' is a blank problem!"
+msgstr "הקובץ '%1' הוא שאלה ריקה!"
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
-#, fuzzy
 msgid "The file '%1' is a directory!"
-msgstr "tr: The file '%1' is a directory!"
+msgstr "הקובץ '%1' הוא תיקייה!"
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
-#, fuzzy
 msgid "The file '%1' is protected!"
-msgstr "tr: The file '%1' is protected!"
+msgstr "הקובץ '%1' הוא מוגן!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
 msgid "The file does not appear to be a text file"
-msgstr ""
+msgstr "הקובץ איננו קובץ טקסט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:94
 msgid "The file you are trying to download doesn't exist"
-msgstr ""
+msgstr "הקובץ שאת/ה מנסה להוריד אינו קיים"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
 msgid "The following courses were successfully hidden: %1"
-msgstr ""
+msgstr "הקורסים הבאים הוחבאו בהצלחה: %1"
 
 #. (@succeeded_courses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
 msgid "The following courses were successfully unhidden: %1"
-msgstr ""
+msgstr "הקורסים הבאים נהפכו לגלויים בהצלחה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
 msgid "The following upgrades are available for your WeBWorK system:"
-msgstr ""
+msgstr "השידרוגים הבאים זמינים עבור מערכת ה-WeBWorK שלך:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
-msgstr ""
+msgstr "למשתמשים הבאים לא הוקצה האוסף הזה ולכן נתעלם מהם: %1"
 
-#
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
-#, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr "הציון עבור שאלה זו זה הגדול מבין ניקוד השאלה, וניקוד השאלה %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
@@ -6907,25 +6113,24 @@ msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
+"הציון עבור שאלה זו זה הגדול מבין ניקוד השאלה, והממוצע המותאם של השאלות: %1."
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
-#, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr " שם קידומת גרסת ההדפסה עבור אוסף %1 שונה ל-'%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
-msgstr ""
+msgstr "המוסד שמיחס לקורס %1 שונה מ-%2 ל-%3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
 msgid "The institution associated with the course %1 is now %2"
-msgstr ""
+msgstr "המוסד שמיוחס לקורס %1 הוא כעת %2"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
@@ -6933,17 +6138,19 @@ msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
+"לא קיים חשבון מדריך בעל מהה המשתמש %1. אנא צור את החשבון באופן ידני דרך "
+"WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
-msgstr ""
+msgstr "אינדקס הסיפרייה הוא ישן יותר מהסיפרייה, אתה צריך להריץ OPL-update."
 
 #. ($r->param('new_set_name')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
 msgid ""
 "The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
-msgstr ""
+msgstr "השם '%1' הוא לא שם אוסף תקין. השתמש רק באותיות, ספרות, ובסימנים . - _"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
 msgid ""
@@ -6951,6 +6158,8 @@ msgid ""
 "Its contents are displayed in the right panel next to the list of homework "
 "sets."
 msgstr ""
+"קובץ מידע שם הקורס (נמצא בתיקיית התבניות). התוכן שלו מופיע בפאנל הימני לייד "
+"הרשימה של אוספי שיעורי הבית."
 
 #. ($openDate, $dueDate, $answerDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
@@ -6958,147 +6167,127 @@ msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
+"תאריך הפתיחה: %1, תאריך סגירה: %2, ותאריך תשובות: %3 חייבים ליות מוגדרים "
+"ובסדר כרונולוגי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
 msgid "The password and password confirmation for the instructor must match."
-msgstr ""
+msgstr "הסיסמה ואימות הסיסמה של המדריך חייבות להתאים."
 
-#
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
-#, fuzzy
 msgid ""
 "The password you entered in the %1 field does not match your current "
 "password. Please retype your current password and try again."
 msgstr ""
-"%1 alanına girdiğiniz şifre ile mevcut şifreniz uyuşmamaktadır. Lütfen "
-"şirfenizi girerek tekrar deneyiniz."
+"הסיסמה שהזנת בשדה %1 לא מתאימה לסיסמתך הנוכחית. אנא הזן את סיסמתך הנוכחית "
+"ונסה שוב."
 
-#
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
-#, fuzzy
 msgid ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 msgstr ""
-"%1 ve %2  alanlarına girdiğiniz şifreler uyuşmadı. Yeni şifrenizi girerek "
-"tekrar deneyiniz."
+"הסיסמאות שהזנת בשדות %1 ו-%2 לא מתאימות. אנא הזן מחדש את סיסמתך החדשה ונסה "
+"שנית."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
 msgid "The path to the original file should be absolute"
-msgstr "tr: The path to the original file should be absolute"
+msgstr "המסלול לקוץ המקור צריך להיות מוחלט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:505
 msgid "The percentage of active students with correct answers for each problem"
-msgstr ""
+msgstr "אחוז הסטודנטים הפעילים עם תשובות נכונות לכל בעיה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
 "is in the 50% column."
-msgstr ""
+msgstr "אחוז הסטודנטים עם ניקוד כזה לפחות. הציון הממוצע הוא בעמודת 50%."
 
-#
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
-#, fuzzy
 msgid "The recorded score for this test is  %1/%2."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "הציון המוזן למבחן זה הוא %1/%2."
 
-#
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
-#, fuzzy
 msgid "The recorded score for this test is %1/%2."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "הציון המוזן למבחן זה הוא %1/%2."
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
-msgstr ""
+msgstr "תאריך הניקוד מופחת צריך להיות בין תאריך הפתיחה %1 ותאריך סגירה %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1069
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1142
 msgid ""
 "The reduced scoring date should be between the open date and close date."
-msgstr ""
+msgstr "תאריך הניקוד המופחת צריך להיות בין תאריך הפתיחה לתאריך הסגירה."
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
-#, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr "הניקוד לשאלה זו יכול להספר לניקוד של שאלה %1."
 
-#
 #. ($setName,$effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
-#, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
-msgstr "tr: The selected problem set (%1) is not a valid set for %2"
+msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"
 
-#
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
-#, fuzzy
 msgid "The set %1 is assigned to %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "האוסף %1 משויך ל-%2."
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
-#, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr "tr: The hardcopy header for set %1 has been renamed to '%2'."
+msgstr "כותרת האוסף עבור אוסף %1 שונתה ל-'%2'."
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
 msgid ""
 "The set name '%1' is already in use.  Pick a different name if you would "
 "like to start a new set."
-msgstr ""
+msgstr "שם האוסף '%1' כבר נמצא בשימוש. בחר שם אחר אם ברצונך לפתוח אוסף חדש."
 
-#
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
-#, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "גרסת-האוסף (%1, גרסה %2) לא משויכת למשתמש %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
-msgstr ""
+msgstr "הפתרון הוסר."
 
-#
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
-#, fuzzy
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
-msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
+msgstr "קוד המקור ל'אוסף %1 / שאלה %2' שונה מ-'%3' ל-'%4'"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
-msgstr ""
+msgstr "כבר לא ניתן להגיש את המבחן (מספר %1) לניקוד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
 "The time limit on this assignment was exceeded. The assignment may be "
 "checked, but the result will not be counted."
 msgstr ""
+"הזמן המוגבל למשימה זו נגמר. ניתן לבדוק את מטלה זו, אך התוצאות לא תספרנה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:178
 msgid ""
@@ -7106,39 +6295,31 @@ msgid ""
 "individual basis, but WeBWorK will use this value for default when a set is "
 "created."
 msgstr ""
+"מועד ההגשה ביום עבור המטלה. ניתן לשינוי באופן פרטני, אבל WeBWorK ישתמש בערך "
+"זה כברירת מחדל כשנוצר אוסף."
 
-#
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
-#, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
-msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
+msgstr "הכותרת של קורס %1 שונתה מ-%2 ל-%3"
 
-#
 #. ($rename_newCourseID, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
-#, fuzzy
 msgid "The title of the course %1 is now %2"
-msgstr ""
-"tr: The source file for 'set %1 / problem %2' has been changed from %3 to "
-"'%4'."
+msgstr "הכותרת של הקורס %1 היא עכשיו %2"
 
-#
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
-#, fuzzy
 msgid "The user %1 has been assigned %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "%2 הוקצה למשתמש %1."
 
 #. ($enableReducedScoring)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
-msgstr ""
+msgstr "הערך %1 עבור \"אפשר ניקוד מופחת\" אינו חוקי. הוא יוחלף בערך 'N'."
 
 #. ($timeCap)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
@@ -7146,56 +6327,58 @@ msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
+"הערך %1 עבור האפשרות  \"זמן מבחן מקסימלי\" הוא לא תקיןף הוא יוחלף ב-'0'."
 
 #. ($hideScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
-msgstr ""
+msgstr "הערך %1 עבור האפשרות \"החבאת ציון\" הוא לא תקין; הוא יוחלף ב-'N'."
 
 #. ($hideWork)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
-msgstr ""
+msgstr "הערך %1 עבור האפשרות \"החבאת עבודה\" הוא לא תקין; הוא יוחלף ב-'N'."
 
 #. ($relaxRestrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
-msgstr ""
+msgstr "הערך %1 עבור האפשרות \"הרגע הגבלת IP\" הוא לא תקין; הוא יוחלף ב-'לא'."
 
 #. ($restrictIP)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
-msgstr ""
+msgstr "הערך %1 עבור האפשרות \"הגבלת IP\" הוא לא תקין; הוא יוחלף ב-'לא'."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
 msgstr ""
+"שרת ה-WeBWorK חייב לאפשר רישום של התיקיות הללו. אנא תקן את שגיאות ההרשאה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:128
 msgid "Theme (refresh page after saving changes to reveal new theme.)"
-msgstr ""
+msgstr "עיצוב (רענן את העמוד לאחר שמירת השינויים על מנת לראות את העיצוב החדש)."
 
-#
+# Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
 msgid "Then by"
-msgstr "tr: Then by"
+msgstr "ואז לפי"
 
 #. ($count_line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:578
 msgid "There are %1 matching WeBWorK problems"
-msgstr ""
+msgstr "יש %1 בעיות WeBWorK מתאימות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:154
 msgid ""
@@ -7203,12 +6386,17 @@ msgid ""
 "Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
 "Column theme uses the full page width for each column"
 msgstr ""
+"כרגע יש שני עיצובים לגרסת ההדפסה שניתנים לבחירה: עמודה אחת, ושתי עמודות. "
+"עיצוב בשתי עמודות הוא עיציב גרסת ההדפסה המסורתי. עיצוב בעמודה האחת משתמש בכל "
+"רוחב הדף לכל עמודה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
 msgid ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
+"כרגע יש ני עיצובים (או ערכות נושא) שניתנים לבחירה: math3 ו-math4. העיצוב "
+"מגדיר תחושה ומראה אחידים עבור דפי הרשת של קורס ה-WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
@@ -7218,6 +6406,8 @@ msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
+"ישנם שדות במסד נתונים נוספים שלא הוגדרו בסכמה עבור לפחות טבלה אחת. אפשר "
+"להסיר אותם ממסד הנתונים רק באופן ידני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
@@ -7226,33 +6416,39 @@ msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
+"ישנם טבלאות מסד נתונים נוספות שלא הוגדרו בסכמה. ניתן להסיר אותם ממסד הנתונים "
+"רק באופן ידני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
 msgstr ""
+"ישנם שדות במסד נתונים נוספים שלא הוגדרו בסכמה עבור לפחות טבלה אחת. אפשר "
+"להסיר אותם ממסד הנתונים רק באופן ידני. שמותם לא ישונו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:576
 msgid "There are no matching WeBWorK problems"
-msgstr ""
+msgstr "אין בעיות WeBWorK מתאימות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
+"ישנן טבלאות או ערכים שחסרות במסד הנתונים. יש לעדכן את מסד הנתונים לפני "
+"שמכניסים את הקורס לארכיון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
 msgid "There are upgrades available for the Open Problem Library."
-msgstr ""
+msgstr "ישנם עדכונים זמינים לספרית השאלות הפתוחות."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
-msgstr ""
+msgstr "יש שידרוגים זמינים עבור הענף הנוכחי של PG מענף %1 ב-remote בשם %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
@@ -7260,6 +6456,7 @@ msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
+"ישנם שידרוגים זמינים לענף הנוכחי ב-WeBWorK מתוך ענף %1 ב-remote בשם %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
@@ -7268,6 +6465,9 @@ msgid ""
 "their name, you destroy all of the data for achievement $achievementID for "
 "this student."
 msgstr ""
+"פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
+"הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
+"הנתונים של הישג $achievementID של תלמיד זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -7276,28 +6476,31 @@ msgid ""
 "their name, you destroy all of the data for homework set $setID for this "
 "student."
 msgstr ""
+"פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
+"הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
+"הנתונים של אוסף שיעורי הבית $setID של תלמיד זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:276
 msgid "There is NO undo for unassigning a set."
-msgstr ""
+msgstr "אי אפשר לחזור בך מביטול הקצאה של אוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:127
 msgid "There is NO undo for unassigning students."
-msgstr ""
+msgstr "אי אפשר לחזור בך מביטול הקצאת תלמידים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
 msgid "There is a new version of PG available."
-msgstr ""
+msgstr "יש גרסה חדשה של PG."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
 msgid "There is a new version of WeBWorK available."
-msgstr ""
+msgstr "יש גרסה חדשה של WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:472
 msgid "There is a written solution available"
-msgstr ""
+msgstr "קיים פתרון כתוב."
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
@@ -7307,38 +6510,44 @@ msgid ""
 "files can be edited using the \"Email\" link and the \"File Manager\" link "
 "in the left margin."
 msgstr ""
+"אין מידע על ציון נוסף. אפשר להוסיף הודעה לגבי ציונים נוספים ל- [TMPL]/email/"
+"%1. זה מתאחד בעזרת הקובץ [Scoring]/%2. ניתן לערוך קבצים אלו בעזרת קישורי הדוא"
+"\"ל ומנהל הקבצים בצד שמאל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
-msgstr ""
+msgstr "לא קיים קובץ עץ סיפרייה עבור ספרייה זו, אתה תצטרך להריץ OPL-update. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:734
 msgid "There is no undo for deleting files or directories!"
-msgstr ""
+msgstr "אי אפשר לחזור בך ממחיקת קבצים או תיקייות!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:474
 msgid ""
 "There is no written solution available for this problem, but you can still "
 "view the correct answers"
-msgstr ""
+msgstr "לא קיים פתרון כתוב לשאלה זו, אבל עדיין ניתן לצפות בתשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:476
 msgid "There is no written solution available for this problem."
-msgstr ""
+msgstr "לא קיים פתרון כתוב לשאלה זו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
+"ייתכן שישנה בעיה בשאלה. אנא עדכן את המדריך שלך, לרבות בהודעות השגיאה שלהלן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
+"הייתה שגיאה בתהליך ההתחברות. אנה פנה למדריך שלך או עם מנהל מערכת במידה "
+"והבעיה הזאת נמשכת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
@@ -7350,73 +6559,61 @@ msgstr ""
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
-msgstr ""
+msgstr "הייתה שגיאה בתהליך ההתחברות. אנא פנה למדריך או למנהל מערכת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:316
 msgid ""
 "These users and higher get the \"Show Past Answers\" button on the problem "
 "page."
-msgstr ""
+msgstr "משתמשים אלו והלאה מקבלים את כפתור \"הראה תשובות מהעבר\" בעמוד הבעיות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "This action can take a long time if there are many students."
-msgstr ""
+msgstr "הפעולה יכולה להמשך זמן רב אם ישנם תלמידים רבים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 msgid "This action will not overwrite existing users."
-msgstr ""
+msgstr "פעולה זו לא תדרוס משתמשים קיימים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
-#, fuzzy
 msgid "This answer is NOT completely correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr "התשוב הזאת לא נכונה לגמרי."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
-#, fuzzy
 msgid "This answer is NOT correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr "התשובה הזאת לא נכונה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
-#, fuzzy
 msgid "This answer is correct."
-msgstr "Yukarıdaki yanıt doğru."
+msgstr "התשובה הזאת נכונה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
 msgid ""
 "This course supports guest logins. Click %1 to log into this course as a "
 "guest."
-msgstr ""
+msgstr "הקורס הזה תומך במשתמשים אורחים. לחץ %1 כדי להתחבר לקורס בתור אורח."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
 msgid "This homework set contains no problems."
-msgstr "Bu soru grubunda soru bulunmamaktadır."
+msgstr "אוסף שיעורי הבית לא מכיל שאלות."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
 msgid "This homework set is closed."
-msgstr "Bu soru grubu kapalı."
+msgstr "אוסף שיעורי הבית הוא סגור"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
 msgid "This homework set is not yet open."
-msgstr "Bu soru grubu henüz açık değil."
+msgstr "אוסף שיעורי הבית הזה עדיין לא פתוח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
-#, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
-"tr: This is a blank problem template file and can not be edited directly. "
-"Use the 'Save as' action below to create a local copy of the file and add it "
-"to the current problem set."
+"זה קובץ תבנית שאלה ריק ואי אפשר לערוך אותו ישירות. אנא השתמש בפעולת ה-\"גרסה "
+"חדשה\" למטה כדי ליצור העתק מקומי של הקובץ ולהוסיפו לאוסף השאלות הנוכחי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7430,6 +6627,12 @@ msgid ""
 "in the edit assigned users field contains links which take you to a page "
 "where you can edit what students the set is assigned to."
 msgstr ""
+"טבלה זו מראה את אוספי שיעורי הבית הנוכחיים של כיתה זו. השדות משמאל לימין הם: "
+"ערוך נתוני אוסף, ערוך שאלות, ערוך הקצאות משתמשים, ראות לתלמידים, מופעל ניקוד "
+"מופחת, תאריך פתיחה, תאריך הגשה, והתאריך בו התשובות מוצגות. שדה ה-\"ערוך "
+"נתוני אוסף\" מכיל ריבועים לסימון בחירה וקישור לדף עריכת נתוני אוסף. התאים "
+"בשדת \"ערוך שאלות\" מכילים קישורים שמפנים לדף שבו ניתן לערוך לאיזה תלמידים "
+"מוקצה הקורס/"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:93
 msgid ""
@@ -7440,6 +6643,10 @@ msgid ""
 "are earned.  The \"level\" category is used for the achievements associated "
 "to a users level."
 msgstr ""
+"זהו עורך ההישגים.  הוא משמש לערוך את ההישגים שזמינים לתלמידים. אנא זכור את "
+"העובדות הבאות: הישגים הם מוצגים, ומוערכים, בסדר שהם רשומים. הקטגוריה ה-"
+"\"סודית\" יוצרת הישגים שמוחבאים מהתלמידים עד שהם הרוויחו אותם. הקטגורית ה-"
+"\"שלב\" משמשת להישגים שמקושרים לשלב המשתמש."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:91
 msgid ""
@@ -7453,6 +6660,12 @@ msgid ""
 "\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
 "page contains a table containing the student usernames and their information."
 msgstr ""
+"זהו דף רשימת הכיתה, בו ניתן לצפות ולערוך את הנתונים של כל התלמידים שרשומים "
+"בקורס. החלק העליון של דף זה מכיל טפסים שמאפשרים לסנן את התלמדים, לסדר אותם "
+"לפי סדר מסויים, לערוך נתוני תלמידים, לתת להם סיסמ חדש, ליבא/ליצא נתוני "
+"תלמידים לקבצים חיצוניים, או להוסיף/למחוק תלמידים. לביצוע פעולה אנא בחר את "
+"הפעולה הרצוייה והחנס את המידע הדרוש בשדות למטה, ולחץ על כפתור \\\"בצע פעולה!"
+"\"\\ בתחתית הטופס. תחתית הדף כוללת טבלה שמכילה את שמות התלמידים ואת נתוניהם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:90
 msgid ""
@@ -7467,16 +6680,23 @@ msgid ""
 "of the page contains a table displaying the sets and several pieces of "
 "relevant information."
 msgstr ""
+"זהו דף עורך אוספי שיעורי הבית, שבו ניתן לצפות ולערוך אוספי שיעורי בית "
+"שקיימים בקורס ואת השאלות שהם מכילים. החל העליון של דף זה מכיל טפסים שמאפשרים "
+"סינון של האוספים, לסדר אותם בסדר מסויים, לערוך אוספי שיעורי בית, לפרסם אוספי "
+"שיעורי בית, ליבא/ליצא אוספים לקובץ חיצוני, לנקד אוספים, או ליצור/למחוק "
+"אוספים. ליצוע פעולה אנא בחר בעולה לביצוע, מלא את המידע הדרוש בשדות למטה, "
+"ולחץ על כפתור \\\"בצע פעולה!\"\\ בתחתית הטופס. תחתית הדף מכילה טבלה שמציגה "
+"את האוספים וכמה נתונים רלוונטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:203
 msgid ""
 "This is the number of achievement points given to each user for completing a "
 "problem."
-msgstr ""
+msgstr "זהו מספר נקודות ההישג שניתנות לכל משתמש עבור השלמת פתרון לשאלה."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
 msgid "This problem contains a video which must be viewed online."
-msgstr ""
+msgstr "השאלה מכילה וידיאו שיש לראות באופן מקוון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
@@ -7484,32 +6704,31 @@ msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
+"לשאלה זו יש תתי שאלות פתוחות. ניתן לראותן על ידי שימוש בקישורים משמאל או על "
+"ידי ביקור בעמוד האוסף."
 
 #. ($shownYet{$problemFile})
 #. ($prettyID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
 msgid "This problem uses the same source file as number %1."
-msgstr ""
+msgstr "שאלה זו משתמשת באותו קובץ מקור כמו שאלה %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 msgid "This problem will not count towards your grade."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr "שאלה זו לא תיחשב לציון שלך."
 
 #. ($EMAIL)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
 msgid "This sample mail would be sent to %1"
-msgstr ""
+msgstr "דוא\"ל דוגמה זה ישלח ל-%1"
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
-#, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr "הניקוד לשאלה זו לא יחשב לניקוד בשאלה %1 או באוסף. "
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -7518,21 +6737,20 @@ msgid ""
 "the file [Scoring]/%2. These files can be edited using the \"Email\" link "
 "and the \"File Manager\" link in the left margin."
 msgstr ""
+"הודעת הניקוד מיוצרת מ-[TMPL]/email/%1. היר מאוחדת באמצעות בקובץ  [Scoring]/"
+"%2. קבצים אלה ניתנים לעריכה בעזרת קישור ה-\"דוא\"ל\" וה-\"עורך הקבצים\" בצד "
+"שמאל."
 
-#
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
-#, fuzzy
 msgid "This set %1 is assigned to %2."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "האוסף הזה, %1, הוקצה ל-%2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
-#, fuzzy
 msgid "This set doesn't contain any problems yet."
-msgstr "Bu soru grubunda soru bulunmamaktadır."
+msgstr "אוסף זה עדיין לא מכיל שום שאלות."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
@@ -7540,20 +6758,23 @@ msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
 msgstr ""
+"לאוסף זה קיימת תקופת ניקוד מופחת שתחל ב-%1 ותסתיים ב-%2. בתקופה זו כל עבודה "
+"נספרת כ-%3%מערכה המקורי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:271
 msgid ""
 "This set has a set-level proctor password to authorize logins. Enter the "
 "password below."
 msgstr ""
+"לאוסף ישנה סיסמת משגיח ברמת-אוסף, כדי לנטר הרשאות. הזמן את הסיסמה בתיבה "
+"שלעיל."
 
-#
+# Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
-#, fuzzy
 msgid "This set is %1"
-msgstr "tr: This set is %1"
+msgstr "האוסף הזה הוא %1"
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
@@ -7561,10 +6782,12 @@ msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
 msgstr ""
+"האוסף הזה נמצא בתקופת הניקוד המופחת שלו. כל תשובה נספרת כ-%1% מהערך המקורי "
+"שלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:178
 msgid "This set needs to be assigned to you before you can grade it."
-msgstr ""
+msgstr "יש להקצות אליך את האוסף הזה לפני שתוכל לנקד אותו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:182
 msgid ""
@@ -7573,6 +6796,9 @@ msgid ""
 "comma separated list.  The minimum score required on the sets is specified "
 "in the following field."
 msgstr ""
+"האוסף לא יהיה זמין לסטודנטים עד אשר הם ירוויחו ניקוד מסויים באוספים שצוינו "
+"בשדה זה. האוספים צריך להכתב כרשימה מופרדת בפסיקים. הניקוד המינימלי הנדרש "
+"באוסף יצויין בשדה שלאחר מכן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:218
 msgid ""
@@ -7585,28 +6811,32 @@ msgid ""
 "std_problem_grader (the all or nothing grader).  It will work with custom "
 "graders if they are written appropriately."
 msgstr ""
+"זה קובע אם תקופת הניקוד המופחת תופעל. אם כן, יש למלא למטה אורך לפי ברירת "
+"המחדל לתקופת הניקוד המופחת, ואת ערך העבודה בתקופה זו.  <p>כדי להשתמש בזה, יש "
+"גם להפעיל את תקפת הניקוד המופחת עבור כל מטלה ולמלא את אורך התקופה על ידי "
+"עריכת נתוני האוסף. <p>זה עובד עם avg_problem_grader (שהוא המנקד האוטומטי) ו-"
+"std_problem_grader (מנקד ההכל או כלום). זה יעבוד עם מנקדים שנכתבו על ידי "
+"המשתמשים, אם הם נכתבו כראוי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
 msgid "This source file does not exist!"
-msgstr ""
+msgstr "קובץ מקור זה לא קיים!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
-#, fuzzy
 msgid "This source file is a directory!"
-msgstr "tr: The file '%1' is a directory!"
+msgstr "קובץ מקור זה הוא תיקייה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
 msgid "This source file is not a plain file!"
-msgstr ""
+msgstr "קובץ המקור הוא לא קובץ ריק!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
 msgid "This source file is not readable!"
-msgstr ""
+msgstr "לא ניתן לקרוא קובץ מקור זה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:382
 msgid ""
@@ -7615,6 +6845,9 @@ msgid ""
 "value of -1 uses the default from course configuration. The value of 0 "
 "disables rerandomization."
 msgstr ""
+"זה מפרט את תקופת הרנדומיזציה מחדש: מספר הניסיונות לפני שנוצרת בעיה חדשה על "
+"ידי שינוי ערך הזרע. הערך -1 מסמל את ברירת המחדל של הקורס. הערך 0 מבטל את "
+"הרנדומיזציה מחדש."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:257
 msgid ""
@@ -7627,6 +6860,12 @@ msgid ""
 "Hardcopy for Selected Sets' button at the end of the table.  There is also a "
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
+"הטבלה מציגה את אוספי שיעורי הבית הזמינים עבור כיתה זו, ביחד על סטטוס נוכחי. "
+"לחץ על הקישור בשם האוסף כדי לצפות בשאלות באוסף. לחיצה על הקישורים בראש "
+"הטבלה  יסדר את הטבלה לפי השדה המתאים. אתה יכול גם לבחור אוספים להורדה בפורמט "
+"PDF או TeX באזרת הקישור ליד שם אוספי השאלות, ואז לחיצה על כפתור \"הורד גרסת "
+"הדפסה כ-PDF או TeX של האוספים שנבחרו\" שבתחתית הטבלה. יש גם כפתורי ריקון שלח "
+"דוא\"ל למדריך בתחתית הטבלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
 msgid ""
@@ -7636,41 +6875,42 @@ msgid ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 msgstr ""
+"הטבלה הזאת מראה את השאלות שבאוסף הזה. העמודות מימין לשמאל הן: שם השאלה, כמה "
+"נסיונות בוצעו, כמה נסיונות נותרו, השווי בנקודות, וסטטוס ההשלמה. לחץ על "
+"הקישור בשם השאלה כדי להגיע לד, השאלה. "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
-#, fuzzy
 msgid "Time"
-msgstr "tr: Test Date"
+msgstr "זמן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
 msgid "Time Interval for New Test Versions (min; 0=infty)"
-msgstr ""
+msgstr "מרווח זמנים לגרסאות מבחן חדשות (מינימום; 0=אינסוף)"
 
 #. ($elapsedTime,$allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "Time taken on test: %1 min (%2 min allowed)."
-msgstr ""
+msgstr "זמן שנלקח לבחינה: %1 דקות (%2 דקות מורשות)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:221
 msgid "Timestamp"
-msgstr ""
+msgstr "חותמת זמן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:146
 msgid "Timezone for the course"
-msgstr ""
+msgstr "איזור זמנים של הקורס"
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
 msgid "To access this set you must score at least %1% on set %2."
-msgstr ""
+msgstr "על מנת לגשת לאוסף זה, עליך לצבור ניקוד של לפחות %1% באוסף %2."
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
-msgstr ""
+msgstr "כדי לגשת לאוסף זה עליך לצבור ניקוד של לפחות %1%באוספים הבאים: %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
 msgid ""
@@ -7678,23 +6918,28 @@ msgid ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
+"כדי להוסיף מדריך נוסף לקורס חדש, מלא את פרטי המשתמש למטה. מזהה המשתמש יכול "
+"להכיל רק מספרים, אותיות, מקפים, נקודות, פסיקים, וקווים תחתונים.\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
 msgstr ""
+"על מנת להוסיף את מנהלי ה-WeBWorK לקורס החדש (כמנהלים), סמן את התיבה שלהלן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:278
 msgid ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 msgstr ""
+"על מנת לשנות סטטוס (נקודות או ציונים) לסטודנט זה עבור אוסף אחד, לחץ על "
+"הקישור לאוסף הנ\"ל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
 msgid ""
 "To copy problem templates from an existing course, select the course below."
-msgstr ""
+msgstr "על מנת להעתיק תבניות מקורס קיים, בחר בקורס להלן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
@@ -7702,168 +6947,146 @@ msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
+"על מנת לערוך גרסה מסוימת של סטודנט לאוסף הנ\"ל, ערוך (את כל) האוספים המוקצים "
+"לו/ה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
-#, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
-"tr: To edit this text you must first make a copy of this file using the "
-"'Save as' action below."
+"כדי לערוך את הטקסט עליך להכין ראשית עותק של הקובץ על ידי שימוש בפעולת 'גרסה "
+"חדשה' שלהלן."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
 msgstr ""
-"tr: To edit this text you must use the 'Save AS' action below to save it to "
-"another file."
+"כדי לערוך את הטקסט הנ\"ל עליך להשתמש בפעולת 'גרסה חדשה' שלהלן כדי לשמור אותו "
+"לקובץ אחר."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
-#, fuzzy
 msgid "To this Problem"
-msgstr "tr: Edit this problem"
+msgstr "עבור שאלה זו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
 msgid "To:"
-msgstr ""
+msgstr "נמען:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
 msgid "Totals"
-msgstr ""
+msgstr "סה\"כ"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only (not problem scores)"
-msgstr ""
+msgstr "סה\"כ בלבד (ללא ניקודי שאלות)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 msgid "Totals only, only after answer date"
-msgstr ""
+msgstr "סה\"כ בלבד, רק לאחר תאריך התשובות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
 msgid "Transfer"
-msgstr ""
+msgstr "העבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
 msgid "True"
-msgstr ""
+msgstr "נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2266
 msgid "Try it"
-msgstr ""
+msgstr "נסה זאת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:189
 msgid "Tunic of Extension"
-msgstr ""
+msgstr "טוניקת ההארכה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:105
 msgid "Two Columns"
-msgstr ""
+msgstr "שתי עמודות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Type"
-msgstr ""
+msgstr "סוג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
-#
 #. ($achievementName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
-#, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr "tr: Unable to change the set header for set %1. Unknown error."
+msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
 msgid "Unable to obtain error messages from within the PG question."
-msgstr ""
+msgstr "לא צלחה השגת הודעות השגיאה מתוך שאלת ה-PG."
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
-#, fuzzy
 msgid "Unable to write to '%1': %2"
-msgstr "tr: Saved to file '%1'"
+msgstr "לא ניתן לרשום ל'%1': %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
-#, fuzzy
 msgid "Unarchive"
-msgstr "קורסים"
+msgstr "הסר מהארכיון"
 
-#
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
-#, fuzzy
 msgid "Unarchive %1 to course:"
-msgstr "קורסים"
+msgstr "הוצא מהארכיון את %1 לקורס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Unarchive Course"
-msgstr ""
+msgstr "הסר קורס מהארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
-#, fuzzy
 msgid "Unarchive Next Course"
-msgstr "קורסים"
+msgstr "הסר את הקורס הבא מהארכיון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
-#, fuzzy
 msgid "Unassign from All Users"
-msgstr "tr: unassigned problem file"
+msgstr "בטל הקצאה מכל המשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
-#, fuzzy
 msgid "Unassign selected sets from selected users"
-msgstr "tr: unassigned problem file"
+msgstr "בטל הקצאה של האוספים הנבחרים מהמשתמשים הנבחרים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
 "Unassignments were not done.  You need to both click to \"Allow unassign\" "
 "and click on the Unassign button."
 msgstr ""
+"ביטול הקצאות לא בוצעה. עליך ללחוץ הן על \"אפשר ביטול הקצאה\" והן על כפתור "
+"ביטול הקצאה."
 
-#
 #. ($unattempted,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
-#, fuzzy
 msgid "Unattempted: %1/%2"
-msgstr "tr: Unable to write to '%1': %2"
+msgstr "לא נוסה: %1/%2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
-#, fuzzy
 msgid "Unclassified Problems"
-msgstr "tr: Edit Problems"
+msgstr "שאלות לא מסווגות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
 msgid "Ungraded"
-msgstr ""
+msgstr "לא נוקדו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
-#, fuzzy
 msgid "Unhide Courses"
-msgstr "קורסים"
+msgstr "הפוך קורסים לגלויים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
 msgid ""
@@ -7871,139 +7094,130 @@ msgid ""
 "date of the Gateway Test this will allow you to generate a new version of "
 "the test."
 msgstr ""
+"הסר נעילה מגרסה נוספית של מבחן השער. אם ניסית טרם תאריך הסגירה של מבחן השער, "
+"הנ\"ל יאפשר לך ליצור גרסה חדשה של המבחן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:163
 msgid "Unpack"
-msgstr ""
+msgstr "לפרוק"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:385
 msgid "Unpack archives automatically"
-msgstr ""
+msgstr "לפרוק ארכיונים אוטומטית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
-#, fuzzy
 msgid "Unselect all courses"
-msgstr "tr: Unselect all users"
+msgstr "בטל בחירה לכל הקורסים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
 msgid "Unselect all sets"
-msgstr "tr: Unselect all sets"
+msgstr "אל תבחר את כל הקורסים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
 msgid "Unselect all users"
-msgstr "tr: Unselect all users"
+msgstr "אל תבחר את כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Update"
-msgstr ""
+msgstr "עדכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:803
 msgid "Update Display"
-msgstr ""
+msgstr "עדכן תצוגה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:724
 msgid "Update Menus"
-msgstr ""
+msgstr "עדכן תפריטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "Update settings and refresh page"
-msgstr ""
+msgstr "עדכן הגדרות ורענן עמוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
 msgid "Update the checked directories?"
-msgstr ""
+msgstr "לעדכן את התיקיות המסומנות?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
 msgid "Updated location description."
-msgstr ""
+msgstr "תיאור מיקום מעודכן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
-#, fuzzy
 msgid "Upgrade"
-msgstr "ציונים"
+msgstr "שדרוג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Upgrade Course Tables"
-msgstr ""
+msgstr "עדכן טבלאות קורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
-#, fuzzy
 msgid "Upgrade Courses"
-msgstr "קורסים"
+msgstr "עדכן קורסים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
 msgid "Upgrade process completed"
-msgstr ""
+msgstr "עדכן תהליכים שהושלמו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:370
 msgid "Upload"
-msgstr ""
+msgstr "העלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:161
 msgid "Use Date Picker"
-msgstr ""
+msgstr "השתמש בבוחר התאריכים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
 msgid "Use Default Header File"
-msgstr ""
+msgstr "השתמש בקובץ קידומת לפי ברירת המחדל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
 msgid "Use Equation Editor?"
-msgstr ""
+msgstr "השתמש בעורך המשוואות?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:239
 msgid "Use Item"
-msgstr ""
+msgstr "השתמש בפריט"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
 msgid "Use System Default"
-msgstr "tr: Use System Default"
+msgstr "השתמש בברירת המחדל של המערכת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
 msgid "Use browser back button to return from preview mode"
-msgstr ""
+msgstr "השתמש בכפתור חזרה של הדפדפן כדי לחזור ממצב תצוגה מקדימה"
 
-#
 #. (CGI::b("$achievementID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
-#, fuzzy
 msgid "Use in achievement %1"
-msgstr "tr: selected sets"
+msgstr "השתמש בהישג %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
-#, fuzzy
 msgid "Use in new achievement:"
-msgstr "tr: selected sets"
+msgstr "השתמש בהישג חדש:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
 msgid "Use log base 10 instead of base <i>e</i>"
-msgstr ""
+msgstr "השתמש בלוגריתם בבסיס 10 במקום בבסיס <i>e</i>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:370
 msgid "Use older answer checkers"
-msgstr ""
+msgstr "השתמש בבודקי תשובות ישנים יותר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
 msgid ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 msgstr ""
+"השתמש בממשק שלהלן על מנת לגשת בקלות לכלי מדריך נפוצים בשימוש, או בחר כלי "
+"מהרשימה שמשמאל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
 msgid ""
@@ -8011,41 +7225,37 @@ msgid ""
 "or an error in a problem you are attempting. Along with your message, "
 "additional information about the state of the system will be included."
 msgstr ""
+"השתמש בטופס זה כדי לדווח לפרופסור שלך על בעיה עם מערכת WeBWorK או על שגיאה "
+"בשאלה שאתה מנסה לפתור. יחד עם ההודעה, ישלח מידע נוסף על מצב המערכת שלך."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
-msgstr ""
+msgstr "משתמש '%1' לא יועתק מקורס המנהל שכן זהו המדריך הראשוני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
-msgstr ""
+msgstr "מזהה משתמש"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
-#, fuzzy
 msgid "User Settings"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr "הגדרות משתמש"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
-#, fuzzy
 msgid "User Values"
-msgstr "שם משתמש"
+msgstr "ערכי משתמש"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
-#, fuzzy
 msgid "User's name is:"
-msgstr "tr: Filename"
+msgstr "שם המשתמש הוא:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
 msgid "User's username is:"
-msgstr ""
+msgstr "שם המשתמש הוא:"
 
 #. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
@@ -8055,37 +7265,32 @@ msgid ""
 "UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
 "database corruption."
 msgstr ""
+"שאלת משתמש חסרה עבור משתמש=%1 אוסף=%2 שאלה=%3. זה עשוי להיות סימן של מסד "
+"נתונים פגום."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
-#, fuzzy
 msgid "Username"
-msgstr "tr: Filename"
+msgstr "שם משתמש"
 
 #. ($user_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
 msgid "Username presented:  %1"
-msgstr ""
+msgstr "שם משתמש שמוצג: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
-#, fuzzy
 msgid "Users"
-msgstr "הוסף משתמשים"
+msgstr "משתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
-#, fuzzy
 msgid "Users Assigned to Set %2"
-msgstr "tr: Edit Assigned Users"
+msgstr "משתמש מוקצה לאוסף %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "Users List"
-msgstr "tr: Users List"
+msgstr "רשימת משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:311
 msgid ""
@@ -8093,25 +7298,30 @@ msgid ""
 "Normally guest users are not allowed to change the e-mail address since it "
 "does not make sense to send e-mail to anonymous accounts."
 msgstr ""
+"משתמש ברמה זו ואילך מורשים לשנות את כתובת הדוא\"ל שלהם. בדרך כלל, משתמשים "
+"אורחים לא מורשים לשנות את כתובת הדוא\"ל שלהם שכן זה לא יהיה הגיוני לשלוח "
+"דואר למשתמשים אנונימיים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:287
 msgid ""
 "Users at this level and higher are allowed to change their password. "
 "Normally guest users are not allowed to change their password."
 msgstr ""
+"משתמשים ברמה זו ואילך מורשים לשנות את סיסמתם. באופן כללי, משתמשים אורחים לא "
+"מורשים לשנות את סיסמתם."
 
-#
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
-#, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
-msgstr "tr: Users sorted by %1, then by %2, then by %3"
+msgstr "משתמשים מוינו לפי %1, לאחר מכן לפי %2, ואז לפי %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:306
 msgid ""
 "Users with at least this permission level get a link in the left panel for "
 "reporting bugs to the bug tracking system in Rochester"
 msgstr ""
+"משתמשים עם רמת הרשאה כזו לפחות מקבלים קישור בפאנל השמאלי כדי לדווח על באגים "
+"למערכת ניטור הבאגים ברוצ'סטר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:405
 msgid ""
@@ -8121,37 +7331,38 @@ msgid ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 msgstr ""
+"משתמשים עם רמת הרשאות זו או גבוהה יותר יקבלו משוב מתלמידים באופן אוטומטי "
+"(נוצר כשהתלמידים לוחצים על כפתור \"צור קשר עם המדריך\" שנמצא בכל דף שאלה). "
+"בנוסף, הודעת המשוב תישלח לכתובות למטה. כדי לשלוח רק לכתובות למטה, בחר את רמת "
+"ההרשאות \"אף אחד\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Using contents of the default message $default_msg_file instead."
-msgstr ""
+msgstr "משתמש בתוכן של הודעת ברירת המחדל $default_msg_file במקום."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
-#, fuzzy
 msgid "Using what display mode?: "
-msgstr "tr: Display Mode"
+msgstr "באיזה מצב תצוגה להשתמש?:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
 msgid "Using what seed?: "
-msgstr ""
+msgstr "להשתמש באיזה זרע?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:222
 msgid "Value of work done in Reduced Scoring Period"
-msgstr ""
+msgstr "ערך העבודה נעשה בתקופת ניקוד מופחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
 msgid "Variable Documentation:"
-msgstr ""
+msgstr "תיעוד משתנה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
 msgid "Versions of a set can only be edited for one user at a time."
-msgstr ""
+msgstr "גרסאות של אוסף ניתנות לעריכה עבור משתמש אחד בלבד כל פעם."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
@@ -8159,130 +7370,106 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
 msgid "View"
-msgstr "tr: View"
+msgstr "הצג"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:528
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:572
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
-#, fuzzy
 msgid "View Problems"
-msgstr "tr: Edit Problems"
+msgstr "בעיות תצוגה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
 msgid "View equations as"
-msgstr ""
+msgstr "הצג משוואות כ"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
-#, fuzzy
 msgid "View it"
-msgstr "tr: View"
+msgstr "הצג את זה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
-msgstr "tr: View statistics by set"
+msgstr "הצג סטטיסטיקה לפי אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
 msgid "View statistics by student"
-msgstr "tr: View statistics by student"
+msgstr "הצג סטטיסטיקה לפי תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
-msgstr "tr: View student progress by set"
+msgstr "הצג התקדמיות תלמיד לפיי אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
-msgstr "tr: View student progress by student"
+msgstr "הצג התקדמות תלמיד לפי תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
-#, fuzzy
 msgid "View/Edit"
-msgstr "tr: Edit"
+msgstr "הצג/ערוך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
-#, fuzzy
 msgid "Viewing temporary file:"
-msgstr "Geçici dosya görüntüleniyor: "
+msgstr "מציג קובץ זמני:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:787
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:829
 msgid "Visibility"
-msgstr "tr: Visibility"
+msgstr "ראות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
 msgid "Visible"
-msgstr "tr: Visible"
+msgstr "ניתן לצפייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
-#, fuzzy
 msgid "Visible to Students"
-msgstr "tr: visible to students"
+msgstr "גלוי לסטודנטים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
-#, fuzzy
 msgid "Warning"
-msgstr "נשאר"
+msgstr "הזהרה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
-#, fuzzy
 msgid "Warning messages"
-msgstr "כלי ניקוד"
+msgstr "הודעות הזהרה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
-msgstr ""
-"tr: Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "זהירות: מחיקה הורסת את כל המידע שנוגע למשתמשים והיא בלתי הפיכה!"
 
 #. ($problem_desc , CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1223
 msgid "Warnings encountered while processing %1. Error text: %2"
-msgstr ""
+msgstr "אזהרות שעלו במהלך עיבוד %1. הודעת שגיאה: %2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
-#, fuzzy
 msgid "WeBWorK Error"
-msgstr "WeBWorK"
+msgstr "שגיאת WeBWorK"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
-#, fuzzy
 msgid "WeBWorK Warnings"
-msgstr "WeBWorK"
+msgstr "אזהרות WeBWorK"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
 msgid ""
 "WeBWorK currently has translations for four languages: \"English en\", "
 "\"Turkish tr\", \"Spanish es\", and \"French fr\" "
 msgstr ""
+"ל-WeBWorK יש כרגע תרגומים לארבע שפות: \"אנגלית en\", \"טורקית tr\", \"ספרדית "
+"es\", ו-\"צרפתית fr\""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:86
 msgid ""
@@ -8292,6 +7479,9 @@ msgid ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 msgstr ""
+"WeBWorK נתקלה שגיאת תוכנה בזמן הניסיון לעבד את שאלה זו. סביר להניח שיש שגיאה "
+"בשאלה עצמה. אם אתה תלמיד, דווח על הודעת שגיאה זו למרצה שלך כדי שיתקן את "
+"השאלה. אם אתה המרצה, אנא פנה לפלט השגיאה למטה למידע נוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
 msgid ""
@@ -8302,36 +7492,42 @@ msgid ""
 "professor to have them corrected. If you are a professor, please consult the "
 "warning output below for more information."
 msgstr ""
+"WeBWorK נתקלה בהזהרות בזמן עיבוד הבקשה שלך. אם זה קרה בזמן צפייה בשאלה, זה "
+"כנראה נגרם בגלל שגיאה או דו-משמעות בשאלה. אם לא, זה עשוי להעיד על בעיה "
+"במערכת ה-WeBWorK עצמה. אם אתה תלמיד, דווח על הודעת שגיאה זו למרצה שלך כדי "
+"שיתקן את השאלה. אם אתה המרצה, אנא פנה לפלט השגיאה למטה למידע נוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:491
 msgid ""
 "WeBWorK was unable to generate a different version of this problem; close "
 "this tab, and return to the original problem."
 msgstr ""
+"WeBWorK לא הצליחה ליצור גרסה חדשה של שאלה זו. סגור חלון זה, וחזור לשאלה "
+"המקורית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:309
 msgid ""
 "WeBWorK was unable to generate a paper copy of this homework set.  Please "
 "inform your instructor. "
 msgstr ""
+"WeBWorK לא הצליחה ליצור גרסת הדפסה אוסף שיעורי הבית הזה. אנא דווח על כך "
+"למדריך שלך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:344
 msgid "Weight"
-msgstr ""
+msgstr "משקל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
 msgstr "!WebWork ברוכים הבאים ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1289
 msgid "What could be inside?"
-msgstr ""
+msgstr "מה יכל להיות בפנים?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
 msgid "What field should filtered users match on?"
-msgstr "tr: What field should filtered users match on?"
+msgstr "באיזה שדה תלמידים צריכים להתאים?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:370
 msgid ""
@@ -8339,19 +7535,24 @@ msgid ""
 "view another version of this problem.  If set to -1 the feature is disabled "
 "and if set to -2 the course default is used."
 msgstr ""
+"כאשר לסטודנט יש יותר נסיונות משמצויין כאן, הם יוכלו לראות גרסה אחרת של "
+"הבעיה. אם מוזן -1 האופציה מבוטלת, ואם מוזן -2 ייעשה שימוש בברירת המחדל של "
+"הקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:301
 msgid ""
 "When acting as a student, this permission level and higher can submit "
 "answers for that student."
 msgstr ""
+"רמת ההרשאה הזאת וגבוהות ממנה רשאים להגיש תשובות עבור תלמיד כאשר הם פועלים "
+"בשמו."
 
 #. (CGI::em($r->maketext("before")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2307
 msgid ""
 "When changing problem numbers, we will move the problem to be %1 the chosen "
 "number."
-msgstr ""
+msgstr "כאשר משנים מספרים בבעיה, נזיז את הבעיה להיות %1 המספר הנבחר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:384
 msgid ""
@@ -8362,6 +7563,11 @@ msgid ""
 "ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
 "percent sign</ul>"
 msgstr ""
+"כשתלמידים לוחצים על כפתור <em>של דוא\"ל למדריך</em> כדי לשלוח משוב, WeBWorK "
+"ממלא את שורת הנושא. כאן אתה יכול לכתוב את שורת הנושא. ניתן לשים בה מספר "
+"נתונים שממולאים בעזרת סדרות הבריחה הבאות. <p><ul><li>%c = מזהה קורס <li>%u = "
+"מזהה משתמש <li>%p = מזהה שאלה <li>%x = קבוצה <li> %r = תרגול <li>%% = סימן "
+"אחוז</ul>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:167
 msgid ""
@@ -8369,6 +7575,8 @@ msgid ""
 "total cumulative homework score.  This score includes all sets assigned to "
 "the student."
 msgstr ""
+"כאשר אפשרות זו נבחרת, הסטודנט יראה שורה בעמוד הציונים עם הציון הכולל שלהם "
+"בשיעורי הבית. הניקוד יכלול את כל האוספים שמוקצים לסטודנט."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:333
 msgid ""
@@ -8376,6 +7584,9 @@ msgid ""
 "in the answer blank.  Below this level, old answers are never shown.  "
 "Typically, that is the desired behaviour for guest accounts."
 msgstr ""
+"כשצופים בשאלה, WeBWork בדרך כלל מראה את התשובה האחרונ שנשלחה בשדה התשובה. "
+"מתחת לרמה זו, תשובות ישנות לא מוצגות לעולם. בדרך כלל זה מיועד לחשבונות "
+"אורחים."
 
 #. (CGI::b($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:153
@@ -8384,6 +7595,8 @@ msgid ""
 "data for achievement %1 for this student. Make sure this is what you want to "
 "do."
 msgstr ""
+"כשאתה מבטל הקצאה על ידי ביטול הבחירה של השם שלו, אתה הורס את כל המידע עבור "
+"הישג %1 של תלמיד זה. תוודא שזה אכן כוונתך."
 
 #. (CGI::b($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:128
@@ -8393,6 +7606,9 @@ msgid ""
 "the set to these students and they will receive new versions of the "
 "problems. Make sure this is what you want to do before unchecking students."
 msgstr ""
+"כשאתה מבטל הקצאה על ידי ביטול הבחירה של השם שלו,  אתה הורס את כל מידע של "
+"אוסף שיעורי בית %1 עבור תלמיד זה. לאחר מכן תצטרך להקצות להם את האוסף מחדש "
+"והם יקבלו גרסאות חדשות של השאלות. תוודא שזה אכן מה שאתה רוצה לעשות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:280
 msgid ""
@@ -8401,52 +7617,42 @@ msgid ""
 "student will receive a new version of each problem. Make sure this is what "
 "you want to do before unchecking sets."
 msgstr ""
+"כשאתה מבטל בחירה של אוסף שיעורי בית (ושומר את השינויים), אתה הורס את כל "
+"המידע של אוסף זה עבור תלמיד זה. אם אתה מקצה אותו מחדש, התלמיד יקבל גרסה חדשה "
+"של כל שאלה. ודא שזה מה שאתה רוצה לעשות לפני ביטול הבחירה."
 
-#
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
-#, fuzzy
 msgid "Will open on %1."
-msgstr "יפתח ב-[1_]"
+msgstr "ייפתח ב-%1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Worth"
-msgstr "Değeri"
+msgstr "ערך"
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
-"tr: Write permissions have not been enabled for '%1'.  Changes must be saved "
-"to another file for viewing."
+"הרשאות כתיבה לא אופשרו ל-'%1'. יש לשמור שינויים בקובץ אחר על מנת לראותם."
 
-#
 #. ($self->shortPath($currentDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
-"tr: Write permissions have not been enabled in '%1'.  Changes must be saved "
-"to a different directory for viewing."
+"הראשות כתיבה לא אופשרו ב-'%1'. יש לשמור שינויים בתיקיה אחרת בטרם ניתן לראותם."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
-msgstr ""
-"tr: Write permissions have not been enabled in the templates directory.  No "
-"changes can be made."
+msgstr "הרשאות כתיבה לא הופעלו בתיקיית התבניות. לא ניתן לבצע שינויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
@@ -8460,7 +7666,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
 msgid "Yes"
-msgstr "tr: Yes"
+msgstr "כן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:455
 msgid ""
@@ -8468,6 +7674,8 @@ msgid ""
 "these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"אתה כרגע בודק תשובות לגרסה אחרת של השאלה - אלו לא יישמרו, ואתה צריך לזכור "
+"לחזור לבעיה המקורית לאחר שתסיים כאן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:460
 msgid ""
@@ -8475,73 +7683,64 @@ msgid ""
 "- these will not be recorded, and you should remember to return to your "
 "original problem once you are done here."
 msgstr ""
+"אתה כעת צופה בתשובות לגרסאות אחרות של השאלה - הם לא ישמרו, ויש לחזור לשאלה "
+"המקורית כשתסיים כאן."
 
 #. ($userSet->set_id, $r->connection->remote_ip)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:253
 msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
-msgstr ""
+msgstr "אתה לא רשאי ליצר גרסת הדפסה של %1 מכתובת ה-IP שלך, %2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools"
-msgstr "tr: You are not authorized to access the instructor tools."
+msgstr "אתה לא רשאי להשתמש בכלי המדריך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools."
-msgstr "tr: You are not authorized to access the instructor tools."
+msgstr "אתה לא רשאי להשתמש בכלי המדריך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
 msgid "You are not authorized to access the instructor tools."
-msgstr "tr: You are not authorized to access the instructor tools."
+msgstr "אתה לא רשאי לגשת לכלי המדריך"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
 msgid "You are not authorized to modify homework sets."
-msgstr "tr: You are not authorized to modify homework sets."
+msgstr "אתה לא רשאי לשנות אוספי שיעורי בית"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
 msgid "You are not authorized to modify problems."
-msgstr "tr: You are not authorized to modify problems."
+msgstr "אתה לא רשאי לשנות שאלות."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
 msgid "You are not authorized to modify set definition files."
-msgstr "tr: You are not authorized to modify set definition files."
+msgstr "אתה לא רשאי לשנות קבצי הגדרה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
-#, fuzzy
 msgid "You are not authorized to modify student data"
-msgstr "tr: You are not authorized to modify student data."
+msgstr "אתה לא רשאי לשנות פרטי תלמיד."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
 msgid "You are not authorized to perform this action."
-msgstr "tr: You are not authorized to perform this action."
+msgstr "אתה לא רשאי לבצע פעולה זו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:246
 msgid ""
 "You are not permitted to generate a hardcopy for a set with hidden work."
-msgstr ""
+msgstr "אתה לא רשאי ליצר גרסת הדפסה של אוסף עם עבודה מוחבאת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:234
 msgid "You are not permitted to generate a hardcopy for an unopened set."
-msgstr ""
+msgstr "אתה לא רשאי ליצר גרסת הדפסה של אוף שלא נפתח."
 
 #. ($showMeAnother{MaxReps},$solutionShown)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:484
@@ -8549,42 +7748,41 @@ msgid ""
 "You are only allowed to click on Show Me Another %quant(%1,time,times) per "
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
+"אתה רשאי ללחוץ על \"תראה לי עוד אחת\" %quant(%1,פעם,פעמים) לכל שאלה. %2 סגור "
+"חלון זה, וחזור לשאלה המקורית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
 msgid "You are out of time.  Press grade now!"
-msgstr ""
+msgstr "נגמר לך הזמן. לחץ על נקד עכשיו!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:316
 msgid "You can also examine the following temporary files: "
-msgstr ""
+msgstr "אתה יכול לצפות גם בקבצים הזמניים הבאים:"
 
-#
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "ניתן להרוויח ניקוד חלקי בבעיה זו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
-#, fuzzy
 msgid "You can not specify an absolute path"
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה לא יכול לתת מסלול מוחלט"
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
 msgid "You can only %1 one file at a time."
-msgstr ""
+msgstr "אתה יכול %1 רק קובץ אחד בכל פעם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:98
 msgid "You can only download regular files."
-msgstr ""
+msgstr "ניתן להוריד רק קבצים רגילים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:508
 msgid "You can only edit text files"
-msgstr ""
+msgstr "ניתן לערוך רק קבצי טקסט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:786
 msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
-msgstr ""
+msgstr "ניתן לפרוק רק קבצים עם הסיומות '.tgz', '.tar' או '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
@@ -8592,158 +7790,141 @@ msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
 msgstr ""
+"אתה יכול להשתמש באפשרות זו %quant(%1,עוד פעם, עוד פעמים, כמה פעמים שתרצה) על "
+"שאלה זו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:866
 msgid "You can't download directories"
-msgstr ""
+msgstr "לא ניתן להוריד תיקייות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:867
 msgid "You can't download files of that type"
-msgstr ""
+msgstr "לא ניתן להוריד קבצים מסוג זה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
-#, fuzzy
 msgid "You can't edit a directory"
-msgstr "tr: The file '%1' is a directory!"
+msgstr "לא ניתן לערוך תיקיות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
 msgid "You can't view files of that type"
-msgstr ""
+msgstr "לא ניתן לצפות בקבצים מסוג זה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
 msgid "You cannot archive the course you are currently using."
-msgstr ""
+msgstr "לא ניתן להוסיף לארכיון את הקורס שבו אתה משתמש כרגע."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
-#, fuzzy
 msgid "You cannot delete the course you are currently using."
-msgstr "tr: You cannot delete yourself!"
+msgstr "אתה לא יכול למחוק את הקורס בו אתה משתמש כרגע."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
 msgid "You cannot delete yourself!"
-msgstr "tr: You cannot delete yourself!"
+msgstr "אתה לא יכול למחוק את עצמך!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1842
 msgid ""
 "You cannot use this version of Set Detail to edit just-in-time type sets.  "
 "You must use Set Detail 2."
 msgstr ""
+"אתה לא יכוללהשתמש בגרסה הזאת של פרטי האוסף כדי לערוך אוספי מסוג \"בדיוק בזמן"
+"\". אתה צריך להשתמש בפרטי אוסף 2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
-#, fuzzy
 msgid "You did not specify a new set name."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "לא מלאת שם לאוסף החדש."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
 msgid "You didn't enter any message."
-msgstr ""
+msgstr "לא מלאת את תוכן ההודעה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
-msgstr "Adres değiştirmek için yetkiniz yok."
+msgstr "אין לך את ההרשאות לשנות כתובות דוא\"ל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
-#, fuzzy
 msgid "You do not have permission to change the hardcopy theme."
-msgstr "Adres değiştirmek için yetkiniz yok."
+msgstr "אין לך את ההרשאות הדרושות כדי לשנות את עיצוב גרסת ההדפסה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
-msgstr "Şifre değiştirmek için yetkiniz yok."
+msgstr "אין לך את ההרשאות לשנות את "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
-#, fuzzy
 msgid "You do not have permission to edit this file."
-msgstr "Bu hatanın detaylarını görmeye yetkiniz yok."
+msgstr "אין לך הרשאות לערוך את הקובץ הזה."
 
-#
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
-#, fuzzy
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr "Şifre değiştirmek için yetkiniz yok."
+msgstr "אין לך את ההרשאות הדרושות כדי ליצור גרסת הדפסה בפורמט %1."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "You do not have permission to view the details of this error."
-msgstr "Bu hatanın detaylarını görmeye yetkiniz yok."
+msgstr "אין לך את ההרשאות לצפות בפרטים של השגיאה זו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
-msgstr ""
+msgstr "אין לך שום חפצים!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
 msgid "You exceeded the allowed time."
-msgstr ""
+msgstr "עברת את הזמן המותר."
 
-#
 #. ($numLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
-#, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
-msgstr "%1 %2 kaldı."
+msgstr "נשארו לך %1 ניסיון/ות למבחן זה."
 
-#
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
-#, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr "[negquant,_1,Sınırsız deneme hakkı,deneme hakkı,deneme hakkı] kaldı."
+msgstr "נותר לך egquant(%1,נסיונות לא מוגבלים,נסיון,ניסיונות)%n."
 
 #. ($attempts_before_rr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
-msgstr ""
+msgstr "נותרו לך %quant(%1,ניסיון,ניסיונות) לפני שתקבל גרסה חדשה."
 
-#
 #. ($attempts)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
-#, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
-msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
+msgstr "ניסית שאלה זו %quant(%1,פעם,פעמים)."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
 msgid "You have been logged out of WeBWorK."
-msgstr "WeBWorK sisteminden çıkış yaptınız."
+msgstr "התנתקת מ-WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
 msgid "You have less than 1 minute to complete this test."
-msgstr ""
+msgstr "נותר לך פחות מדקה 1 לפתרון מבחן זה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:882
 msgid "You have not chosen a file to upload."
-msgstr ""
+msgstr "לא בחרת קובץ להעלות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "You have requested that the following items be deleted"
-msgstr ""
+msgstr "בקשת שהפריטים הבאים ימחקו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1005
 msgid "You have specified an illegal file"
-msgstr ""
+msgstr "בחרת קובץ לא חוקי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1237
 msgid "You have specified an illegal path"
-msgstr ""
+msgstr "בחרת מסלול לא חוקי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:465
 msgid ""
 "You may check your answers to this problem without affecting the maximum "
 "number of tries to your original problem."
 msgstr ""
+"אתה יכול לבדוק את התשובות שלך לשאלה זו בלי להשפיע על מספר הניסיונות המקסימלי "
+"של השאלה המקורית."
 
 #. ($phrase_for_privileged_users)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:575
@@ -8752,39 +7933,36 @@ msgid ""
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 msgstr ""
+"אתה יכול לבחור להציג כל נתון מהנתונים הבאים. תשובות נכונות, רמזים, ופתרונות "
+"הם זמינים %1 רק לאחר תאריך התשובות של אוסף שיעורי הבית."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
 msgid "You may not change your own password here!"
-msgstr "tr: You may not change your own password here!"
+msgstr "לא ניתן לשנות את הסיסמה שלך כאן!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
-#, fuzzy
 msgid "You may still check your answers."
-msgstr "tr: You may not change your own password here!"
+msgstr "אתה עדיין יכול לבדוק את התשובות שלך."
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before Show Me Another "
 "is available."
-msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
+msgstr ""
+"יש לנסות את שאלה זו %quant(%1,פעם,פעמים) לפני שאפשר להשתמש ב-\"תראה לי עוד "
+"אחת\"."
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
-msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
+msgstr "יש לנסות את שאלה זו %quant(%1,פעם,פעמים) לפני שאפשרות זו תהפוך לזמינה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
 msgid "You must confirm the password for the initial instructor."
-msgstr ""
+msgstr "אתה חייב לאשר את הסיסמה למדריך הראשוני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:541
@@ -8792,108 +7970,83 @@ msgid ""
 "You must log into this set via your Learning Management System (e.g. "
 "Blackboard, Moodle, etc...)."
 msgstr ""
+"אתה חייב להתחבר לאוסף זה דרך מערכת ניהול הלמידה שלך (לדוגמה: Blackboard, "
+"Moodle, וכו')."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
 msgid "You must provide a student ID, a set ID, and a problem number."
-msgstr ""
+msgstr "אתה חייב למלא מזהה משתמש, מזהה אוסף, ומספר שאלה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
-#, fuzzy
 msgid "You must select a course to rename."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חייב לבחור קורס שאת שמו תרצה לשנות."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
-#, fuzzy
 msgid "You must select at least one file for the archive"
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב לבחור לפחות קובץ אחד להוספה לארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
 msgid "You must select at least one file to delete"
-msgstr ""
+msgstr "אתה חייב לבחור לפחות קובץ אחד למחיקה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-#, fuzzy
 msgid "You must select one or more sets for scoring"
-msgstr "tr: No sets selected for scoring"
+msgstr "אתה חייב לבחור לפחות אוסף אחד לניקוד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
-#, fuzzy
 msgid "You must specify a course ID."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חייב למלא מזהה קורס."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
-#, fuzzy
 msgid "You must specify a course name."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חייב למלא שם קורס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
-#, fuzzy
 msgid "You must specify a file name"
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חיב למלא שם קובץ"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
-#, fuzzy
 msgid "You must specify a first name for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב למלא שם פרטי למדריך הראשוני."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
-#, fuzzy
 msgid "You must specify a last name for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב למלא שם משפחה למדריך הראשוני."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
-#, fuzzy
 msgid "You must specify a new institution for the course."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב למלא מוסד חדש עבור קורס זה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
-#, fuzzy
 msgid "You must specify a new name for the course."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב למלא שם חדש לקורס זה."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
-#, fuzzy
 msgid "You must specify a new title for the course."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חייב למלא כותרת חדשה לקורס זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
 msgid "You must specify a password for the initial instructor."
-msgstr ""
+msgstr "אתה חייב למלא סיסמה למדריך הראשוני."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
 msgid "You must specify a user ID."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr "אתה חייב למלא מזהה משתמש."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
-#, fuzzy
 msgid "You must specify an email address for the initial instructor."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "אתה חייב למלא כתובת דוא\"ל של במדריך הראשוני."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
-#, fuzzy
 msgid "You must specify an file name in order to save a new file."
-msgstr "tr: You must specify an file name in order to save a new file."
+msgstr "יש לפרט שם קובץ כדי לשמור בקובץ חדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:488
 msgid ""
@@ -8901,38 +8054,34 @@ msgid ""
 "Canvas, etc...) to access this set.  Try logging in to the Learning "
 "Managment System and visiting the set from there."
 msgstr ""
+"אתה חייב להשתמש במערכת ניהול הלמידה שלך (לדוגמה: Blackboard, Moodle, Canvas, "
+"וכו') כדי לגשת לאוסף הזה. נסה להתחבר למערכת ניהול הלמידה ולבקר באוסף משם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1260
 msgid "You need to select a \"Target Set\" before you can edit it."
-msgstr ""
+msgstr "אתה צריך לבחור אוסף שאותו תרצה לערוך."
 
-#
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
-#, fuzzy
 msgid "You need to select a file to %1."
-msgstr "tr: Please specify a file to save to."
+msgstr "אתה צריך לבחור קובץ כדי לבצע %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
-#, fuzzy
 msgid "You need to select a set definition file to view."
-msgstr "tr: You are not authorized to modify set definition files."
+msgstr "אתה צריך לבחור הגדרת אוסף לצפייה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
-msgstr ""
+msgstr "אתה צריך לבחור אוסף מקורס זה לצפייה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1369
 msgid "You need to select a set to view."
-msgstr ""
+msgstr "אתה צריך לבחור אוסף לצפייה"
 
-#
 #. (wwRound(0, $pg->{result}->{score} * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
-#, fuzzy
 msgid "You received a score of %1 for this attempt."
-msgstr "Bu soru için %1 puan aldınız."
+msgstr "קיבלת ציון %1 עבור ניסיון זה"
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
@@ -8940,393 +8089,299 @@ msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
+"לא תוכל להמשיך לשאלה %1 עד שהשלמת, או שנגמר לך הניסיונות, של שאלה זו והשאלות "
+"המוכלות שמזכות נקודות."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
-msgstr ""
+msgstr "לא תוכל להמשיך לשאלה %1 עד שהשלמת, או שנגמר לך הניסיונות, של שאלה."
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1213
 msgid "Your %1 name contains illegal characters"
-msgstr ""
+msgstr "שם ה-%1 שלך מכיל תוים לא חוקיים."
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1214
 msgid "Your %1 name may not begin with a dot"
-msgstr ""
+msgstr "שם ה-%1 לא יכול להתחיל בנקודה"
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1215
 msgid "Your %1 name may not contain a path component"
-msgstr ""
+msgstr "שם ה-%1 לא יכול להכיל מרכיב מסלול"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:495
 msgid ""
 "Your LTI OAuth verification failed.  If this recurs, please speak with your "
 "instructor"
 msgstr ""
+"אימות ה-LTI OAuth שלך נכשל. אם בעיה זו חוזרת על עצמה, אנא פנה למדריך שלך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:483
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:494
 msgid "Your authentication failed.  Please return to Oncourse and login again."
-msgstr ""
+msgstr "האימות שלך נכשל. אנא חזור ל-Oncourse והתחבר שוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:237
 msgid ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
-msgstr ""
+msgstr "האימות שלך נכשל. אנא נסה שוב. אנא פנה למדריך שלך אם אתה צריך עזרה."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
 msgid "Your browser does not support the video tag."
-msgstr ""
+msgstr "הדפדפן שלך לא תומך ב-video tag."
 
 #. ($PGBranch, $PGRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
-msgstr ""
+msgstr "ענף ה-PG הנוכחי שלך הוא עדכני לפי ענף %1 ב-remote בשם %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
-msgstr ""
+msgstr "ענף ה-WeBWorK הנוכחי שלך הוא עדכני לפי ענף %1 ב-remote בשם %2."
 
 #. ($LibraryBranch, $LibraryRemote)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
 msgid "Your current branch of the Open Problem Library is up to date."
-msgstr ""
+msgstr "הענף הנוכחי שלך שלסיפריית השאלות הפתוחה הוא עדכני."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
-#, fuzzy
 msgid "Your display options have been saved."
-msgstr "E-posta adresiniz değiştirildi."
+msgstr "אפשרויות התצוגה נשמרו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
 msgid "Your email address has been changed."
-msgstr "E-posta adresiniz değiştirildi."
+msgstr "כתובת הדוא\"ל שלך שונתה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1239
 msgid "Your file name contains illegal characters"
-msgstr ""
+msgstr "שם הקובץ מכיל תוים לא חוקיים."
 
-#
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
-#, fuzzy
 msgid "Your overall recorded score is %1.  %2"
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "סה\"כ הניקוד שלך הוא %1. %2"
 
-#
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
-#, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "הציון שלך במבחן זה (מספר %1) הוא %2/%3."
 
-#
+# $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
-#, fuzzy
 msgid "Your score on this %1 WAS recorded."
-msgstr "Notunuz kaydedildi."
+msgstr "הציון שלך ב-%1 הזה נשמרה."
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
-#, fuzzy
 msgid "Your score on this %1 is %2/%3."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr "הציון שלך ב-%1 זה הוא %2/%3."
 
-#
+# $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
-#, fuzzy
 msgid "Your score on this %1 was NOT recorded."
-msgstr "Notunuz kaydedildi."
+msgstr "הניקוד שלך ב-%1 זה לא נשמרה."
 
-#
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
-#, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr "Notunuz kaydedildi."
+msgstr "הניקוד שלך על הגשה זו (נבדקה, לא נשמרה) הוא %1/%2."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
-#, fuzzy
 msgid "Your score on this problem was recorded."
-msgstr "Notunuz kaydedildi."
+msgstr "הניקוד שלך בשאלה זו נשמר."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
-msgstr ""
-"Notunuz kaydedilemedi, çünkü notun veritabanına kaydı sırasında bir hata "
-"oluştu."
+msgstr "הניקוד שלך לא נשמר בגלל שהיה כישלון בשמירת נתוני השאלה במסד הנתונים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
 msgid "Your score was not recorded because this homework set is closed."
-msgstr "Notunuz kaydedilemedi çünkü bu soru grubu kapalı."
+msgstr "הניקוד שלך לא נשמר בגלל שאוסף שיעורי בית זה הוא סגור."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr "הניקוד שלך לא נשמר בגלל ששאלה זו לא הוקצאה אליך."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
-#, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr "הניקוד שלך לא נשמר בגלל שגירסת אוסף השאלות הזאת לא פתוחה."
 
-#
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr ""
+"הציון שלך לא נשמר כי עברת את הגבלת הזמן של מבחן זה. (זמן שעבר: %1 דק', הגבלת "
+"זמן: %2 דק'.)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr "הניקוד שלך לא נשמר כי אין לך עוד ניסיונות לגרסת האוסף הזאת."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
-#, fuzzy
 msgid "Your score was not recorded."
-msgstr "Notunuz kaydedildi."
+msgstr "הניקוד שלך לא נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
 msgid "Your score was not successfully sent to the LMS"
-msgstr ""
+msgstr "הניקוד שלך לא נשלח בהצלחה ל-LMS"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
 msgid "Your score was recorded."
-msgstr "Notunuz kaydedildi."
+msgstr "הניקוד שלך לא נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
 msgid "Your score was successfully sent to the LMS"
-msgstr ""
+msgstr "הניקוד לך נשלח בהצלחה ל-LMS"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
 msgid "Your session has timed out due to inactivity. Please log in again."
-msgstr "Oturumunuz zaman aşımına uğradı. Lütfen tekrar giriş yapınız."
+msgstr "נותקת עקב חוסר פעילות. אנא התחבר שוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
 msgid "Your systems are up to date!"
-msgstr ""
+msgstr "המערוכות שלך עדכניות!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
-#, fuzzy
 msgid "[Edit]"
-msgstr "עריכה []"
+msgstr "[ערוך]"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
-#, fuzzy
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
-msgstr ""
-"tr: This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_תיאור_עורך_הישגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
-#, fuzzy
 msgid "_ANSWER_LOG_DESCRIPTION"
-msgstr ""
-"tr: This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_תיאור_רשימת_תשובות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
-msgstr ""
-"tr: This is the classlist editor page, where you can view and edit the "
-"records of all the students currently enrolled in this course.  The top of "
-"the page contains forms which allow you to filter which students to view, "
-"sort your students in a chosen order, edit student records, give new "
-"passwords to students, import/export student records from/to external files, "
-"or add/delete students.  To use, please select the action you would like to "
-"perform, enter in the relevant information in the fields below, and hit the "
-"\"Take Action!\" button at the bottom of the form.  The bottom of the page "
-"contains a table containing the student usernames and their information."
+msgstr "_תיאור_עורך_רשימת_כיתה"
 
-#
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
-msgstr ""
-"%1 uses an external authentication system.  You've authenticated through "
-"that system, but aren't allowed to log in to this course."
+msgstr "_הודעת_אימות_חיצונית"
 
-#
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
-msgstr ""
-"tr: This course supports guest logins. Click %1 to log into this course as a "
-"guest."
+msgstr "_הודעת_התחברות_אורח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
-msgstr ""
-"tr: This is the homework sets editor page where you can view and edit the "
-"homework sets that exist in this course and the problems that they contain. "
-"The top of the page contains forms which allow you to filter which sets to "
-"display in the table, sort the sets in a chosen order, edit homework sets, "
-"publish homework sets, import/export sets from/to an external file, score "
-"sets, or create/delete sets.  To use, please select the action you would "
-"like to perform, enter in the relevant information in the fields below, and "
-"hit the \"Take Action!\" button at the bottom of the form.  The bottom of "
-"the page contains a table displaying the sets and several pieces of relevant "
-"information."
+msgstr "_תיאור_עורך_שיעורי_הבית"
 
-#
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
-msgstr ""
-"If you check %1 your login information will be remembered by the browser you "
-"are using, allowing you to visit WeBWorK pages without typing your user name "
-"and password (until your session expires). This feature is not safe for "
-"public workstations, untrusted machines, and machines over which you do not "
-"have direct control."
+msgstr "_הודעת_היתחברות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
 msgid "_PROBLEM_SET_SUMMARY"
-msgstr ""
+msgstr "_תקציר_אוסף_שאלות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
-msgstr ""
-" WebWork bu problemi işlerken bir yazılım hatası ile karşılaştı. Problemin "
-"kendisinde bir hata olması muhtemeldir. Eğer bir öğrenci iseniz bu hatayı "
-"ilgili kişilere bildiriniz. Eğer yetkili bir kişiyseniz daha fazla bilgi "
-"için alttaki hata raporunu inceleyiniz."
+msgstr "_שגיאת_בקשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
 msgid "_USER_TABLE_SUMMARY"
-msgstr ""
+msgstr "_תקציר_טבלת_משתמשים"
 
-#
+# Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
-msgstr "tr: a duplicate of the first selected set"
+msgstr "שכפול של האוסף הראשון שנבחר"
 
-#
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
-msgstr "tr: a new empty set"
+msgstr "אוסף ריק חדש"
 
+# Context is "Save to a new file named:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
 msgid "a new file named:"
-msgstr ""
+msgstr "קובץ חדש בשם:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
-msgstr "tr: a single set"
+msgstr "אוסף אחד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "active"
-msgstr "tr: Inactive"
+msgstr "פעיל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
-#, fuzzy
 msgid "add problems"
-msgstr "tr: Add problem"
+msgstr "הוסף שאלות"
 
 #. ($setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
-msgstr ""
+msgstr "הוסף אוסף גלובלי %1 ברשימת שאלות האוסף: %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
 msgid "added missing permission level for user"
-msgstr ""
+msgstr "נוספה רמת ההרשאות החסרה למשתמש"
 
+# #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "admin"
-msgstr ""
+msgstr "מנהל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
 msgid "all achievements"
-msgstr ""
+msgstr "כל ההישגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
-#, fuzzy
 msgid "all current users"
-msgstr "tr: all users"
+msgstr "כל המשתמשים העכשיויים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
-msgstr ""
+msgstr "כל תאריכי האוסופים של <b>משתמש</b> אחד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1319
@@ -9340,15 +8395,12 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:982
 msgid "all sets"
-msgstr "tr: all sets"
+msgstr "כל האוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
-#, fuzzy
 msgid "all students"
-msgstr "tr: all sets"
+msgstr "כל התלמדים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
@@ -9358,353 +8410,291 @@ msgstr "tr: all sets"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
 msgid "all users"
-msgstr "tr: all users"
+msgstr "כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "all users for one <b>set</b>"
-msgstr ""
+msgstr "כל המשתמשים של <b>אוסף</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid "alphabetically"
-msgstr ""
+msgstr "בסדר אלפבתי"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:661
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:672
-#, fuzzy
 msgid "answer"
-msgstr "tr: Answer Date"
+msgstr "תשובה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
 msgid "any users"
-msgstr "tr: any users"
+msgstr "כל משתמש"
 
+# Context is "Create _____ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
+msgstr "בתור"
 
-#
+# Context is "Import achievements from ____ assigning the achievements to ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
 msgid "assigning the achievements to"
-msgstr "tr: Assign this set to which users?"
+msgstr "מקצה את ההישגים ל-"
 
-#
+# Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
-#, fuzzy
 msgid "assigning this set to"
-msgstr "tr: Assign this set to which users?"
+msgstr "מקצה את האוסף ל-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
-#, fuzzy
 msgid "avg attempts"
-msgstr "ניסיונות"
+msgstr "ממוצע ניסיונות"
 
+# Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
 msgid "blank problem template(s) to end of homework set"
-msgstr ""
+msgstr "תבנית שאלה ריקה לסיום אוסף שיעורי הבית"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
 msgid "by last login date"
-msgstr ""
+msgstr "לפי תאריך ההתחברות האחרון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
-msgstr "tr: changes abandoned"
+msgstr "שינויים לא נשמרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
-msgstr "tr: changes saved"
+msgstr "שינויים נשמרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "class list data"
-msgstr "עורך רשימות כיתה"
+msgstr "נתוני רשימת כיתה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
-msgstr ""
+msgstr "נתוני רשימת כיתה של <b>המשתמשים</b> שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
-#, fuzzy
 msgid "close"
-msgstr "tr: Closed"
+msgstr "סגור"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:685
 msgid "column"
-msgstr ""
+msgstr "עמודה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
 msgid "columns:"
-msgstr ""
+msgstr "עמודות:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
 msgid "correct"
 msgstr "נכון"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
-#, fuzzy
 msgid "course files"
-msgstr "קורסים"
+msgstr "קבצי קורס"
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
-#, fuzzy
 msgid "deleted %1 sets"
-msgstr "tr: deleted %1 sets"
+msgstr "נמחקו %1 אוספים"
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
-#, fuzzy
 msgid "deleted %1 users"
-msgstr "tr: deleted %1 users"
+msgstr "נמחקו %1 משתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
-#, fuzzy
 msgid "editing all achievements"
-msgstr "tr: editing all sets"
+msgstr "עורך את כל ההישגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
 msgid "editing all sets"
-msgstr "tr: editing all sets"
+msgstr "עורך את כל האוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
 msgid "editing all users"
-msgstr "tr: editing all users"
+msgstr "עורך את כל המשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
-#, fuzzy
 msgid "editing selected achievements"
-msgstr "tr: selected sets"
+msgstr "עורך את ההישגים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
 msgid "editing selected sets"
-msgstr "tr: editing selected sets"
+msgstr "עורך את האוספים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing selected users"
-msgstr "tr: editing selected users"
+msgstr "עורך את המשתמשים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
 msgid "editing visible sets"
-msgstr "tr: editing visible sets"
+msgstr "עורך את האוספים שניתנים לצפייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing visible users"
-msgstr "tr: editing visible users"
+msgstr "עורך את המשתמשים שניתנים לצפייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
-#, fuzzy
 msgid "email:"
-msgstr "דואל אלקטרוני"
+msgstr "דוא\"ל:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
-#, fuzzy
 msgid "empty"
-msgstr "ניסיון"
+msgstr "ריק"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
 msgid "enter matching set IDs below"
-msgstr "tr: enter matching set IDs below"
+msgstr "הכנס את מזהי האוספים המתאימים למטה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
-#, fuzzy
 msgid "entry rows."
-msgstr "tr: Edit Problems"
+msgstr "שורות קליטה"
 
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
 msgid "error adding set location %1 for set %2: %3"
-msgstr ""
+msgstr "שגיאה בהוספת מיקום %1 עבור אוסף %2:%3"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
-msgstr "tr: export abandoned"
+msgstr "יצוא בוטל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
-#, fuzzy
 msgid "exporting all achievements"
-msgstr "tr: exporting all sets"
+msgstr "מיצא את כל ההישגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
 msgid "exporting all sets"
-msgstr "tr: exporting all sets"
+msgstr "מיצא את כל האוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
-#, fuzzy
 msgid "exporting selected achievements"
-msgstr "tr: Export selected sets"
+msgstr "מיצא את ההישגים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
 msgid "exporting selected sets"
-msgstr "tr: exporting selected sets"
+msgstr "מיצא את האוספים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
 msgid "exporting visible sets"
-msgstr "tr: exporting visible sets"
+msgstr "מיצא את האוספים שניתנים לצפייה"
 
-#
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr "tr: The set header for set %1 has been renamed to '%2'."
+msgstr "עבור %1(%2) שלו הוקצאו %3 אוספים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
-msgstr ""
+msgstr "עבור <b>אוסף</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 msgid "for one <b>user</b>"
-msgstr ""
+msgstr "עבור <b>משתמש</b> אחד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
-#, fuzzy
 msgid "for students"
-msgstr "tr: hidden from students"
+msgstr "עבור תלמידים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
 msgid "from"
-msgstr ""
+msgstr "מקור"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
 msgid "giving new passwords to all users"
-msgstr "tr: giving new passwords to all users"
+msgstr "נותן סיסמה חדשה לכל המשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to selected users"
-msgstr "tr: giving new passwords to selected users"
+msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to visible users"
-msgstr "tr: giving new passwords to visible users"
+msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
 
-#
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
-#, fuzzy
 msgid "global %1 for set %2 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr "הגלובלי %1 עבור אוסף %2 לא נמצא."
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
-#, fuzzy
 msgid "global set %1  not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr "אוסף גלובלי  %1 לא נמצא."
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
-#, fuzzy
 msgid "global set %1 not found."
-msgstr "tr: The file '%1' cannot be found."
+msgstr "אוסף גלובלי %1 לא נמצא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
-msgstr ""
+msgstr "משגיח_ציון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "guest"
-msgstr ""
+msgstr "אורח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
-#, fuzzy
 msgid "hidden"
-msgstr "tr: Hidden"
+msgstr "מוחבא"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "hidden from"
-msgstr "görüntülenmiyor"
+msgstr "מוחבא מ-"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
-msgstr "tr: hidden from students"
+msgstr "מוחבא מתלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
 msgid "hidden sets"
-msgstr "tr: hidden sets"
+msgstr "אוספים מוחבאים"
 
+# does not need to be translated
 #. ('j','k','_0')
 #. ('j','k')
 #: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
 #: /opt/webwork/pg/lib/Value/Vector.pm:280
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
-msgstr ""
+msgstr "i"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
 msgid "illegal character in input: '/'"
-msgstr ""
+msgstr "תו לא חוקי בקלט : '/'"
 
+# Context is " Show users who match _____ in their _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
 msgid "in their"
-msgstr ""
+msgstr "בשלהם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "inactive"
-msgstr "tr: Inactive"
+msgstr "לא פעיל"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
 msgid "incorrect"
@@ -9712,91 +8702,72 @@ msgstr "לא נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
 msgid "index"
-msgstr ""
+msgstr "מדד"
 
 #. ($restrictLoc, $setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
 msgid "input set location %1 already exists for set %2."
-msgstr ""
+msgstr "מיקום האוסף שהוכנס %1 כבר קיים עבור אוסף %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
 msgid "list of insertable macros"
-msgstr ""
+msgstr "רשימת קיצורי המאקרו שניתן להכניס"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
-#, fuzzy
 msgid "locations selected below"
-msgstr "tr: exporting selected sets"
+msgstr "המיקומים שנבחרו למטה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
-#, fuzzy
 msgid "login"
-msgstr "כניסה"
+msgstr "התחבר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
-#, fuzzy
 msgid "login ID"
-msgstr "כניסה"
+msgstr "מזהה התחברות"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
-#, fuzzy
 msgid "login/studentID:"
-msgstr "tr: Student ID"
+msgstr "מזהה משתמש/התחברות:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "login_proctor"
-msgstr ""
+msgstr "התחברות_משגיח"
 
-#
+# Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
-#, fuzzy
 msgid "made visible for"
-msgstr "görüntüleniyor"
+msgstr "נהפך לגלוי עבור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
 msgid "max"
-msgstr ""
+msgstr "מקסימום"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
 msgid "multiple sets"
-msgstr "tr: multiple sets"
+msgstr "מספר אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
-#, fuzzy
 msgid "new set:"
-msgstr "tr: no sets"
+msgstr "אוסף חדש:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
-#, fuzzy
 msgid "new users"
-msgstr "tr: no users"
+msgstr "משתמשים חדשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
-#, fuzzy
 msgid "no achievements"
-msgstr "tr: selected sets"
+msgstr "אין הישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
 msgid "no achievements."
-msgstr ""
+msgstr "אין הישגים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
-#, fuzzy
 msgid "no location"
-msgstr "הראה פתרונות"
+msgstr "אין מיקום"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1073
@@ -9806,15 +8777,12 @@ msgstr "הראה פתרונות"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:981
 msgid "no sets"
-msgstr "tr: no sets"
+msgstr "שום אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
-#, fuzzy
 msgid "no students"
-msgstr "tr: no sets"
+msgstr "אין תלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
@@ -9823,209 +8791,177 @@ msgstr "tr: no sets"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
 msgid "no users"
-msgstr "tr: no users"
+msgstr "שום משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
-msgstr ""
+msgstr "אף אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
 msgid "nth colum of merge file"
-msgstr ""
+msgstr "העמודה ה-n של קובץ האיחוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
 msgid "number of students not defined"
-msgstr ""
+msgstr "מספר התלמידים שלא הוגדרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
-msgstr ""
+msgstr "<b>אוסף</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
 msgid "one <b>set</b> for  <b>users</b>"
-msgstr ""
+msgstr "<b>אוסף</b> אחד עבור <b>משתמשים</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "one <b>user</b> (on one <b>set</b>)"
-msgstr ""
+msgstr "<b>משתמש</b> אחד (<b>באוסף</b> אחד)"
 
+# Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
 msgid "only"
-msgstr ""
+msgstr "רק"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
-#, fuzzy
 msgid "only best scores"
-msgstr "tr: Test Score"
+msgstr "רק הציונים הטובים ביותר"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
-#, fuzzy
 msgid "or"
-msgstr "tr: Sort"
+msgstr "או"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
-#, fuzzy
 msgid "or Problems from"
-msgstr "בעיות"
+msgstr "או שאלות מ-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
 msgid "out of"
-msgstr ""
+msgstr "מתוך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
 msgid "overwrite all data"
-msgstr ""
+msgstr "דרוס את כל הנתונים"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:678
 msgid "part"
-msgstr ""
+msgstr "חלק"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
 msgid "permissions for %1 not defined"
-msgstr ""
+msgstr "הההרשאות של %1 לא מוגדרות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
 msgid "pg debug"
-msgstr ""
+msgstr "דיבאג PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
 msgid "pg internal errors"
-msgstr ""
+msgstr "שגיאות פנימיות של PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
 msgid "pg warning"
-msgstr ""
+msgstr "הזהרת PG"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
-#, fuzzy
 msgid "point"
-msgstr "הראה רמזים"
+msgstr "נקודה"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
-#, fuzzy
 msgid "points"
-msgstr "הראה רמזים"
+msgstr "קודות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
 msgid "preserve existing data"
-msgstr ""
+msgstr "שמר מידע קיים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
-#, fuzzy
 msgid "preview answers"
-msgstr "הראה תשובות"
+msgstr "צפה בתשובות"
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:667
-#, fuzzy
 msgid "problem"
-msgstr "tr: Problem"
+msgstr "שאלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
-#, fuzzy
 msgid "problems"
-msgstr "tr: Problem"
+msgstr "שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "professor"
-msgstr ""
+msgstr "מרצה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "progress"
-msgstr ""
+msgstr "התקדמות"
 
 #. ($line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
 msgid "readSetDef error, can't read the line: ||%1||"
-msgstr ""
+msgstr "שגיאת קריאת הגדרת אוסף, לא יכול לקרוא את השורה: ||%1||"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
-#, fuzzy
 msgid "recitation #"
-msgstr "tr: Recitation"
+msgstr "תרגול  #"
 
-#
 #. ($studentName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
-#, fuzzy
 msgid "record for user %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr "רישם לא נמצא עבור משתמש %1"
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
-#, fuzzy
 msgid "record for visible user %1 not found"
-msgstr "tr: The file '%1' cannot be found."
+msgstr "רישום לא נמצא עבור משתמש גלוי %1 לא נמצא"
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
-msgstr ""
+msgstr "מיקום ההגבלות %1 לא קיים. הגבלות ה-IP לא הופעלו"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:684
 msgid "row"
-msgstr ""
+msgstr "שורה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
-#, fuzzy
 msgid "section #"
-msgstr "tr: Section"
+msgstr "קבוצה #"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
-#, fuzzy
 msgid "section:"
-msgstr "tr: Section"
+msgstr "קבוצה:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#, fuzzy
 msgid "selected <b>sets</b>"
-msgstr "tr: selected sets"
+msgstr "<b>האוספים</b> שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
-msgstr ""
+msgstr "<b>משתמשים</b> שנבחרו <b>לאוספים</b> שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
-#, fuzzy
 msgid "selected achievements"
-msgstr "tr: selected sets"
+msgstr "ההישגים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
-#, fuzzy
 msgid "selected achievements."
-msgstr "tr: selected sets"
+msgstr "ההישגים שנבחרו."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1321
@@ -10039,9 +8975,8 @@ msgstr "tr: selected sets"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:983
 msgid "selected sets"
-msgstr "tr: selected sets"
+msgstr "אוספים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
@@ -10054,308 +8989,244 @@ msgstr "tr: selected sets"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
 msgid "selected users"
-msgstr "tr: selected users"
+msgstr "משתמשים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
-#, fuzzy
 msgid "separate multiple IDs with commas"
-msgstr "tr: Match on what? (separate multiple IDs with commas)"
+msgstr "הפרד מספר מזהים בעזרת פסיקים."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
-#, fuzzy
 msgid "set"
-msgstr "סט"
+msgstr "אוסף"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#, fuzzy
 msgid "sets"
-msgstr "tr: no sets"
+msgstr "אוספים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
 msgid "sets checked below"
-msgstr ""
+msgstr "אוספים שנבדקו למטה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
-#, fuzzy
 msgid "sets hidden from students"
-msgstr "tr: hidden from students"
+msgstr "אוספים שמוחבאים מהתלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
-#, fuzzy
 msgid "sets visible to students"
-msgstr "tr: visible to students"
+msgstr "אוספים שגלויים לתלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
-#, fuzzy
 msgid "sets with matching set IDs:"
-msgstr "tr: enter matching set IDs below"
+msgstr "אוספים עם מזההים תואמים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
 msgid "showing all sets"
-msgstr "tr: showing all sets"
+msgstr "מציג את כל האוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
 msgid "showing all users"
-msgstr "tr: showing all users"
+msgstr "מציג את כל המשתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
-#, fuzzy
 msgid "showing hidden sets"
-msgstr "tr: showing no sets"
+msgstr "מראה אוספים מוחבאים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
-#, fuzzy
 msgid "showing matching sets"
-msgstr "tr: showing matching users"
+msgstr "מראה אוספים תואמים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing matching users"
-msgstr "tr: showing matching users"
+msgstr "מציג את המשתמשים התואמים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
 msgid "showing no sets"
-msgstr "tr: showing no sets"
+msgstr "לא מציג שום אוספים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing no users"
-msgstr "tr: showing no users"
+msgstr "לא מציג שום משתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
 msgid "showing selected sets"
-msgstr "tr: showing selected sets"
+msgstr "מציג אוספי שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing selected users"
-msgstr "tr: showing selected users"
+msgstr "מציג משתמשים שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
-#, fuzzy
 msgid "showing visible sets"
-msgstr "tr: exporting visible sets"
+msgstr "מראה אוספים גלויים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
-#, fuzzy
 msgid "still open"
-msgstr "יפתח ב-[1_]"
+msgstr "עדיין פתוח"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
-#, fuzzy
 msgid "student"
-msgstr "tr: Student ID"
+msgstr "תלמיד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
-#, fuzzy
 msgid "students"
-msgstr "tr: Student ID"
+msgstr "תלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "submission"
-msgstr "שלח תשובות"
+msgstr "הגשה"
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "submission (test %1)"
-msgstr "שלח תשובות"
+msgstr "הגשה (מבחן %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "summary"
-msgstr ""
+msgstr "תקציר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "ta"
-msgstr ""
+msgstr "עוזר מורה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "test"
-msgstr "tr: %1 test"
+msgstr "מבחן"
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "test (%1)"
-msgstr "tr: %1 test"
+msgstr "מבחן (%1)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
-#, fuzzy
 msgid "test date"
-msgstr "tr: Test Date"
+msgstr "תאריך מבחן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
-#, fuzzy
 msgid "test time"
-msgstr "tr: %1 test"
+msgstr "זמן מבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
 msgid "the following file"
-msgstr ""
+msgstr "הקובץ הבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1253
 msgid "the following file(s)"
-msgstr ""
+msgstr "הקבצים הבאים"
 
-#
 #. ($forcedSourceFile)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
-#, fuzzy
 msgid "the original path to the file is %1"
-msgstr "tr: the original path to the file is %1"
+msgstr "המסלול המקורי לקבוץ הוא %1"
 
-#
+# Context is "Sort by ___ then by ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
-#, fuzzy
 msgid "then by"
-msgstr "tr: Then by"
+msgstr "ואז לפי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
 msgid "then delete them"
-msgstr ""
+msgstr "ואז תמחק אותם"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "time"
 msgstr "זמן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
 msgid "time limit exceeded"
-msgstr ""
+msgstr "עברה מגבלת הזמן"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "times"
 msgstr "מספר פעמים"
 
+# Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
 msgid "to"
-msgstr ""
+msgstr "ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
 msgid "to all users, create global data, and"
-msgstr ""
+msgstr "לכל המשתמשים, צור מידע גלובלי, ו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
-msgstr ""
+msgstr "<b>לאוסף</b> אחד"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
-#, fuzzy
 msgid "top score"
-msgstr "tr: Test Score"
+msgstr "הציון הגבוהה ביותר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
 msgid "total"
-msgstr ""
+msgstr "סה\"כ"
 
-#
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
-#, fuzzy
 msgid "unable to write to directory %1"
-msgstr "tr: Saved to file '%1'"
+msgstr "כתיבה בתיקייה %1 נכשלה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
 msgid "unlimited"
 msgstr "לא מוגבל"
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
-#, fuzzy
 msgid "userID: %1 --"
-msgstr "tr: Replace %1"
+msgstr "מזהה משתמש: %1--"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
-msgstr ""
+msgstr "שם משתמש, שם משפחה, שם פרטי, קבוצה, רמת הישגים, נקודות הישגים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "users"
-msgstr "tr: no users"
+msgstr "משתמשים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
 msgid "users who match on selected field"
-msgstr "tr: users who match on selected field"
+msgstr "משתמשים שתאמו בשדות שנבחרו"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
-#, fuzzy
 msgid "users who match:"
-msgstr "tr: users who match on selected field"
+msgstr "משתמשים שתואמים:"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
-#, fuzzy
 msgid "visible"
-msgstr "tr: Visible"
+msgstr "גלוי"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1363
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:685
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:851
 msgid "visible sets"
-msgstr "tr: visible sets"
+msgstr "אוספים שניתנים לצפייה"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
-msgstr "tr: visible to students"
+msgstr "ניתן לצפייה לתלמידים"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
@@ -10364,480 +9235,442 @@ msgstr "tr: visible to students"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
 msgid "visible users"
-msgstr "tr: visible users"
+msgstr "משתמשים שניתנים לצפייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
-msgstr ""
+msgstr "עם אוספים בשם:"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
-msgstr ""
+msgstr "לא קריאה מקובץ %1/%2 לא תצליח: האם הוא קיים? האם הוא ניתן לקריאה?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#, fuzzy
 msgid "your students"
-msgstr "tr: visible to students"
+msgstr "התלמידים שלך"
 
 #
+#, fuzzy
+msgid "set %1."
+msgstr "tr: Revert to %1"
+
+#
+msgid "navNext"
+msgstr "tr:&nbspNext"
+
+#
+msgid "navNextGrey"
+msgstr "tr:&nbspNext"
+
+#
+msgid "navPrev"
+msgstr "tr:&nbspPrev"
+
+#
+msgid "navPrevGrey"
+msgstr "tr:&nbspPrev"
+
+#
+msgid "navProbListGrey"
+msgstr "tr:&nbspUp"
+
+#
+msgid "navUp"
+msgstr "tr:&nbspUp"
+
+#
+msgid "Apply Options"
+msgstr "tr: Apply Options"
+
+#
+msgid "Disable"
+msgstr "tr: Disable"
+
+#
+#, fuzzy
+msgid "Reduced Credit %1 for all sets"
+msgstr "tr: Reduced Credit %1 for all sets"
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_1"
+msgstr ""
+"tr: This assignment has a Reduced Credit Period that begins %1 and ends on "
+"the due date, %2.  During this period all additional work done counts %3% of "
+"the original."
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_2"
+msgstr ""
+"tr: This assignment had a Reduced Credit Period that began %1 and ended on "
+"the due date, %2.  During that period all additional work done counted %3% "
+"of the original."
+
+#
+msgid ""
+"Report bugs in a WeBWorK question/problem using this link. The very first "
+"time you do this you will need to register with an email address so that "
+"information on the bug fix can be reported back to you."
+msgstr ""
+"tr: Report bugs in a WeBWorK question/problem using this link. The very "
+"first time you do this you will need to register with an email address so "
+"that information on the bug fix can be reported back to you."
+
+#
+msgid "Unable to make '[_1]' the set header for [_2]"
+msgstr "tr: Unable to make '%1' the set header for %2"
+
+#
+msgid "Can't determine user of temporary edit file [_1]."
+msgstr "tr: Can't determine user of temporary edit file %1."
+
+#
+msgid "Top level of author information on the wiki."
+msgstr "tr: Top level of author information on the wiki."
+
+#
+msgid "Reverting to original file '[_1]'"
+msgstr "tr: Reverting to original file '%1'"
+
+#
+msgid "Wiki summary page for MathObjects"
+msgstr "tr: Wiki summary page for MathObjects"
+
+#
+msgid "Snippets of PG code illustrating specific techniques"
+msgstr "tr: Snippets of PG code illustrating specific techniques"
+
+#
+msgid "Error copying [_1] to [_2]"
+msgstr "tr: Error copying %1 to %2"
+
+#
+msgid ""
+"Note: this problem viewer is for viewing purposes only. As of right now, "
+"testing functionality is not possible."
+msgstr ""
+"tr: Note: this problem viewer is for viewing purposes only. As of right now, "
+"testing functionality is not possible."
+
+#
+msgid "webwork"
+msgstr "webwork"
+
+#
+msgid "submit button clicked"
+msgstr "gönder düğmesine basıldı"
+
+#
+msgid ""
+"Test snippets of PG code in interactive lab.  Good way to learn PG language."
+msgstr ""
+"tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
+"language."
+
+#
+msgid "View Using Seed Number"
+msgstr "tr: View Using Seed Number"
+
+#
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"tr: The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+
+#
+msgid ""
+"Documentation from source code for PG modules and macro files. Often the "
+"most up-to-date information."
+msgstr ""
+"tr: Documentation from source code for PG modules and macro files. Often the "
+"most up-to-date information."
+
+#
+msgid ""
+"PG mark down syntax used to format WeBWorK questions. This interactive lab "
+"can help you to learn the techniques."
+msgstr ""
+"tr: PG mark down syntax used to format WeBWorK questions. This interactive "
+"lab can help you to learn the techniques."
+
+#
+msgid ""
+"Error: This path is already in the temporary edit directory -- no new "
+"temporary file is created. path = [_1]"
+msgstr ""
+"tr: Error: This path is already in the temporary edit directory -- no new "
+"temporary file is created. path = %1"
+
+#
+msgid ""
+"Please use radio buttons to choose the method for saving this file. Can't "
+"recognize saveMode: |[_1]|."
+msgstr ""
+"tr: Please use radio buttons to choose the method for saving this file. "
+"Can't recognize saveMode: |%1|."
+
+#
+msgid "Resources"
+msgstr "tr: Resources"
+
+#
+msgid "Duplicate"
+msgstr "tr: Duplicate"
+
+#
+msgid "This path |[_1]| is not the path to a temporary edit file."
+msgstr "tr: This path |%1| is not the path to a temporary edit file."
+
+#
+msgid "Save as new independent problem"
+msgstr "tr: Save as new independent problem"
+
+#
+msgid "Unknown file type"
+msgstr "tr: Unknown file type"
+
 #, fuzzy
 #~ msgid "answer "
-#~ msgstr "tr: Answer Date"
+#~ msgstr "תשובה"
 
-#
 #, fuzzy
 #~ msgid "Will open on %1"
-#~ msgstr "יפתח ב-[1_]"
+#~ msgstr "ייפתח ב-%1."
 
-#
 #, fuzzy
 #~ msgid "User ID:"
-#~ msgstr "הוסף משתמשים"
+#~ msgstr "מזהה משתמש"
 
-#
+#, fuzzy
 #~ msgid "Viewing temporary file"
-#~ msgstr "tr: Viewing temporary file"
+#~ msgstr "מציג קובץ זמני:"
 
-#
 #, fuzzy
 #~ msgid "You are not authorized to access instructor tools"
-#~ msgstr "tr: You are not authorized to access the instructor tools."
+#~ msgstr "אתה לא רשאי לגשת לכלי המדריך"
 
-#
 #, fuzzy
 #~ msgid "all current users."
-#~ msgstr "tr: all users"
+#~ msgstr "כל המשתמשים העכשיויים"
 
-#
 #, fuzzy
 #~ msgid "font-hidden"
-#~ msgstr "tr: Hidden"
+#~ msgstr "מוחבא"
 
-#
 #, fuzzy
 #~ msgid "font-visible"
-#~ msgstr "tr: Visible"
+#~ msgstr "גלוי"
 
-#
 #, fuzzy
 #~ msgid "no users."
-#~ msgstr "tr: no users"
+#~ msgstr "שום משתמשים"
 
-#
-#, fuzzy
-#~ msgid "set %1."
-#~ msgstr "tr: Revert to %1"
-
-#
 #, fuzzy
 #~ msgid "submitAnswers"
 #~ msgstr "שלח תשובות"
 
-#
 #, fuzzy
 #~ msgid "All sets %1 all students"
-#~ msgstr "tr: All sets %1 all students"
+#~ msgstr "כל האוספים הם מוחבאים מכל התלמדים"
 
-#
 #, fuzzy
 #~ msgid "Bad Nonce for user "
-#~ msgstr "tr: Set Header for set %1"
+#~ msgstr "אין רישום למשתמש %1."
 
-#
 #, fuzzy
 #~ msgid "Can't write to file: %1"
-#~ msgstr "tr: Saved to file '%1'"
+#~ msgstr "לא יכול לכתוב בקובץ %1"
 
-#
 #, fuzzy
 #~ msgid "Change Display Options"
-#~ msgstr "tr: Display Options"
+#~ msgstr "שנה אפשרויות תצוגה"
 
-#
 #, fuzzy
 #~ msgid "Changes saved."
-#~ msgstr "tr: changes saved"
+#~ msgstr "שינויים נשמרו"
 
-#
 #, fuzzy
 #~ msgid "Comment: "
-#~ msgstr "tr: Comment"
+#~ msgstr "הגב"
 
-#
 #, fuzzy
 #~ msgid "Hardcopy Theme:"
-#~ msgstr "tr: Hardcopy Header"
+#~ msgstr "עיצוב גרסת הדפסה"
 
-#
 #, fuzzy
 #~ msgid "No sets selected for scoring."
-#~ msgstr "tr: No sets selected for scoring"
+#~ msgstr "לא נבחרו אוספים לנקד"
 
-#
 #, fuzzy
 #~ msgid "Note: "
-#~ msgstr "tr: Note"
+#~ msgstr "פתק"
 
-#
 #, fuzzy
 #~ msgid "Recitation:"
-#~ msgstr "tr: Recitation"
+#~ msgstr "תרגול"
 
-#
 #, fuzzy
 #~ msgid "Save as:"
-#~ msgstr "tr: Save as"
+#~ msgstr "שמור בשם"
 
-#
 #, fuzzy
 #~ msgid "Log into"
-#~ msgstr "יציאה"
+#~ msgstr "התחבר ל-%1"
 
-#
 #, fuzzy
 #~ msgid "Sets assigned to $userID"
-#~ msgstr "tr: Edit Assigned Users"
+#~ msgstr "האוספים שהוקצאו למשתמש"
 
-#
-#~ msgid "navNext"
-#~ msgstr "tr:&nbspNext"
-
-#
-#~ msgid "navNextGrey"
-#~ msgstr "tr:&nbspNext"
-
-#
-#~ msgid "navPrev"
-#~ msgstr "tr:&nbspPrev"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "tr:&nbspPrev"
-
-#
+#, fuzzy
 #~ msgid "navProbList"
-#~ msgstr "tr:&nbspUp"
+#~ msgstr "רשימת שאלות"
 
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "tr:&nbspUp"
-
-#
-#~ msgid "navUp"
-#~ msgstr "tr:&nbspUp"
-
-#
+#, fuzzy
 #~ msgid "Problem [_1]"
-#~ msgstr "תרגיל [1_]"
+#~ msgstr "שאלה %1"
 
-#
 #, fuzzy
 #~ msgid "[_1]% correct"
-#~ msgstr "נכון [1_]%"
+#~ msgstr "%1% נכון"
 
-#
 #, fuzzy
 #~ msgid "At least one of these answers is NOT completely correct."
-#~ msgstr "Yanıtların en az bir tanesi %1doğru değil."
+#~ msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
 
-#
 #, fuzzy
 #~ msgid "[_1]: Problem [_2]"
-#~ msgstr "tr: set %1/problem %2"
+#~ msgstr "%1: שאלה %2"
 
-#
 #, fuzzy
 #~ msgid "Show me another [_1]"
-#~ msgstr "tr: Show in another window"
+#~ msgstr "הראה לי עוד אחת %1"
 
-#
 #, fuzzy
 #~ msgid "Edit "
-#~ msgstr "tr: Edit"
+#~ msgstr "ערוך"
 
-#
 #, fuzzy
 #~ msgid "Assign "
-#~ msgstr "tr: Edit Assigned Users"
+#~ msgstr "הקצה"
 
-#
 #, fuzzy
 #~ msgid "Delete "
-#~ msgstr "tr: Delete"
+#~ msgstr "מחק"
 
-#
 #, fuzzy
 #~ msgid "Export "
-#~ msgstr "tr: Export"
+#~ msgstr "יצא"
 
-#
 #, fuzzy
 #~ msgid "Add "
-#~ msgstr "הוסף משתמשים"
+#~ msgstr "הוסף הכל"
 
-#
-#~ msgid "Apply Options"
-#~ msgstr "tr: Apply Options"
-
-#
-#~ msgid "Disable"
-#~ msgstr "tr: Disable"
-
-#
+#, fuzzy
 #~ msgid "Enable/Disable reduced scoring for selected sets"
-#~ msgstr "tr: Enable/Disable reduced scoring for selected sets"
+#~ msgstr "בטל הקצאה של האוספים הנבחרים מהמשתמשים הנבחרים"
 
-#
 #, fuzzy
 #~ msgid ""
 #~ "No students shown.  Choose one of the options above to \n"
 #~ "\t              list the students in the course."
 #~ msgstr ""
-#~ "tr: No students shown.  Choose one of the options above to list the "
-#~ "students in the course."
+#~ "לא מוצגים תלמידים. אנא בחר את אחד  מהאפשרויות לעיל כדי לראות את התלמידים "
+#~ "בקורס."
 
-#
-#, fuzzy
-#~ msgid "Reduced Credit %1 for all sets"
-#~ msgstr "tr: Reduced Credit %1 for all sets"
-
-#
 #, fuzzy
 #~ msgid "Reduced Credit %1 for selected sets"
-#~ msgstr "tr: Reduced Credit %1 for selected sets"
+#~ msgstr "עורך את האוספים שנבחרו"
 
-#
 #, fuzzy
 #~ msgid "Reduced Credit %1 for visable sets"
-#~ msgstr "tr: Reduced Credit %1 for visable sets"
+#~ msgstr "האוסף שבוקש '%1' עדיין לא זמין"
 
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "tr: This assignment has a Reduced Credit Period that begins %1 and ends "
-#~ "on the due date, %2.  During this period all additional work done counts "
-#~ "%3% of the original."
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "tr: This assignment had a Reduced Credit Period that began %1 and ended "
-#~ "on the due date, %2.  During that period all additional work done counted "
-#~ "%3% of the original."
-
-#
+#, fuzzy
 #~ msgid "completely"
-#~ msgstr "tr: completely"
+#~ msgstr "הושלם."
 
-#
+#, fuzzy
 #~ msgid "Course Information for course [_1]"
-#~ msgstr "tr: Course Information for course %1"
+#~ msgstr "דווח עבור קורס %1:"
 
-#
+#, fuzzy
 #~ msgid "Cancel Password"
-#~ msgstr "tr: Cancel Password"
+#~ msgstr "שנה סיסמה"
 
-#
+#, fuzzy
 #~ msgid "Hardcopy Header for set [_1]"
-#~ msgstr "tr: Hardcopy Header for set %1"
+#~ msgstr "קידומת גירסת הדפסה"
 
-#
-#~ msgid ""
-#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
-#~ "time you do this you will need to register with an email address so that "
-#~ "information on the bug fix can be reported back to you."
-#~ msgstr ""
-#~ "tr: Report bugs in a WeBWorK question/problem using this link. The very "
-#~ "first time you do this you will need to register with an email address so "
-#~ "that information on the bug fix can be reported back to you."
-
-#
+#, fuzzy
 #~ msgid "hardcopy header file"
-#~ msgstr "tr: hardcopy header file"
+#~ msgstr "קידומת גירסת הדפסה"
 
-#
+#, fuzzy
 #~ msgid "Unpublished"
-#~ msgstr "לא פורסם"
+#~ msgstr "פרסם"
 
-#
+#, fuzzy
 #~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-#~ msgstr "tr: Unable to change the hardcopy header for set %1. Unknown error."
+#~ msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
 
-#
-#~ msgid "Unable to make '[_1]' the set header for [_2]"
-#~ msgstr "tr: Unable to make '%1' the set header for %2"
-
-#
-#~ msgid "Can't determine user of temporary edit file [_1]."
-#~ msgstr "tr: Can't determine user of temporary edit file %1."
-
-#
-#~ msgid "Top level of author information on the wiki."
-#~ msgstr "tr: Top level of author information on the wiki."
-
-#
+#, fuzzy
 #~ msgid "Save Password"
-#~ msgstr "tr: Save Password"
+#~ msgstr "סיסמה חדשה"
 
-#
-#~ msgid "Reverting to original file '[_1]'"
-#~ msgstr "tr: Reverting to original file '%1'"
-
-#
-#~ msgid "Wiki summary page for MathObjects"
-#~ msgstr "tr: Wiki summary page for MathObjects"
-
-#
+#, fuzzy
 #~ msgid "Password/Email"
-#~ msgstr "סיסמא/מייל"
+#~ msgstr "סיסמה"
 
-#
-#~ msgid "Snippets of PG code illustrating specific techniques"
-#~ msgstr "tr: Snippets of PG code illustrating specific techniques"
-
-#
-#~ msgid "Error copying [_1] to [_2]"
-#~ msgstr "tr: Error copying %1 to %2"
-
-#
+# Context is "This set is visible" or "This set is hidden"
+#, fuzzy
 #~ msgid "This set is [_1] students."
-#~ msgstr "Bu soru grubu öğrenciler tarafından %1."
+#~ msgstr "האוסף הזה הוא %1"
 
-#
+#, fuzzy
 #~ msgid "blank problem"
-#~ msgstr "tr: blank problem"
+#~ msgstr "הוסף שאלות"
 
-#
-#~ msgid ""
-#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
-#~ "testing functionality is not possible."
-#~ msgstr ""
-#~ "tr: Note: this problem viewer is for viewing purposes only. As of right "
-#~ "now, testing functionality is not possible."
-
-#
+#, fuzzy
 #~ msgid "Save Export"
-#~ msgstr "tr: Save Export"
+#~ msgstr "יצא"
 
-#
-#~ msgid "webwork"
-#~ msgstr "webwork"
-
-#
-#~ msgid "submit button clicked"
-#~ msgstr "gönder düğmesine basıldı"
-
-#
+#, fuzzy
 #~ msgid "Problem Source Code"
-#~ msgstr "tr: Problem Source Code"
+#~ msgstr "מספר שאלה"
 
-#
-#~ msgid ""
-#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-#~ msgstr ""
-#~ "tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-
-#
+#, fuzzy
 #~ msgid "Page generated at [_1] at [_2]"
-#~ msgstr "tr: Page generated at %1 at %2"
+#~ msgstr "דף נוצר ב-%1"
 
-#
-#~ msgid "View Using Seed Number"
-#~ msgstr "tr: View Using Seed Number"
-
-#
+#, fuzzy
 #~ msgid "Published"
-#~ msgstr "פורסם"
+#~ msgstr "פרסם"
 
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "tr: The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-
-#
-#~ msgid ""
-#~ "Documentation from source code for PG modules and macro files. Often the "
-#~ "most up-to-date information."
-#~ msgstr ""
-#~ "tr: Documentation from source code for PG modules and macro files. Often "
-#~ "the most up-to-date information."
-
-#
-#~ msgid ""
-#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
-#~ "lab can help you to learn the techniques."
-#~ msgstr ""
-#~ "tr: PG mark down syntax used to format WeBWorK questions. This "
-#~ "interactive lab can help you to learn the techniques."
-
-#
-#~ msgid ""
-#~ "Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = [_1]"
-#~ msgstr ""
-#~ "tr: Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = %1"
-
-#
-#~ msgid ""
-#~ "Please use radio buttons to choose the method for saving this file. Can't "
-#~ "recognize saveMode: |[_1]|."
-#~ msgstr ""
-#~ "tr: Please use radio buttons to choose the method for saving this file. "
-#~ "Can't recognize saveMode: |%1|."
-
-#
+#, fuzzy
 #~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-#~ msgstr "Seçilen problem (%1), %2 soru drubu için geçerli bir soru değil."
+#~ msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"
 
-#
-#~ msgid "Resources"
-#~ msgstr "tr: Resources"
-
-#
-#~ msgid "Duplicate"
-#~ msgstr "tr: Duplicate"
-
-#
-#~ msgid "This path |[_1]| is not the path to a temporary edit file."
-#~ msgstr "tr: This path |%1| is not the path to a temporary edit file."
-
-#
+#, fuzzy
 #~ msgid ""
 #~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
 #~ "error."
-#~ msgstr ""
-#~ "tr: Unable to change the source file path for set %1, problem %2. Unknown "
-#~ "error."
+#~ msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
 
-#
+#, fuzzy
 #~ msgid "Options Information"
-#~ msgstr "tr: Options Information"
+#~ msgstr "תיאור אתר"
 
-#
-#~ msgid "Save as new independent problem"
-#~ msgstr "tr: Save as new independent problem"
-
-#
+#, fuzzy
 #~ msgid "Cancel Export"
-#~ msgstr "tr: Cancel Export"
+#~ msgstr "ביטול"
 
-#
+#, fuzzy
 #~ msgid "options information"
-#~ msgstr "tr: options information"
+#~ msgstr "תיאור אתר"
 
-#
+#, fuzzy
 #~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-#~ msgstr "tr: The selected problem(%1) is not a valid problem for set %2."
-
-#
-#~ msgid "Unknown file type"
-#~ msgstr "tr: Unknown file type"
+#~ msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"

--- a/lib/WeBWorK/Localize/heb.po
+++ b/lib/WeBWorK/Localize/heb.po
@@ -21,11 +21,15 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
 "1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+msgid "# of active students"
+msgstr "מספר תלמידים פעילים"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr "# נכון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr "#שגוי"
 
@@ -38,15 +42,15 @@ msgid "% correct with review"
 msgstr "% נכון עם ביקורת"
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr "% תלמידים"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr "%1 (עורך ישן)"
 
@@ -82,17 +86,17 @@ msgid "%1 students out of %2"
 msgstr "%1 תלמידים מתוך %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr "%1 כותרת ומוסד שונו מ%2 ל%3 ומ%4 ל%5"
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 משתמשים יוצאו לקובץ %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -127,8 +131,8 @@ msgstr "%1% הושלמו"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr "%1% נכון"
 
@@ -165,7 +169,7 @@ msgstr "הסיסמה של %1 שונתה"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: שאלה %2"
 
@@ -175,12 +179,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1: שאלה %2 תראה לי עוד אחת"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr "%1: התקיה של הקורס לא נמצאה."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr "%quant(%1,קורס נהפך לגלוי, קורסים נהפכו לגלויים) בהצלחה."
 
@@ -195,49 +199,49 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr "%quant(%1,קובץ נפרק,קבצים נפרקו) נפרק בהצלחה"
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "%quant(%1, מהשאלות לא נענתה, מהשאלות לא נענו)."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr "%quant_1(הקורס הוחבא, הקורסים הוחבאו) בהצלחה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr "מתוך 100"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr "(כל שינויים שלא נשמרו ימחקו)"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr "(צפייה ברמז למדריך: הראה לתלמיד את הרמז לאחר מספר זה של נסיונות:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(שאלה זו לא תחשב בחישוב הציון לגליון.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr "(מבחן זה הוגש באיחור מכיוון שהוא לא הוגש בזמן המוגדר.)"
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "(הניקוד שלך על זה %1 לא זמין עד %2.)"
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr "(הניקוד שלך על זה  %1 לא זמין.)"
 
@@ -281,7 +285,7 @@ msgstr ""
 "בזמן תקופת הניקוד המופחת, הוא יראה את ההודעה \"אתה בתקופת ניקוד מופחת: כל "
 "הגשה נוספת תחשב כ-50% מהניקוד המקורי.\"</p><p>כדי להשתמש אפשרות זאת, יש גם "
 "לאפשר ניקוד מופחת ולבחור תאריך ניקוד מופחת לכל מטלה בנפרד, על-ידי עריכתו של "
-"הנתונים של האוסף בעזרת עורך אוספי שיעורי הבית.</p><p>זה עובד עם "
+"הנתונים של הגליון בעזרת עורך אוספי שיעורי הבית.</p><p>זה עובד עם "
 "avg_problem_grader (שהוא המנקד לפי ברירת המחדל) ועם std_problem_grader "
 "( מנקד לפי הכל או כלום). זה יעבוד גם עם מנקדים שנכתבו על-ידי המשתמשים, אם הם "
 "נכתבו כנדרש.</p>"
@@ -338,18 +342,32 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr "קורס עם מזהה %1 כבר קיים."
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
 msgstr ""
 "תקייה עם השם %1 כבר קיימת. יש למחוק את הקורס הזה לפני שניתן להוציאו מהארכיון."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
@@ -366,14 +384,14 @@ msgstr ""
 "חסרות וכולן קריאות. אם לא, אנא פנה למדריך שלך."
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr "קבר קיים מיקום בשם %1 במסד הנתונים. האם התכוונת לערוך אותו?"
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -382,17 +400,17 @@ msgstr ""
 "%4 הודעה/ות."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr "נוצר קובץ חדש ב-'%1'"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
-msgstr "נוצר קובץ חדש ב-'%1' עם התוכן שמפורט למטה. לא נעשו שינויים באוסף %2"
+msgstr "נוצר קובץ חדש ב-'%1' עם התוכן שמפורט למטה. לא נעשו שינויים בגליון %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -440,37 +458,37 @@ msgstr ""
 "האוספים שהוקצאו מובילים לעמוד בו ניתן לראות ולהקצות אוספים עבור אותו משתשמש."
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr "סטטוס מותאם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr "תשובות לא נשמרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr "תשובות לא נשמרו --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "תשובות רק נבדקו --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "התשובות נבדקו בלבד --  תשובות לא נשמרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "בטל שינויים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "בטל יצוא"
@@ -480,12 +498,12 @@ msgid "Achievement"
 msgstr "הישג"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr "הישג %1 נוצר עם מעריך '%2'."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "הישג %1 קיים. לא נוצר הישג"
 
@@ -502,13 +520,13 @@ msgstr "עורך מעריכי הישגים"
 msgid "Achievement Evaluator for achievement %1"
 msgstr "מעריך הישגים עבור הישג %1"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr "מזהה הישג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr "מזהה הישג כבר קיים! לא נוצר הישג חדש. קובץ לא נשמר."
 
@@ -524,12 +542,16 @@ msgstr "עורך משתמש יעידים"
 msgid "Achievement has been assigned to all users."
 msgstr "ההישג הוקצה לכל המשתמשים."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+msgid "Achievement has been assigned to selected users."
+msgstr "ההישג הוקצה למשתמשים שנבחרו."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr "ההישג הוסר לכל המשתמשים."
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr "נקודות הישגים נשמרו ל-%1"
 
@@ -549,17 +571,17 @@ msgid "Act as:"
 msgstr "מתחזה ל-:"
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr "מתחזה ל%1."
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr "פעולה %1 לא נמצאה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "פעיל"
 
@@ -582,7 +604,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "הוסף"
@@ -591,9 +613,9 @@ msgstr "הוסף"
 msgid "Add All"
 msgstr "הוסף הכל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr "הוסף קורס"
 
@@ -605,7 +627,7 @@ msgstr "הוסף תלמידים"
 msgid "Add Users"
 msgstr "הוסף משתמשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr "הוסף מנהלי WeBWorK לקורס חדש"
 
@@ -613,12 +635,12 @@ msgstr "הוסף מנהלי WeBWorK לקורס חדש"
 msgid "Add a new test for which Gateway?"
 msgstr "הוסף מבחן חדש לאיזה בוחן מחסום?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "איזה סוג קובץ להוסיף?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "כמה סטודנטים להוסיף?"
 
@@ -626,41 +648,41 @@ msgstr "כמה סטודנטים להוסיף?"
 msgid "Add problems to"
 msgstr "הוסף שאלות ל-"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
-msgstr "הוסף לאיזה אוסף?"
+msgstr "הוסף לאיזה גליון?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "איזה משתמשים להוסיף?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr "נוסף %1 ל%2 בתור שאלה %3"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "נוסף '%1' ל%2 בתור קידומת הדפסה חדשה"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
-msgstr "נוסף '%1' ל%2 בתור קידומת אוסף חדשה"
+msgstr "נוסף '%1' ל%2 בתור קידומת גליון חדשה"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr "נוספו כתובות %1 למיקום %2."
 
@@ -669,7 +691,7 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr "כתובות נוספות לקבלת משוב בדוא\"ל."
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
@@ -678,21 +700,21 @@ msgstr ""
 "אמינות מסד הנתונים של WeBWorK לפני שאתה ממשיך."
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr "הכתובת(/ות) %1 שברשימת ההוספה כבר במיקום %2, ולכן דולגה(/ו)."
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr "הכתובת(/ות) %1 שברשימת המחיקה לא במיקום %2, ולכן דולגה(/ו)."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
@@ -700,18 +722,18 @@ msgstr ""
 "הכתובת(ות) %1 היא(/הן) לא בצורה מזוהה. אנא בדוק את הנתונים שהוזנו ושלח שוב."
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 "הכתובת(ות) %1 היא(/הן) לא בצורה מזוהה. אנא בדוק את הנתונים שהוזנו ונסה שוב."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr "כתובות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
@@ -721,7 +743,7 @@ msgstr ""
 "192.168.1.101), מסכת כתובת (לדוגמה 192.168.1.0/24), או טווח IP (לדוגמה "
 "192.168.1.101-192.168.1.150)):"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -739,7 +761,7 @@ msgstr "הוסף 24 שעות לתאריך סגירת שיעורי הבית."
 msgid "Adds 48 hours to the close date of a homework."
 msgstr "הוסף 48 שעות לתאריך סגירת שיעורי הבית."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr "סטטוס מותאם"
 
@@ -749,10 +771,10 @@ msgstr "חיפוש מתקדם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
 msgid "After set answer date"
-msgstr "לאחר תאריך התשובות של האוסף"
+msgstr "לאחר תאריך התשובות של הגליון"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr "לאחר תחילת תקופת הניקוד המופחת, כל ניקוד נספר כ-%1% מערכו."
@@ -765,15 +787,15 @@ msgstr "כל ההגלות שנבחרו יחוברו על ידי \"ו-\""
 msgid "All assignments were made successfully."
 msgstr "כל המטלות בוצעו בהצלחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr "כל התשובות לעיל הם נכונות."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr "כל התשבות לעיל שניתנות לניקוד הן נכונותם."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr "כל הקבצים הללו יהיו נגשים לאיחוד דואר."
 
@@ -793,7 +815,7 @@ msgstr "כל האוספים הם מוחבאים מכל התלמדים"
 msgid "All sets made visible for all students"
 msgstr "כל האוספים הם ניתנים לצפייה לכל התלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr "כל התלמידים בקורס"
 
@@ -857,25 +879,25 @@ msgstr "תליון ההארכה"
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr "שגיאה ארעה בזמן הוספת הקורס %1 לארכיון:"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr "שגיאה ארעה בזמן שינוי כותרתו של הקורס %1."
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr "שגיאה ארעה בזמן מחיקת הקורס %1:"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "שגיאה ארעה בזמן שינוי השם של הקורס %1 ל-%2:"
 
@@ -893,8 +915,8 @@ msgstr "תאריך תשובות"
 msgid "Answer Log"
 msgstr "רשימת תשובות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "תצוגה מקדימה של תשובות"
 
@@ -907,12 +929,12 @@ msgid "Answer:"
 msgstr "תשובה:"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr "מידע קבוצת תשובות"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr "מידע גיבוב תשובות"
 
@@ -934,19 +956,24 @@ msgstr "תאריך התשובות לא יכול להיות לפני או בזמ�
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr "תשובות לא יכולות להפוך לזמינות עד זמן או לאחר תאריך הסגירה!"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "כל שינוי שנעשה למטה יוחל על ההישגים עבור כל התלמידים."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
-msgstr "כל שינוי שנעשה למטה יוחל על האוסף עבור כל התלמידים."
+msgstr "כל שינוי שנעשה למטה יוחל על הגליון עבור כל התלמידים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
-msgstr "כל שינוי שנעשה למטה יופיע באוסף רק עבור התלמיד/ים למעלה."
+msgstr "כל שינוי שנעשה למטה יופיע בגליון רק עבור התלמיד/ים למעלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -957,18 +984,18 @@ msgstr ""
 "כל פעם שמשנים שמספרי שאלות, השאלות תמיד ימוספרו באופן עוקב מהמספר אחד. "
 "כשמוחקים שאלות, ישארו רווחים במספור אלא עם כן סומנה האפשרות למעלה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr "צרף"
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
-msgstr "צרף בסופו של האוסף %1"
+msgstr "צרף בסופו של הגליון %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr "הוסף לארכיון"
 
@@ -982,26 +1009,26 @@ msgstr "ארכיון '%1\" נוצר בהצלחה  (%quant( %2, קובץ))"
 msgid "Archive '%1' deleted"
 msgstr "ארכיון '%1' נמחק"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr "הוסף קורס לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr "הוסף קורסים לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr "הוסף את הקורס הבא לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr "הוסף את הקורס הזה לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr "קרוסים בארכיון"
 
@@ -1012,7 +1039,7 @@ msgstr ""
 "מוסיף את הקורס לארכיון בתור %1.tar.gz. רענן את מנהל הקבצים כדי לראות אותו."
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
@@ -1020,7 +1047,7 @@ msgstr ""
 "אתה בטוח שאתה רוצה למחוק את הקורס %1 אחרי שהוא נוסף לארכיון? זה בלתי הפיך!"
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
@@ -1028,10 +1055,14 @@ msgstr ""
 "אתה בטוח שאתה למחוק את הקורס %1? כל המידע והקבצים של הקורס ימחקו. זה בלתי "
 "הפיך."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
 msgstr "הקצה"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr "הקצה %1 לכל המשתמשים, צור מידע גלובלי, ו %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1043,7 +1074,7 @@ msgstr "הקצה את האוספים שנבחרו לתלמידים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
-msgstr "לאיזה משתמשים להקצות אוסף זה?"
+msgstr "לאיזה משתמשים להקצות גליון זה?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
@@ -1055,17 +1086,17 @@ msgstr "הקצה לכל המשתמשים הנוכחיים"
 msgid "Assigned"
 msgstr "הוקצה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "אוספים שהוקצו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr "הקצה הישגים למשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr "הקצה ל-"
 
@@ -1073,7 +1104,11 @@ msgstr "הקצה ל-"
 msgid "Assignment type"
 msgstr "סוג מטלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+msgid "Assignments only"
+msgstr "רק מטלות"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
 
@@ -1082,7 +1117,7 @@ msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
 msgid "Att. to Open Children"
 msgstr "נסיונות לפתיחת תתי-שאלות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr "נסה לשדרג תקיות"
 
@@ -1094,7 +1129,7 @@ msgstr "בוצע נסיון"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "ניסיונות"
 
@@ -1102,13 +1137,14 @@ msgstr "ניסיונות"
 msgid "Audit"
 msgstr "צופה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr "האימות נכשל. אנא פנה למדריך."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "מידע על הכותב"
 
@@ -1116,12 +1152,12 @@ msgstr "מידע על הכותב"
 msgid "Automatic"
 msgstr "אוטומטי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr "הצג שאלות ישירוצ לאחר טעינת העמוד"
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr "גיבוי לקובץ <code>%1/%2</code> נוצר."
 
@@ -1166,16 +1202,16 @@ msgstr ""
 "כברירת מחדל, משוב נשלח לכל המשתמשים לעיל שיש להם רשות לקבל משוב. המשוב נשלח "
 "לכל כתובת שמפורטת פה. הפרד כתובות דוא\"ל באמצעות פסיק."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr "תאריך הסגירה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr "זמן הגשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr "עוגת התפיחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1205,7 +1241,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr "לא יכול ליצור את הארכיון '%1': פקודה החזירה %2"
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr "לא יכול ליצור סביבת קורס עבור %1 בגלל ש%2"
 
@@ -1240,17 +1276,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "לא יכול להשיג היסטורית סיסמאות עבור המשתמש '%1': %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr "לא יכול לפתוח את %1"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr "לא יכול לפתוח את הקובץ %1"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr "לא יכול לקרוא את קובץ האיחוד %1. לא נשלחה שום הודעה"
 
@@ -1259,7 +1295,7 @@ msgstr "לא יכול לקרוא את קובץ האיחוד %1. לא נשלחה 
 msgid "Can't rename file: %1"
 msgstr "לא יכול לשנות את שם הקובץ: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr "לא יכול לשנות שם לאותו השם."
 
@@ -1268,11 +1304,11 @@ msgstr "לא יכול לשנות שם לאותו השם."
 msgid "Can't unpack '%1': command returned %2"
 msgstr "לא יכול לפרוק '%1': פקודה החזירה %2"
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr "לא יכול לכתוב בקובץ %1"
 
@@ -1283,7 +1319,7 @@ msgstr "לא יכול לכתוב בקובץ %1"
 msgid "Cancel"
 msgstr "ביטול"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr "ביטול דוא\"ל"
 
@@ -1296,8 +1332,8 @@ msgstr "לא יכול לפתוח %1"
 msgid "Cap Test Time at Set Close Date?"
 msgstr "הגבל את זמן המבחן לזמן הסגירה?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr "קטגוריה"
 
@@ -1311,17 +1347,17 @@ msgstr "גרום לשעורי הבית שנבחרו להניב פי-2 יותר �
 msgid ""
 "Causes a homework problem to become a clone of another problem from the same "
 "set."
-msgstr "גרום לשאלת שיעורי בית להפוך להעתק של בעיה אחרת באותו האוסף."
+msgstr "גרום לשאלת שיעורי בית להפוך להעתק של בעיה אחרת באותו הגליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr "גרום לשאלת שיעורי בית אחת להיות שווה פי-2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr "שנה כותרת קורס ל-:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr "שנה מזהה קורס ל-:"
 
@@ -1335,7 +1371,7 @@ msgstr "שנה אפשרויות תצוגה"
 msgid "Change Email Address"
 msgstr "שנה כתובת דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr "שנה מוסד ל-:"
 
@@ -1344,32 +1380,32 @@ msgstr "שנה מוסד ל-:"
 msgid "Change Password"
 msgstr "שנה סיסמה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr "שנה הגדרות משתמש"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr "שנה את מוסד הקורס מ%1 ל%2"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr "שנה את כתרת הקורס מ%1 ל%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "שינויים בוטלו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "שינויי בקובץ זה עוד לא נשמרו."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "שינויים נשמרו"
 
@@ -1384,47 +1420,47 @@ msgstr "משנה את גרעין השאלות עבור התצוגה, אבל לא
 msgid "Chapter:"
 msgstr "פרק:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "בדוק תשובות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr "בדוק מבחן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr "בדוק שההרשאות מוגדרות כנדרש"
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr "בדוק אם קיים והאם התקייה %1 ניתנת לקריאה על ידי השרת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "בודק הודעות שגיאה נוספות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:477
 msgid "Choose the set which you would like to be worth twice as much."
-msgstr "בחר את האוסף שתרצה שיחשב פי-2."
+msgstr "בחר את הגליון שתרצה שיחשב פי-2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:386
 msgid "Choose the set which you would like to enable partial credit for."
-msgstr "בחר את האוסף עבורו תרצה להפעיל ניקו חלקי."
+msgstr "בחר את הגליון עבורו תרצה להפעיל ניקוד חלקי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
-msgstr "בחר את האוסף שתרצה לשחזר"
+msgid "Choose the set which you would like to resurrect."
+msgstr "בחר את הגליון שתרצה לשחזר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
 msgid "Choose the set whose close date you would like to extend."
-msgstr "בחר את האוסף שתרצה להאריך את תאריך הסגירה שלו."
+msgstr "בחר את הגליון שתרצה להאריך את תאריך הסגירה שלו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
@@ -1456,16 +1492,16 @@ msgid ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 msgstr ""
-"לחץ על שמו של תלמיד על מנת לראות את גירסתו של אוסף שיעורי הבית. לחץ על "
+"לחץ על שמו של תלמיד על מנת לראות את גירסתו של גליון שיעורי הבית. לחץ על "
 "הכותרות כדי למיין את הטבלה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
-"לחץ על שם המשתמש כדי לערוך מידע של אוסף שאלות ספציפי, (למשל תאריך הגשה) עבור "
+"לחץ על שם המשתמש כדי לערוך מידע של גליון שאלות ספציפי, (למשל תאריך הגשה) עבור "
 "תלמידים אלו."
 
 #. ($clientIP->ip()
@@ -1479,7 +1515,7 @@ msgstr ""
 "כתובת ה-IP של הלקוח  %1 לא מאושרת לעבודה על מטלה זו, מכיוון שלמטלה יש הגבלות "
 "כתובת IP ואין מיקומים מותרים לפי הגבלה זו. פנה למרצה כדי לפתור בעיה זו."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr "סגור"
 
@@ -1517,7 +1553,7 @@ msgid "Closes"
 msgstr "סוגר"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr "סוגר את  %1"
 
@@ -1526,39 +1562,39 @@ msgstr "סוגר את  %1"
 msgid "Closes:"
 msgstr "סוגר את:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr "הסתר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr "הסתר הכל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "הגב"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr "תוצאות עבור מטלה זו לא זמינות עד %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr "תוצאות עבור מטלה זו לא זמינות."
 
@@ -1566,7 +1602,7 @@ msgstr "תוצאות עבור מטלה זו לא זמינות."
 msgid "Completed."
 msgstr "הושלם."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr "אישור"
 
@@ -1576,7 +1612,7 @@ msgstr "אישור"
 msgid "Confirm %1's New Password"
 msgstr "אשר אתה הסיסמה החדשה של %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr "אשר סיסמה:"
 
@@ -1590,8 +1626,8 @@ msgid "Continue"
 msgstr "המשך"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "הועתקו קבצים משניים מ%1 למיקום חדש ב%2"
 
@@ -1605,7 +1641,7 @@ msgstr "העתק"
 msgid "Copy file as:"
 msgstr "העתק קובץ בשם:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr "העתק תבנית מ-:"
 
@@ -1613,8 +1649,8 @@ msgstr "העתק תבנית מ-:"
 msgid "Copy this Problem"
 msgstr "העתק שאלה זו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "נכון"
@@ -1623,7 +1659,7 @@ msgstr "נכון"
 msgid "Correct Adjusted Status"
 msgstr "תקן סטטוס מותאם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr "תשובה נכונה"
 
@@ -1640,20 +1676,20 @@ msgid "Correct answers"
 msgstr "תשובות נכונות"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr "נכון: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr "תשובות נכונות"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
-msgstr "לא יכל להוסיף %1 שאלות לאוסף זה. המספר חייב להיות בין %1 ל%2"
+msgstr "לא יכל להוסיף %1 שאלות לגליון זה. המספר חייב להיות בין %1 ל%2"
 
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
@@ -1667,48 +1703,49 @@ msgid "Couldn't change your email address: %1"
 msgstr "לא היה ניתן לשנות את כתובת הדוא\"ל שלך: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr "לא היה ניתן למצוא את ענף ספריית השאלות הפתוחה %1 ב-remote בשם %2"
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr "לא היה ניתן למצוא את ענף ה-PG ששמו %1 ב-remote בשם %2"
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr "לא היה ניתן למצוא את ענף ה-WeBWork ששמו %1 ב-remote בשם %2"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr "לא היה ניתן לשמור את אפשרויות התצוגה: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr "כמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr "נספר למכיל"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr "מסד הנתונים של הקורס %1 עובד כשורה"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr "יש לעדכן את מסד הנתונים של הקורס %1 לפני שמשנים את שמו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1718,13 +1755,13 @@ msgstr "ניהול הקורס"
 msgid "Course Configuration"
 msgstr "תצורת קורס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr "מזהה הקורס יכול להכיל רק אותיות, מספרים, מקפים, וקוים תחתונים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr "מזהה קורס:"
 
@@ -1733,13 +1770,13 @@ msgstr "מזהה קורס:"
 msgid "Course Info"
 msgstr "מידע על הקורס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr "שם קורס:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr "כותרת קורס:"
 
@@ -1747,15 +1784,15 @@ msgstr "כותרת קורס:"
 msgid "Course archived."
 msgstr "הקורס הוכנס לארכיון."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "קורסים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1777,28 +1814,28 @@ msgstr "צור"
 msgid "Create CSV"
 msgstr "צור CSV"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr "צור מיקום:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
-msgstr "צור אוסף חדש בקו0רס הזה:"
+msgstr "צור גליון חדש בקורס הזה:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr "צור הישג חדש עם מזהה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
-msgstr "איזה סוג של אוסף ליצור?"
+msgstr "איזה סוג של גליון ליצור?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr "צור שאלה ללא שיכות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1815,34 +1852,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr "מאפין התפיחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr "נוכחי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr "המיקמים שמוגדרים כרגע מפורטים למטה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr "מידע"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr "טבלאות מסד הנתנים הם תקינים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr "טבלאות מסד הנתונים מתעדכנות."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr "טבלאות מסד נתונים תקינים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr "מסד נתונים:"
 
@@ -1854,7 +1891,7 @@ msgstr "תאריך"
 msgid "Debug"
 msgstr "דיבאג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1879,85 +1916,85 @@ msgstr "זמן ברירת המחדל (בדקות) של תקופת הניקוד �
 msgid "Default Time that the Assignment is Due"
 msgstr "זמן ברירת המחדל שבו יש להגיש את המטלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "מחק"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr "מחק קורס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr "מחק את כל הכתובות הקיימות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr "מחק את הקורס לאחר הכנסתו לארכיון. זהירות אין אפשרות לחזור בך!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr "מחק קורס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "כמה למחוק?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr "למחוק?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr "מחק מיקום:"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr "%quant(%1, נמחק הישג, נמחקו הישגים)"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr "נמחקו מקום/ות: %1"
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr "נמחקו הכתובות %1 מהמיקום."
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr "מוחק קובץ זמני ב%1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr "המחיקה תמחוק את כל מידע המיקום וכתובות שקשורות עליו, והיא בלתי הפיך!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr "מחיקה הורסת את כל המידע שקשור להישג והיא בלתי הפיכה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
 msgid "Deletion destroys all set-related data and is not undoable!"
-msgstr "מחיקה הורסת את כל המידע הקשור לאוסף והיא לא הפיכה!"
+msgstr "מחיקה הורסת את כל המידע הקשור לגליון והיא לא הפיכה!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr "מחיקה הורסת את כת המידע הקשור למשתמש והיא בלתי הפיכה!"
 
@@ -1965,13 +2002,13 @@ msgstr "מחיקה הורסת את כת המידע הקשור למשתמש וה�
 msgid "Deny From"
 msgstr "תמנע מ-"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr "תיאור"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr "פעולה לא זוהתה"
 
@@ -1989,47 +2026,47 @@ msgstr "התקייה '%1' לא הוסרה: %2"
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr "התיקייה '%1' הוסרה (פריטים שנמחקו: %2)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr "שגיאות התרי תיקייה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr "מבנה תיקייה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr "למבנה התיקייה חסרים תיקייות או שלשרת הרשת אין את היתרים הנדרשים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr "מבנה התקייה הוא תקין"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr "יש לתקן את מבנה התיקייה באופן ידני לפני הכנסה לארכיון."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr "יש לתקן את מבנה התיקייה באופן ידני לפני שנוי השם."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr "יש לתקן את מבנה התיקייה או את ההיתרים. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr "מצב תצוגה:"
@@ -2037,6 +2074,11 @@ msgstr "מצב תצוגה:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
 msgstr "הראה תשובות מהעבר"
+
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
+msgstr "הצגת הצינים למטלה זו אסורה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
@@ -2052,36 +2094,36 @@ msgstr "אל תבטל את ההקצאה של תלמידים אלא אם אתה �
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:274
 msgid "Do not uncheck a set unless you know what you are doing."
-msgstr "אל תבטל אוסף אם אתה לא יודע מה אתה עושה."
+msgstr "אל תבטל גליון אם אתה לא יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr "אל תבטל הקצאת תלמידים אם אתה לא יודע מה אתה עושה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr "אל תוסיף לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr "אל תסיר מהארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr "אל תשדרג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr "אל תמחק"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr "אל תעשה שינויים"
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "לא מזהה את מצב השמירה: |%1|. שגיאה לא ידוע."
 
@@ -2090,17 +2132,17 @@ msgstr "לא מזהה את מצב השמירה: |%1|. שגיאה לא ידוע."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr "לא מזהה את סוג תצוגת הסטטיסטיקה: |%1|."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr "אל תשנה שם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr "אל תשתמש הישג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr "בוצע"
 
@@ -2130,10 +2172,10 @@ msgstr "הורד קובץ להדפסה"
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "הורד קובץ להדפסה עבור האוספים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
-msgstr "הורד גרסת הדפסה כ-PDF או TeX של האוסף הנוכחי"
+msgstr "הורד גרסת הדפסה כ-PDF או TeX של הגליון הנוכחי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
@@ -2142,7 +2184,7 @@ msgstr "הורד גרסת הדפסה כ-PDF או TeX של האוספים שנב�
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
 msgid "Download hardcopy of set %1 for %2?"
-msgstr "הורד קובץ להדפסה של אוסף %1 עבור %2?"
+msgstr "הורד קובץ להדפסה של גליון %1 עבור %2?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
 msgid "Download:"
@@ -2152,9 +2194,19 @@ msgstr "הורדה:"
 msgid "Drop"
 msgstr "עזוב"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
-msgstr "שכפל את האוסף הזה ותן לו שם"
+msgstr "שכפל את הגליון הזה ותן לו שם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:371
 msgid ""
@@ -2178,7 +2230,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr "דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "שלח דוא\"ל למדריך"
 
@@ -2196,7 +2248,7 @@ msgstr "דוא\"ל משוב מתלמידים נשלח אוטומטית לדרג�
 msgid "E-mail verbosity level"
 msgstr "אורך פורמט הדוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr "דוא\"ל:"
 
@@ -2204,50 +2256,50 @@ msgstr "דוא\"ל:"
 msgid "Earned"
 msgstr "הושג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "ערוך"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
-msgstr "ערוך %1 מהאוסף %2"
+msgstr "ערוך %1 מהגליון %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
-msgstr "ערוך את כל המידע של האוסף"
+msgstr "ערוך את כל המידע של הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
 msgstr "ערוך משתמשים שהוקצאו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr "ערוך מעריך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr "ערוך קידומת"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr "ערוך מיקום:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr "ערוך שאלה"
 
@@ -2258,18 +2310,18 @@ msgstr "ערוך שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
 msgid "Edit Set"
-msgstr "ערוך אוסף"
+msgstr "ערוך גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
-msgstr "ערוך את מידע האוסף"
+msgstr "ערוך את מידע הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
 msgid "Edit Target Set"
-msgstr "ערוך את האוסף הנבחר"
+msgstr "ערוך את הגליון הנבחר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "ערוך איזה משתמשים?"
 
@@ -2285,17 +2337,17 @@ msgstr "ערוך"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
-msgstr "ערוך את המידע של האוסף %1 עבור כל התלמידים שלהם שהוקצעו לאוסף הזה."
+msgstr "ערוך את המידע של הגליון %1 עבור כל התלמידים שלהם שהוקצעו לגליון הזה."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
-msgstr "ערוך את האוסף %1 עבור המשתמש הזה."
+msgstr "ערוך את הגליון %1 עבור המשתמש הזה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2311,23 +2363,23 @@ msgid "Edit which sets?"
 msgstr "איזה אוספים לערוך?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr "עריכה1"
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr "עריכה2"
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr "עריכה3"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr "עורך %1 בקובץ '%2'"
 
@@ -2337,44 +2389,44 @@ msgid "Editing achievement in file '%1'"
 msgstr "עורך את ההישג בקובץ '%1'"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr "עורך את המיקום %1"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
-msgstr "עורך את המידע של אוסף השאלות %1 עבור התלמידים הספציפים האלה: %2"
+msgstr "עורך את המידע של גליון השאלות %1 עבור התלמידים הספציפים האלה: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr "עורך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr "עורך שורות:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "כתובת דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr "גוף הדוא\"ל"
 
@@ -2382,22 +2434,22 @@ msgstr "גוף הדוא\"ל"
 msgid "Email Instructor On Failed Attempt"
 msgstr "שלח דוא\"ל למדריך בכל נסיון כושל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr "קישור דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr "כתובת דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "שלח דוא\"ל למדריך"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
@@ -2406,7 +2458,7 @@ msgstr ""
 "שולח דוא\"ל ל%quant(%1,נמען, נמענים). תקבל הודעה כאשר המשימה תושלם. זה עשוי "
 "לקחת כמה דקות אם הכיתה גדולה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr "דוא\"ל נשלח ל-:"
 
@@ -2448,8 +2500,8 @@ msgstr ""
 "אפשר ניקוד מופחת עבור מחבן שיעורי בית. יאפשר לשלוח תשובות עבור ניקוד חלקי 24 "
 "שעות לאחר תאריך הסגירה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr "מופעל"
 
@@ -2472,15 +2524,15 @@ msgid ""
 "sets."
 msgstr ""
 "הפעל את השימוש במערכת הפרסום המותנה. כדי להשתמש בפרסום מותנה צריך לפרט רשימה "
-"של שמות בדף פרטי אוסף השאלות, ולפרט ציון מינימלי. לתלמידים לא יהיה גישה "
-"לאוסף הזה עד שהגיעו לציון המינימלי בכל האוספים שנרשמו."
+"של שמות בדף פרטי גליון השאלות, ולפרט ציון מינימלי. לתלמידים לא יהיה גישה "
+"לגליון הזה עד שהגיעו לציון המינימלי בכל האוספים שנרשמו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
 msgid ""
 "Enables the use of the date picker on the Homework Sets Editor 2 page and "
 "the Problem Set Detail page"
 msgstr ""
-"מפעיל את השימוש בבורר התאריך על אוספי שיעורי הבית דף עורך 2 ודף פרטי אוסף "
+"מפעיל את השימוש בבורר התאריך על אוספי שיעורי הבית דף עורך 2 ודף פרטי גליון "
 "השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:253
@@ -2496,22 +2548,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "רשום"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr "רשום, פרש, וכו'."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "סטטוס רישום"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "הכנס שם קובץ כאן"
 
@@ -2527,8 +2579,8 @@ msgstr ""
 "הכנס מידע כאן לגבי התלמידים שאתה רוצה להוסיף כל סיסמה של תלמיד תהיה מזהה "
 "התלמיד שלו בהתחלה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "הוכנס"
 
@@ -2544,7 +2596,7 @@ msgstr "תצוגת משוואה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1442
 msgid "Error adding set-level proctor: %1"
-msgstr "שגיאה בהוספת משגיח אוסף: %1"
+msgstr "שגיאה בהוספת משגיח גליון: %1"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1344
@@ -2552,13 +2604,13 @@ msgstr "שגיאה בהוספת משגיח אוסף: %1"
 msgid ""
 "Error getting old set-proctor password from the database: %1.  No update to "
 "the password was done."
-msgstr "שגיאה בהשגת סיסמת משגיח אוסף ישנה ממסד הנתונים: %1. לא שונתה הסיסמה."
+msgstr "שגיאה בהשגת סיסמת משגיח גליון ישנה ממסד הנתונים: %1. לא שונתה הסיסמה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
 msgid "Error message:"
 msgstr "הודעת שגיאה:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr "הודעות שגיאה"
 
@@ -2570,7 +2622,7 @@ msgstr "שגיאה: תאריך תשובות חייב לבוא אחרי תארי�
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1534
 msgid "Error: Close date must come after open date in set %1"
-msgstr "שגיאה: תאריך הסגירה חייב לבוא אחרי תאריך הפתיחה באוסף %1"
+msgstr "שגיאה: תאריך הסגירה חייב לבוא אחרי תאריך הפתיחה בגליון %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1551
@@ -2578,10 +2630,10 @@ msgid ""
 "Error: Reduced scoring date must come between the open date and close date "
 "in set %1"
 msgstr ""
-"שגיאה: תאריך ניקוד מופחת חייב לבוא בין תאריך הפתיחה לתאריך הסגירה באוסף %1"
+"שגיאה: תאריך ניקוד מופחת חייב לבוא בין תאריך הפתיחה לתאריך הסגירה בגליון %1"
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr "שגיאה: אי אפשר לקרוא את הקובץ המקורי %1."
@@ -2591,21 +2643,25 @@ msgstr "שגיאה: אי אפשר לקרוא את הקובץ המקורי %1."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1528
 msgid "Error: answer date cannot be more than 10 years from now in set %1"
-msgstr "שגיאה: תאריך תשובות לא יכולל להיות יותר מ-10 שנים מעכשיו באוסף %1"
+msgstr "שגיאה: תאריך תשובות לא יכולל להיות יותר מ-10 שנים מעכשיו בגליון %1"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1082
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1526
 msgid "Error: close date cannot be more than 10 years from now in set %1"
-msgstr "שיגאה: תאריך סגירה לא יכול להיות יותר מ-10 שנים מהיום באוסף %1"
+msgstr "שיגאה: תאריך סגירה לא יכול להיות יותר מ-10 שנים מהיום בגליון %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
 msgid "Error: open date cannot be more than 10 years from now in set %1"
-msgstr "שגיאה: תאריך פתיחה לא יכול להיות יותר מ-10 שנים מהיום באוסף %1"
+msgstr "שגיאה: תאריך פתיחה לא יכול להיות יותר מ-10 שנים מהיום בגליון %1"
 
 #. ($problem_desc, $problem_name, CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1230
@@ -2616,7 +2672,7 @@ msgstr ""
 "אירעו שגיאות בזמן עיבוד %1. שאלה %2 לא נכנסה לקובץ ההדפסה. טקסט שגיאה: %3"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2626,7 +2682,7 @@ msgstr ""
 "hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרים של תיקיית הקורס, %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
@@ -2636,27 +2692,27 @@ msgstr ""
 "הקובץ hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרית של תיקיית "
 "הקורס, %11"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr "מעריך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr "קובץ מעריך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr "חוץ מאולי השגיאות לעיל, כל הקורסים שנבחרו בם כר מוחבאים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr "חוץ מאולי השגיאות לעיל, כל הקורסים שנבחרו בם כר גלויים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
@@ -2665,24 +2721,24 @@ msgstr ""
 "אותם:"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr "לא היה אפשרות לשמור את הקובץ %1 ולכן הוא נמחק."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr "פתח"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr "פתח הכל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "יצא"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr "יצא הישגים שנבחרו."
 
@@ -2690,7 +2746,7 @@ msgstr "יצא הישגים שנבחרו."
 msgid "Export selected sets"
 msgstr "יצא את האוספים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "איזה סוג קובץ ליצא?"
 
@@ -2698,12 +2754,12 @@ msgstr "איזה סוג קובץ ליצא?"
 msgid "Export which sets?"
 msgstr "איזה אוספים ליצא?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "איזה משתמשים ליצא?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr "הישגים יוצאו ל-%1"
 
@@ -2719,29 +2775,29 @@ msgstr ""
 "מאריך את תאריך הסגירה של בוחן מחסום ב-24 שעות. שים לב: הבוחן חייב להיות פתוח "
 "כדי שזה יעבוד."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr "שם פרטי"
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr "יצירת הישג חדש נכשלה: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "יצירת הישג חדש נכשלה: לא פורט מזהה הישג!"
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
 msgid "Failed to create new set: %1"
-msgstr "יצירת אוסף חדש נכשלה: %1"
+msgstr "יצירת גליון חדש נכשלה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
-msgstr "יצירת אוסף חדש נכשלה: לא הוכנס שם לאוסף!"
+msgstr "יצירת גליון חדש נכשלה: לא הוכנס שם לגליון!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr "שכפול ההישג נכשל: לא נבחר הישג לשכפול! "
@@ -2749,21 +2805,21 @@ msgstr "שכפול ההישג נכשל: לא נבחר הישג לשכפול! "
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
 msgid "Failed to duplicate set: %1"
-msgstr "שכפול אוסף נכשל: %1"
+msgstr "שכפול גליון נכשל: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
-msgstr "שיכפול אוסף נכשל: לא הוכנס שם לאוסף!"
+msgstr "שיכפול גליון נכשל: לא הוכנס שם לגליון!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
-msgstr "שכפול אוסף נכשל: לא נבחר אוסף לשכפול!"
+msgstr "שכפול גליון נכשל: לא נבחר גליון לשכפול!"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr "שכפול האוסף נכשל: אוסף %1 כבר קיים!"
+msgstr "שכפול הגליון נכשל: גליון %1 כבר קיים!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
 msgid "Failed to enter student:"
@@ -2772,10 +2828,10 @@ msgstr "הוספת תלמיד נכשלה:"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr "פתיחת %1 נכשלה"
 
@@ -2785,11 +2841,11 @@ msgid "Failed to save: %1"
 msgstr "השמירה נכשלה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr " לא נכון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr "האפשרותת כבר נוצלה עד תומה עבור שאלה זו"
 
@@ -2801,42 +2857,42 @@ msgstr "משוב"
 msgid "Feedback by Section."
 msgstr "משוב לפי קבוצה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr "הודעת משוב"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr "השדה תקין"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr "שדה חסר במסד הנתונים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr "שדה חסר בתבנית"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr "הקובץ '%1' קיים. הקובץ לא נשמר. לא בוצעו ציונים."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
 "הקובץ '%1' קיים. הקובץ לא נשמר. לא בוצעו שינויים. אתה יכול לשנות את מיקום "
-"הקובץ של שאלה זו באופן ידני מדף 'עורך אוסף שיעורי בית'."
+"הקובץ של שאלה זו באופן ידני מדף 'עורך גליון שיעורי בית'."
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
@@ -2878,7 +2934,7 @@ msgstr "הקובץ הועתק בהצלחה"
 msgid "File successfully renamed"
 msgstr "שם הקובץ שונה בהצלחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "שם קובץ"
 
@@ -2887,7 +2943,7 @@ msgstr "שם קובץ"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr "קבצים עם הסיומת '.%1' בדרכ כלל שייכים ל-'%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "לפי אזה טקסט לסנן?"
 
@@ -2901,28 +2957,28 @@ msgstr "סינון:"
 msgid "First"
 msgstr "ראשון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "שם פרטי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr "שם פרטי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -2933,7 +2989,7 @@ msgstr ""
 "(אתה לא יכול להתשתמש ב .../blah/blah למשל). אנא בחר קובץ אחר או העבר את "
 "הקובץ הדרוש לתיקיית הדוא\"ל "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr "אלץ מספור עוקב של של השאלות החל ממספר אחד"
 
@@ -2944,6 +3000,10 @@ msgid ""
 msgstr ""
 "אלץ מספור עוקב של של השאלות החל ממספר אחד ( זה תמיד נעשה כשמסדרים בעיות מחדש)"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
+msgstr "פורמט"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
 msgstr "פורמט עבור נשורת נושא בדוא\"ל משוב."
@@ -2953,19 +3013,23 @@ msgstr "פורמט עבור נשורת נושא בדוא\"ל משוב."
 msgid "Format:"
 msgstr "פורמט:"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+msgid "Found no directories containing problems"
+msgstr "לא נמצאו תיקיות המכילות שאלות."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr "מהקורס הזה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr "שדה הנמען חייב להכיל לפחות כתובת דוא\"ל תקינה אחת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "שולח:"
 
@@ -2993,7 +3057,7 @@ msgid "General"
 msgstr "כללי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr "מידע כללי"
 
@@ -3011,13 +3075,18 @@ msgstr "השג שאלות מאוסף סיפרייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
 msgid "Get Target Set Problems"
-msgstr "השג את שאלות האוסף הנבחר"
+msgstr "השג את שאלות הגליון הנבחר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr "קבל גרסה חדשה של שאלה זו."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr "תן סיסמה חדשה ל-"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "לאיזה משתמשים לתת סיסמה חדשה?"
 
@@ -3027,7 +3096,7 @@ msgstr "תן ניקוד מלא על שאלת שיעורי בית אחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1079
 msgid "Gives full credit on every problem in a set."
-msgstr "תן ניקוד מלא על כל שאלה באוסף."
+msgstr "תן ניקוד מלא על כל שאלה בגליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:762
 msgid "Gives half credit on a single homework problem."
@@ -3035,38 +3104,48 @@ msgstr "תן חצי ניקוד על שאלה אחת משעורי הבית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:878
 msgid "Gives half credit on every problem in a set."
-msgstr "תן חצי ניקוד על כל שאלה מאוסף."
+msgstr "תן חצי ניקוד על כל שאלה מגליון."
 
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
 msgid "Global problem %1 for set %2 not found."
-msgstr "שאלה גלובאלית %1 עבור אוסף %2 לא נמצאה."
+msgstr "שאלה גלובאלית %1 עבור גליון %2 לא נמצאה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
-msgstr "מידע אוסף גלובאלי יופיע במקום מידע משתמש ספציפי"
+msgstr "מידע ??? גלובאלי על הגליון יופיע במקום מידע משתמש ספציפי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:155
 msgid "Go"
 msgstr "התחל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr "נקד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr "נקד שאלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr "נקד מבחן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr "מנקד"
 
@@ -3094,7 +3173,7 @@ msgstr "כרך ההארה הגדול"
 msgid "Guest Login"
 msgstr "כניסת אורח"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr "קידומות HTTP"
 
@@ -3121,12 +3200,16 @@ msgstr "קידומת גירסת הדפסה"
 msgid "Hardcopy Theme"
 msgstr "עיצוב גרסת הדפסה"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr "קידומות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "עזרה"
 
@@ -3138,12 +3221,12 @@ msgstr "הנה גרסה חדשה של השאלה."
 msgid "Hidden"
 msgstr "מוחבא"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr "החבא הכל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr "החבא קורס"
 
@@ -3155,8 +3238,8 @@ msgstr "החבא רמזים"
 msgid "Hide Hints from Students"
 msgstr "החבא רמזים מהתלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr "החבא קורסים לא פעילים"
 
@@ -3168,7 +3251,7 @@ msgstr "החבא את כל הכתובות"
 msgid "Hide path:"
 msgstr "החבא כתובת:"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr "רמז:"
 
@@ -3182,13 +3265,13 @@ msgstr "רמזים"
 msgid "Hmwk Sets Editor"
 msgstr "עורך שיעורי בית"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
-msgstr "אוסף שיעורי בית"
+msgstr "גליונות שיעורי בית"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr "סך הכל שיעורי בית"
 
@@ -3196,15 +3279,15 @@ msgstr "סך הכל שיעורי בית"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr "לא יכול למצוא את הקובץ  [ACHEVDIR]/surprise_message.txt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr "אייקון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr "קוץ אייקון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3225,16 +3308,16 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
-"אם זה מופעל אז מדריכים שיכולים לקבל משוב יקבלו הודע בכל פעם שלתלמיד נגמר "
+"אם זה מופעל אז מדריכים שיכולים לקבל משוב יקבלו הודעה בכל פעם שלתלמיד נגמר "
 "הנסיונות על שאלה והשאלות המוכלות בלי לקבל סטאטוס מותאם של 100%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 "אם זה מופעל אז תלמידים לא יוכלו לנסות שאלה עד שהשלימו את כל השאלות הקודמות, "
 "והאשלות המוכלות במידת הצורך."
@@ -3252,12 +3335,16 @@ msgstr ""
 "לא בטוחה עבור מקומות עובודה ציבוריים, מחשבים לא בטוחים, ומחשבים שבהם אתה לא "
 "שולט באופן ישיר."
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
 msgstr "נבחר קובץ לא חוקי '%1' "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr "שם קובץ לא חוקי, מכיל '..'"
 
@@ -3265,9 +3352,11 @@ msgstr "שם קובץ לא חוקי, מכיל '..'"
 msgid "Import"
 msgstr "יבא"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
-msgstr "יבא הישגים מ-"
+# Context is "Import achievements from ____ assigning the achievements to ___"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "יבא הישגים מ- %1 והקצב את ההישגים ל- %2-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
@@ -3281,21 +3370,21 @@ msgstr "כמה אוספים ליבא?"
 msgid "Import sets with names"
 msgstr "יבא אוספים עם שמות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "מאיזה קובץ ליבא משתמשים?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr "יבא Imported %quant(%1,הישג, הישגים)"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr "בתהליך: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "לא פעיל"
 
@@ -3303,17 +3392,17 @@ msgstr "לא פעיל"
 msgid "Inactivity time before a user is required to login again"
 msgstr "זמן אי-פעילות לפני שהמשתמש נדרש להתחבר שוב"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr "הוסף תיבת הצלחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr "לא נכון"
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr "לא נכון: %1/%2"
 
@@ -3322,7 +3411,7 @@ msgstr "לא נכון: %1/%2"
 msgid "Init"
 msgstr "התחל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr "מוסד:"
 
@@ -3330,16 +3419,16 @@ msgstr "מוסד:"
 msgid "Instructor Tools"
 msgstr "כלי מדריך"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr "הצגת פתרון למדריך: הראה לתלמיד פתרון לאחר מועד ההגשה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr "כתובת משוב לא תקינה."
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3350,7 +3439,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr "סוג קידומת לא תקין %1"
 
@@ -3366,16 +3455,20 @@ msgid ""
 msgstr ""
 "זה לפני תאריך הפתיחה. כנראה תרצה למספר מחדש את השאלות אם אתה מוחק מהאמצע."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr "חפצים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr "קפוץ לעמוד:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr "קפוץ לשאלה:"
 
@@ -3387,7 +3480,7 @@ msgstr "פאראמטרים \"בדיוק בזמן\""
 msgid "Keywords:"
 msgstr "מילות מפתח:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr "שם משפחה"
 
@@ -3408,28 +3501,28 @@ msgstr "אחרון"
 msgid "Last Answer"
 msgstr "תשובה אחרונה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "שם משפחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr "עמודה אחרונה של קובץ האיחוד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr "שם משפחה"
 
@@ -3458,18 +3551,18 @@ msgstr "כרך ההארה הקטן"
 msgid "Level:"
 msgstr "שלב:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "דפדפן ספרייה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "דפדפן ספרייה 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr "דפדפן ספרייה 3"
@@ -3506,13 +3599,13 @@ msgstr "מקומי"
 msgid "Local Problems"
 msgstr "שאלות מקומיות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr "מיקום"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -3521,20 +3614,20 @@ msgstr ""
 "לטעון מחדש את דף ניהול המיקומים?)."
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr "מיקום %1 נוצר, עם כתובת %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr "מחיקת מיקום דורשת אישור."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr "תיאור מיקום:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr "שם מיקום:"
 
@@ -3542,8 +3635,8 @@ msgstr "שם מיקום:"
 msgid "Log In Again"
 msgstr "התחבר שוב"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "התנתק"
 
@@ -3551,20 +3644,20 @@ msgstr "התנתק"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr "התחבר ל-%1"
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr "מחובר בתור %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr "התחבר"
 
@@ -3576,23 +3669,23 @@ msgstr "נתוני התחברות"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "שם התחברות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "סטטוס התחברות"
 
@@ -3600,7 +3693,7 @@ msgstr "סטטוס התחברות"
 msgid "Logout"
 msgstr "התנתק"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "תפריט ראשי"
 
@@ -3613,20 +3706,20 @@ msgstr "צור"
 msgid "Make Archive"
 msgstr " צור ארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr "בצע שינויים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr "בצע את השינויים הבאים בקורס:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr "נהל מיקומים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr "מנקד אוטומטי"
@@ -3640,7 +3733,7 @@ msgid "Mark Correct"
 msgstr "סמן כנכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr "סמן כנכון?"
 
@@ -3648,8 +3741,9 @@ msgstr "סמן כנכון?"
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "התאמה לפי מה? (הפרד מספר מזהים שונים באמצעות פסיק)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "אובייקטים מתמטיים"
 
@@ -3667,49 +3761,49 @@ msgstr ""
 "מספר מקסימאלי של פעמים שניתן להשתמש בכפתור \"תראה לי עוד אחת\" עבור כל בעיה "
 "(1- => לא מוגבל)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr "קובץ איחוד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr "הודעה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr "קובץ הודעה:"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr "הודעה נשמרה לקובץ <code>%1/%2</code>."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr "הודעה:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "הודעות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr "Method"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr "חסר קלט הכרחי. אנא ודא שמלאת את כל שדות יצירת המיקום ושלח שוב."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr "הזז"
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr "הודעה נשלח ל%2 ב%2."
 
@@ -3722,17 +3816,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr "חבילה מסתורית (עם סרט אדום)"
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr "מספר הסדות"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3741,7 +3835,7 @@ msgstr "שם"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
 msgid "Name for new set here"
-msgstr "שם לאוסף חדש "
+msgstr "שם לגליון חדש "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
 msgid "Name of course information file"
@@ -3749,7 +3843,7 @@ msgstr "שם של  קובץ מידע של הקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
-msgstr "תן שם לאוסף החדש"
+msgstr "תן שם לגליון החדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1552
 msgid "Necromancers Charm"
@@ -3773,12 +3867,12 @@ msgstr "קובץ חדש"
 msgid "New Folder"
 msgstr "תיקייה חדשה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr "שם חדש:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "סיסמה חדשה"
 
@@ -3790,29 +3884,31 @@ msgstr "שם קובץ חדש:"
 msgid "New folder name:"
 msgstr "שם תיקייה חדש:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "סיסמאות חדשות נשמרו"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr "גרסה חדשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1852
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
-msgstr "יש ליבא קבצי .def של אוסף שאלות חדש בעזרת עורך אוספי שיעורי בית 2"
+msgstr "יש ליבא קבצי .def של גליון שאלות חדש בעזרת עורך אוספי שיעורי בית 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "שאלה הבאה"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr "הדף הבא"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3820,20 +3916,25 @@ msgstr "הדף הבא"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "לא"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr "אין תיאור"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr "עדיין לא הוקצו הישגים"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr "לא מוצגים הישגים. צור הישג!"
 
@@ -3851,9 +3952,9 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
-msgstr "לא בוצע שום שינוי לשום אוסף"
+msgstr "לא בוצע שום שינוי לשום גליון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3865,7 +3966,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr "לא נשמרו שינויים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr "לא הוגדר מזהה קורס"
 
@@ -3873,40 +3974,40 @@ msgstr "לא הוגדר מזהה קורס"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
 msgid "No data exists for set %1 and problem %2"
-msgstr "לא קיימים נתונים עבור אוסף %1 ושאלה %2"
+msgstr "לא קיימים נתונים עבור גליון %1 ושאלה %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr "לא פורט שם קובץ לשמירה! ההודעה לא נשמרה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr "אין חשבונות אורחים זמינים. אנא נסה מאוחר יותר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr "לא פורט מיקום לערוך?! אנה בדוק את הנתונים שהקלדת."
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr "לא קיים מיקום עם השם %1 במסד הנתונים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr "לא קיים קובץ נתוני איחוד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr "לא פורט מזהה הישג חדש. לא נוצר הישג חדש. קובץ לא נשמר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr "לא נמצאו שאלות שתואמות לפאראמטרים שנתנו."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3914,22 +4015,22 @@ msgstr "לא נבחרו נמענים. אנא בחר נמען אחד או יות�
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
-msgstr "אין רישום לאוסף הגלובאלי %1."
+msgstr "אין רישום לגליון הגלובאלי %1."
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr "אין רישום למשתמש %1."
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr "לא נמצא רישום עבור שאלה %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr "לא נמצא רישום."
 
@@ -3942,7 +4043,7 @@ msgstr "עדיין לא קיימים אוספים בקורס זה"
 msgid "No sets selected for scoring"
 msgstr "לא נבחרו אוספים לנקד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -3950,15 +4051,15 @@ msgstr ""
 "לא מוצגים אוספים. בחר את אחת האפשרויות לעיל כדי להציג את האוספים בקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr "לא פורט מסלול קובץ מקור"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr "אין קובץ מקור לשאלה בקובץ ה-def."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -3977,15 +4078,19 @@ msgid "No user specific data exists for user %1"
 msgstr "לא קיימים נתוניי משתמש עבור משתמש %1"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
 msgstr "לא נשלחו שינויים תקפים עבור מיקום %1."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
+msgstr "אף גירסה של מטלה זו נלקח עדיין."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr "כלום"
 
@@ -3999,26 +4104,31 @@ msgstr "לא נבחרו פריטים"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
-msgstr "לאף אחד מהמשתמשים הנבחרים לא הוקצה האוסף הזה: %1"
+msgstr "לאף אחד מהמשתמשים הנבחרים לא הוקצה הגליון הזה: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "לא מחובר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
-msgstr "פתק"
+msgstr "הערה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "Note:"
+msgstr "הערה:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr "שים לב: ניקוד המבחן מנקד את כל השאלות, לא רק מהדף הזה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr "מספר"
 
@@ -4034,8 +4144,8 @@ msgstr "מספר שאלות בכל דף (0=הכל)"
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr "מספר מבחנים עבור פסק זמן (0=אינסוף)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr "אישור"
 
@@ -4059,7 +4169,7 @@ msgstr "עמודה אחת"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:306
 msgid "Only after set answer date"
-msgstr "רק לאחר תאריך התשובות של האוסף"
+msgstr "רק לאחר תאריך התשובות של הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:296
 msgid ""
@@ -4067,7 +4177,7 @@ msgid ""
 "instructor."
 msgstr "רק רמת ההיתר הזאת ומעלה מקבלים גישה לכפתור לשליחת דוא\"ל למדריך."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr "פתח"
 
@@ -4085,13 +4195,13 @@ msgstr "תאריך פתיחה"
 msgid "Open Problem Library"
 msgstr "ספריית שאלות פתוחות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr "פתח בחלון חדש"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr "פתח בחלון חדש"
 
@@ -4105,10 +4215,10 @@ msgstr "פתח, נסגר ב-%1."
 msgid "Open, complete by %1."
 msgstr "פתח, השלם עד %1."
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
-msgstr "פתח, ניקוד מופלת מתחיל ב-%1"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
@@ -4120,7 +4230,7 @@ msgstr "פותח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
-msgstr "פותח אוסף שחעורח בית ל-24 שעות"
+msgstr "פותח גליון שיעורי בית ל-24 שעות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:195
 msgid "Optional Modules"
@@ -4130,12 +4240,12 @@ msgstr "מערכות אפשריות"
 msgid "Order Problems Randomly"
 msgstr "סדר שאלות באופן אקראי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr "דפדפן ספרייה מקורית"
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4159,70 +4269,73 @@ msgstr "דרוס קבצים קיימים באופן שקט"
 msgid "PG - Problem Display/Answer Checking"
 msgstr "PG - הצגת שאלה/בדיקת תשובה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr "הודעות דיבאג של PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr "שגיאות PG פנימיות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr "רינדור שאלת PG נכשל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr "הודעות שגיאות עיבוד של שאלת PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr "הודעות הזהרה של PG"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr "מידע PG"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr "מעבדת PG"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr "PGML"
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr "POD"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "תצוגה מקדימה בלבד -- התשובות לא נשמרות"
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr "מספר שאלה"
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr "ערך שאלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "רפד שדות"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr "דף נוצר ב-%1"
 
@@ -4235,16 +4348,16 @@ msgstr "סיסמה"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr "סיסמה (השאר ריק עבור משגיח רגיל)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr "סיסמה:"
 
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr "תשובות מהעבר עבור %1, אוסף %2, שאלה %3"
+msgstr "תשובות מהעבר עבור %1, גליון %2, שאלה %3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr "אחוז"
 
@@ -4260,7 +4373,7 @@ msgstr ""
 "אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. <br/>עמודת ה-50% מראה את "
 "החציון של מספר הניסיונות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
@@ -4268,18 +4381,18 @@ msgstr ""
 "אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. עמודת ה-50% מראה את "
 "החציון של מספר הניסיונות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "רמת הרשאה"
 
@@ -4287,7 +4400,7 @@ msgstr "רמת הרשאה"
 msgid "Permissions"
 msgstr "היתרים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4300,35 +4413,35 @@ msgstr ""
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given full credit."
-msgstr "אנא בחר שם אוסף ומספר מספר שאלה של השאלה שיש לתת לה  ניקוד מלא."
+msgstr "אנא בחר שם גליון ומספר מספר שאלה של השאלה שיש לתת לה  ניקוד מלא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:811
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given half credit."
-msgstr "אנא בחר שם אוסף ומספר מספר שאלה של השאלה שיש לתת לה חצי ניקוד."
+msgstr "אנא בחר שם גליון ומספר מספר שאלה של השאלה שיש לתת לה חצי ניקוד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:587
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its incorrect attempt count reset."
 msgstr ""
-"אנא בחר שם אוסף ומספר מספר שאלה של השאלה שלה יש לאפס את ספירת הניסיונות."
+"אנא בחר שם גליון ומספר מספר שאלה של השאלה שלה יש לאפס את ספירת הניסיונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:698
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its weight doubled."
-msgstr "אנא בחר את שם האוסף ומספר השאלה של השאלה שאת משקלה יש להכפיל."
+msgstr "אנא בחר את שם הגליון ומספר השאלה של השאלה שאת משקלה יש להכפיל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1214
 msgid ""
 "Please choose the set, the problem you would like to copy, and the problem "
 "you would like to copy it to."
 msgstr ""
-"אנא בחר את האוסף, השאלה שתרצה להעתיק, ואת השאלה אליה תרציה להעתיק אותה."
+"אנא בחר את הגליון, השאלה שתרצה להעתיק, ואת השאלה אליה תרציה להעתיק אותה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr "אנא תקן את השגיאות הבאות ונסה שוב:"
 
@@ -4341,7 +4454,7 @@ msgstr "אנה הכנס ערך תואם בשדה הסינון."
 msgid "Please enter your username and password for %1 below:"
 msgstr "אנה הכנס את שם המשתמש והסיסמה שלךעבור %1 למטה:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr "אנא בחר שם מיקום למחיקה."
 
@@ -4353,55 +4466,56 @@ msgstr "אנא בחר פעולה לבצע"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
 msgid "Please select at least one set and try again."
-msgstr "אנא בחר לפחות אוסף אחד ונסה שוב."
+msgstr "אנא בחר לפחות גליון אחד ונסה שוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
 msgid "Please select at least one user and try again."
 msgstr "אנא בחר לפחות משתמש אחד ונסה שוב."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "אנא בחר קובץ לשמירה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr "נקודות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr "שיקוי השכחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr "פרטי בדיקה מקדימה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr "צפייה מוקדמת בהודעה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr "צפייה מוקדמת בתשובות שלי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr "צפייה מוקדמת במבחן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr "צפייה מוקדמת בהודעה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
-msgstr "הצג אוסף עבור:"
+msgstr "הצג גליון עבור:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "שאלה קודמת"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr "עמוד קודם"
@@ -4410,12 +4524,12 @@ msgstr "עמוד קודם"
 msgid "Primary sort"
 msgstr "מיון ראשי"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr "הדפס מבחן"
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr "שאלה"
 
@@ -4432,20 +4546,20 @@ msgstr "שאלה #"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr "שאלה %1"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr "שאלה %1."
 
@@ -4463,8 +4577,8 @@ msgstr "עורך שאלות2"
 msgid "Problem Editor3"
 msgstr "עורך שאלות3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "רשימת שאלות"
 
@@ -4480,28 +4594,29 @@ msgstr "מספר שאלה"
 msgid "Problem Number "
 msgstr "מספר שאלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "טכניקות שאלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "מציג השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr "השאלה נבחרת באופן אקראי מתוך קבוצת שאלות ייעודיות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "שאלות"
 
@@ -4551,11 +4666,11 @@ msgstr ""
 "כדי להתחיל ולנקד מבחן עם משגיח צריך הרשאת משגיח. תן סיסמה כדי שיהיה סיסמה "
 "אחת שכל התלמידים יוכלו להתחיל בעזרתה מבחן עם משגיח."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "פרסם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr "תרגול"
 
@@ -4569,28 +4684,28 @@ msgid "Really delete the items listed above?"
 msgstr "אתה באמת רוצה למחוק את הפריטים לעיל?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "תרגול"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "שמור ניקוד לאוספים בודדים"
 
@@ -4604,26 +4719,16 @@ msgid "Reduced Scoring Date"
 msgstr "תאריך ניקוד מופחת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr "ביטול ניקוד מופחת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
 msgstr "הפעלת ניקוד מופחת"
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr "נתוני ניקוד מופחת %1"
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
-msgstr "ניקוד מופחת מצחיל ב-%1."
 
 # Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
@@ -4640,12 +4745,12 @@ msgstr "רענן"
 msgid "Refresh Display"
 msgstr "רענן תצוגה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr "רענן רשימה"
 
@@ -4654,7 +4759,7 @@ msgid "Relax IP restrictions when?"
 msgstr "הרגע הגבלות IP מתי?"
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "נותר"
 
@@ -4666,7 +4771,7 @@ msgstr "זכור אותי"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr "זכור לחזור לשאלה המקורית כשסיימת כאן!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4676,13 +4781,13 @@ msgid "Rename"
 msgstr "שנה שם"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr "שנה את שם %1 ל-%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr "שנה שם לקורס"
 
@@ -4690,19 +4795,19 @@ msgstr "שנה שם לקורס"
 msgid "Rename file as:"
 msgstr "שנה שם קובץ ל-:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr "הצג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr "הצג הכל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr "הצג שאלה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr "מספר שאלות מחדש"
 
@@ -4720,53 +4825,54 @@ msgid "Reorder problems only"
 msgstr "סדר מחדש שאלות בלבד"
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr "החלףשאלה נוכחית: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "איזה משתמשים להחליף?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr "השב ל-:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr "דווח על באגים בשאלה הזו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "דווח על באגים"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr "דווח עבור קורס %1:"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr "דווח מבנה מסד נתונים עבור קורס %1:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr "בקש גרסה חדשה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr "בקש מידע"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr "בקש גרסה חדשה כעת"
 
@@ -4775,7 +4881,7 @@ msgstr "בקש גרסה חדשה כעת"
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr "לא נמצא האוסף שבוקש '%1'  במסד הנתונים עבור משתמש %2."
+msgstr "לא נמצא הגליון שבוקש '%1'  במסד הנתונים עבור משתמש %2."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -4784,15 +4890,15 @@ msgid ""
 "generator %2 was called.  Try re-entering the set from the problem sets "
 "listing page."
 msgstr ""
-"האוסף שבוקש '%1' הוא מטלת שיעורי בית אבל יוצר התכנים של בוחן המחסום/בוחן %2 "
-"נקרא.  נסה  להכניס מחדש את האוסף מעמוד רישום אוספי השאלות."
+"הגליון שבוקש '%1' הוא מטלת שיעורי בית אבל יוצר התכנים של בוחן המחסום/בוחן %2 "
+"נקרא.  נסה  להכניס מחדש את הגליון מעמוד רישום אוספי השאלות."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
 msgid ""
 "Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
 "authorization has been obtained."
-msgstr "האוסף שבוקש '%1' הוא מטלת בבוחן מוגנת, אבל לא הושג אימות משגיח תקין."
+msgstr "הגליון שבוקש '%1' הוא מטלת בבוחן מוגנת, אבל לא הושג אימות משגיח תקין."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
@@ -4801,28 +4907,28 @@ msgid ""
 "assignment content generator %2 was called.  Try re-entering the set from "
 "the problem sets listing page."
 msgstr ""
-"האוסף שבוקש '%1' הוא מטלת בוחן/מבחן אבל יוצר התכנים של מטלות שיעורי הבית %2 "
-"נקרא. נסה להכניס מחדש את האוסף מעמוד רישום אוספי השאלות."
+"הגליון שבוקש '%1' הוא מטלת בוחן/מבחן אבל יוצר התכנים של מטלות שיעורי הבית %2 "
+"נקרא. נסה להכניס מחדש את הגליון מעמוד רישום אוספי השאלות."
 
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr "האוסף שבוקש '%1' לא הוקצה למשמתמש %2."
+msgstr "הגליון שבוקש '%1' לא הוקצה למשמתמש %2."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
 msgid "Requested set '%1' is not available yet."
-msgstr "האוסף שבוקש '%1' עדיין לא זמין"
+msgstr "הגליון שבוקש '%1' עדיין לא זמין"
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
 msgid "Requested set '%1' is not yet open."
-msgstr "האוסף שבוקש '%1' עדיין לא נפתח."
+msgstr "הגליון שבוקש '%1' עדיין לא נפתח."
 
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr "הגרסה שבוקשה (%1) של האוסף '%2' לא הוקצאה למשתמש %3."
+msgstr "הגרסה שבוקשה (%1) של הגליון '%2' לא הוקצאה למשתמש %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
@@ -4833,8 +4939,8 @@ msgid "Reset"
 msgstr "אתחל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr "אתחל טופס"
 
@@ -4842,11 +4948,7 @@ msgstr "אתחל טופס"
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr "מאתחל את מספר הניסיונות הלא נכונים על שאלת שיעורי בית אחת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr "החזר איזה בוחן מחסום?"
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4878,22 +4980,22 @@ msgstr "הגבל ל-"
 msgid "Restrict release by set(s)"
 msgstr "הגבל פרסום לפי אוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "תוצאות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr "התוצאה של הפעולה האחרונה שבוצעה"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr "התוצאה של הפעולה האחרונה שבוצעה: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr "תוצאות של הגשה זו"
 
@@ -4905,19 +5007,27 @@ msgstr "התוצאות של הפעולה האחרונה"
 msgid "Results of last action performed: "
 msgstr "התוצאות של הפעולה האחרונה שבוצעה:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr "החזר איזה בוחן מחסום?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
 msgstr "כותרת שונתה"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "שחזר"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr "שחזר ל-%1"
@@ -4930,19 +5040,19 @@ msgstr "טבעת ההפחתה"
 msgid "Robe of Longevity"
 msgstr "חלוק אריכות הימים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr "קבוצה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
-msgstr "שם אוסף"
+msgstr "שם גליון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr "סטאטוס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr "מזהה תלמיד"
 
@@ -4951,86 +5061,86 @@ msgstr "מזהה תלמיד"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "שמור"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr "שמור %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "שמור בשם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr "שמור שינויים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "שמור בשם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr "שמור כברירת מחדל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "שמור שינויים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr "שמור קובץ ב-:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr "שמור ל-%1 וצפה"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr "שמור לקובץ '%1'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr "הגדרות שדה של הסכמה ומסד הנתונים לא מתאימות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr "הגדרות טבלה של הסכמה ומסד הנתונים לא מתאימות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5045,11 +5155,11 @@ msgstr "ציון (%)"
 msgid "Score required for release"
 msgstr "ציון שנדרש עבור פרסום"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "נקד את האוספים שנבחרו ושמור ב-:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr "סיכום ניקוד עבור שליחה אחרונה:"
 
@@ -5074,15 +5184,15 @@ msgid "Scoring Tools"
 msgstr "כלי ניקוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
-"מידע קידומת גרסת הדפסה או מסך של אוסף לא יכול להשתנות עבור תלמיד ספציפי."
+"מידע קידומת גרסת הדפסה או מסך של גליון לא יכול להשתנות עבור תלמיד ספציפי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr "מגילת התחייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5092,24 +5202,24 @@ msgstr "מיון משני"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "קבוצה"
@@ -5124,11 +5234,15 @@ msgstr "קבוצה:"
 msgid "Seed"
 msgstr "זרע"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr "בחר"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+msgid "Select a Homework Set"
+msgstr "בחר גליון שיעורי בית"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -5136,13 +5250,13 @@ msgstr "בחר מקבץ שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
-msgstr "בחר אוסף מהקורס הזה"
+msgstr "בחר גליון מהקורס הזה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr "בחר קורס למחיקה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5152,25 +5266,25 @@ msgstr ""
 "מספרים אותיות וקוים תחתונים. כותרת הקורס מופיע בדף הבית של הקורס ויוכלה "
 "להיות כל מחרוזת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr "בחר קורס להוציא מהארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr "בחר מתכונת מסד נתונים למטה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr "בחר פורמט רשימה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr "אז בחר לעיל:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr "בחר את כל הקורסים המתאימים"
 
@@ -5178,27 +5292,27 @@ msgstr "בחר את כל הקורסים המתאימים"
 msgid "Select all sets"
 msgstr "בחר את כל האוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "בחר את כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "בחר בפעולה לבצע"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr "בחר פעולה שתרצה לבצע:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr "בחור קורס/ים להוסיף לארכיון."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr "בחר קורס/ים להחביא או להפוך לגלוי/ם."
 
@@ -5207,14 +5321,14 @@ msgid ""
 "Select one or more sets and one or more users below to assign/unassign each "
 "selected set to/from all selected users."
 msgstr ""
-"בחר אוסף אחד או יותר ומשתמש אחד או יותר כדי להקצות/לבטל הקצאת כל אוסף שנבחר "
+"בחר גליון אחד או יותר ומשתמש אחד או יותר כדי להקצות/לבטל הקצאת כל גליון שנבחר "
 "לכל המשתמש שנבחר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
 msgid "Select sets below to assign them to the newly-created users."
 msgstr "בחר אוספים למטה כדי להקצות אותם למשתמשים החדשים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5236,49 +5350,49 @@ msgid ""
 "also select multiple users from the users list. You will receive hardcopy "
 "for each (set, user) pair."
 msgstr ""
-"בחר אוסף שיעורי בית עבורו תרצה ליצור גרסת הדפסה. אתה גם יכול לבחור מספר "
-"משתמשים מרשימת המשתמשים. אתה תקבל גרסת הדפסה עבור כל זוג (אוסף, תלמיד)."
+"בחר גליון שיעורי בית עבורו תרצה ליצור גרסת הדפסה. אתה גם יכול לבחור מספר "
+"משתמשים מרשימת המשתמשים. אתה תקבל גרסת הדפסה עבור כל זוג (גליון, תלמיד)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
 msgid ""
 "Select user(s) and/or set(s) below and click the action button of your "
 "choice."
-msgstr "בחר משתמש/ים ו/או אוסף/ים ולחץ על כפתור הפעולה לפי בחירתך."
+msgstr "בחר משתמש/ים ו/או גליון/ים ולחץ על כפתור הפעולה לפי בחירתך."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr "תלמידים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr "שלח דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr "שלח דוא\"ל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr "שלח ל-:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
-msgstr "אוסף"
+msgstr "גליון"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
 msgid "Set %1 exists.  No set created"
-msgstr "אוסף %1 קיים. לא נוצר אוסף"
+msgstr "גליון %1 קיים. לא נוצר גליון"
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
 msgid "Set %1 has been created."
-msgstr "אוסף %1 נוצר"
+msgstr "גליון %1 נוצר"
 
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
 msgid "Set %1 was assigned to %2"
-msgstr "אוסף %1 הוקצה ל%2"
+msgstr "גליון %1 הוקצה ל%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
 msgid "Set Assigner"
@@ -5287,28 +5401,28 @@ msgstr "מקצה האוספים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
 msgid "Set Definition Filename"
-msgstr "שם קובץ הגדרת אוסף"
+msgstr "שם קובץ הגדרת גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
 msgid "Set Definition Files"
-msgstr "קבצי הגדרת אוסף"
+msgstr "קבצי הגדרת גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
-msgstr "תיאור אוסף"
+msgstr "תיאור גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
-msgstr "פרטי אוסף 2 עבור אוסף %2"
+msgstr "פרטי גליון 2 עבור גליון %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:423
 msgid "Set Detail for set %2"
-msgstr "פרטי אוסף עבור אוסף %2"
+msgstr "פרטי גליון עבור גליון %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5316,18 +5430,18 @@ msgstr "פרטי אוסף עבור אוסף %2"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
 msgid "Set Header"
-msgstr "קידומת אוסף"
+msgstr "קידומת גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
 msgid "Set ID"
-msgstr "מזהה אוסף"
+msgstr "מזהה גליון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
-msgstr "נתוני אוסף"
+msgstr "נתוני גליון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "רשימת אוספים"
 
@@ -5337,7 +5451,7 @@ msgstr "רשימת אוספים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:802
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:825
 msgid "Set Name"
-msgstr "שם אוסף"
+msgstr "שם גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
@@ -5352,12 +5466,16 @@ msgstr "שם אוסף"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
 msgid "Set Name "
-msgstr "שם אוסף"
+msgstr "שם גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
 msgstr "קידומות אוספים  לא משומשות בהצגת בחני מחסום."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
 msgid ""
@@ -5388,7 +5506,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "אוספים"
 
@@ -5400,7 +5518,7 @@ msgstr "האוספים שהוקצאו למשתמש"
 msgid "Sets assigned to %1"
 msgstr "האוספים שהוקצאו ל-%1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr "הגדרה"
 
@@ -5409,11 +5527,11 @@ msgid "Shift dates so that the earliest is"
 msgstr "הזז תאריכים כך שהמוקדם ביותר הוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr "הצג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr "הצג מקורות מישניים"
 
@@ -5421,7 +5539,7 @@ msgstr "הצג מקורות מישניים"
 msgid "Show Date & Size"
 msgstr "הצג תאריך וגודל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "הראה רמזים"
 
@@ -5429,8 +5547,8 @@ msgstr "הראה רמזים"
 msgid "Show Me Another"
 msgstr "תראה לי עוד אחת"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "הראה תשובות מהעבר"
 
@@ -5442,8 +5560,8 @@ msgstr "הראה שאלות במבחנים שבוצעו"
 msgid "Show Scores on Finished Assignments?"
 msgstr "הראה ציונים על מטלות שבוצעו?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "הראה פתרונות"
 
@@ -5451,7 +5569,7 @@ msgstr "הראה פתרונות"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr "הראה ציון בסך כל שיעורי הבית בעמוד הציונים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "אזה משתמשים להציג?"
 
@@ -5460,17 +5578,17 @@ msgstr "אזה משתמשים להציג?"
 msgid "Show all paths"
 msgstr "הראה את כל המסלולים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "הראה תשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr "הראה לי עוד אחת"
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr "הראה לי עוד אחת %1"
 
@@ -5479,7 +5597,7 @@ msgstr "הראה לי עוד אחת %1"
 msgid "Show path ..."
 msgstr "הראה מסלול ..."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr "הראה תשובות שנשמרו?"
 
@@ -5490,17 +5608,17 @@ msgstr "איזה אוספים להציג?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "הצג/החבא תיאור אתר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "הראה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr "מראה"
 
@@ -5510,7 +5628,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "מראה %1 מתוך %2 אוספים."
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr "מראה %1 מתוך %2 אוספים"
 
@@ -5526,13 +5644,13 @@ msgstr "פשוט"
 msgid "Site Information"
 msgstr "תיאור אתר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr "דלג על הוספת קורס זה לארכיון"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr "פתרון:"
 
@@ -5541,7 +5659,7 @@ msgstr "פתרון:"
 msgid "Solutions"
 msgstr "פתרונות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr "חלק מהתשובות ינוקדו מאוחר יותר."
 
@@ -5553,6 +5671,16 @@ msgid ""
 msgstr ""
 "חלק מקבצים אלה הם תיקיות. מחק תיקיות רק אם אתה בטוח שאתה יודעה מה אתה עושה. "
 "אתה יכול לעשות נזק רציני לקורס אם אתה מוחק את הדבר הלא נכון."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
@@ -5577,14 +5705,14 @@ msgstr ""
 "משהו לא כשורה עם הפאראמטרים של ה-LTI שלך. אם בעיה זו חוזרת על עצמה, אנא פנה "
 "למדריך שלך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "מיין"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "מיין לפי"
 
@@ -5613,7 +5741,7 @@ msgid ""
 "was modified."
 msgstr "מסלולי קבצי קוד לא יכולים לכלול .. או להתחיל ב- /: המסלול שהזנת שונה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5641,53 +5769,53 @@ msgstr "סטטיסטיקה עבור"
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr "סטטיסטיקה עבור %1 אוסף %2.  נסגר ב-%3"
+msgstr "סטטיסטיקה עבור %1 גליון %2.  נסגר ב-%3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
 msgid "Statistics for %1 student %2"
 msgstr "סטטיסטיקה עבור %1 סטודנט %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "סטטוס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "עצור התחזות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr "הפסק להוסיף לארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr "הפסק להוסיף קורסים לארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "מזהה תלמיד"
 
@@ -5706,7 +5834,7 @@ msgstr "התקדמות תלמיד"
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr "התקדמות התלמיד עבור %1 אוסף %2.  נסגר ב-%3"
+msgstr "התקדמות התלמיד עבור %1 גליון %2.  נסגר ב-%3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
@@ -5717,14 +5845,14 @@ msgstr "התקדמות התלמיד עבור %1 תלמיד %2"
 msgid "Student answers"
 msgstr "תשובות התלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr "נושא:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr "נושא:"
 
@@ -5736,76 +5864,80 @@ msgstr "זמן הגשה:"
 msgid "Submit"
 msgstr "שלח"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "שלח תשובות"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
 msgstr "שלח תשובות עבור %1"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "הצלחה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr "מדד הצלחה"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr "הקורס %1 הוכנס לארכיון בהצלחה."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr "ההישג החדש %1 נוצר בהצלחה"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
 msgid "Successfully created new set %1"
-msgstr "האוסף החדש %1 נוצר בהצלחה"
+msgstr "הגליון החדש %1 נוצר בהצלחה"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr "הקורס %1 נוצר בהצלחה"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr "הקורס %1 נמחק בהצלחה."
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr "שם הקורס שונה בהצלחה מ-%1 ל-%2"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "%1 הוסר בהצלחה מהארכיון עבור קורס %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr "טבלה מוגדרת במסד הנתונים אך חסרה בסכמה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr "טבלה מוגדרת בסכמה אך חסרה במסד הנתונים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr "הטבלה תקינה"
 
@@ -5823,22 +5955,22 @@ msgstr "בצע את מבחן %1"
 msgid "Take %1 test."
 msgstr "בצע את מבחן %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "בצע פעולה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
 msgid "Target Set:"
-msgstr "האוסף שנבחר:"
+msgstr "הגליון שנבחר:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
@@ -5899,18 +6031,18 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 "תקופת הניקוד המופחת היא התקופה בברירת המחדל לפני תאריך ההגשה בה כל התקדמות "
-"שמבצע התלמיד נספרת בערך ניקו מופחת. כשנבחרת אפשרות הניקוד מופחת עבור אוסף "
+"שמבצע התלמיד נספרת בערך ניקו מופחת. כשנבחרת אפשרות הניקוד מופחת עבור גליון "
 "תאריך הניקוד המופחת יהיה תאריך ההגשה פחות המספר הזה בתור ברירת מחדל. לאחר "
 "מכן, ניתן לשנות את תאריך הניקוד המופחת. אם אפשרות זו נבחרת ואם תאריך הניקוד "
 "זה עבר, אבל לא עבר תאריך ההגשה, תופיעה הודעה כגון \"למטלה זו יש תקופת ניקוד "
 "מופחת שמתחילה ב-08/11/2009 בשעה 18:17 ונגמרת בתאריך ההגשה, 10/11/2009 בשעה "
 "18:17. בתקופה זו כל עבודה תשובות נוספות נספרות כ-50% מערכם המקורי\"."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "פרוייקט WeBWorK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -5926,8 +6058,8 @@ msgid ""
 "but WeBWorK will use this value when a set is created."
 msgstr ""
 "כמה זמן (בדקות) אחרי תאריך ההגשה שהתשובות יהיו זמינות לתלמיד לצפייה. אתה "
-"יכול לשנות את זה עבור אוסף שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה "
-"כשהאוסף נוצר."
+"יכול לשנות את זה עבור גליון שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה "
+"כשהגליון נוצר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
 msgid ""
@@ -5936,17 +6068,17 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 "כמה זמן (בדקות) לפני תאריך ההגשה שבו נפתחת המטלה. אה יכול לשנות את זה עבור "
-"אוסף שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה כשהאוסף נוצר."
+"גליון שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה כשהגליון נוצר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr "התשובה לעיל היא לא נכונה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "התשובה למעלה נכונה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr "התשובה תנוקד מאוחר יותר."
 
@@ -5963,7 +6095,7 @@ msgstr ""
 "נבחר כאן \"מקסימום\"  אז שאלות מוכלות יהיו זמינות רק לאחר שלתמיד נגמרו "
 "הניסיונות."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
@@ -5972,7 +6104,7 @@ msgstr ""
 "שיבדוק שהקובץ constants.pm מעודכן."
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6015,59 +6147,59 @@ msgid ""
 msgstr ""
 "אורך פורמט הדוא\"ל קובע כמה מידע יכנס באופן אוטומטי לדוא\"ל משוב. הרמות הן "
 "<ol><li value=\"Simple\"> פשוט: שלח רק את תגובת המשוב וקישור של ההקשר <li "
-"value=\"Standard\"> סטנדרטי: כמו בפשוט, רק בתוספת משתמש, אוסף, שאלה, ונתוני "
+"value=\"Standard\"> סטנדרטי: כמו בפשוט, רק בתוספת משתמש, גליון, שאלה, ונתוני "
 "PG. <li value=\"Debug\"> דיבאג: כמו סטנדרטי, רק בתוספת סביבת השאלה (נתונים "
 "לדיבאג) </ol>"
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "שם המעריך עבור %1 שונה ל-'%2'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr "הקובץ %1/%2 כבר קיים ולא ניתן לדרוס אותו. ההודע לא נשמרה"
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr "הקובץ %1/%2 לא נמצא."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr "הקובץ %1/%2 לא ניתן לקריאה על ידי שרת הרשת."
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr "לא היה אפשר למצוא את הקובץ '%1'."
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr "אי אפשר לקרוא את הקובץ '%1'!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr "הקובץ '%1' הוא שאלה ריקה!"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr "הקובץ '%1' הוא תיקייה!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr "הקובץ '%1' הוא מוגן!"
 
@@ -6080,35 +6212,35 @@ msgid "The file you are trying to download doesn't exist"
 msgstr "הקובץ שאת/ה מנסה להוריד אינו קיים"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr "הקורסים הבאים הוחבאו בהצלחה: %1"
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr "הקורסים הבאים נהפכו לגלויים בהצלחה: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr "השידרוגים הבאים זמינים עבור מערכת ה-WeBWorK שלך:"
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
-msgstr "למשתמשים הבאים לא הוקצה האוסף הזה ולכן נתעלם מהם: %1"
+msgstr "למשתמשים הבאים לא הוקצה הגליון הזה ולכן נתעלם מהם: %1"
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr "הציון עבור שאלה זו זה הגדול מבין ניקוד השאלה, וניקוד השאלה %1."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -6116,24 +6248,24 @@ msgstr ""
 "הציון עבור שאלה זו זה הגדול מבין ניקוד השאלה, והממוצע המותאם של השאלות: %1."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr " שם קידומת גרסת ההדפסה עבור אוסף %1 שונה ל-'%2'."
+msgstr " שם קידומת גרסת ההדפסה עבור גליון %1 שונה ל-'%2'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr "המוסד שמיחס לקורס %1 שונה מ-%2 ל-%3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr "המוסד שמיוחס לקורס %1 הוא כעת %2"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
@@ -6141,7 +6273,7 @@ msgstr ""
 "לא קיים חשבון מדריך בעל מהה המשתמש %1. אנא צור את החשבון באופן ידני דרך "
 "WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr "אינדקס הסיפרייה הוא ישן יותר מהסיפרייה, אתה צריך להריץ OPL-update."
@@ -6150,7 +6282,7 @@ msgstr "אינדקס הסיפרייה הוא ישן יותר מהסיפרייה,
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
 msgid ""
 "The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
-msgstr "השם '%1' הוא לא שם אוסף תקין. השתמש רק באותיות, ספרות, ובסימנים . - _"
+msgstr "השם '%1' הוא לא שם גליון תקין. השתמש רק באותיות, ספרות, ובסימנים . - _"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
 msgid ""
@@ -6162,7 +6294,7 @@ msgstr ""
 "הרשימה של אוספי שיעורי הבית."
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
@@ -6170,7 +6302,7 @@ msgstr ""
 "תאריך הפתיחה: %1, תאריך סגירה: %2, ותאריך תשובות: %3 חייבים ליות מוגדרים "
 "ובסדר כרונולוגי."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr "הסיסמה ואימות הסיסמה של המדריך חייבות להתאים."
 
@@ -6192,8 +6324,8 @@ msgstr ""
 "הסיסמאות שהזנת בשדות %1 ו-%2 לא מתאימות. אנא הזן מחדש את סיסמתך החדשה ונסה "
 "שנית."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "המסלול לקוץ המקור צריך להיות מוחלט"
 
@@ -6202,7 +6334,7 @@ msgstr "המסלול לקוץ המקור צריך להיות מוחלט"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr "אחוז הסטודנטים הפעילים עם תשובות נכונות לכל בעיה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -6210,17 +6342,17 @@ msgid ""
 msgstr "אחוז הסטודנטים עם ניקוד כזה לפחות. הציון הממוצע הוא בעמודת 50%."
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr "הציון המוזן למבחן זה הוא %1/%2."
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr "הציון המוזן למבחן זה הוא %1/%2."
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr "תאריך הניקוד מופחת צריך להיות בין תאריך הפתיחה %1 ותאריך סגירה %2"
@@ -6232,55 +6364,64 @@ msgid ""
 msgstr "תאריך הניקוד המופחת צריך להיות בין תאריך הפתיחה לתאריך הסגירה."
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "הניקוד לשאלה זו יכול להספר לניקוד של שאלה %1."
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
-msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"
+msgstr "גליון השאלות הנבחר (%1) הוא לא גליון חוקי עבור %2"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
-msgstr "האוסף %1 משויך ל-%2."
+msgstr "הגליון %1 משויך ל-%2."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr "כותרת האוסף עבור אוסף %1 שונתה ל-'%2'."
+msgstr "כותרת הגליון עבור גליון %1 שונתה ל-'%2'."
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
 msgid ""
 "The set name '%1' is already in use.  Pick a different name if you would "
 "like to start a new set."
-msgstr "שם האוסף '%1' כבר נמצא בשימוש. בחר שם אחר אם ברצונך לפתוח אוסף חדש."
+msgstr "שם הגליון '%1' כבר נמצא בשימוש. בחר שם אחר אם ברצונך לפתוח גליון חדש."
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr "גרסת-האוסף (%1, גרסה %2) לא משויכת למשתמש %3."
+msgstr "גרסת-הגליון (%1, גרסה %2) לא משויכת למשתמש %3."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
 msgstr "הפתרון הוסר."
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
-msgstr "קוד המקור ל'אוסף %1 / שאלה %2' שונה מ-'%3' ל-'%4'"
+msgstr "קוד המקור ל'גליון %1 / שאלה %2' שונה מ-'%3' ל-'%4'"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr "כבר לא ניתן להגיש את המבחן (מספר %1) לניקוד."
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"tr: The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6296,33 +6437,33 @@ msgid ""
 "created."
 msgstr ""
 "מועד ההגשה ביום עבור המטלה. ניתן לשינוי באופן פרטני, אבל WeBWorK ישתמש בערך "
-"זה כברירת מחדל כשנוצר אוסף."
+"זה כברירת מחדל כשנוצר גליון."
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr "הכותרת של קורס %1 שונתה מ-%2 ל-%3"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr "הכותרת של הקורס %1 היא עכשיו %2"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr "%2 הוקצה למשתמש %1."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr "הערך %1 עבור \"אפשר ניקוד מופחת\" אינו חוקי. הוא יוחלף בערך 'N'."
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
@@ -6330,34 +6471,36 @@ msgstr ""
 "הערך %1 עבור האפשרות  \"זמן מבחן מקסימלי\" הוא לא תקיןף הוא יוחלף ב-'0'."
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr "הערך %1 עבור האפשרות \"החבאת ציון\" הוא לא תקין; הוא יוחלף ב-'N'."
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr "הערך %1 עבור האפשרות \"החבאת עבודה\" הוא לא תקין; הוא יוחלף ב-'N'."
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr "הערך %1 עבור האפשרות \"הרגע הגבלת IP\" הוא לא תקין; הוא יוחלף ב-'לא'."
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr "הערך %1 עבור האפשרות \"הגבלת IP\" הוא לא תקין; הוא יוחלף ב-'לא'."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6370,8 +6513,8 @@ msgstr "עיצוב (רענן את העמוד לאחר שמירת השינויי�
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "ואז לפי"
 
@@ -6398,10 +6541,10 @@ msgstr ""
 "כרגע יש ני עיצובים (או ערכות נושא) שניתנים לבחירה: math3 ו-math4. העיצוב "
 "מגדיר תחושה ומראה אחידים עבור דפי הרשת של קורס ה-WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
@@ -6409,9 +6552,9 @@ msgstr ""
 "ישנם שדות במסד נתונים נוספים שלא הוגדרו בסכמה עבור לפחות טבלה אחת. אפשר "
 "להסיר אותם ממסד הנתונים רק באופן ידני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
@@ -6419,7 +6562,7 @@ msgstr ""
 "ישנם טבלאות מסד נתונים נוספות שלא הוגדרו בסכמה. ניתן להסיר אותם ממסד הנתונים "
 "רק באופן ידני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6431,7 +6574,7 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr "אין בעיות WeBWorK מתאימות."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
@@ -6439,35 +6582,35 @@ msgstr ""
 "ישנן טבלאות או ערכים שחסרות במסד הנתונים. יש לעדכן את מסד הנתונים לפני "
 "שמכניסים את הקורס לארכיון."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr "ישנם עדכונים זמינים לספרית השאלות הפתוחות."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr "יש שידרוגים זמינים עבור הענף הנוכחי של PG מענף %1 ב-remote בשם %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 "ישנם שידרוגים זמינים לענף הנוכחי ב-WeBWorK מתוך ענף %1 ב-remote בשם %2."
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 "פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
 "הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
-"הנתונים של הישג $achievementID של תלמיד זה."
+"הנתונים של הישג %1 של תלמיד זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6478,11 +6621,11 @@ msgid ""
 msgstr ""
 "פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
 "הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
-"הנתונים של אוסף שיעורי הבית $setID של תלמיד זה."
+"הנתונים של גליון שיעורי הבית $setID של תלמיד זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:276
 msgid "There is NO undo for unassigning a set."
-msgstr "אי אפשר לחזור בך מביטול הקצאה של אוסף."
+msgstr "אי אפשר לחזור בך מביטול הקצאה של גליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
@@ -6490,11 +6633,11 @@ msgstr "אי אפשר לחזור בך מביטול הקצאה של אוסף."
 msgid "There is NO undo for unassigning students."
 msgstr "אי אפשר לחזור בך מביטול הקצאת תלמידים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr "יש גרסה חדשה של PG."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr "יש גרסה חדשה של WeBWorK."
 
@@ -6514,7 +6657,7 @@ msgstr ""
 "%1. זה מתאחד בעזרת הקובץ [Scoring]/%2. ניתן לערוך קבצים אלו בעזרת קישורי הדוא"
 "\"ל ומנהל הקבצים בצד שמאל."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6534,14 +6677,14 @@ msgstr "לא קיים פתרון כתוב לשאלה זו, אבל עדיין נ�
 msgid "There is no written solution available for this problem."
 msgstr "לא קיים פתרון כתוב לשאלה זו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 "ייתכן שישנה בעיה בשאלה. אנא עדכן את המדריך שלך, לרבות בהודעות השגיאה שלהלן."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
@@ -6549,13 +6692,13 @@ msgstr ""
 "הייתה שגיאה בתהליך ההתחברות. אנה פנה למדריך שלך או עם מנהל מערכת במידה "
 "והבעיה הזאת נמשכת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6575,15 +6718,15 @@ msgstr "הפעולה יכולה להמשך זמן רב אם ישנם תלמיד�
 msgid "This action will not overwrite existing users."
 msgstr "פעולה זו לא תדרוס משתמשים קיימים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr "התשוב הזאת לא נכונה לגמרי."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr "התשובה הזאת לא נכונה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr "התשובה הזאת נכונה."
 
@@ -6593,27 +6736,31 @@ msgid ""
 "guest."
 msgstr "הקורס הזה תומך במשתמשים אורחים. לחץ %1 כדי להתחבר לקורס בתור אורח."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
-msgstr "אוסף שיעורי הבית לא מכיל שאלות."
+msgstr "גליון שיעורי הבית לא מכיל שאלות."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
-msgstr "אוסף שיעורי הבית הוא סגור"
+msgstr "גליון שיעורי הבית הוא סגור"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
-msgstr "אוסף שיעורי הבית הזה עדיין לא פתוח"
+msgstr "גליון שיעורי הבית הזה עדיין לא פתוח"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
 "זה קובץ תבנית שאלה ריק ואי אפשר לערוך אותו ישירות. אנא השתמש בפעולת ה-\"גרסה "
-"חדשה\" למטה כדי ליצור העתק מקומי של הקובץ ולהוסיפו לאוסף השאלות הנוכחי."
+"חדשה\" למטה כדי ליצור העתק מקומי של הקובץ ולהוסיפו לגליון השאלות הנוכחי."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "הנה גרסה חדשה של השאלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6628,9 +6775,9 @@ msgid ""
 "where you can edit what students the set is assigned to."
 msgstr ""
 "טבלה זו מראה את אוספי שיעורי הבית הנוכחיים של כיתה זו. השדות משמאל לימין הם: "
-"ערוך נתוני אוסף, ערוך שאלות, ערוך הקצאות משתמשים, ראות לתלמידים, מופעל ניקוד "
+"ערוך נתוני גליון, ערוך שאלות, ערוך הקצאות משתמשים, ראות לתלמידים, מופעל ניקוד "
 "מופחת, תאריך פתיחה, תאריך הגשה, והתאריך בו התשובות מוצגות. שדה ה-\"ערוך "
-"נתוני אוסף\" מכיל ריבועים לסימון בחירה וקישור לדף עריכת נתוני אוסף. התאים "
+"נתוני גליון\" מכיל ריבועים לסימון בחירה וקישור לדף עריכת נתוני גליון. התאים "
 "בשדת \"ערוך שאלות\" מכילים קישורים שמפנים לדף שבו ניתן לערוך לאיזה תלמידים "
 "מוקצה הקורס/"
 
@@ -6694,41 +6841,45 @@ msgid ""
 "problem."
 msgstr "זהו מספר נקודות ההישג שניתנות לכל משתמש עבור השלמת פתרון לשאלה."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr "השאלה מכילה וידיאו שיש לראות באופן מקוון."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 "לשאלה זו יש תתי שאלות פתוחות. ניתן לראותן על ידי שימוש בקישורים משמאל או על "
-"ידי ביקור בעמוד האוסף."
+"ידי ביקור בעמוד הגליון."
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr "שאלה זו משתמשת באותו קובץ מקור כמו שאלה %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "שאלה זו לא תיחשב לציון שלך."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr "דוא\"ל דוגמה זה ישלח ל-%1"
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
-msgstr "הניקוד לשאלה זו לא יחשב לניקוד בשאלה %1 או באוסף. "
+msgstr "הניקוד לשאלה זו לא יחשב לניקוד בשאלה %1 או בגליון. "
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -6743,22 +6894,22 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
-msgstr "האוסף הזה, %1, הוקצה ל-%2."
+msgstr "הגליון הזה, %1, הוקצה ל-%2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
-msgstr "אוסף זה עדיין לא מכיל שום שאלות."
+msgstr "גליון זה עדיין לא מכיל שום שאלות."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
 msgstr ""
-"לאוסף זה קיימת תקופת ניקוד מופחת שתחל ב-%1 ותסתיים ב-%2. בתקופה זו כל עבודה "
+"לגליון זה קיימת תקופת ניקוד מופחת שתחל ב-%1 ותסתיים ב-%2. בתקופה זו כל עבודה "
 "נספרת כ-%3%מערכה המקורי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:271
@@ -6766,28 +6917,28 @@ msgid ""
 "This set has a set-level proctor password to authorize logins. Enter the "
 "password below."
 msgstr ""
-"לאוסף ישנה סיסמת משגיח ברמת-אוסף, כדי לנטר הרשאות. הזמן את הסיסמה בתיבה "
+"לגליון ישנה סיסמת משגיח ברמת-גליון, כדי לנטר הרשאות. הזמן את הסיסמה בתיבה "
 "שלעיל."
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
-msgstr "האוסף הזה הוא %1"
+msgstr "הגליון הזה הוא %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
 msgstr ""
-"האוסף הזה נמצא בתקופת הניקוד המופחת שלו. כל תשובה נספרת כ-%1% מהערך המקורי "
+"הגליון הזה נמצא בתקופת הניקוד המופחת שלו. כל תשובה נספרת כ-%1% מהערך המקורי "
 "שלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:178
 msgid "This set needs to be assigned to you before you can grade it."
-msgstr "יש להקצות אליך את האוסף הזה לפני שתוכל לנקד אותו."
+msgstr "יש להקצות אליך את הגליון הזה לפני שתוכל לנקד אותו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:182
 msgid ""
@@ -6796,9 +6947,9 @@ msgid ""
 "comma separated list.  The minimum score required on the sets is specified "
 "in the following field."
 msgstr ""
-"האוסף לא יהיה זמין לסטודנטים עד אשר הם ירוויחו ניקוד מסויים באוספים שצוינו "
+"הגליון לא יהיה זמין לסטודנטים עד אשר הם ירוויחו ניקוד מסויים באוספים שצוינו "
 "בשדה זה. האוספים צריך להכתב כרשימה מופרדת בפסיקים. הניקוד המינימלי הנדרש "
-"באוסף יצויין בשדה שלאחר מכן."
+"בגליון יצויין בשדה שלאחר מכן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:218
 msgid ""
@@ -6814,27 +6965,27 @@ msgstr ""
 "זה קובע אם תקופת הניקוד המופחת תופעל. אם כן, יש למלא למטה אורך לפי ברירת "
 "המחדל לתקופת הניקוד המופחת, ואת ערך העבודה בתקופה זו.  <p>כדי להשתמש בזה, יש "
 "גם להפעיל את תקפת הניקוד המופחת עבור כל מטלה ולמלא את אורך התקופה על ידי "
-"עריכת נתוני האוסף. <p>זה עובד עם avg_problem_grader (שהוא המנקד האוטומטי) ו-"
+"עריכת נתוני הגליון. <p>זה עובד עם avg_problem_grader (שהוא המנקד האוטומטי) ו-"
 "std_problem_grader (מנקד ההכל או כלום). זה יעבוד עם מנקדים שנכתבו על ידי "
 "המשתמשים, אם הם נכתבו כראוי."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr "קובץ מקור זה לא קיים!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr "קובץ מקור זה הוא תיקייה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr "קובץ המקור הוא לא קובץ ריק!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr "לא ניתן לקרוא קובץ מקור זה!"
 
@@ -6861,13 +7012,13 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 "הטבלה מציגה את אוספי שיעורי הבית הזמינים עבור כיתה זו, ביחד על סטטוס נוכחי. "
-"לחץ על הקישור בשם האוסף כדי לצפות בשאלות באוסף. לחיצה על הקישורים בראש "
+"לחץ על הקישור בשם הגליון כדי לצפות בשאלות בגליון. לחיצה על הקישורים בראש "
 "הטבלה  יסדר את הטבלה לפי השדה המתאים. אתה יכול גם לבחור אוספים להורדה בפורמט "
 "PDF או TeX באזרת הקישור ליד שם אוספי השאלות, ואז לחיצה על כפתור \"הורד גרסת "
 "הדפסה כ-PDF או TeX של האוספים שנבחרו\" שבתחתית הטבלה. יש גם כפתורי ריקון שלח "
 "דוא\"ל למדריך בתחתית הטבלה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6875,12 +7026,12 @@ msgid ""
 "status.  Click on the link on the name of the problem to take you to the "
 "problem page."
 msgstr ""
-"הטבלה הזאת מראה את השאלות שבאוסף הזה. העמודות מימין לשמאל הן: שם השאלה, כמה "
+"הטבלה הזאת מראה את השאלות שבגליון הזה. העמודות מימין לשמאל הן: שם השאלה, כמה "
 "נסיונות בוצעו, כמה נסיונות נותרו, השווי בנקודות, וסטטוס ההשלמה. לחץ על "
 "הקישור בשם השאלה כדי להגיע לד, השאלה. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr "זמן"
 
@@ -6889,7 +7040,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr "מרווח זמנים לגרסאות מבחן חדשות (מינימום; 0=אינסוף)"
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr "זמן שנלקח לבחינה: %1 דקות (%2 דקות מורשות)."
 
@@ -6902,17 +7053,17 @@ msgid "Timezone for the course"
 msgstr "איזור זמנים של הקורס"
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
-msgstr "על מנת לגשת לאוסף זה, עליך לצבור ניקוד של לפחות %1% באוסף %2."
+msgstr "על מנת לגשת לגליון זה, עליך לצבור ניקוד של לפחות %1% בגליון %2."
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
-msgstr "כדי לגשת לאוסף זה עליך לצבור ניקוד של לפחות %1%באוספים הבאים: %2."
+msgstr "כדי לגשת לגליון זה עליך לצבור ניקוד של לפחות %1%באוספים הבאים: %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
@@ -6921,7 +7072,7 @@ msgstr ""
 "כדי להוסיף מדריך נוסף לקורס חדש, מלא את פרטי המשתמש למטה. מזהה המשתמש יכול "
 "להכיל רק מספרים, אותיות, מקפים, נקודות, פסיקים, וקווים תחתונים.\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -6933,25 +7084,25 @@ msgid ""
 "To change status (scores or grades) for this student for one set, click on "
 "the individual set link."
 msgstr ""
-"על מנת לשנות סטטוס (נקודות או ציונים) לסטודנט זה עבור אוסף אחד, לחץ על "
-"הקישור לאוסף הנ\"ל."
+"על מנת לשנות סטטוס (נקודות או ציונים) לסטודנט זה עבור גליון אחד, לחץ על "
+"הקישור לגליון הנ\"ל."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr "על מנת להעתיק תבניות מקורס קיים, בחר בקורס להלן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
-"על מנת לערוך גרסה מסוימת של סטודנט לאוסף הנ\"ל, ערוך (את כל) האוספים המוקצים "
+"על מנת לערוך גרסה מסוימת של סטודנט לגליון הנ\"ל, ערוך (את כל) האוספים המוקצים "
 "לו/ה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
@@ -6959,8 +7110,8 @@ msgstr ""
 "כדי לערוך את הטקסט עליך להכין ראשית עותק של הקובץ על ידי שימוש בפעולת 'גרסה "
 "חדשה' שלהלן."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -6972,11 +7123,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "עבור שאלה זו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr "נמען:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr "סה\"כ"
 
@@ -6993,7 +7144,8 @@ msgid "Transfer"
 msgstr "העבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr "נכון"
 
@@ -7009,46 +7161,46 @@ msgstr "טוניקת ההארכה"
 msgid "Two Columns"
 msgstr "שתי עמודות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr "סוג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr "URI"
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
+msgstr "לא ניתן לשנות את המעריך של גליון %1. שגיאה לא מזוהה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr "לא צלחה השגת הודעות השגיאה מתוך שאלת ה-PG."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr "לא ניתן לרשום ל'%1': %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr "הסר מהארכיון"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr "הוצא מהארכיון את %1 לקורס:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr "הסר קורס מהארכיון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr "הסר את הקורס הבא מהארכיון"
 
@@ -7070,7 +7222,7 @@ msgstr ""
 "ביטול הקצאה."
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr "לא נוסה: %1/%2"
 
@@ -7078,13 +7230,13 @@ msgstr "לא נוסה: %1/%2"
 msgid "Unclassified Problems"
 msgstr "שאלות לא מסווגות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr "לא נוקדו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr "הפוך קורסים לגלויים"
 
@@ -7105,7 +7257,7 @@ msgstr "לפרוק"
 msgid "Unpack archives automatically"
 msgstr "לפרוק ארכיונים אוטומטית"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr "בטל בחירה לכל הקורסים"
 
@@ -7113,12 +7265,12 @@ msgstr "בטל בחירה לכל הקורסים"
 msgid "Unselect all sets"
 msgstr "אל תבחר את כל הקורסים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "אל תבחר את כל המשתמשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr "עדכון"
 
@@ -7130,37 +7282,37 @@ msgstr "עדכן תצוגה"
 msgid "Update Menus"
 msgstr "עדכן תפריטים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr "עדכן הגדרות ורענן עמוד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr "לעדכן את התיקיות המסומנות?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr "תיאור מיקום מעודכן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr "שדרוג"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr "עדכן טבלאות קורס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr "עדכן קורסים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr "עדכן תהליכים שהושלמו"
 
@@ -7174,11 +7326,12 @@ msgid "Use Date Picker"
 msgstr "השתמש בבוחר התאריכים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr "השתמש בקובץ קידומת לפי ברירת המחדל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr "השתמש בעורך המשוואות?"
 
@@ -7186,20 +7339,20 @@ msgstr "השתמש בעורך המשוואות?"
 msgid "Use Item"
 msgstr "השתמש בפריט"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "השתמש בברירת המחדל של המערכת"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr "השתמש בכפתור חזרה של הדפדפן כדי לחזור ממצב תצוגה מקדימה"
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr "השתמש בהישג %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr "השתמש בהישג חדש:"
 
@@ -7219,7 +7372,7 @@ msgstr ""
 "השתמש בממשק שלהלן על מנת לגשת בקלות לכלי מדריך נפוצים בשימוש, או בחר כלי "
 "מהרשימה שמשמאל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -7229,13 +7382,13 @@ msgstr ""
 "בשאלה שאתה מנסה לפתור. יחד עם ההודעה, ישלח מידע נוסף על מצב המערכת שלך."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr "משתמש '%1' לא יועתק מקורס המנהל שכן זהו המדריך הראשוני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr "מזהה משתמש"
@@ -7257,15 +7410,15 @@ msgstr "שם המשתמש הוא:"
 msgid "User's username is:"
 msgstr "שם המשתמש הוא:"
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
 "UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
 "database corruption."
 msgstr ""
-"שאלת משתמש חסרה עבור משתמש=%1 אוסף=%2 שאלה=%3. זה עשוי להיות סימן של מסד "
+"שאלת משתמש חסרה עבור משתמש=%1 גליון=%2 שאלה=%3. זה עשוי להיות סימן של מסד "
 "נתונים פגום."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
@@ -7278,7 +7431,7 @@ msgid "Username presented:  %1"
 msgstr "שם משתמש שמוצג: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -7286,9 +7439,9 @@ msgstr "משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
 msgid "Users Assigned to Set %2"
-msgstr "משתמש מוקצה לאוסף %2"
+msgstr "משתמש מוקצה לגליון %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "רשימת משתמשים"
 
@@ -7311,7 +7464,7 @@ msgstr ""
 "מורשים לשנות את סיסמתם."
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "משתמשים מוינו לפי %1, לאחר מכן לפי %2, ואז לפי %3"
 
@@ -7336,17 +7489,18 @@ msgstr ""
 "בנוסף, הודעת המשוב תישלח לכתובות למטה. כדי לשלוח רק לכתובות למטה, בחר את רמת "
 "ההרשאות \"אף אחד\"."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
-msgstr "משתמש בתוכן של הודעת ברירת המחדל $default_msg_file במקום."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
+msgstr "משתמש בתוכן של הודעת ברירת המחדל %1 במקום."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr "באיזה מצב תצוגה להשתמש?:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr "להשתמש באיזה זרע?"
 
@@ -7354,21 +7508,21 @@ msgstr "להשתמש באיזה זרע?"
 msgid "Value of work done in Reduced Scoring Period"
 msgstr "ערך העבודה נעשה בתקופת ניקוד מופחת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr "תיעוד משתנה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
-msgstr "גרסאות של אוסף ניתנות לעריכה עבור משתמש אחד בלבד כל פעם."
+msgstr "גרסאות של גליון ניתנות לעריכה עבור משתמש אחד בלבד כל פעם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "הצג"
 
@@ -7381,7 +7535,7 @@ msgstr "הצג"
 msgid "View Problems"
 msgstr "בעיות תצוגה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "הצג משוואות כ"
 
@@ -7392,7 +7546,7 @@ msgstr "הצג את זה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
-msgstr "הצג סטטיסטיקה לפי אוסף"
+msgstr "הצג סטטיסטיקה לפי גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
@@ -7401,7 +7555,7 @@ msgstr "הצג סטטיסטיקה לפי תלמיד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
-msgstr "הצג התקדמיות תלמיד לפיי אוסף"
+msgstr "הצג התקדמיות תלמיד לפיי גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
@@ -7412,8 +7566,8 @@ msgstr "הצג התקדמות תלמיד לפי תלמיד"
 msgid "View/Edit"
 msgstr "הצג/ערוך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr "מציג קובץ זמני:"
@@ -7436,17 +7590,17 @@ msgstr "ניתן לצפייה"
 msgid "Visible to Students"
 msgstr "גלוי לסטודנטים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr "הזהרה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr "הודעות הזהרה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr "זהירות: מחיקה הורסת את כל המידע שנוגע למשתמשים והיא בלתי הפיכה!"
 
@@ -7455,11 +7609,16 @@ msgstr "זהירות: מחיקה הורסת את כל המידע שנוגע למ
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr "אזהרות שעלו במהלך עיבוד %1. הודעת שגיאה: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr "שגיאת WeBWorK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr "אזהרות WeBWorK"
 
@@ -7483,7 +7642,7 @@ msgstr ""
 "בשאלה עצמה. אם אתה תלמיד, דווח על הודעת שגיאה זו למרצה שלך כדי שיתקן את "
 "השאלה. אם אתה המרצה, אנא פנה לפלט השגיאה למטה למידע נוסף."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7510,7 +7669,7 @@ msgid ""
 "WeBWorK was unable to generate a paper copy of this homework set.  Please "
 "inform your instructor. "
 msgstr ""
-"WeBWorK לא הצליחה ליצור גרסת הדפסה אוסף שיעורי הבית הזה. אנא דווח על כך "
+"WeBWorK לא הצליחה ליצור גרסת הדפסה גליון שיעורי הבית הזה. אנא דווח על כך "
 "למדריך שלך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:344
@@ -7525,7 +7684,7 @@ msgstr "!WebWork ברוכים הבאים ל-"
 msgid "What could be inside?"
 msgstr "מה יכל להיות בפנים?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "באיזה שדה תלמידים צריכים להתאים?"
 
@@ -7607,7 +7766,7 @@ msgid ""
 "problems. Make sure this is what you want to do before unchecking students."
 msgstr ""
 "כשאתה מבטל הקצאה על ידי ביטול הבחירה של השם שלו,  אתה הורס את כל מידע של "
-"אוסף שיעורי בית %1 עבור תלמיד זה. לאחר מכן תצטרך להקצות להם את האוסף מחדש "
+"גליון שיעורי בית %1 עבור תלמיד זה. לאחר מכן תצטרך להקצות להם את הגליון מחדש "
 "והם יקבלו גרסאות חדשות של השאלות. תוודא שזה אכן מה שאתה רוצה לעשות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:280
@@ -7617,8 +7776,8 @@ msgid ""
 "student will receive a new version of each problem. Make sure this is what "
 "you want to do before unchecking sets."
 msgstr ""
-"כשאתה מבטל בחירה של אוסף שיעורי בית (ושומר את השינויים), אתה הורס את כל "
-"המידע של אוסף זה עבור תלמיד זה. אם אתה מקצה אותו מחדש, התלמיד יקבל גרסה חדשה "
+"כשאתה מבטל בחירה של גליון שיעורי בית (ושומר את השינויים), אתה הורס את כל "
+"המידע של גליון זה עבור תלמיד זה. אם אתה מקצה אותו מחדש, התלמיד יקבל גרסה חדשה "
 "של כל שאלה. ודא שזה מה שאתה רוצה לעשות לפני ביטול הבחירה."
 
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
@@ -7627,12 +7786,12 @@ msgstr ""
 msgid "Will open on %1."
 msgstr "ייפתח ב-%1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "ערך"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
@@ -7640,31 +7799,33 @@ msgstr ""
 "הרשאות כתיבה לא אופשרו ל-'%1'. יש לשמור שינויים בקובץ אחר על מנת לראותם."
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
 "הראשות כתיבה לא אופשרו ב-'%1'. יש לשמור שינויים בתיקיה אחרת בטרם ניתן לראותם."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "הרשאות כתיבה לא הופעלו בתיקיית התבניות. לא ניתן לבצע שינויים"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "כן"
 
@@ -7696,15 +7857,15 @@ msgstr "אתה לא רשאי ליצר גרסת הדפסה של %1 מכתובת �
 msgid "You are not authorized to access the Instructor tools"
 msgstr "אתה לא רשאי להשתמש בכלי המדריך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr "אתה לא רשאי להשתמש בכלי המדריך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "אתה לא רשאי לגשת לכלי המדריך"
 
@@ -7714,7 +7875,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "אתה לא רשאי לשנות אוספי שיעורי בית"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "אתה לא רשאי לשנות שאלות."
 
@@ -7723,20 +7884,20 @@ msgstr "אתה לא רשאי לשנות שאלות."
 msgid "You are not authorized to modify set definition files."
 msgstr "אתה לא רשאי לשנות קבצי הגדרה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "אתה לא רשאי לשנות פרטי תלמיד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "אתה לא רשאי לבצע פעולה זו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:246
 msgid ""
 "You are not permitted to generate a hardcopy for a set with hidden work."
-msgstr "אתה לא רשאי ליצר גרסת הדפסה של אוסף עם עבודה מוחבאת."
+msgstr "אתה לא רשאי ליצר גרסת הדפסה של גליון עם עבודה מוחבאת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:234
 msgid "You are not permitted to generate a hardcopy for an unopened set."
@@ -7751,7 +7912,7 @@ msgstr ""
 "אתה רשאי ללחוץ על \"תראה לי עוד אחת\" %quant(%1,פעם,פעמים) לכל שאלה. %2 סגור "
 "חלון זה, וחזור לשאלה המקורית."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr "נגמר לך הזמן. לחץ על נקד עכשיו!"
 
@@ -7762,6 +7923,10 @@ msgstr "אתה יכול לצפות גם בקבצים הזמניים הבאים:"
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "ניתן להרוויח ניקוד חלקי בבעיה זו"
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -7785,7 +7950,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr "ניתן לפרוק רק קבצים עם הסיומות '.tgz', '.tar' או '.tar.gz'"
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -7809,15 +7974,15 @@ msgstr "לא ניתן לערוך תיקיות"
 msgid "You can't view files of that type"
 msgstr "לא ניתן לצפות בקבצים מסוג זה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr "לא ניתן להוסיף לארכיון את הקורס שבו אתה משתמש כרגע."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr "אתה לא יכול למחוק את הקורס בו אתה משתמש כרגע."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "אתה לא יכול למחוק את עצמך!"
 
@@ -7826,14 +7991,14 @@ msgid ""
 "You cannot use this version of Set Detail to edit just-in-time type sets.  "
 "You must use Set Detail 2."
 msgstr ""
-"אתה לא יכוללהשתמש בגרסה הזאת של פרטי האוסף כדי לערוך אוספי מסוג \"בדיוק בזמן"
-"\". אתה צריך להשתמש בפרטי אוסף 2."
+"אתה לא יכוללהשתמש בגרסה הזאת של פרטי הגליון כדי לערוך אוספי מסוג \"בדיוק בזמן"
+"\". אתה צריך להשתמש בפרטי גליון 2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
 msgid "You did not specify a new set name."
-msgstr "לא מלאת שם לאוסף החדש."
+msgstr "לא מלאת שם לגליון החדש."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr "לא מלאת את תוכן ההודעה."
 
@@ -7860,37 +8025,41 @@ msgstr "אין לך הרשאות לערוך את הקובץ הזה."
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "אין לך את ההרשאות הדרושות כדי ליצור גרסת הדפסה בפורמט %1."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "אין לך את ההרשאות לצפות בפרטים של השגיאה זו."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr "אין שום מידע על הישכים עבורך!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr "אין לך שום חפצים!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr "עברת את הזמן המותר."
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "נשארו לך %1 ניסיון/ות למבחן זה."
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "נותר לך egquant(%1,נסיונות לא מוגבלים,נסיון,ניסיונות)%n."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr "נותרו לך %quant(%1,ניסיון,ניסיונות) לפני שתקבל גרסה חדשה."
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "ניסית שאלה זו %quant(%1,פעם,פעמים)."
 
@@ -7898,7 +8067,7 @@ msgstr "ניסית שאלה זו %quant(%1,פעם,פעמים)."
 msgid "You have been logged out of WeBWorK."
 msgstr "התנתקת מ-WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr "נותר לך פחות מדקה 1 לפתרון מבחן זה"
 
@@ -7934,13 +8103,17 @@ msgid ""
 "set."
 msgstr ""
 "אתה יכול לבחור להציג כל נתון מהנתונים הבאים. תשובות נכונות, רמזים, ופתרונות "
-"הם זמינים %1 רק לאחר תאריך התשובות של אוסף שיעורי הבית."
+"הם זמינים %1 רק לאחר תאריך התשובות של גליון שיעורי הבית."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+msgid "You may not change your answers when going on to the next part!"
+msgstr "לא ניתן לשנות תשובות כאשר אתה מתקדם לחלק הבא!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "לא ניתן לשנות את הסיסמה שלך כאן!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr "אתה עדיין יכול לבדוק את התשובות שלך."
 
@@ -7954,13 +8127,13 @@ msgstr ""
 "אחת\"."
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "יש לנסות את שאלה זו %quant(%1,פעם,פעמים) לפני שאפשרות זו תהפוך לזמינה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr "אתה חייב לאשר את הסיסמה למדריך הראשוני."
 
@@ -7970,14 +8143,14 @@ msgid ""
 "You must log into this set via your Learning Management System (e.g. "
 "Blackboard, Moodle, etc...)."
 msgstr ""
-"אתה חייב להתחבר לאוסף זה דרך מערכת ניהול הלמידה שלך (לדוגמה: Blackboard, "
+"אתה חייב להתחבר לגליון זה דרך מערכת ניהול הלמידה שלך (לדוגמה: Blackboard, "
 "Moodle, וכו')."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
 msgid "You must provide a student ID, a set ID, and a problem number."
-msgstr "אתה חייב למלא מזהה משתמש, מזהה אוסף, ומספר שאלה."
+msgstr "אתה חייב למלא מזהה משתמש, מזהה גליון, ומספר שאלה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr "אתה חייב לבחור קורס שאת שמו תרצה לשנות."
 
@@ -7989,20 +8162,25 @@ msgstr "אתה חייב לבחור לפחות קובץ אחד להוספה לא�
 msgid "You must select at least one file to delete"
 msgstr "אתה חייב לבחור לפחות קובץ אחד למחיקה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr "אתה חייב לבחור לפחות אוסף אחד לניקוד"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+msgid "You must select one or more sets for scoring!"
+msgstr "אתה חייב לבחור לפחות גליון אחד לניקוד!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+msgid "You must specify a %1 name"
+msgstr "אתה חייב למלא שם של %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr "אתה חייב למלא מזהה קורס."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr "אתה חייב למלא שם קורס"
 
@@ -8010,41 +8188,41 @@ msgstr "אתה חייב למלא שם קורס"
 msgid "You must specify a file name"
 msgstr "אתה חיב למלא שם קובץ"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr "אתה חייב למלא שם פרטי למדריך הראשוני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr "אתה חייב למלא שם משפחה למדריך הראשוני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr "אתה חייב למלא מוסד חדש עבור קורס זה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr "אתה חייב למלא שם חדש לקורס זה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr "אתה חייב למלא כותרת חדשה לקורס זה."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr "אתה חייב למלא סיסמה למדריך הראשוני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "אתה חייב למלא מזהה משתמש."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr "אתה חייב למלא כתובת דוא\"ל של במדריך הראשוני."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "יש לפרט שם קובץ כדי לשמור בקובץ חדש"
 
@@ -8055,11 +8233,11 @@ msgid ""
 "Managment System and visiting the set from there."
 msgstr ""
 "אתה חייב להשתמש במערכת ניהול הלמידה שלך (לדוגמה: Blackboard, Moodle, Canvas, "
-"וכו') כדי לגשת לאוסף הזה. נסה להתחבר למערכת ניהול הלמידה ולבקר באוסף משם."
+"וכו') כדי לגשת לגליון הזה. נסה להתחבר למערכת ניהול הלמידה ולבקר בגליון משם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1260
 msgid "You need to select a \"Target Set\" before you can edit it."
-msgstr "אתה צריך לבחור אוסף שאותו תרצה לערוך."
+msgstr "אתה צריך לבחור גליון שאותו תרצה לערוך."
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
@@ -8068,23 +8246,23 @@ msgstr "אתה צריך לבחור קובץ כדי לבצע %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
 msgid "You need to select a set definition file to view."
-msgstr "אתה צריך לבחור הגדרת אוסף לצפייה."
+msgstr "אתה צריך לבחור הגדרת גליון לצפייה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
-msgstr "אתה צריך לבחור אוסף מקורס זה לצפייה."
+msgstr "אתה צריך לבחור גליון מקורס זה לצפייה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1369
 msgid "You need to select a set to view."
-msgstr "אתה צריך לבחור אוסף לצפייה"
+msgstr "אתה צריך לבחור גליון לצפייה"
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr "קיבלת ציון %1 עבור ניסיון זה"
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
@@ -8093,7 +8271,7 @@ msgstr ""
 "המוכלות שמזכות נקודות."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8132,27 +8310,28 @@ msgid ""
 "instructor if you need help."
 msgstr "האימות שלך נכשל. אנא נסה שוב. אנא פנה למדריך שלך אם אתה צריך עזרה."
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr "הדפדפן שלך לא תומך ב-video tag."
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr "ענף ה-PG הנוכחי שלך הוא עדכני לפי ענף %1 ב-remote בשם %2."
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr "ענף ה-WeBWorK הנוכחי שלך הוא עדכני לפי ענף %1 ב-remote בשם %2."
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr "הענף הנוכחי שלך שלסיפריית השאלות הפתוחה הוא עדכני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr "אפשרויות התצוגה נשמרו."
 
@@ -8164,69 +8343,82 @@ msgstr "כתובת הדוא\"ל שלך שונתה."
 msgid "Your file name contains illegal characters"
 msgstr "שם הקובץ מכיל תוים לא חוקיים."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstt "שם הקובץ שנתת אינו תקני! "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr "ההודעה שלך נשלח בהצלחה."
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr "סה\"כ הניקוד שלך הוא %1. %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "הציון שלך במבחן זה (מספר %1) הוא %2/%3."
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr "הציון שלך ב-%1 הזה נשמרה."
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr "הציון שלך ב-%1 זה הוא %2/%3."
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr "הניקוד שלך ב-%1 זה לא נשמרה."
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "הניקוד שלך על הגשה זו (נבדקה, לא נשמרה) הוא %1/%2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr "הניקוד שלך בשאלה זו נשמר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr "הניקוד שלך לא נשמר בגלל שהיה כישלון בשמירת נתוני השאלה במסד הנתונים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
-msgstr "הניקוד שלך לא נשמר בגלל שאוסף שיעורי בית זה הוא סגור."
+msgstr "הניקוד שלך לא נשמר בגלל שגליון שיעורי בית זה הוא סגור."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "הניקוד שלך לא נשמר בגלל ששאלה זו לא הוקצאה אליך."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
-msgstr "הניקוד שלך לא נשמר בגלל שגירסת אוסף השאלות הזאת לא פתוחה."
+msgstr "הניקוד שלך לא נשמר בגלל שגירסת גליון השאלות הזאת לא פתוחה."
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
@@ -8234,44 +8426,44 @@ msgstr ""
 "הציון שלך לא נשמר כי עברת את הגבלת הזמן של מבחן זה. (זמן שעבר: %1 דק', הגבלת "
 "זמן: %2 דק'.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
-msgstr "הניקוד שלך לא נשמר כי אין לך עוד ניסיונות לגרסת האוסף הזאת."
+msgstr "הניקוד שלך לא נשמר כי אין לך עוד ניסיונות לגרסת הגליון הזאת."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr "הניקוד שלך לא נשמר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr "הניקוד שלך לא נשלח בהצלחה ל-LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "הניקוד שלך לא נשמר."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr "הניקוד לך נשלח בהצלחה ל-LMS"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "נותקת עקב חוסר פעילות. אנא התחבר שוב."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr "המערוכות שלך עדכניות!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr "[ערוך]"
@@ -8284,7 +8476,7 @@ msgstr "_תיאור_עורך_הישגים"
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr "_תיאור_רשימת_תשובות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr "_תיאור_עורך_רשימת_כיתה"
 
@@ -8307,43 +8499,53 @@ msgstr "_תיאור_עורך_שיעורי_הבית"
 msgid "_LOGIN_MESSAGE"
 msgstr "_הודעת_היתחברות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
-msgstr "_תקציר_אוסף_שאלות"
+msgstr "_תקציר_גליון_שאלות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr "_שגיאת_בקשה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr "_תקציר_טבלת_משתמשים"
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+msgid "a duplicate of the first selected achievement."
+msgstr "כשכפול של ההישג הראשון שנבחר"
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
-msgstr "שכפול של האוסף הראשון שנבחר"
+msgstr "שכפול של הגליון הראשון שנבחר"
+
+# Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+msgid "a new empty achievement."
+msgstr "הישג ריק חדש"
 
 # Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
-msgstr "אוסף ריק חדש"
+msgstr "גליון ריק חדש"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr "קובץ חדש בשם:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
-msgstr "אוסף אחד"
+msgstr "גליון אחד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr "פעיל"
 
@@ -8352,11 +8554,11 @@ msgid "add problems"
 msgstr "הוסף שאלות"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
-msgstr "הוסף אוסף גלובלי %1 ברשימת שאלות האוסף: %2"
+msgstr "הוסף גליון גלובלי %1 ברשימת שאלות ??? האוסף: %2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr "נוספה רמת ההרשאות החסרה למשתמש"
 
@@ -8366,13 +8568,13 @@ msgid "admin"
 msgstr "מנהל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr "כל ההישגים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -8401,51 +8603,57 @@ msgstr "כל האוספים"
 msgid "all students"
 msgstr "כל התלמדים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "all users for one <b>set</b>"
-msgstr "כל המשתמשים של <b>אוסף</b> אחד"
+msgstr "כל המשתמשים של <b>גליון</b> אחד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr "בסדר אלפבתי"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr "תשובה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "כל משתמש"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr "בתור"
 
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
-msgstr "מקצה את ההישגים ל-"
-
 # Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 msgid "assigning this set to"
-msgstr "מקצה את האוסף ל-"
+msgstr "מקצה את הגליון ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
@@ -8454,22 +8662,22 @@ msgstr "ממוצע ניסיונות"
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
-msgstr "תבנית שאלה ריקה לסיום אוסף שיעורי הבית"
+msgstr "תבנית שאלה ריקה לסיום גליון שיעורי הבית"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr "לפי תאריך ההתחברות האחרון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "שינויים לא נשמרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "שינויים נשמרו"
@@ -8486,17 +8694,17 @@ msgstr "נתוני רשימת כיתה של <b>המשתמשים</b> שנבחרו
 msgid "close"
 msgstr "סגור"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr "עמודה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr "עמודות:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "נכון"
 
@@ -8510,7 +8718,7 @@ msgid "deleted %1 sets"
 msgstr "נמחקו %1 אוספים"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr "נמחקו %1 משתמשים"
 
@@ -8522,7 +8730,7 @@ msgstr "עורך את כל ההישגים"
 msgid "editing all sets"
 msgstr "עורך את כל האוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "עורך את כל המשתמשים"
 
@@ -8534,7 +8742,7 @@ msgstr "עורך את ההישגים שנבחרו"
 msgid "editing selected sets"
 msgstr "עורך את האוספים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "עורך את המשתמשים שנבחרו"
 
@@ -8542,7 +8750,7 @@ msgstr "עורך את המשתמשים שנבחרו"
 msgid "editing visible sets"
 msgstr "עורך את האוספים שניתנים לצפייה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "עורך את המשתמשים שניתנים לצפייה"
 
@@ -8551,7 +8759,7 @@ msgstr "עורך את המשתמשים שניתנים לצפייה"
 msgid "email:"
 msgstr "דוא\"ל:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr "ריק"
 
@@ -8564,16 +8772,16 @@ msgid "entry rows."
 msgstr "שורות קליטה"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
-msgstr "שגיאה בהוספת מיקום %1 עבור אוסף %2:%3"
+msgstr "שגיאה בהוספת מיקום %1 עבור גליון %2:%3"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "יצוא בוטל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr "מיצא את כל ההישגים"
 
@@ -8581,7 +8789,7 @@ msgstr "מיצא את כל ההישגים"
 msgid "exporting all sets"
 msgstr "מיצא את כל האוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr "מיצא את ההישגים שנבחרו"
 
@@ -8600,7 +8808,7 @@ msgstr "עבור %1(%2) שלו הוקצאו %3 אוספים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
-msgstr "עבור <b>אוסף</b> אחד"
+msgstr "עבור <b>גליון</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
@@ -8615,15 +8823,15 @@ msgstr "עבור תלמידים"
 msgid "from"
 msgstr "מקור"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "נותן סיסמה חדשה לכל המשתמשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
 
@@ -8631,18 +8839,18 @@ msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
 msgid "global %1 for set %2 not found."
-msgstr "הגלובלי %1 עבור אוסף %2 לא נמצא."
+msgstr "הגלובלי %1 עבור גליון %2 לא נמצא."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
 msgid "global set %1  not found."
-msgstr "אוסף גלובלי  %1 לא נמצא."
+msgstr "גליון גלובלי  %1 לא נמצא."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
 msgid "global set %1 not found."
-msgstr "אוסף גלובלי %1 לא נמצא."
+msgstr "גליון גלובלי %1 לא נמצא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
@@ -8652,9 +8860,9 @@ msgstr "משגיח_ציון"
 msgid "guest"
 msgstr "אורח"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "מוחבא"
@@ -8663,7 +8871,7 @@ msgstr "מוחבא"
 msgid "hidden from"
 msgstr "מוחבא מ-"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "מוחבא מתלמידים"
@@ -8675,45 +8883,50 @@ msgstr "אוספים מוחבאים"
 # does not need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr "i"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+# does not need to be translated
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr "if"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr "תו לא חוקי בקלט : '/'"
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr "בשלהם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr "לא פעיל"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "לא נכון"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr "מדד"
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
-msgstr "מיקום האוסף שהוכנס %1 כבר קיים עבור אוסף %2."
+msgstr "מיקום הגליון שהוכנס %1 כבר קיים עבור גליון %2."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr "רשימת קיצורי המאקרו שניתן להכניס"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr "המיקומים שנבחרו למטה"
 
@@ -8721,7 +8934,7 @@ msgstr "המיקומים שנבחרו למטה"
 msgid "login"
 msgstr "התחבר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr "מזהה התחברות"
 
@@ -8750,21 +8963,21 @@ msgstr "מספר אוספים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "new set:"
-msgstr "אוסף חדש:"
+msgstr "גליון חדש:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 msgid "new users"
 msgstr "משתמשים חדשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr "אין הישגים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr "אין הישגים."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr "אין מיקום"
 
@@ -8783,40 +8996,44 @@ msgstr "שום אוספים"
 msgid "no students"
 msgstr "אין תלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "שום משתמשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr "אף אחד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr "העמודה ה-n של קובץ האיחוד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
 msgstr "מספר התלמידים שלא הוגדרו"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
-msgstr "<b>אוסף</b> אחד"
+msgstr "<b>גליון</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
 msgid "one <b>set</b> for  <b>users</b>"
-msgstr "<b>אוסף</b> אחד עבור <b>משתמשים</b>"
+msgstr "<b>גליון</b> אחד עבור <b>משתמשים</b>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "one <b>user</b> (on one <b>set</b>)"
-msgstr "<b>משתמש</b> אחד (<b>באוסף</b> אחד)"
+msgstr "<b>משתמש</b> אחד (<b>בגליון</b> אחד)"
 
 # Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
@@ -8828,7 +9045,7 @@ msgstr "רק"
 msgid "only best scores"
 msgstr "רק הציונים הטובים ביותר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8840,53 +9057,57 @@ msgstr "או"
 msgid "or Problems from"
 msgstr "או שאלות מ-:"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr "מתוך"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr "דרוס את כל הנתונים"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr "חלק"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr "הההרשאות של %1 לא מוגדרות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr "דיבאג PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr "שגיאות פנימיות של PG"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr "הזהרת PG"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr "נקודה"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr "קודות"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr "שמר מידע קיים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr "צפה בתשובות"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr "שאלה"
 
@@ -8904,10 +9125,10 @@ msgid "progress"
 msgstr "התקדמות"
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
-msgstr "שגיאת קריאת הגדרת אוסף, לא יכול לקרוא את השורה: ||%1||"
+msgstr "שגיאת קריאת הגדרת גליון, לא יכול לקרוא את השורה: ||%1||"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
 msgid "recitation #"
@@ -8919,18 +9140,18 @@ msgid "record for user %1 not found"
 msgstr "רישם לא נמצא עבור משתמש %1"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr "רישום לא נמצא עבור משתמש גלוי %1 לא נמצא"
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr "מיקום ההגבלות %1 לא קיים. הגבלות ה-IP לא הופעלו"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr "שורה"
 
@@ -8952,13 +9173,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr "<b>משתמשים</b> שנבחרו <b>לאוספים</b> שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr "ההישגים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr "ההישגים שנבחרו."
 
@@ -8977,17 +9198,17 @@ msgstr "ההישגים שנבחרו."
 msgid "selected sets"
 msgstr "אוספים שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "משתמשים שנבחרו"
 
@@ -8998,7 +9219,7 @@ msgstr "הפרד מספר מזהים בעזרת פסיקים."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
 msgid "set"
-msgstr "אוסף"
+msgstr "גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
@@ -9025,7 +9246,7 @@ msgstr "אוספים עם מזההים תואמים"
 msgid "showing all sets"
 msgstr "מציג את כל האוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "מציג את כל המשתמשים"
 
@@ -9040,7 +9261,7 @@ msgstr "מראה אוספים מוחבאים"
 msgid "showing matching sets"
 msgstr "מראה אוספים תואמים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "מציג את המשתמשים התואמים"
 
@@ -9048,7 +9269,7 @@ msgstr "מציג את המשתמשים התואמים"
 msgid "showing no sets"
 msgstr "לא מציג שום אוספים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "לא מציג שום משתמשים"
 
@@ -9056,13 +9277,17 @@ msgstr "לא מציג שום משתמשים"
 msgid "showing selected sets"
 msgstr "מציג אוספי שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "מציג משתמשים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
 msgstr "מראה אוספים גלויים"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
@@ -9078,16 +9303,16 @@ msgstr "תלמיד"
 msgid "students"
 msgstr "תלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr "הגשה"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr "הגשה (מבחן %1)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr "תקציר"
 
@@ -9095,12 +9320,12 @@ msgstr "תקציר"
 msgid "ta"
 msgstr "עוזר מורה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr "מבחן"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr "מבחן (%1)"
 
@@ -9112,7 +9337,7 @@ msgstr "תאריך מבחן"
 msgid "test time"
 msgstr "זמן מבחן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr "הקובץ הבא"
 
@@ -9121,14 +9346,14 @@ msgid "the following file(s)"
 msgstr "הקבצים הבאים"
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr "המסלול המקורי לקבוץ הוא %1"
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr "ואז לפי"
 
@@ -9136,7 +9361,11 @@ msgstr "ואז לפי"
 msgid "then delete them"
 msgstr "ואז תמחק אותם"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "זמן"
 
@@ -9144,43 +9373,40 @@ msgstr "זמן"
 msgid "time limit exceeded"
 msgstr "עברה מגבלת הזמן"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "מספר פעמים"
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
 msgstr "ל-"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
-msgstr "לכל המשתמשים, צור מידע גלובלי, ו"
-
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
-msgstr "<b>לאוסף</b> אחד"
+msgstr "<b>לגליון</b> אחד"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr "הציון הגבוהה ביותר"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr "סה\"כ"
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr "כתיבה בתיקייה %1 נכשלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "לא מוגבל"
 
@@ -9189,27 +9415,27 @@ msgstr "לא מוגבל"
 msgid "userID: %1 --"
 msgstr "מזהה משתמש: %1--"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr "שם משתמש, שם משפחה, שם פרטי, קבוצה, רמת הישגים, נקודות הישגים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr "משתמשים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "משתמשים שתאמו בשדות שנבחרו"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr "משתמשים שתואמים:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "גלוי"
@@ -9222,20 +9448,25 @@ msgstr "גלוי"
 msgid "visible sets"
 msgstr "אוספים שניתנים לצפייה"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "ניתן לצפייה לתלמידים"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "משתמשים שניתנים לצפייה"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -9243,200 +9474,207 @@ msgstr "עם אוספים בשם:"
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr "לא קריאה מקובץ %1/%2 לא תצליח: האם הוא קיים? האם הוא ניתן לקריאה?"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
 msgstr "התלמידים שלך"
 
-#
-#, fuzzy
-msgid "set %1."
-msgstr "tr: Revert to %1"
+#~ msgid "Import achievements from"
+#~ msgstr "יבא הישגים מ-"
 
-#
-msgid "navNext"
-msgstr "tr:&nbspNext"
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "פתח, ניקוד מופלת מתחיל ב-%1"
 
-#
-msgid "navNextGrey"
-msgstr "tr:&nbspNext"
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "נתוני ניקוד מופחת %1"
 
-#
-msgid "navPrev"
-msgstr "tr:&nbspPrev"
-
-#
-msgid "navPrevGrey"
-msgstr "tr:&nbspPrev"
-
-#
-msgid "navProbListGrey"
-msgstr "tr:&nbspUp"
-
-#
-msgid "navUp"
-msgstr "tr:&nbspUp"
-
-#
-msgid "Apply Options"
-msgstr "tr: Apply Options"
-
-#
-msgid "Disable"
-msgstr "tr: Disable"
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "ניקוד מופחת מצחיל ב-%1."
 
 #
 #, fuzzy
-msgid "Reduced Credit %1 for all sets"
-msgstr "tr: Reduced Credit %1 for all sets"
+#~ msgid "set %1."
+#~ msgstr "tr: Revert to %1"
 
 #
-msgid "_REDUCED_CREDIT_MESSAGE_1"
-msgstr ""
-"tr: This assignment has a Reduced Credit Period that begins %1 and ends on "
-"the due date, %2.  During this period all additional work done counts %3% of "
-"the original."
+#~ msgid "navNext"
+#~ msgstr "tr:&nbspNext"
 
 #
-msgid "_REDUCED_CREDIT_MESSAGE_2"
-msgstr ""
-"tr: This assignment had a Reduced Credit Period that began %1 and ended on "
-"the due date, %2.  During that period all additional work done counted %3% "
-"of the original."
+#~ msgid "navNextGrey"
+#~ msgstr "tr:&nbspNext"
 
 #
-msgid ""
-"Report bugs in a WeBWorK question/problem using this link. The very first "
-"time you do this you will need to register with an email address so that "
-"information on the bug fix can be reported back to you."
-msgstr ""
-"tr: Report bugs in a WeBWorK question/problem using this link. The very "
-"first time you do this you will need to register with an email address so "
-"that information on the bug fix can be reported back to you."
+#~ msgid "navPrev"
+#~ msgstr "tr:&nbspPrev"
 
 #
-msgid "Unable to make '[_1]' the set header for [_2]"
-msgstr "tr: Unable to make '%1' the set header for %2"
+#~ msgid "navPrevGrey"
+#~ msgstr "tr:&nbspPrev"
 
 #
-msgid "Can't determine user of temporary edit file [_1]."
-msgstr "tr: Can't determine user of temporary edit file %1."
+#~ msgid "navProbListGrey"
+#~ msgstr "tr:&nbspUp"
 
 #
-msgid "Top level of author information on the wiki."
-msgstr "tr: Top level of author information on the wiki."
+#~ msgid "navUp"
+#~ msgstr "tr:&nbspUp"
 
 #
-msgid "Reverting to original file '[_1]'"
-msgstr "tr: Reverting to original file '%1'"
+#~ msgid "Apply Options"
+#~ msgstr "tr: Apply Options"
 
 #
-msgid "Wiki summary page for MathObjects"
-msgstr "tr: Wiki summary page for MathObjects"
+#~ msgid "Disable"
+#~ msgstr "tr: Disable"
 
 #
-msgid "Snippets of PG code illustrating specific techniques"
-msgstr "tr: Snippets of PG code illustrating specific techniques"
-
-#
-msgid "Error copying [_1] to [_2]"
-msgstr "tr: Error copying %1 to %2"
-
-#
-msgid ""
-"Note: this problem viewer is for viewing purposes only. As of right now, "
-"testing functionality is not possible."
-msgstr ""
-"tr: Note: this problem viewer is for viewing purposes only. As of right now, "
-"testing functionality is not possible."
-
-#
-msgid "webwork"
-msgstr "webwork"
-
-#
-msgid "submit button clicked"
-msgstr "gönder düğmesine basıldı"
-
-#
-msgid ""
-"Test snippets of PG code in interactive lab.  Good way to learn PG language."
-msgstr ""
-"tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
-"language."
-
-#
-msgid "View Using Seed Number"
-msgstr "tr: View Using Seed Number"
-
-#
-msgid ""
-"The text box now contains the source of the original problem. You can "
-"recover lost edits by using the Back button on your browser."
-msgstr ""
-"tr: The text box now contains the source of the original problem. You can "
-"recover lost edits by using the Back button on your browser."
-
-#
-msgid ""
-"Documentation from source code for PG modules and macro files. Often the "
-"most up-to-date information."
-msgstr ""
-"tr: Documentation from source code for PG modules and macro files. Often the "
-"most up-to-date information."
-
-#
-msgid ""
-"PG mark down syntax used to format WeBWorK questions. This interactive lab "
-"can help you to learn the techniques."
-msgstr ""
-"tr: PG mark down syntax used to format WeBWorK questions. This interactive "
-"lab can help you to learn the techniques."
-
-#
-msgid ""
-"Error: This path is already in the temporary edit directory -- no new "
-"temporary file is created. path = [_1]"
-msgstr ""
-"tr: Error: This path is already in the temporary edit directory -- no new "
-"temporary file is created. path = %1"
-
-#
-msgid ""
-"Please use radio buttons to choose the method for saving this file. Can't "
-"recognize saveMode: |[_1]|."
-msgstr ""
-"tr: Please use radio buttons to choose the method for saving this file. "
-"Can't recognize saveMode: |%1|."
-
-#
-msgid "Resources"
-msgstr "tr: Resources"
-
-#
-msgid "Duplicate"
-msgstr "tr: Duplicate"
-
-#
-msgid "This path |[_1]| is not the path to a temporary edit file."
-msgstr "tr: This path |%1| is not the path to a temporary edit file."
-
-#
-msgid "Save as new independent problem"
-msgstr "tr: Save as new independent problem"
-
-#
-msgid "Unknown file type"
-msgstr "tr: Unknown file type"
-
 #, fuzzy
+#~ msgid "Reduced Credit %1 for all sets"
+#~ msgstr "Reduced Credit %1 for all sets"
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
+#~ msgstr ""
+#~ "tr: This assignment has a Reduced Credit Period that begins %1 and ends "
+#~ "on the due date, %2.  During this period all additional work done counts "
+#~ "%3% of the original."
+
+#
+#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
+#~ msgstr ""
+#~ "tr: This assignment had a Reduced Credit Period that began %1 and ended "
+#~ "on the due date, %2.  During that period all additional work done counted "
+#~ "%3% of the original."
+
+#
+#~ msgid ""
+#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
+#~ "time you do this you will need to register with an email address so that "
+#~ "information on the bug fix can be reported back to you."
+#~ msgstr ""
+#~ "tr: Report bugs in a WeBWorK question/problem using this link. The very "
+#~ "first time you do this you will need to register with an email address so "
+#~ "that information on the bug fix can be reported back to you."
+
+#
+#~ msgid "Unable to make '[_1]' the set header for [_2]"
+#~ msgstr "tr: Unable to make '%1' the set header for %2"
+
+#
+#~ msgid "Can't determine user of temporary edit file [_1]."
+#~ msgstr "tr: Can't determine user of temporary edit file %1."
+
+#
+#~ msgid "Top level of author information on the wiki."
+#~ msgstr "tr: Top level of author information on the wiki."
+
+#
+#~ msgid "Reverting to original file '[_1]'"
+#~ msgstr "tr: Reverting to original file '%1'"
+
+#
+#~ msgid "Wiki summary page for MathObjects"
+#~ msgstr "tr: Wiki summary page for MathObjects"
+
+#
+#~ msgid "Snippets of PG code illustrating specific techniques"
+#~ msgstr "tr: Snippets of PG code illustrating specific techniques"
+
+#
+#~ msgid "Error copying [_1] to [_2]"
+#~ msgstr "tr: Error copying %1 to %2"
+
+#
+#~ msgid ""
+#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
+#~ "testing functionality is not possible."
+#~ msgstr ""
+#~ "tr: Note: this problem viewer is for viewing purposes only. As of right "
+#~ "now, testing functionality is not possible."
+
+#
+#~ msgid "webwork"
+#~ msgstr "webwork"
+
+#
+#~ msgid "submit button clicked"
+#~ msgstr "gönder düğmesine basıldı"
+
+#
+#~ msgid ""
+#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
+#~ "language."
+#~ msgstr ""
+#~ "tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
+#~ "language."
+
+#
+#~ msgid "View Using Seed Number"
+#~ msgstr "tr: View Using Seed Number"
+
+#
+#~ msgid ""
+#~ "Documentation from source code for PG modules and macro files. Often the "
+#~ "most up-to-date information."
+#~ msgstr ""
+#~ "tr: Documentation from source code for PG modules and macro files. Often "
+#~ "the most up-to-date information."
+
+#
+#~ msgid ""
+#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
+#~ "lab can help you to learn the techniques."
+#~ msgstr ""
+#~ "tr: PG mark down syntax used to format WeBWorK questions. This "
+#~ "interactive lab can help you to learn the techniques."
+
+#
+#~ msgid ""
+#~ "Error: This path is already in the temporary edit directory -- no new "
+#~ "temporary file is created. path = [_1]"
+#~ msgstr ""
+#~ "tr: Error: This path is already in the temporary edit directory -- no new "
+#~ "temporary file is created. path = %1"
+
+#
+#~ msgid ""
+#~ "Please use radio buttons to choose the method for saving this file. Can't "
+#~ "recognize saveMode: |[_1]|."
+#~ msgstr ""
+#~ "tr: Please use radio buttons to choose the method for saving this file. "
+#~ "Can't recognize saveMode: |%1|."
+
+#
+#~ msgid "Resources"
+#~ msgstr "tr: Resources"
+
+#
+#~ msgid "Duplicate"
+#~ msgstr "tr: Duplicate"
+
+#
+#~ msgid "This path |[_1]| is not the path to a temporary edit file."
+#~ msgstr "tr: This path |%1| is not the path to a temporary edit file."
+
+#
+#~ msgid "Save as new independent problem"
+#~ msgstr "tr: Save as new independent problem"
+
+#
+#~ msgid "Unknown file type"
+#~ msgstr "tr: Unknown file type"
+
 #~ msgid "answer "
 #~ msgstr "תשובה"
 
-#, fuzzy
 #~ msgid "Will open on %1"
 #~ msgstr "ייפתח ב-%1."
 
@@ -9454,7 +9692,7 @@ msgstr "tr: Unknown file type"
 
 #, fuzzy
 #~ msgid "all current users."
-#~ msgstr "כל המשתמשים העכשיויים"
+#~ msgstr "כל המשתמשים הפעילים ??? עכשיויים"
 
 #, fuzzy
 #~ msgid "font-hidden"
@@ -9503,10 +9741,6 @@ msgstr "tr: Unknown file type"
 #, fuzzy
 #~ msgid "No sets selected for scoring."
 #~ msgstr "לא נבחרו אוספים לנקד"
-
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "פתק"
 
 #, fuzzy
 #~ msgid "Recitation:"
@@ -9586,7 +9820,7 @@ msgstr "tr: Unknown file type"
 
 #, fuzzy
 #~ msgid "Reduced Credit %1 for visable sets"
-#~ msgstr "האוסף שבוקש '%1' עדיין לא זמין"
+#~ msgstr "הגליון שבוקש '%1' עדיין לא זמין"
 
 #, fuzzy
 #~ msgid "completely"
@@ -9614,7 +9848,7 @@ msgstr "tr: Unknown file type"
 
 #, fuzzy
 #~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-#~ msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
+#~ msgstr "לא ניתן לשנות את המעריך של גליון %1. שגיאה לא מזוהה."
 
 #, fuzzy
 #~ msgid "Save Password"
@@ -9627,7 +9861,7 @@ msgstr "tr: Unknown file type"
 # Context is "This set is visible" or "This set is hidden"
 #, fuzzy
 #~ msgid "This set is [_1] students."
-#~ msgstr "האוסף הזה הוא %1"
+#~ msgstr "הגליון הזה הוא %1"
 
 #, fuzzy
 #~ msgid "blank problem"
@@ -9651,13 +9885,13 @@ msgstr "tr: Unknown file type"
 
 #, fuzzy
 #~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-#~ msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"
+#~ msgstr "גליון השאלות הנבחר (%1) הוא לא גליון חוקי עבור %2"
 
 #, fuzzy
 #~ msgid ""
 #~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
 #~ "error."
-#~ msgstr "לא ניתן לשנות את המעריך של אוסף %1. שגיאה לא מזוהה."
+#~ msgstr "לא ניתן לשנות את המעריך של גליון %1. שגיאה לא מזוהה."
 
 #, fuzzy
 #~ msgid "Options Information"
@@ -9673,4 +9907,4 @@ msgstr "tr: Unknown file type"
 
 #, fuzzy
 #~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-#~ msgstr "אוסף השאלות הנבחר (%1) הוא לא אוסף חוקי עבור %2"
+#~ msgstr "השאלה הנבחר (%1) הוא לא חוקי עבור גליון %2"

--- a/lib/WeBWorK/Localize/hu.po
+++ b/lib/WeBWorK/Localize/hu.po
@@ -1,0 +1,8833 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# 
+# Translators:
+# pcsiba <pcsiba@gmail.com>, 2014,2016-2017
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: Hungarian (http://www.transifex.com/webwork/webwork2/language/hu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+msgid "#corr"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+msgid "#incorr"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
+msgid "% correct"
+msgstr "% helyes"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
+msgid "% correct with review"
+msgstr "% ellenőrzéssel helyes "
+
+# Percent students
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+msgid "% students"
+msgstr "% diák"
+
+#. ($prettySetID)
+#. ($prettyProblemID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+msgid "%1 (old editor)"
+msgstr "%1 (régi szerkesztő)"
+
+#. ($display_name, $vnum)
+# Gateway (test 3)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
+msgid "%1 (test %2)"
+msgstr "%1 (%2 teszt)"
+
+#. ($achievement->{points})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
+msgid "%1 Points:"
+msgstr "%1 pont"
+
+#. ($name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
+msgid "%1 Problems:"
+msgstr "%1 feladat"
+
+#. ($numAdded, $numSkipped, join(", ", @$skipped)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
+msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
+msgstr "%1 feladatsor hozzáadva, %2 feladatsor átugorva. Az átugrott feladatsorok: (%3)"
+
+#. ($numExported, $numSkipped, (($numSkipped)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
+msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
+msgstr "%1 feladatsor exportálva, %2 feladatsor átugorva. Az átugrott feladatsorok: (%3) "
+
+#. ($count, $numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
+msgid "%1 students out of %2"
+msgstr "%1 diák a %2 közül"
+
+#. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle,
+#. $rename_oldCourseInstitution, $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
+msgstr "A %1 kurzus címe %2 -ról(ről) %3 - ra(re) és intézménye %4 -ról(ről) %5 - ra(re) változott "
+
+#. (scalar @userIDsToExport, $dir, $fileName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+msgid "%1 users exported to file %2/%3"
+msgstr "%1 felhasználó exportálva a %2/%3 állományba"
+
+#. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+msgid ""
+"%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
+msgstr "%1 felhasználó cserélve, %2 hozzáadva, %3 átugorva. Az átugrott feladatsorok: (%4) "
+
+#. (CGI::strong($course)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:202
+msgid ""
+"%1 uses an external authentication system (e.g., Oncourse,  CAS,  "
+"Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try"
+" again."
+msgstr "%1 külső autentikációs  rendszert (pl. Oncourse, CAS, Blackboard, Moodle, Canvas, etc.) használ. Kérem térjen vissza a használt rendszerbe és próbálja meg újra."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:97
+msgid ""
+"%1 uses an external authentication system.  You've authenticated through "
+"that system, but aren't allowed to log in to this course."
+msgstr "%1 külső autentikációs  rendszert használ. Önt ez a rendszer hitelesítette, de nincs engedélyezve a belépése ebbe a kurzusba."
+
+#. ($levelpercentage)
+#. ($percentage)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
+msgid "%1% Complete"
+msgstr "%1% teljesítve"
+
+#. (wwRound(0, $answerScore*100)
+#. (int($answerScore*100)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+msgid "%1% correct"
+msgstr "%1% helyes"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
+msgid "%1's Current Address"
+msgstr "%1 jelenlegi címe"
+
+#. ($user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
+msgid "%1's Current Password"
+msgstr "%1 jelenlegi jelszava"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
+msgid "%1's New Address"
+msgstr "%1 új címe"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
+msgid "%1's New Password"
+msgstr "%1 új jelszava"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
+msgid "%1's new password cannot be blank."
+msgstr "%1 új jelszava nem lehet üres"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
+msgid "%1's password has been changed."
+msgstr "%1 jelszava megváltozott."
+
+#. ($setID, $problemID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+msgid "%1: Problem %2"
+msgstr "%1: %2 feladata"
+
+#. ($setID, $problemID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
+msgid "%1: Problem %2 Show Me Another"
+msgstr ""
+
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+msgid "%1: The directory for the course not found."
+msgstr "%1: Ennek a kurzusnak a könyvtára nem található."
+
+#. ($succeeded_count)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+msgid "%quant(%1,course was, courses were) successfully unhidden."
+msgstr ""
+
+#. ($num)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:297
+msgid "%quant(%1,error) occured while generating hardcopy:"
+msgstr ""
+
+#. ($n)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:802
+msgid "%quant(%1,file) unpacked successfully"
+msgstr ""
+
+#. ($numBlanks)
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+msgid ""
+"%quant(%1,of the questions remains,of the questions remain) unanswered."
+msgstr "%quant(%1,kérdés maradt,kérdés maradt) megválaszolatlan."
+
+#. ($succeeded_count)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+msgid "%quant_1( course was, courses were) successfully hidden."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+msgid "%score"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+msgid "(Any unsaved changes will be lost.)"
+msgstr "(Minden nem mentett változtatás el fog veszni.)"
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+msgid ""
+"(Instructor hint preview: show the student hint after the following number "
+"of attempts:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+msgid "(This problem will not count towards your grade.)"
+msgstr "(Ez a feladat nem számít be az értékelésbe.)"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+msgid ""
+"(This test is overtime because it was not submitted in the allowed time.)"
+msgstr ""
+
+#. ($testNoun, $self->formatDateTime($set->answer_date)
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+msgid "(Your score on this %1 is not available until %2.)"
+msgstr ""
+
+#. ($testNoun)
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+msgid "(Your score on this %1 is not available.)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
+msgid "(correct)"
+msgstr "(helyes)"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
+msgid "(gw/quiz) After version answer date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
+msgid "(incorrect)"
+msgstr "(helytelen)"
+
+#. ($recScore)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
+msgid "(score %1)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
+msgid "1 student"
+msgstr "1 diák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
+msgid ""
+"<p>After the Reduced Scoring Date all additional work done by the student "
+"counts at a reduced rate. Here is where you set the reduced rate which must "
+"be a percentage. For example if this value is 50% and a student views a "
+"problem during the Reduced Scoring Period, they will see the message \"You "
+"are in the Reduced Scoring Period: All additional work done counts 50% of "
+"the original.\" </p><p>To use this, you also have to enable Reduced Scoring "
+"and set the Reduced Scoring Date for individual assignments by editing the "
+"set data using the Hmwk Sets Editor.</p><p>This works with the "
+"avg_problem_grader (which is the the default grader) and the "
+"std_problem_grader (the all or nothing grader). It will work with custom "
+"graders if they are written appropriately.</p>"
+msgstr ""
+
+# Leave HTML in place
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
+msgid ""
+"<p>When viewing a problem, users may choose different methods of rendering "
+"formulas via an options box in the left panel. Here, you can adjust what "
+"display modes are listed.</p><p>Some display modes require other software to"
+" be installed on the server. Be sure to check that all display modes "
+"selected here work from your server.</p><p>The display modes are <ul><li> "
+"plainText: shows the raw LaTeX srings for formulas.<li> images: produces "
+"images using the external programs LaTeX and dvipng.<li> MathJax: a "
+"successor to jsMath, uses javascript to place render "
+"mathematics.</ul></p></p>You must use at least one display mode. If you "
+"select only one, then the options box will not give a choice of modes (since"
+" there will only be one active).</p>"
+msgstr ""
+
+# Leave HTML in place
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
+msgid ""
+"<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
+"new problem</i> when Show Me Another is clicked</li> "
+"<li><b>SMAshowSolutions</b>: shows walk-through solution <i>for the new "
+"problem</i> when Show Me Another is clicked; a check is done first to make "
+"sure that a solution exists </li><li><b>SMAshowCorrect</b>: correct answers "
+"<i>for the new problem</i> can be viewed when Show Me Another is clicked; "
+"note that <b>SMAcheckAnswers</b> needs to be enabled at the same "
+"time</li><li><b>SMAshowHints</b>: show hints <i>for the new problem</i> "
+"(assuming they exist)</li></ul>Note: there is very little point enabling the"
+" button unless you check at least one of these options - the students would "
+"simply see a new version that they can not attempt or learn from.</p>"
+msgstr ""
+
+#. ($add_courseID)
+#. ($rename_newCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+msgid "A course with ID %1 already exists."
+msgstr "Ezzel az azonosítóvall (ID %1) már létezik kurzus!"
+
+#. ($courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+msgid ""
+"A directory already exists with the name %1. You must first delete this "
+"existing course before you can unarchive."
+msgstr "Ezzel a névvel (%1) már létezik könyvtár. Önnek előbb törölnie kell ezt a létező kurzust, mielőtt vissza tudná állítani az archívumból."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
+msgid "A file with that name already exists"
+msgstr "Ilyen nevű állomány már létezik."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
+msgid ""
+"A hardcopy file was generated, but it may not be complete or correct. Please"
+" check that no problems are missing and that they are all legible. If not, "
+"please inform your instructor."
+msgstr ""
+
+#. ($locationID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+msgid ""
+"A location with the name %1 already exists in the database.  Did you mean to"
+" edit that location instead?"
+msgstr ""
+
+#. ($subject, $number_of_recipients, $courseName, $failed_messages)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+msgid ""
+"A message with the subject line \"%1\" has been sent to %quant(%2,recipient)"
+" in the class %3.  There were %4 message(s) that could not be sent."
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+msgid "A new file has been created at '%1'"
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
+msgid ""
+"A new file has been created at '%1' with the contents below.  No changes "
+"have been made to set %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
+msgid ""
+"A period (.) indicates a problem has not been attempted, and a number from 0"
+" to 100 indicates the grade earned. The number on the second line gives the "
+"number of incorrect attempts."
+msgstr ""
+
+# Leave symbol codes in place
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
+msgid ""
+"A switch to govern the use of a Progress Bar for the student; this also "
+"enables/disables the highlighting of the current problem in the side bar, "
+"and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
+"(&#x2717;), or unattempted (no symbol)."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:101
+msgid ""
+"A table showing all the current users along with several fields of user "
+"information. The fields from left to right are: Login Name, Login Status, "
+"Assigned Sets, First Name, Last Name, Email Address, Student ID, Enrollment "
+"Status, Section, Recitation, Comments, and Permission Level.  Clicking on "
+"the links in the column headers will sort the table by the field it "
+"corresponds to. The Login Name fields contain checkboxes for selecting the "
+"user.  Clicking the link of the name itself will allow you to act as the "
+"selected user.  There will also be an image link following the name which "
+"will take you to a page where you can edit the selected user's information."
+"  Clicking the emails will allow you to email the corresponding user.  "
+"Clicking the links in the entries in the assigned sets columns will take you"
+" to a page where you can view and reassign the sets for the selected user."
+msgstr ""
+
+# Short for ADJUSTED STATUS
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+msgid "ADJ STATUS"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+msgid "ANSWERS NOT RECORDED"
+msgstr "A VÁLASZ NINCS ELMENTVE"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+msgid "ANSWERS NOT RECORDED --"
+msgstr "A VÁLASZ NINCS ELMENTVE --"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+msgid "ANSWERS ONLY CHECKED -- "
+msgstr "A VÁLASZ CSAK ELLENŐRIZVE LETT --"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
+msgstr "A VÁLASZ CSAK ELLENŐRIZVE - A VÁLASZ NICS RÖGZÍTVE"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+msgid "Abandon changes"
+msgstr "A változások elhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
+msgid "Abandon export"
+msgstr "Az export elhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
+msgid "Achievement"
+msgstr "Eredmény"
+
+#. ($targetAchievementID, $self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+msgid "Achievement %1 created with evaluator '%2'."
+msgstr "'%2' értékelő létrehozta a %1 eredményt."
+
+#. ($newAchievementID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+msgid "Achievement %1 exists.  No achievement created"
+msgstr "%1 eredmény már létezik. Az eredmény-típus nem lett létrehozva"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
+msgid "Achievement Editor"
+msgstr "Eredmény szerkesztő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:726
+msgid "Achievement Evaluator Editor"
+msgstr "Eredmény-értékelő szerkesztő"
+
+#. ($achievementID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:173
+msgid "Achievement Evaluator for achievement %1"
+msgstr "%1 eredmény értékelője"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+msgid "Achievement ID"
+msgstr "Eredmény-azonosító"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+msgid "Achievement ID exists!  No new achievement created.  File not saved."
+msgstr "Ez az eredmény-azonosító már létezik! Nem lett új eredmény-katégória  "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:202
+msgid "Achievement Points Per Problem"
+msgstr "Feladatonkénti eredmény-pontok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:736
+msgid "Achievement User Editor"
+msgstr "Felhasználói eredményszerkesztő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
+msgid "Achievement has been assigned to all users."
+msgstr "Az eredmény hozzá lett rendelve az összes felhasználóhoz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
+msgid "Achievement has been unassigned to all students."
+msgstr "Az eredmény-hozzárendelés vissza lett vonva az összes diáknál"
+
+#. (CGI::a({href=>$fileManagerURL},$scoreFileName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+msgid "Achievement scores saved to %1"
+msgstr "Az eredmények pontszáma el lett mentve ehhez: %1 "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
+msgid "Achievements"
+msgstr "Eredmények"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
+msgid "Act as"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:159
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:161
+msgid "Act as:"
+msgstr ""
+
+#. (HTML::Entities::encode_entities($eUserID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+msgid "Acting as %1."
+msgstr ""
+
+#. ($actionID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+msgid "Action %1 not found"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+msgid "Active"
+msgstr "Aktív"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:198
+msgid ""
+"Activiating this will enable Mathchievements for webwork.  Mathchievements "
+"can be managed by using the Achievement Editor link."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:208
+msgid ""
+"Activiating this will enable achievement items. This features rewards "
+"students who earn achievements with items that allow them to affect their "
+"homework in a limited way."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
+msgid "Add"
+msgstr "Hozzáadás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:942
+msgid "Add All"
+msgstr "Mindet add hozzá"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+msgid "Add Course"
+msgstr "Kurzus hozzáadása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
+msgid "Add Students"
+msgstr "Diák hozzáadása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
+msgid "Add Users"
+msgstr "Felhasználók hozzáadása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+msgid "Add WeBWorK administrators to new course"
+msgstr "Add hozzá az új kurzushoz annak WeBWorK adminisztrátorait"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1384
+msgid "Add a new test for which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+msgid "Add as what filetype?"
+msgstr "Milyen állomány(fájl)típusként adja hozzá?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+msgid "Add how many students?"
+msgstr "Hány diákot adjon hozzá?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
+msgid "Add problems to"
+msgstr "A feladat hozzáadása ehhez:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+msgid "Add to what set?"
+msgstr "Melyik feladatsorhoz adja hozzá?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+msgid "Add which new users?"
+msgstr "Hány felhasználót adjon hozzá?"
+
+#. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ?
+#. join('.',jitar_id_to_seq($targetProblemNumber)
+#. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ?
+#. join('.',jitar_id_to_seq($targetProblemNumber)
+#. ($new_file_path, $setID, $targetProblemNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+msgid "Added %1 to %2 as problem %3"
+msgstr ""
+
+#. ($self->shortPath($sourceFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+msgid "Added '%1' to %2 as new hardcopy header"
+msgstr ""
+
+#. ($self->shortPath($sourceFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+msgid "Added '%1' to %2 as new set header"
+msgstr ""
+
+#. (join(', ', @toAdd)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+msgid "Added addresses %1 to location %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:409
+msgid "Additional addresses for receiving feedback e-mail."
+msgstr ""
+
+#. ($badLocAddr)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+msgid ""
+"Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
+"Please double check the integrity of the WeBWorK database before continuing."
+msgstr ""
+
+#. (join(', ', @noAdd)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+msgid ""
+"Address(es) %1 in the add list is(are) already in the location %2, and so "
+"were skipped."
+msgstr ""
+
+#. (join(', ', @noDel)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+msgid ""
+"Address(es) %1 in the delete list is(are) not in the location %2, and so "
+"were skipped."
+msgstr ""
+
+#. ($badAddr)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+msgid ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and resubmit."
+msgstr ""
+
+#. ($badAddr)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+msgid ""
+"Address(es) %1 is(are) not in a recognized form.  Please check your data "
+"entry and try again."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+msgid "Addresses"
+msgstr "Címek"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+msgid ""
+"Addresses for new location.  Enter one per line, as single IP addresses "
+"e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges "
+"(e.g., 192.168.1.101-192.168.1.150)):"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+msgid ""
+"Addresses to add to the location.  Enter one per line, as single IP "
+"addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP"
+" ranges (e.g., 192.168.1.101-192.168.1.150)):"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:190
+msgid "Adds 24 hours to the close date of a homework."
+msgstr "A házi feladat lezárásának meghosszabbítása 24 órával"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:273
+msgid "Adds 48 hours to the close date of a homework."
+msgstr "A házi feladat lezárásának meghosszabbítása 48 órával"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+msgid "Adjusted Status"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:595
+msgid "Advanced Search"
+msgstr "Bővített keresés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
+msgid "After set answer date"
+msgstr ""
+
+#. ($reducedScoringPerCent)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+msgid ""
+"After the reduced scoring period begins all work counts for %1% of its "
+"value."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715
+msgid "All Selected Constraints Joined by \"And\""
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:52
+msgid "All assignments were made successfully."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+msgid "All of the answers above are correct."
+msgstr "Az összes fenti válasz helyes."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+msgid "All of the gradeable answers above are correct."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+msgid "All of these files will also be made available for mail merge."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
+msgid "All selected sets hidden from all students"
+msgstr "Az összes kiválasztott feladatsor elrejtve az összes diák elől"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
+msgid "All selected sets made visible for all students"
+msgstr "Az összes kiválasztott feladatsor láthatóvá téve az összes diák számára"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
+msgid "All sets hidden from all students"
+msgstr "Az összes feladatsor elrejtve az összes diák elől"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
+msgid "All sets made visible for all students"
+msgstr "Az összes feladatsor láthatóvá téve az összes diák számára"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+msgid "All students in course"
+msgstr "A kurzus összes diákja"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:57
+msgid "All unassignments were made successfully."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
+msgid "All visible hidden from all students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
+msgid "All visible sets made visible for all students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
+msgid "Allow unassign"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
+msgid "Allowed error, as a percentage, for numerical comparisons"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
+msgid "Allowed to <em>act as</em> another user"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
+msgid "Allowed to change their e-mail address"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
+msgid "Allowed to change their password"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
+msgid "Allowed to login to the course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
+msgid "Allowed to see solutions before the answer date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:324
+msgid "Allowed to see the correct answers before the answer date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
+msgid "Allowed to view past answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
+msgid "Allowed to view problems in sets which are not open yet"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1441
+msgid "Amulet of Extension"
+msgstr ""
+
+#. ($archive_courseID)
+#. ($unarchive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+msgid "An error occured while archiving the course %1:"
+msgstr ""
+
+#. ($rename_oldCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+msgid "An error occured while changing the title of the course %1."
+msgstr ""
+
+#. ($delete_courseID)
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+msgid "An error occured while deleting the course %1:"
+msgstr ""
+
+#. ($rename_oldCourseID, $rename_newCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+msgid "An error occured while renaming the course %1 to %2:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:475
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:805
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:828
+msgid "Answer Date"
+msgstr "A válasz dátuma"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
+msgid "Answer Log"
+msgstr "A válaszok naplója"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+msgid "Answer Preview"
+msgstr "A válasz megmutatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1268
+msgid "Answer(s) submitted:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
+msgid "Answer:"
+msgstr "Válasz:"
+
+# Leave out spaces
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+msgid "AnswerGroupInfo"
+msgstr ""
+
+# Leave out spaces
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+msgid "AnswerHashInfo"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
+msgid "Answers"
+msgstr "Válaszok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
+msgid "Answers Available"
+msgstr "Válaszok engedélyezve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
+msgid "Answers cannot be due until on or after the open date!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1050
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1123
+msgid "Answers cannot be made available until on or after the close date!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
+msgid "Any changes made below will be reflected in the set for ALL students."
+msgstr "Bármely fenti változás a feladatsorban alkalmazódik az összes diákra."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+msgid ""
+"Any changes made below will be reflected in the set for ONLY the student(s) "
+"listed above."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
+msgid ""
+"Any time problem numbers are intentionally changed, the problems will always"
+" be renumbered consecutively, starting from one.  When deleting problems, "
+"gaps will be left in the numbering unless the box above is checked."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+msgid "Append"
+msgstr ""
+
+#. (CGI::strong("$fullSetID")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
+msgid "Append to end of %1 set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+msgid "Archive"
+msgstr ""
+
+#. ($archive, $n)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
+msgid "Archive '%1' created successfully (%quant( %2, file))"
+msgstr ""
+
+#. ($name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:938
+msgid "Archive '%1' deleted"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+msgid "Archive Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+msgid "Archive Courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+msgid "Archive next course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+msgid "Archive this Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+msgid "Archived Courses"
+msgstr ""
+
+#. ($courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
+msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
+msgstr ""
+
+#. (CGI::b($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+msgid ""
+"Are you sure that you want to delete the course %1 after archiving? This "
+"cannot be undone!"
+msgstr ""
+
+#. (CGI::b($delete_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+msgid ""
+"Are you sure you want to delete the course %1? All course files and data "
+"will be destroyed. There is no undo available."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
+msgid "Assign"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
+msgid "Assign All Sets to Current User"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
+msgid "Assign selected sets to selected users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
+msgid "Assign this set to which users?"
+msgstr "Mely felhasználókhoz rendelje ezt a feladatsort?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
+msgid "Assign to All Current Users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+msgid "Assigned"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+msgid "Assigned Sets"
+msgstr "Hozzárendelt feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+msgid "Assigned achievements to users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+msgid "Assigned to"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
+msgid "Assignment type"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+msgid "At least one of the answers above is NOT correct."
+msgstr ""
+
+# Short for "Attempts to Open Children"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
+msgid "Att. to Open Children"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+msgid "Attempt to upgrade directories"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
+msgid "Attempted"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+msgid "Attempts"
+msgstr "Próbálkozások"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
+msgid "Audit"
+msgstr "ellenőrzés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+msgid "Authentication failed.  Please speak to your instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+msgid "Author Info"
+msgstr "Szerző adatai"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
+msgid "Automatic"
+msgstr "Automatikus"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+msgid "Automatically render problems on page load"
+msgstr ""
+
+#. ($emailDirectory,$old_default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+msgid "Backup file <code>%1/%2</code> created."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:745
+msgid "Basic Search"
+msgstr "Alap keresés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
+msgid "Binary"
+msgstr "Bináris"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1163
+msgid "Box of Transmogrification"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:885
+msgid "Browse"
+msgstr "Keres"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:812
+msgid "Browse from:"
+msgstr "Keresés innen:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
+msgid ""
+"By default, feeback is always sent to all users specified to recieve "
+"feedback.  This variable sets the system to only email feedback to users who"
+" have the same section as the user initiating the feedback.  I.E.  Feedback "
+"will only be sent to section leaders."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:410
+msgid ""
+"By default, feeback is sent to all users above who have permission to "
+"receive feedback. Feedback is also sent to any addresses specified in this "
+"blank. Separate email address entries by commas."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+msgid "CLOSE DATE"
+msgstr "A lezárás dátuma"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+msgid "CLOSE TIME"
+msgstr "A lezárás ideje"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
+msgid "Cake of Enlargment"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
+msgid "Can e-mail instructor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
+msgid "Can report bugs"
+msgstr "Be lehet jelenteni a hibákat "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
+msgid "Can show old answers"
+msgstr "Meg tudja mutatni a régi válaszokat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
+msgid "Can submit answers for a student"
+msgstr "El tudja fogadni a válaszokat a diáknak"
+
+#. ($!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
+msgid "Can't copy file: %1"
+msgstr "Nem tudja a %1 állományt másolni"
+
+#. ($archive,systemError($?)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
+msgid "Can't create archive '%1': command returned %2"
+msgstr "Nem lehet létrehozni a '%1' archívumot: a parancs %2 hibaüzenetet adott"
+
+#. ($courseID,  $@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+msgid "Can't create course environment for %1 because %2"
+msgstr "Nem lehet létrehozni %1 számára a kurzuskörnyezetet, mert %2 "
+
+#. ($!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
+msgid "Can't create directory: %1"
+msgstr "Nem lehet létrehozni a %1 könvytárat"
+
+#. ($name, $!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
+msgid "Can't create file '%1': %2"
+msgstr "Nem lehet létrehozni a '%1' állományt: %2 "
+
+#. ($!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
+msgid "Can't create file: %1"
+msgstr "Nem lehet létrehozni a '%1' állományt"
+
+#. ($name, $!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
+msgid "Can't delete archive '%1': %2"
+msgstr "Nem lehet törölni a '%1' archívumot: %2"
+
+#. ($eUserID,$@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
+msgid "Can't get password record for effective user '%1': %2"
+msgstr "Nem kapható meg %1 aktív felhasználó jelszó rekordját: %2"
+
+#. ($userID,$@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
+msgid "Can't get password record for user '%1': %2"
+msgstr "Nem kapható meg %1 felhasználó jelszó rekordját: %2"
+
+#. ($filePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+msgid "Can't open %1"
+msgstr "Nem lehet megnyitni ezt: %1"
+
+#. ($filePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+msgid "Can't open file %1"
+msgstr "Nem lehet megnyitni a %1 állományt"
+
+#. ($merge_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+msgid "Can't read merge file %1. No message sent"
+msgstr "A %1 egyesített állomány nem olvasható. Nem lett üzenet küldve"
+
+#. ($!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
+msgid "Can't rename file: %1"
+msgstr "Nem lehet átnevezni a %1 állományt"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+msgid "Can't rename to the same name."
+msgstr "Nem lehet átnevezni  ugyanarra a névre"
+
+#. ($archive,systemError($?)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:805
+msgid "Can't unpack '%1': command returned %2"
+msgstr ""
+
+#. ($!)
+#. ($fullPath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+msgid "Can't write to file %1"
+msgstr "Nem lehet írni a %1 állományba"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
+msgid "Cancel"
+msgstr "Mégse"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+msgid "Cancel E-mail"
+msgstr ""
+
+#. ($filePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
+msgid "Cannot open %1"
+msgstr "Nem lehet megnyitni %1 -t"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
+msgid "Cap Test Time at Set Close Date?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+msgid "Category"
+msgstr "Kategória"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:451
+msgid ""
+"Cause the selected homework set to count for twice as many points as it "
+"normally would."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1164
+msgid ""
+"Causes a homework problem to become a clone of another problem from the same"
+" set."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
+msgid "Causes a single homework problem to be worth twice as much."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+msgid "Change Course Title to:"
+msgstr "A kurzus címének változtatása erre:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+msgid "Change CourseID to:"
+msgstr "A kurzusazonosító megváltoztatása erre:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
+msgid "Change Display Settings"
+msgstr "A megjelenítési beállítások megváltoztatása "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
+msgid "Change Email Address"
+msgstr "Az e-mai cím változtatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+msgid "Change Institution to:"
+msgstr "Az intézmény megváltoztatása erre:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
+msgid "Change Password"
+msgstr "A jelszó változtatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+msgid "Change User Settings"
+msgstr "A felhasználói beállítások megváltoztatása"
+
+#. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+msgid "Change course institution from %1 to %2"
+msgstr "Az kurzus intézményének %1 -ról(ről) %2 -ra(re) változtatása"
+
+#. ($rename_oldCourseTitle, $rename_newCourseTitle)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+msgid "Change title from %1 to %2"
+msgstr "A cím %1 -ról(ről) %2 -ra(re) változtatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+msgid "Changes abandoned"
+msgstr "A változtatások elhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+msgid "Changes in this file have not yet been permanently saved."
+msgstr "Az állomány változásait jelenleg nem menthetőek véglegesen."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+msgid "Changes saved"
+msgstr "A változtatások mentve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1354
+msgid ""
+"Changing the problem seed for display, but there are no problems showing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:598
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:727
+msgid "Chapter:"
+msgstr "Fejezet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+msgid "Check Answers"
+msgstr "A válaszok ellenőrzése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+msgid "Check Test"
+msgstr "A teszt ellenőrzése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+msgid "Check that it's permissions are set correctly."
+msgstr "Ellenőrizze, hogy a jogosultságai helyesen lettek beállítva"
+
+#. ($emailDirectory)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+msgid ""
+"Check whether it exists and whether the directory %1 can be read by the "
+"webserver."
+msgstr "Ellenőrizze, hogy létezik-e és olvasható-e a webszerveren a %1 könyvtár."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+msgid "Checking additional error messages"
+msgstr "További hibaüzenetek ellenőrzése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:477
+msgid "Choose the set which you would like to be worth twice as much."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:386
+msgid "Choose the set which you would like to enable partial credit for."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
+msgid "Choose the set which you would like to ressurect."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
+msgid "Choose the set whose close date you would like to extend."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
+msgid "Choose visibility of the sets to be affected"
+msgstr "Válassza ki az érintett feladatsorok láthatóságát"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
+msgid "Choose which sets to be affected"
+msgstr "Válassza ki mely feladotsorok legyenek érintettek"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:523
+msgid "Class values"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
+msgid "Classlist Editor"
+msgstr "Osztálynévsor szerkesztése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
+msgid "Clear"
+msgstr "Töröl"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
+msgid "Clear Problem Display"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
+msgid ""
+"Click on a student's name to see the student's version of the homework set. "
+"Click heading to sort table."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+msgid ""
+"Click on the login name to edit individual problem set data, (e.g. due "
+"dates) for these students."
+msgstr "Kattintson a bejelentkezési névre ezen diákok feladatsorainak adatainak egyéni módosításához (pl. határidők)."
+
+#. ($clientIP->ip()
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
+msgid ""
+"Client ip address %1 is not allowed to work this assignment, because the "
+"assignment has ip address restrictions and there are no allowed locations "
+"associated with the restriction.  Contact your professor to have this "
+"problem resolved."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+msgid "Close"
+msgstr "Lezárás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:474
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:804
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+msgid "Close Date"
+msgstr "Dátum lezárása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
+msgid "Closed, answers available."
+msgstr "Lezárva, válaszadás lehetséges"
+
+#. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
+msgid "Closed, answers on %1."
+msgstr "Lezárva, válaszadás eddig: %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
+msgid "Closed, answers recently available."
+msgstr "Lezárva, válaszadás jelenleg lehetséges"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
+msgid "Closed."
+msgstr "Lezárva"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
+msgid "Closes"
+msgstr "Lezárás"
+
+#. ($self->formatDateTime($set->due_date,undef,
+#. $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+msgid "Closes %1"
+msgstr "Lezárás ekkor: %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
+msgid "Closes:"
+msgstr "Lezárás:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+msgid "Collapse"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+msgid "Collapse All"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#. ($self->formatDateTime($set->answer_date)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+msgid "Completed results for this assignment are not available until %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+msgid "Completed results for this assignment are not available."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
+msgid "Completed."
+msgstr "Teljesítve."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+msgid "Confirm"
+msgstr "Megerősít"
+
+#. ($e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
+msgid "Confirm %1's New Password"
+msgstr "%1 új jelszavának jóváhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+msgid "Confirm Password:"
+msgstr "Erősítse meg a jelszót:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
+msgid "Congratulations, you earned a new level!"
+msgstr "Gratulálunk, Ön egy új szintet ért el!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
+msgid "Continue"
+msgstr "Folytatás"
+
+#. ($sourceDirectory, $outputDirectory)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+msgid "Copied auxiliary files from %1 to new location at %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
+msgid "Copy"
+msgstr "Másol"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:625
+msgid "Copy file as:"
+msgstr "Másolja az állományt mint:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+msgid "Copy templates from:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
+msgid "Copy this Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
+msgid "Correct"
+msgstr "Helyes"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:644
+msgid "Correct Adjusted Status"
+msgstr "Helyes módosított állapot"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+msgid "Correct Answer"
+msgstr "Helyes válasz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
+msgid "Correct Answers:"
+msgstr "Helyes válaszok:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
+msgid "Correct Status"
+msgstr "Helyes állapot"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
+msgid "Correct answers"
+msgstr "Helyes válaszok"
+
+#. ($total_correct,$num_of_problems)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+msgid "Correct: %1/%2"
+msgstr "Helyes: %1/%2"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+msgid "CorrectAnswers"
+msgstr "HelyesVálasz"
+
+#. ($newBlankProblems, $MAX_NEW_PROBLEMS)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+msgid ""
+"Could not add %1 problems to this set.  The number must be between 1 and %2"
+msgstr "Nem lehet hozzáadni %1 feladatot ehhez a feladatsorhoz. A számnak 1 és %2 között kell lennie."
+
+#. ($e_user_name,$@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
+msgid "Couldn't change %1's password: %2"
+msgstr "Nem lehet véltoztatni %1 ezen jelszaván: %2"
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
+msgid "Couldn't change your email address: %1"
+msgstr "Nem lehet változtatni az Ön %1 e-mail címén"
+
+#. ($LibraryBranch, $LibraryRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+msgid "Couldn't find OPL Branch %1 in remote %2"
+msgstr ""
+
+#. ($PGBranch, $PGRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+msgid "Couldn't find PG Branch %1 in remote %2"
+msgstr ""
+
+#. ($WeBWorKBranch, $WeBWorKRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+msgid "Couldn't find WeBWorK Branch %1 in remote %2"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+msgid "Couldn't save your display options: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+msgid "Counter"
+msgstr "Számláló"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+msgid "Counts for Parent"
+msgstr ""
+
+#. ($rename_oldCourseID)
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+msgid "Course %1 database is in order"
+msgstr ""
+
+#. ($rename_oldCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+msgid "Course %1 databases must be updated before renaming this course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
+msgid "Course Administration"
+msgstr "Kurzus adminisztráció"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
+msgid "Course Configuration"
+msgstr "Kurzus konfiguráció"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
+msgstr "A kurzusazonosító csak betűt, számot, kötőjelet és alulvonást tartalmazhat."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+msgid "Course ID:"
+msgstr "Kurzus azonosító"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
+msgid "Course Info"
+msgstr "Kurzus infó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+msgid "Course Name:"
+msgstr "A kurzus neve:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+msgid "Course Title:"
+msgstr "A kurzus címe"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
+msgid "Course archived."
+msgstr "A kurzus archiválva lett."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
+msgid "Courses"
+msgstr "Kurzusok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+msgid ""
+"Courses are listed either alphabetically or in order by the time of most "
+"recent login activity, oldest first. To change the listing order check the "
+"mode you want and click \"Refresh Listing\".  The listing format is: "
+"Course_Name (status :: date/time of most recent login) where status is "
+"\"hidden\" or \"visible\"."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
+msgid "Create"
+msgstr "Létrehozás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
+msgid "Create CSV"
+msgstr "CSV létrehozása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+msgid "Create Location:"
+msgstr "Elhelyezkedés létrehozása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
+msgid "Create a New Set in This Course:"
+msgstr "Új feladatsor létrehozása ebben a kurzusban:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+msgid "Create a new achievement with ID"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
+msgid "Create as what type of set?"
+msgstr "Milyen típusú feladatsort kíván létrehozni?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
+msgid "Create unattached problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+msgid ""
+"Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
+"directory. Before archiving, the course database is dumped into a "
+"subdirectory of the course's DATA directory. Currently the archive facility "
+"is only available for mysql databases. It depends on the mysqldump "
+"application."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:648
+msgid "Cupcake of Enlargement"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+msgid "Current"
+msgstr "Jelenlegi"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+msgid "Currently defined locations are listed below."
+msgstr "A jelenleg meghatározott elhelyezkedés alább van felsorolva."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+msgid "Data"
+msgstr "Adat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+msgid "Database tables are ok"
+msgstr "Az adatbázis táblák rendben vannak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+msgid "Database tables need updating."
+msgstr "Az adatbázis táblákat frissíteni kell"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+msgid "Database tables ok"
+msgstr "Az adatbázis táblák rendben vannak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+msgid "Database:"
+msgstr "Adatbázis:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
+msgid "Date"
+msgstr "Dátum"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
+msgid "Debug"
+msgstr "Hibakeresés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
+msgid "Default"
+msgstr "Alapértelmezett"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:189
+msgid ""
+"Default Amount of Time (in minutes) after Due Date that Answers are Open"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:183
+msgid ""
+"Default Amount of Time (in minutes) before Due Date that the Assignment is "
+"Open"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:247
+msgid "Default Length of Reduced Scoring Period in minutes"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:177
+msgid "Default Time that the Assignment is Due"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+msgid "Delete"
+msgstr "Törlés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+msgid "Delete Course"
+msgstr "Kurzus törlése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+msgid "Delete all existing addresses"
+msgstr "Törli az összes létező címet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+msgid "Delete course after archiving. Caution there is no undo!"
+msgstr "Az archiválás után törli a kurzust. Vigyázat nincs utólagos visszavonási lehetőség!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+msgid "Delete course:"
+msgstr "Ezen kurzusok törlése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+msgid "Delete how many?"
+msgstr "Mennyit töröljön?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+msgid "Delete it?"
+msgstr "Törli?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+msgid "Delete location:"
+msgstr "Törli az elhelyezkedést:"
+
+#. ($num)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+msgid "Deleted %quant(%1,achievement)"
+msgstr ""
+
+#. (join(', ', @delLocations)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+msgid "Deleted Location(s): %1"
+msgstr "Törli az elhelyezkedés(eke)t: %1 "
+
+#. (join(', ', @toDel)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+msgid "Deleted addresses %1 from location."
+msgstr "Törli a %1 címeket az elhelyezkedésből."
+
+#. ($self->shortPath($self->{tempFilePath})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+msgid "Deleting temp file at %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+msgid ""
+"Deletion deletes all location data and related addresses, and is not "
+"undoable!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+msgid "Deletion destroys all achievement-related data and is not undoable!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
+msgid "Deletion destroys all set-related data and is not undoable!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+msgid "Deletion destroys all user-related data and is not undoable!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
+msgid "Deny From"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
+msgid "Description"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+msgid "Didn't recognize action"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
+msgid "Directory"
+msgstr "Könyvtár"
+
+#. ($file, $!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
+msgid "Directory '%1' not removed: %2"
+msgstr "%1 könyvtár nem lett törölve: %2"
+
+#. ($file, $removed)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:678
+msgid "Directory '%1' removed (items deleted: %2)"
+msgstr "%1 könyvtár törölve (a törölt elemek száma: %2)"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+msgid "Directory permission errors "
+msgstr "Hiba a könyvtárhoz való hozzáféréssel"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+msgid "Directory structure"
+msgstr "Könyvtárstruktúra"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+msgid ""
+"Directory structure is missing directories or the webserver lacks sufficient"
+" privileges."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+msgid "Directory structure is ok"
+msgstr "A könyvtárstruktúra OK"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+msgid "Directory structure needs to be repaired manually before archiving."
+msgstr "Az archiválás előtt a könyvtárstruktúrát kézileg helyre kell állítani. "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+msgid "Directory structure needs to be repaired manually before renaming."
+msgstr "Az átnevezés előtt a könyvtárstruktúrát kézileg helyre kell állítani."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+msgid "Directory structure or permissions need to be repaired. "
+msgstr "A könyvtárstruktúrát vagy jogosultságait helyre kell állítani."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
+msgid "Display Mode:"
+msgstr "Megjelenítési mód:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
+msgid "Display Past Answers"
+msgstr "Mutasd a legutóbbi választ"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
+msgid "Display options: Show"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
+msgid "Display the evaluated student answer"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
+msgid "Do not unassign students unless you know what you are doing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:274
+msgid "Do not uncheck a set unless you know what you are doing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
+msgid "Do not uncheck students, unless you know what you are doing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+msgid "Don't Archive"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+msgid "Don't Unarchive"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+msgid "Don't Upgrade"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+msgid "Don't delete"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+msgid "Don't make changes"
+msgstr ""
+
+#. ($saveMode)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+msgid "Don't recognize saveMode: |%1|. Unknown error."
+msgstr ""
+
+#. ($type)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
+msgid "Don't recognize statistics display type: |%1|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+msgid "Don't rename"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+msgid "Don't use in an achievement"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+msgid "Done"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:69
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
+msgid "Download"
+msgstr ""
+
+#. ($set->set_id)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
+msgid "Download %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:267
+msgid "Download Hardcopy"
+msgstr ""
+
+#. ($pl)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
+msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
+msgstr "A kiválasztott %plural(%1,sor,sorok) PDF vagy TeX kimeneti állományainak letöltése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+msgid "Download PDF or TeX Hardcopy for Current Set"
+msgstr "A jelenlegi sor PDF vagy TeX kimeneti állományainak mentése "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
+msgid "Download PDF or TeX Hardcopy for Selected Sets"
+msgstr "A kiválasztott sorok PDF vagy TeX kimeneti állományainak mentése "
+
+#. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
+msgid "Download hardcopy of set %1 for %2?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
+msgid "Download:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
+msgid "Drop"
+msgstr "Dobd"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
+msgid "Duplicate this set and name it"
+msgstr "Készitse el a feladatsor másolatát és nevezze el"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:371
+msgid ""
+"During summer 2005, a newer version of the answer checkers was implemented "
+"for answers which are functions and numbers.  The newer checkers allow more "
+"functions in student answers, and behave better in certain cases.  Some "
+"problems are specifically coded to use new (or old) answer checkers.  "
+"However, for the bulk of the problems, you can choose what the default will "
+"be here.  <p>Choosing <i>false</i> here means that the newer answer checkers"
+" will be used by default, and choosing <i>true</i> means that the old answer"
+" checkers will be used by default."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
+msgid "E-Mail"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+msgid "E-mail Instructor"
+msgstr "e-mail a tanárnak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:399
+msgid "E-mail addresses which can receive e-mail from a pg problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:404
+msgid ""
+"E-mail feedback from students automatically sent to this permission level "
+"and higher:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:389
+msgid "E-mail verbosity level"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+msgid "E-mail:"
+msgstr "e-mail:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+msgid "Earned"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+msgid "Edit"
+msgstr "Módosít"
+
+#. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual
+#. versions')
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+msgid "Edit %1 of set %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
+msgid "Edit All Set Data"
+msgstr "Az összes feladatsor adatainak módosÍtása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
+msgid "Edit Assigned Users"
+msgstr "A hozzárendelt felhasználók módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+msgid "Edit Evaluator"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+msgid "Edit Header"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+msgid "Edit Location:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+msgid "Edit Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
+msgid "Edit Problems"
+msgstr "A feladatok módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
+msgid "Edit Set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
+msgid "Edit Set Data"
+msgstr "A feladotsor adatainak módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
+msgid "Edit Target Set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+msgid "Edit Which Users?"
+msgstr "Mely felhasználókat módosítja?"
+
+#. ($user)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:199
+msgid "Edit data for %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
+msgid "Edit it"
+msgstr ""
+
+#. (CGI::strong($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+msgid "Edit set %1 data for ALL students assigned to this set."
+msgstr ""
+
+#. (CGI::a({href=>$editSetLink},$setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+msgid "Edit set %1 for this user."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+msgid ""
+"Edit the current value of the location description, if desired, then add and"
+" select addresses to delete, and then click the \"Take Action\" button to "
+"make all of your changes.  Or, click \"Manage Locations\" above to make no "
+"changes and return to the Manage Locations page."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
+msgid "Edit which sets?"
+msgstr "Mely feladatsorokat módosítja?"
+
+# Edit with a number 1 after with no space
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+msgid "Edit1"
+msgstr ""
+
+# Edit with a number 2 after with no space
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+msgid "Edit2"
+msgstr ""
+
+# Edit with a number 3 after with no space
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+msgid "Edit3"
+msgstr ""
+
+#. ($titles{$file_type}, $self->shortPath($inputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+msgid "Editing %1 in file '%2'"
+msgstr ""
+
+#. ($self->shortPath($sourceFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
+msgid "Editing achievement in file '%1'"
+msgstr ""
+
+#. ($locationID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+msgid "Editing location %1"
+msgstr ""
+
+#. (CGI::strong($setID . $vermsg)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+msgid "Editing problem set %1 data for these individual students: %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+msgid "Editor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+msgid "Editor rows:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
+msgid "Email"
+msgstr "e-mail"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+msgid "Email Address"
+msgstr "E-mail cím"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+msgid "Email Body:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
+msgid "Email Instructor On Failed Attempt"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+msgid "Email Link"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+msgid "Email address"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+msgid "Email instructor"
+msgstr "e-mail a tanárnak"
+
+#. (scalar(@{$self->{ra_send_to}})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+msgid ""
+"Email is being sent to %quant(%1,recipient). You will be notified by email "
+"when the task is completed.  This may take several minutes if the class is "
+"large."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+msgid "Emails to be sent to the following:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
+msgid "Enable Achievement Items"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
+msgid "Enable Conditional Release"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
+msgid "Enable Course Achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
+msgid "Enable Progress Bar and current problem highlighting"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
+msgid "Enable Reduced Scoring"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
+msgid "Enable Show Me Another button"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
+msgid "Enable periodic re-randomization of problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:358
+msgid ""
+"Enable reduced scoring for a homework set.  This will allow you to submit "
+"answers for partial credit for 24 hours after the close date."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+msgid "Enabled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
+msgid ""
+"Enables periodic re-randomization of problems after a given number of "
+"attempts. Student would have to click Request New Version to obtain new "
+"version of the problem and to continue working on the problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:213
+msgid ""
+"Enables the use of the conditional release system.  To use conditional "
+"release you need to specify a list of set names on the Problem Set Detail "
+"Page, along with a minimum score.  Students will not be able to access that "
+"homework set until they have achieved the minimum score on all of the listed"
+" sets."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
+msgid ""
+"Enables the use of the date picker on the Homework Sets Editor 2 page and "
+"the Problem Set Detail page"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:253
+msgid ""
+"Enables use of the Show Me Another button, which offers the student a newly-"
+"seeded version of the current problem, complete with solution (if it exists "
+"for that problem)."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
+msgid "Enrolled"
+msgstr "beiratkozott"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+msgid "Enrolled, Drop, etc."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+msgid "Enrollment Status"
+msgstr "Regisztrációs állapot"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+msgid "Enter filename below"
+msgstr "Írja be lent a fájlnevet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
+msgid "Enter filenames below"
+msgstr "Írja be lent a fájlneveket"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:132
+msgid ""
+"Enter information below for students you wish to add. Each student's "
+"password will initially be set to their student ID."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+msgid "Entered"
+msgstr "Belépve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
+msgid "Entered student:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
+msgid "Equation Display"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1442
+msgid "Error adding set-level proctor: %1"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1418
+msgid ""
+"Error getting old set-proctor password from the database: %1.  No update to "
+"the password was done."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
+msgid "Error message:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+msgid "Error messages"
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
+msgid "Error: Answer date must come after close date in set %1"
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1534
+msgid "Error: Close date must come after open date in set %1"
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1551
+msgid ""
+"Error: Reduced scoring date must come between the open date and close date "
+"in set %1"
+msgstr ""
+
+#. ($editFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
+msgid "Error: The original file %1 cannot be read."
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1159
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1528
+msgid "Error: answer date cannot be more than 10 years from now in set %1"
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1526
+msgid "Error: close date cannot be more than 10 years from now in set %1"
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
+msgid "Error: open date cannot be more than 10 years from now in set %1"
+msgstr ""
+
+#. ($problem_desc, $problem_name, CGI::br()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1230
+msgid ""
+"Errors encountered while processing %1. This %2 has been omitted from the "
+"hardcopy. Error text: %3"
+msgstr ""
+
+#. ("$coursesDir/$failed_courses[0]/")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+msgid ""
+"Errors occured while hiding the courses listed below when attempting to "
+"create the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
+msgstr ""
+
+#. ("$coursesDir/$failed_courses[0]/")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+msgid ""
+"Errors occured while unhiding the courses listed below when attempting "
+"delete the file hide_directory in the course's directory. Check the "
+"ownership and permissions of the course's directory, e.g %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+msgid "Evaluator"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+msgid "Evaluator File"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+msgid ""
+"Except for possible errors listed above, all selected courses are already "
+"hidden."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+msgid ""
+"Except for possible errors listed above, all selected courses are already "
+"unhidden."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+msgid ""
+"Existing addresses for the location are given in the scrolling list below.  "
+"Select addresses from the list to delete them:"
+msgstr ""
+
+#. ($filePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+msgid "Existing file %1 could not be backed up and was lost."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+msgid "Expand"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+msgid "Expand All"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+msgid "Export"
+msgstr "Export"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+msgid "Export selected achievements."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
+msgid "Export selected sets"
+msgstr "A kiválasztott feladatsorok exportja"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+msgid "Export to what kind of file?"
+msgstr "Mely fájlokat akarja exportálni?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
+msgid "Export which sets?"
+msgstr "Mely feladatsorokat akarja exportálni?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+msgid "Export which users?"
+msgstr "Mely felhasználókat akarja exportálni?"
+
+#. ($FileName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+msgid "Exported achievements to %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
+msgid "Extend the close date for which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1442
+msgid ""
+"Extends the close date of a gateway test by 24 hours. Note: The test must "
+"still be open for this to work."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "FIRST NAME"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+msgid "Failed to create new achievement: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+msgid "Failed to create new achievement: no achievement ID specified!"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
+msgid "Failed to create new set: %1"
+msgstr "Nem sikerült létrehozni a %1 új feladatsort"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
+msgid "Failed to create new set: no set name specified!"
+msgstr "Nem sikerült létrehozni az új feladatsort: nincs megadva a feladatnév!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+msgid ""
+"Failed to duplicate achievement: no achievement selected for duplication!"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
+msgid "Failed to duplicate set: %1"
+msgstr "Nem sikerült létrehozni a %1 feladatsor másolatát."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
+msgid "Failed to duplicate set: no set name specified!"
+msgstr "Nem sikerült létrehozni a feladatsor másolatát: nincs megadva a feladatnév!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
+msgid "Failed to duplicate set: no set selected for duplication!"
+msgstr "Nem sikerült létrehozni a feladatsor másolatát: nincs kiválaszva feladatsor!"
+
+#. ($newSetID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
+msgid "Failed to duplicate set: set %1 already exists!"
+msgstr "Nem sikerült létrehozni a feladatsor másolatát: a %1 feladatsor már létezik!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
+msgid "Failed to enter student:"
+msgstr ""
+
+#. ($filePath)
+#. ($scoreFilePath)
+#. ($FilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+msgid "Failed to open %1"
+msgstr ""
+
+#. ($@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
+msgid "Failed to save: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+msgid "Feature exhausted for this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
+msgid "Feedback"
+msgstr "Visszacsatolás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:414
+msgid "Feedback by Section."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+msgid "FeedbackMessage"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+msgid "Field is ok"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+msgid "Field missing in database"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+msgid "Field missing in schema"
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+msgid "File '%1' exists.  File not saved.  No changes have been made."
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
+msgid ""
+"File '%1' exists. File not saved. No changes have been made.  You can change"
+" the file path for this problem manually from the 'Hmwk Sets Editor' page"
+msgstr ""
+
+#. ($file,$!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
+msgid "File '%1' not removed: %2"
+msgstr ""
+
+#. ($file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:681
+msgid "File '%1' successfully removed"
+msgstr ""
+
+#. ($name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:935
+msgid "File '%2' uploaded successfully"
+msgstr ""
+
+#. ($name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
+msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
+msgid "File Compare"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
+msgid "File Manager"
+msgstr "Állománykezelő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
+msgid "File saved"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
+msgid "File successfully copied"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:644
+msgid "File successfully renamed"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+msgid "Filename"
+msgstr "Fájlnév"
+
+#. ($extension,$location)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1168
+msgid "Files with extension '.%1' usually belong in '%2'"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+msgid "Filter by what text?"
+msgstr "Melyik szöveg alapján szűrjek?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
+msgid "Filter:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
+msgid "First"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+msgid "First Name"
+msgstr "Keresztnév"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+msgid "First name"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+msgid ""
+"For security reasons, you cannot specify a message file from a directory "
+"higher than the email directory (you can't use ../blah/blah for example). "
+"Please specify a different file or move the needed file to the email "
+"directory"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+msgid "Force problems to be numbered consecutively from one"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2303
+msgid ""
+"Force problems to be numbered consecutively from one (always done when "
+"reordering problems)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
+msgid "Format for the subject line in feedback e-mails"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
+msgid "Format:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
+msgid "From This Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+msgid "From field must contain one valid email address."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+msgid "From:"
+msgstr "Feladó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1075
+msgid "GLOBAL Usage"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
+msgid "Gateway Name "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
+msgid "Gateway Quiz %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:808
+msgid "Gateway parameters"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:120
+msgid "General"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+msgid "General Information"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
+msgid "Generate Hardcopy"
+msgstr "Másolat generálása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
+msgid "Generate hardcopy for selected sets and selected users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
+msgid "Get Library Set Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
+msgid "Get Target Set Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+msgid "Give new password to"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+msgid "Give new password to which users?"
+msgstr "Melyik felhasználónak kér új jelszót?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:968
+msgid "Gives full credit on a single homework problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1079
+msgid "Gives full credit on every problem in a set."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:762
+msgid "Gives half credit on a single homework problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:878
+msgid "Gives half credit on every problem in a set."
+msgstr ""
+
+#. ($problemID, $setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
+msgid "Global problem %1 for set %2 not found."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+msgid "Global set data will be shown instead of user specific data"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:155
+msgid "Go"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+msgid "Grade"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+msgid "Grade Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+msgid "Grade Test"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+msgid "Grader"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
+msgid "Grades"
+msgstr "Eredményesség"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:97
+msgid "Grades have been saved for all current users."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:229
+msgid "Grading assignment:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:967
+msgid "Greater Rod of Revelation"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1078
+msgid "Greater Tome of Enlightenment"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
+msgid "Guest Login"
+msgstr "Vendég felhasználó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+msgid "HTTP Headers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
+msgid "Hardcopy Format:"
+msgstr "Kimeneti formátum:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
+msgid "Hardcopy Generator"
+msgstr "kimeneti generátor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:471
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:783
+msgid "Hardcopy Header"
+msgstr "Fejléc másolata"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
+msgid "Hardcopy Theme"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+msgid "Headers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+msgid "Help"
+msgstr "Súgó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:479
+msgid "Here is a new version of your problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
+msgid "Hidden"
+msgstr "Rejtett"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+msgid "Hide All"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+msgid "Hide Courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
+msgid "Hide Hints"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
+msgid "Hide Hints from Students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+msgid "Hide Inactive Courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
+msgid "Hide all paths"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
+msgid "Hide path:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
+msgid "Hints"
+msgstr "Tippek"
+
+# Hmwk is short for Homework
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
+msgid "Hmwk Sets Editor"
+msgstr "HF-sor szerkesztő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
+msgid "Homework Sets"
+msgstr "Feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+msgid "Homework Totals"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
+msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+msgid "Icon"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+msgid "Icon File"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+msgid ""
+"If a password field is left blank, the student's current password will be "
+"maintained."
+msgstr "Ha a jelszó mezőt üresen hagyja, a diák jelenlegi jelszava megmarad."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:454
+msgid ""
+"If this flag is set then this problem will count towards the grade of its "
+"parent problem.  In general the adjusted status on a problem is the larger "
+"of the problem's status and the weighted average of the status of its child "
+"problems which have this flag enabled."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
+msgid ""
+"If this is enabled then instructors with the ability to receive feedback "
+"emails will be notified whenever a student runs out of attempts on a problem"
+" and its children without receiving an adjusted status of 100%"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
+msgid ""
+"If this is enabled then students will be unable to attempt a problem until "
+"they have completed all of the previous problems, and their child problems "
+"if necessary"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
+msgid ""
+"If you check %1 your login information will be remembered by the browser you"
+" are using, allowing you to visit WeBWorK pages without typing your user "
+"name and password (until your session expires). This feature is not safe for"
+" public workstations, untrusted machines, and machines over which you do not"
+" have direct control."
+msgstr ""
+
+#. ($file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
+msgid "Illegal file '%1' specified"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+msgid "Illegal filename contains '..'"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
+msgid "Import"
+msgstr "Import"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
+msgid "Import achievements from"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
+msgid "Import from where?"
+msgstr "Honnan importálni?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
+msgid "Import how many sets?"
+msgstr "Hány feladatsort importálni?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
+msgid "Import sets with names"
+msgstr "Ezen nevű feladatsorok importálása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+msgid "Import users from what file?"
+msgstr "Mely állományból akar felhasználókat importálni?"
+
+#. ($count)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+msgid "Imported %quant(%1,achievement)"
+msgstr ""
+
+#. ($total_inprogress, $num_of_problems)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+msgid "In progress: %1/%2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+msgid "Inactive"
+msgstr "Inaktív"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:141
+msgid "Inactivity time before a user is required to login again"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+msgid "Include Success Index"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
+msgid "Incorrect"
+msgstr ""
+
+#. ($total_incorrect,$num_of_problems)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+msgid "Incorrect: %1/%2"
+msgstr ""
+
+# Short for Initial
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
+msgid "Init"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+msgid "Institution:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
+msgid "Instructor Tools"
+msgstr "Oktatói eszközök"
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+msgid "Instructor solution preview: show the student solution after due date."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+msgid "Invalid Reply-to address."
+msgstr ""
+
+#. ($output_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+msgid ""
+"Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
+"All email file names must end in the extension \".msg\" choose a file name "
+"with a \".msg\" extension. The message was not saved."
+msgstr ""
+
+#. ($headerType)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+msgid "Invalid headerType %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
+msgid "Invalid user ID or password."
+msgstr "Érvénytelen felhasználói azonosító vagy jelszó."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2306
+msgid ""
+"It is before the open date.  You probably want to renumber the problems if "
+"you are deleting some from the middle."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
+msgid "Items"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+msgid "Jump to Page:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+msgid "Jump to Problem:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
+msgid "Just-In-Time parameters"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:772
+msgid "Keywords:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "LAST NAME"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1089
+msgid "LOCAL Usage"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:135
+msgid "Language (refresh page after saving changes to reveal new language.)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
+msgid "Last"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
+msgid "Last Answer"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+msgid "Last Name"
+msgstr "Vezetéknév"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+msgid "Last column of merge file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+msgid "Last name"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+msgid "Latest Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
+msgid ""
+"Length of time, in seconds, a user has to be inactive before he is required "
+"to login again.<p> This value should be entered as a number, so as 3600 "
+"instead of 60*60 for one hour"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:761
+msgid "Lesser Rod of Revelation"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:877
+msgid "Lesser Tome of Enlightenment"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:768
+msgid "Level:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
+msgid "Library Browser"
+msgstr "Könyvtár böngésző"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
+msgid "Library Browser 2"
+msgstr "Könyvtár böngésző 2"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
+msgid "Library Browser 3"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
+msgid "Library Browser no js"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
+msgid "List of display modes made available to students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
+msgid ""
+"List of e-mail addresses to which e-mail can be sent by a problem. "
+"Professors need to be added to this list if questionaires are used, or other"
+" WeBWorK problems which send e-mail as part of their answer mechanism."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
+msgid "List of options for Show Me Another button"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
+msgid "Local"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
+msgid "Local Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+msgid "Location"
+msgstr ""
+
+#. ($locationID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+msgid ""
+"Location %1 does not exist in the WeBWorK database.  Please check your input"
+" (perhaps you need to reload the location management page?)."
+msgstr ""
+
+#. ($locationID, join(', ', @addresses)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+msgid "Location %1 has been created, with addresses %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+msgid "Location deletion requires confirmation."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+msgid "Location description:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+msgid "Location name:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
+msgid "Log In Again"
+msgstr "Újra bejelentkezni"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+msgid "Log Out"
+msgstr "Kijelentkezés"
+
+#. ($add_courseID)
+#. ($rename_oldCourseID)
+#. ($rename_newCourseID)
+#. ($new_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+msgid "Log into %1"
+msgstr ""
+
+#. (HTML::Entities::encode_entities($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+msgid "Logged in as %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+msgid "Login"
+msgstr "Bejelentkezés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
+msgid "Login Info"
+msgstr "Bejelentkezési információk"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+msgid "Login Name"
+msgstr "Bejelentkezési név"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+msgid "Login Status"
+msgstr "Bejelentkezési állapot"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
+msgid "Logout"
+msgstr "Kijelentkezés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+msgid "Main Menu"
+msgstr "Főmenü"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:859
+msgid "Make"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:354
+msgid "Make Archive"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+msgid "Make changes"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+msgid "Make these changes in  course:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+msgid "Manage Locations"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
+msgid "Manual Grader"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
+msgid "Mark All"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+msgid "Mark Correct"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+msgid "Mark Correct?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
+msgid "Match on what? (separate multiple IDs with commas)"
+msgstr "Találatok (többszörös azonosítók szétválasztása vesszővel)"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+msgid "Math Objects"
+msgstr "Mat. objektumok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
+msgid "Max attempts"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
+msgid "Max. Shown:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
+msgid ""
+"Maximum times Show me Another can be used per problem (-1 => unlimited)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+msgid "Merge file:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+msgid "Message"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+msgid "Message file:"
+msgstr ""
+
+#. ($emailDirectory, $output_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+msgid "Message saved to file <code>%1/%2</code>."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+msgid "Message:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+msgid "Messages"
+msgstr "Üzenetek"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+msgid "Method"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+msgid ""
+"Missing required input data. Please check that you have filled in all of the"
+" create location fields and resubmit."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+msgid "Move"
+msgstr ""
+
+#. ($recipient, $ur->email_address)
+# Msg is short for message
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+msgid "Msg sent to %1 at %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
+msgid "My Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
+msgid "Mysterious Package (with Ribbons)"
+msgstr ""
+
+# Short for Number of Fields
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+msgid "NO OF FIELDS"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
+msgid "Name"
+msgstr "Név"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
+msgid "Name for new set here"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
+msgid "Name of course information file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
+msgid "Name the new set"
+msgstr "Az új feladatsor neve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1552
+msgid "Necromancers Charm"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
+msgid "Never"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
+msgid "New File"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:164
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
+msgid "New Folder"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+msgid "New Name:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+msgid "New Password"
+msgstr "Új jelszó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
+msgid "New file name:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
+msgid "New folder name:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+msgid "New passwords saved"
+msgstr "Az új jelszó mentve"
+
+# No space
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+msgid "NewVersion"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1852
+msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+msgid "Next Problem"
+msgstr "Új feladat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
+msgid "Next page"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+msgid "No"
+msgstr "Nem"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+msgid "No Description"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+msgid "No achievements shown.  Create an achievement!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
+msgid "No action taken"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
+msgid ""
+"No authentication method found for your request.  If this recurs, please "
+"speak with your instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
+msgid "No change made to any set"
+msgstr "Egy feladatsorban sem történt változás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+msgid ""
+"No changes specified.  You must mark the checkbox of the item(s) to be "
+"changed and enter the change data."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
+msgid "No changes were saved!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+msgid "No course id defined"
+msgstr ""
+
+#. ($setID, $problemID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
+msgid "No data exists for set %1 and problem %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+msgid "No filename was specified for saving!  The message was not saved."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+msgid "No guest logins are available. Please try again in a few minutes."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+msgid "No location specified to edit?! Please check your input data."
+msgstr ""
+
+#. ($badID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+msgid "No location with name %1 exists in the database"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+msgid "No merge data file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+msgid ""
+"No new Achievement ID specified.  No new achievement created.  File not "
+"saved."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+msgid "No problems matched the given parameters."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+msgid ""
+"No recipients selected. Please select one or more recipients from the list "
+"below."
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+msgid "No record for global set %1."
+msgstr ""
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+msgid "No record for user %1."
+msgstr ""
+
+#. ($prob)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+msgid "No record found for problem %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+msgid "No record found."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:48
+msgid "No sets in this course yet"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
+msgid "No sets selected for scoring"
+msgstr "Nincsenek feladatsorok kiválasztva értékelésre"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+msgid ""
+"No sets shown.  Choose one of the options above to list the sets in the "
+"course."
+msgstr "Nem jeleníthetőek meg feladatsorok. Válasszon fent egy lehetőséget a kurzus feladatsorainak jegyzékéért. "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+msgid "No source filePath specified"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+msgid "No source_file for problem in .def file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+msgid ""
+"No students shown.  Choose one of the options above to list the students in "
+"the course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
+msgid "No tests taken."
+msgstr ""
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:625
+msgid "No user specific data exists for user %1"
+msgstr ""
+
+#. ($locationID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+msgid "None"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:140
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:170
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:180
+msgid "None Specified"
+msgstr ""
+
+#. (CGI::b(join(", ", @unassignedUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+msgid "None of the selected users are assigned to this set: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+msgid "Not logged in."
+msgstr "Nincs bejelentkezve."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+msgid "Note"
+msgstr "Megjegyzés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+msgid ""
+"Note: grading the test grades all problems, not just those on this page."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+msgid "Number"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
+msgid "Number of Graded Submissions per Test (0=infty)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:287
+msgid "Number of Problems per Page (0=all)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:270
+msgid "Number of Tests per Time Interval (0=infty)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+msgid "OK"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1340
+msgid "Oil of Cleansing"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
+msgid "Old Classlist Editor"
+msgstr ""
+
+# Hmwk is short for Homework
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
+msgid "Old Hmwk Sets Editor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
+msgid "One Column"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:306
+msgid "Only after set answer date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:296
+msgid ""
+"Only this permission level and higher get buttons for sending e-mail to the "
+"instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+msgid "Open"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:472
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:803
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:826
+msgid "Open Date"
+msgstr "A kezdés dátuma"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
+msgid "Open Problem Library"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+msgid "Open in New Window"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+msgid "Open in new window"
+msgstr ""
+
+#. ($self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
+msgid "Open, closes %1."
+msgstr ""
+
+#. ($self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
+msgid "Open, complete by %1."
+msgstr ""
+
+#. ($beginReducedScoringPeriod)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
+msgid "Open, reduced scoring starts on %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
+msgid "Open:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
+msgid "Opens"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
+msgid "Opens any homework set for 24 hours."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:195
+msgid "Optional Modules"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
+msgid "Order Problems Randomly"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+msgid "Orig. Lib. Browser"
+msgstr ""
+
+# Context is "7 Out Of 10"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
+msgid "Out Of"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
+msgid "Over time, closed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
+msgid "Overwrite"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:382
+msgid "Overwrite existing files silently"
+msgstr ""
+
+# PG is a WeBWorK abreviation and should stay PG
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
+msgid "PG - Problem Display/Answer Checking"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+msgid "PG debug messages"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+msgid "PG internal errors"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+msgid "PG question failed to render"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+msgid "PG question processing error messages"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+msgid "PG warning messages"
+msgstr ""
+
+# Doesn't need to be translated
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+msgid "PGInfo"
+msgstr ""
+
+# Doesn't need to be translated
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+msgid "PGLab"
+msgstr ""
+
+# Doesn't need to be translated
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+msgid "PGML"
+msgstr ""
+
+# Doesn't need to be translated
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+msgid "POD"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
+msgstr "A kezdés dátumaCSAK MEGTEKINTÉS - A VÁLASZOK NINCSENEK MENTVE"
+
+# Problem Number
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+msgid "PROB NUMBER"
+msgstr ""
+
+# Problem Value
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+msgid "PROB VALUE"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+msgid "Pad Fields"
+msgstr "Betét mező"
+
+#. (timestamp($self)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+msgid "Page generated at %1"
+msgstr "Az oldal generálva: %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
+msgid "Password"
+msgstr "Jelszó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:921
+msgid "Password (Leave blank for regular proctoring)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+msgid "Password:"
+msgstr ""
+
+#. ($studentUser, $setName, $prettyProblemNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
+msgid "Past Answers for %1, set %2, problem %3"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+msgid "Percent"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:574
+msgid "Percentage of Active Students with Correct Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:570
+msgid ""
+"Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
+"median number of attempts"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+msgid ""
+"Percentile cutoffs for number of attempts. The 50% column shows the median "
+"number of attempts."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+msgid "Permission Level"
+msgstr "Hozzáférési szint"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
+msgid "Permissions"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+msgid ""
+"Place a file named \"hide_directory\" in a course or other directory and it "
+"will not show up in the courses list on the WeBWorK home page. It will still"
+" appear in the Course Administration listing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1016
+msgid ""
+"Please choose the set name and problem number of the question which should "
+"be given full credit."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:811
+msgid ""
+"Please choose the set name and problem number of the question which should "
+"be given half credit."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:587
+msgid ""
+"Please choose the set name and problem number of the question which should "
+"have its incorrect attempt count reset."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:698
+msgid ""
+"Please choose the set name and problem number of the question which should "
+"have its weight doubled."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1214
+msgid ""
+"Please choose the set, the problem you would like to copy, and the problem "
+"you would like to copy it to."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+msgid "Please correct the following errors and try again:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:706
+msgid "Please enter in a value to match in the filter field."
+msgstr ""
+
+#. (CGI::b($course)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
+msgid "Please enter your username and password for %1 below:"
+msgstr "Kérjük adja meg alább %1 felhasználói nevét és jelszavát:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+msgid "Please provide a location name to delete."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
+msgid "Please select action to be performed."
+msgstr "Válassza ki a végrehajtandó művelet."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
+msgid "Please select at least one set and try again."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
+msgid "Please select at least one user and try again."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
+msgid "Please specify a file to save to."
+msgstr "Kérjük válassza ki a mentendő állományt"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+msgid "Points"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
+msgid "Potion of Forgetfullness"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
+msgid "Preflight Log"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+msgid "Preview Message"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+msgid "Preview My Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+msgid "Preview Test"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+msgid "Preview message"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+msgid "Preview set to:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+msgid "Previous Problem"
+msgstr "Előző feladat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
+msgid "Previous page"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
+msgid "Primary sort"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+msgid "Print Test"
+msgstr ""
+
+# Short for Problem
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+msgid "Prob"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
+msgid "Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
+msgid "Problem #"
+msgstr ""
+
+#. ($prettyProblemID)
+#. (join('.',@seq)
+#. ($problemID)
+#. ($problemNumber)
+#. ($prettyProblemIDs{$probID})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+msgid "Problem %1"
+msgstr "%1. feladat"
+
+#. ($problemNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+msgid "Problem %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
+msgid "Problem Editor"
+msgstr "Feladatszerkesztő"
+
+# No space before number
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
+msgid "Problem Editor2"
+msgstr ""
+
+# No space before number
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
+msgid "Problem Editor3"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+msgid "Problem List"
+msgstr "Feladatlista"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
+msgid "Problem Number"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
+msgid "Problem Number "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+msgid "Problem Techniques"
+msgstr "Feladat-technikák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+msgid "Problem Viewer"
+msgstr "Feladat-néző"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+msgid "Problem source is drawn from a grouping set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+msgid "Problems"
+msgstr "Feladatok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:62
+msgid "Problems for all students have been unassigned."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:65
+msgid "Problems for selected students have been reassigned."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:57
+msgid "Problems have been assigned to all current users."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
+msgid "Proctor"
+msgstr "Felügyelő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:203
+msgid "Proctor authorization required."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
+msgid "Proctor password:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
+msgid "Proctor username:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:259
+msgid "Proctored Gateway Quiz %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:268
+msgid "Proctored Gateway Quiz %2 Proctor Login"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:841
+msgid ""
+"Proctored tests require proctor authorization to start and to grade.  "
+"Provide a password to have a single password for all students to start a "
+"proctored test."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+msgid "Publish"
+msgstr "Közzététel"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "RECITATION"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
+msgid "Read only"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:735
+msgid "Really delete the items listed above?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+msgid "Recitation"
+msgstr "Előadás"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+msgid "Record Scores for Single Sets"
+msgstr "A pontszámok mentése az adott feladatsorhoz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:477
+msgid "Reduced Scoring"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
+msgid "Reduced Scoring Date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+msgid "Reduced Scoring Disabled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+msgid "Reduced Scoring Enabled"
+msgstr ""
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,
+#. $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Reduced Scoring Starts %1"
+msgstr ""
+
+#. ($beginReducedScoringPeriod)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
+msgid "Reduced scoring started on %1."
+msgstr ""
+
+# Short for "Reduced Scoring:"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
+msgid "Reduced:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:358
+msgid "Refresh"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2156
+msgid "Refresh Display"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+msgid "Refresh Listing"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
+msgid "Relax IP restrictions when?"
+msgstr ""
+
+# Context is "Attempts Remaining"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+msgid "Remaining"
+msgstr "Maradék"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
+msgid "Remember Me"
+msgstr "Emlékezz rám!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:480
+msgid "Remember to return to your original problem when you're finished here!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
+msgid "Rename"
+msgstr ""
+
+#. ($rename_oldCourseID, $rename_newCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+msgid "Rename %1 to %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+msgid "Rename Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
+msgid "Rename file as:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+msgid "Render"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+msgid "Render All"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+msgid "Render Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+msgid "Renumber Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
+msgid ""
+"Reopens any gateway test for an additional 24 hours. This allows you to take"
+" a test even if the close date has past. This item does not allow you to "
+"take additional versions of the test."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2326
+msgid "Reorder problems only"
+msgstr ""
+
+#. (CGI::strong("$fullSetID/$prettyProbNum")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
+msgid "Replace current problem: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+msgid "Replace which users?"
+msgstr "Mely felhasználókat cseréli?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+msgid "Reply-To:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+msgid "Report Bugs in this Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+msgid "Report bugs"
+msgstr "Hiba bejelentése"
+
+#. ($upgrade_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+msgid "Report for course %1:"
+msgstr ""
+
+#. ($rename_oldCourseID)
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+msgid "Report on database structure for course %1:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+msgid "Request New Version"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+msgid "Request information"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+msgid "Request new version now."
+msgstr ""
+
+#. ($setName,$effectiveUserName)
+#. ($setName, $effectiveUserName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
+msgid "Requested set '%1' could not be found in the database for user %2."
+msgstr ""
+
+#. ($setName,$node_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
+msgid ""
+"Requested set '%1' is a homework assignment but the gateway/quiz content "
+"generator %2 was called.  Try re-entering the set from the problem sets "
+"listing page."
+msgstr ""
+
+#. ($setName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
+msgid ""
+"Requested set '%1' is a proctored test/quiz assignment, but no valid proctor"
+" authorization has been obtained."
+msgstr ""
+
+#. ($setName,$node_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
+msgid ""
+"Requested set '%1' is a test/quiz assignment but the regular homework "
+"assignment content generator %2 was called.  Try re-entering the set from "
+"the problem sets listing page."
+msgstr ""
+
+#. ($setName,$effectiveUserName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
+msgid "Requested set '%1' is not assigned to user %2."
+msgstr ""
+
+#. ($setName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
+msgid "Requested set '%1' is not available yet."
+msgstr ""
+
+#. ($setName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
+msgid "Requested set '%1' is not yet open."
+msgstr ""
+
+#. ($verNum,$setName,$effectiveUserName)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
+msgid "Requested version (%1) of set '%2' is not assigned to user %3."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
+msgid "Rerandomize after"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:734
+msgid "Reset"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+msgid "Reset Form"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:538
+msgid "Resets the number of incorrect attempts on a single homework problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Ressurect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+msgid ""
+"Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
+"the course database is restored from a subdirectory of the course's DATA "
+"directory. Currently the archive facility is only available for mysql "
+"databases. It depends on the mysqldump application."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:202
+msgid "Restrict Access by IP"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
+msgid "Restrict Locations"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
+msgid "Restrict Problem Progression"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
+msgid "Restrict To"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
+msgid "Restrict release by set(s)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+msgid "Result"
+msgstr "Eredmények"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+msgid "Result of last action performed"
+msgstr ""
+
+#. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams,
+#. \%tableParams)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+msgid "Result of last action performed: %1"
+msgstr "Az utolsó művelet eredményei: %1"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+msgid "Results for this submission"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
+msgid "Results of last action performed"
+msgstr "Az utolsó művelet eredményei"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
+msgid "Results of last action performed: "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+msgid "Revert"
+msgstr "Visszaállít"
+
+#. ($self->shortPath($editFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
+msgid "Revert to %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
+msgid "Ring of Reduction"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:272
+msgid "Robe of Longevity"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "SECTION"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+msgid "SET NAME"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+msgid "STATUS"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "STUDENT ID"
+msgstr "Diák azonosító (ID)"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
+msgid "Save"
+msgstr "mentés"
+
+#. (CGI::b($self->shortPath($self->{sourceFilePath})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+msgid "Save %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
+msgid "Save As"
+msgstr "Mentés mint"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+msgid "Save Changes"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+msgid "Save as"
+msgstr "mentés mint"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+msgid "Save as Default"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+msgid "Save changes"
+msgstr "A változások mentése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+msgid "Save file to:"
+msgstr ""
+
+#. (CGI::b($self->shortPath($self->{editFilePath})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+msgid "Save to %1 and View"
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+msgid "Saved to file '%1'"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+msgid "Schema and database field definitions do not agree"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+msgid "Schema and database table definitions do not agree"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
+msgid "Score"
+msgstr "Eredmény"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+msgid "Score (%)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
+msgid "Score required for release"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+msgid "Score selected set(s) and save to:"
+msgstr "A kiválasztott feladatsor(ok) pontozása és mentése ide:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+msgid "Score summary for last submit:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
+msgid "Score which sets?"
+msgstr "Mely feladatsor eredményei?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
+msgid "Scores"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
+msgid "Scoring Download"
+msgstr "Az eredmények letöltése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
+msgid "Scoring Message"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
+msgid "Scoring Tools"
+msgstr "Pontozási eszközök"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+msgid ""
+"Screen and Hardcopy set header information can not be overridden for "
+"individual students."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
+msgid "Scroll of Ressurection"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
+msgid "Secondary sort"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+msgid "Section"
+msgstr "Fejezet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
+msgid "Section:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
+msgid "Seed"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+msgid "Select"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
+msgid "Select a Problem Collection"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
+msgid "Select a Set from this Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+msgid "Select a course to delete."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+msgid ""
+"Select a course to rename.  The courseID is used in the url and can only "
+"contain alphanumeric characters and underscores. The course title appears on"
+" the course home page and can be any string."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+msgid "Select a course to unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+msgid "Select a database layout below."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+msgid "Select a listing format:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+msgid "Select above then:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+msgid "Select all eligible courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
+msgid "Select all sets"
+msgstr "Az összes feladatsor kiválasztása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+msgid "Select all users"
+msgstr "Az öszes felhasználó kiválasztása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+msgid "Select an action to perform"
+msgstr "Válassza ki a végrehajtandó művelet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+msgid "Select an action to perform:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+msgid "Select course(s) to archive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+msgid "Select course(s) to hide or unhide."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
+msgid ""
+"Select one or more sets and one or more users below to assign/unassign each "
+"selected set to/from all selected users."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
+msgid "Select sets below to assign them to the newly-created users."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+msgid ""
+"Select the course(s) you want to hide (or unhide) and then click \"Hide "
+"Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
+"does no harm (the action is skipped). Likewise unhiding a course that is "
+"already visible does no harm (the action is skipped).  Hidden courses are "
+"still active but are not listed in the list of WeBWorK courses on the "
+"opening page.  To access the course, an instructor or student must know the "
+"full URL address for the course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:489
+msgid ""
+"Select the homework sets for which to generate hardcopy versions. You may "
+"also select multiple users from the users list. You will receive hardcopy "
+"for each (set, user) pair."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
+msgid ""
+"Select user(s) and/or set(s) below and click the action button of your "
+"choice."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+msgid "Selected students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+msgid "Send E-mail"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+msgid "Send Email"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+msgid "Send to:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+msgid "Set"
+msgstr "Feladatsor/Beállítás"
+
+#. ($newSetID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
+msgid "Set %1 exists.  No set created"
+msgstr "A %1 feladatsor létezik. A feladatsor nem lett létrehozva."
+
+#. ($newSetName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
+msgid "Set %1 has been created."
+msgstr ""
+
+#. ($newSetName,$userName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
+msgid "Set %1 was assigned to %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
+msgid "Set Assigner"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
+msgid "Set Definition Filename"
+msgstr "A fájlnév definíciójának beállítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
+msgid "Set Definition Files"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+msgid "Set Description"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
+msgid "Set Detail 2 for set %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:423
+msgid "Set Detail for set %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
+msgid "Set Header"
+msgstr "A feladatsor fejléce"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
+msgid "Set ID"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+msgid "Set Info"
+msgstr "Feladatsor infó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+msgid "Set List"
+msgstr "Feladatsor lista"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:825
+msgid "Set Name"
+msgstr "A feladatsor neve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1215
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:127
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:478
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:588
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:699
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
+msgid "Set Name "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
+msgid ""
+"Set to true for log to mean base 10 log and false for log to mean natural "
+"logarithm"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:355
+msgid ""
+"Set to true to display MathView equation editor icon next to each answer box"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:360
+msgid ""
+"Set to true to display the \"Entered\" column which automatically shows the "
+"evaluated student answer, e.g. 1 if student input is sin(pi/2). If this is "
+"set to false, e.g. to save space in the response area, the student can still"
+" see their evaluated answer by hovering the mouse pointer over the typeset "
+"version of their answer."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+msgid "Sets"
+msgstr "Feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
+msgid "Sets Assigned to User"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
+msgid "Sets assigned to %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+msgid "Setting"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
+msgid "Shift dates so that the earliest is"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+msgid "Show"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+msgid "Show Auxiliary Resources"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:323
+msgid "Show Date & Size"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+msgid "Show Hints"
+msgstr "Tippek megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
+msgid "Show Me Another"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+msgid "Show Past Answers"
+msgstr "Az utolsó válasz megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:302
+msgid "Show Problems on Finished Tests"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:295
+msgid "Show Scores on Finished Assignments?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+msgid "Show Solutions"
+msgstr "A megoldás megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:166
+msgid "Show Total Homework Grade on Grades Page"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+msgid "Show Which Users?"
+msgstr "Mely felhasználók megjelenítése?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
+msgid "Show all paths"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+msgid "Show correct answers"
+msgstr "A helyes válasz megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+msgid "Show me another"
+msgstr ""
+
+#. ($exhausted)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+msgid "Show me another %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
+msgid "Show path ..."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+msgid "Show saved answers?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
+msgid "Show which sets?"
+msgstr "Mely feladatsorok megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+msgid "Show/Hide Site Description"
+msgstr "Az oldal leírásának megjelnítése/rejtése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+msgid "Show:"
+msgstr "Mutasd:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+msgid "Showing"
+msgstr ""
+
+#. (scalar @visibleSetIDs, scalar @allSetIDs)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
+msgid "Showing %1 out of %2 sets."
+msgstr "%2 feladatsorból %1 megjelenítve."
+
+#. (scalar @Users, scalar @allUserIDs)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+msgid "Showing %1 out of %2 users"
+msgstr "%2 felhasználóból %1 megjelenítve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:391
+msgid "Simple"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:68
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:71
+msgid "Site Information"
+msgstr "Oldal-információ"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+msgid "Skip archiving this course"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
+msgid "Solutions"
+msgstr "Megoldások"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+msgid "Some answers will be graded later."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:733
+msgid ""
+"Some of these files are directories. Only delete directories if you really "
+"know what you are doing. You can seriously damage your course if you delete "
+"the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
+msgid ""
+"Some servers handle courses taking place in different timezones.  If this "
+"course is not showing the correct timezone, enter the correct value here.  "
+"The format consists of unix times, such as "
+"\"America/New_York\",\"America/Chicago\", \"America/Denver\", "
+"\"America/Phoenix\" or \"America/Los_Angeles\". Complete list: <a "
+"href=\"http://en.wikipedia.org/wiki/List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:484
+msgid ""
+"Something was wrong with your LTI parameters.  If this recurs, please speak "
+"with your instructor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+msgid "Sort"
+msgstr "rendezés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+msgid "Sort by"
+msgstr "E szerint rendezve"
+
+#. ($names{$primary}, $names{$secondary})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
+msgid "Sort by %1 and then by %2"
+msgstr "%1 majd %2 szerint rendezve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
+#: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
+msgid "Sort:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
+msgid "Source File"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1539
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1573
+msgid ""
+"Source file paths cannot include .. or start with /: your source file path "
+"was modified."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+msgid ""
+"Specify an ID, title, and institution for the new course. The course ID may "
+"contain only letters, numbers, hyphens, and underscores."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:392
+msgid "Standard"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:107
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:686
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:695
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:704
+msgid "Statistics"
+msgstr "Statisztikák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
+msgid "Statistics for"
+msgstr ""
+
+#. ($self->{ce}->{courseName}, $self->{setName},
+#. $self->formatDateTime($self->{set_due_date})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
+msgid "Statistics for %1 set %2. Closes %3"
+msgstr ""
+
+#. ($self->{ce}->{courseName}, $self->{studentName})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
+msgid "Statistics for %1 student %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
+msgid "Status"
+msgstr "Állapot"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+msgid "Stop Acting"
+msgstr "A tevékenység befejezése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+msgid "Stop Archiving"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+msgid "Stop archiving courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+msgid "Student ID"
+msgstr "Diák ID"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+msgid "Student Name"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:767
+msgid "Student Progress"
+msgstr "Diákok előmenetele"
+
+#. ($self->{ce}->{courseName}, $self->{setName},
+#. $self->formatDateTime($self->{set_due_date})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
+msgid "Student Progress for %1 set %2. Closes %3"
+msgstr ""
+
+#. ($self->{ce}->{courseName}, $self->{studentName})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
+msgid "Student Progress for %1 student %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
+msgid "Student answers"
+msgstr "Hallgató válaszai"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
+msgid "Subject:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+msgid "Subject: "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
+msgid "Submission time:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
+msgid "Submit"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+msgid "Submit Answers"
+msgstr "A válasz elküldése"
+
+#. ($effectiveUser)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+msgid "Submit Answers for %1"
+msgstr "%1 válaszainak jóváhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
+msgid "Success"
+msgstr "Sikeres"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
+msgid "Success Index"
+msgstr ""
+
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+msgid "Successfully archived the course %1."
+msgstr ""
+
+#. ($newAchievementID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+msgid "Successfully created new achievement %1"
+msgstr ""
+
+#. ($newSetID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
+msgid "Successfully created new set %1"
+msgstr "Sikeresen létrehozva a(z) %1 új feladatsor"
+
+#. ($add_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+msgid "Successfully created the course %1"
+msgstr ""
+
+#. ($delete_courseID)
+#. ($archive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+msgid "Successfully deleted the course %1."
+msgstr ""
+
+#. ($rename_oldCourseID, $rename_newCourseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+msgid "Successfully renamed the course %1 to %2"
+msgstr ""
+
+#. ($unarchive_courseID, $new_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+msgid "Successfully unarchived %1 to the course %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+msgid "Table defined in database but missing in schema"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+msgid "Table defined in schema but missing in database"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+msgid "Table is ok"
+msgstr ""
+
+#. ($display_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:473
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
+msgid "Take %1 test"
+msgstr "Hajtsd végre a %1 tesztet"
+
+#. ($display_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
+msgid "Take %1 test."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+msgid "Take Action!"
+msgstr "Csináld!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
+msgid "Target Set:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
+msgid "Test Date"
+msgstr "A teszt dátuma"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
+msgid "Test Score"
+msgstr "A teszt eredménye"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
+msgid "Test Time"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
+msgid "Test Time Limit (min; 0=Close Date)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:374
+msgid "Text"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:752
+msgid "Text chapter:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
+msgid "Text section:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
+msgid "Textbook:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1000
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:433
+msgid "That symbolic link takes you outside your course directory"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:258
+msgid ""
+"The Maximum number of times Show me Another can be used per problem by a "
+"student. If set to -1 then there is no limit to the number of times that "
+"Show Me Another can be used."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:248
+msgid ""
+"The Reduced Scoring Period is the default period before the due date during "
+"which all additional work done by the student counts at a reduced rate. When"
+" enabling reduced scoring for a set the reduced scoring date will be set to "
+"the due date minus this number. The reduced scoring date can then be "
+"changed. If the Reduced Scoring is enabled and if it is after the reduced "
+"scoring date, but before the due date, a message like \"This assignment has "
+"a Reduced Scoring Period that begins 11/08/2009 at 06:17pm EST and ends on "
+"the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
+"work done counts 50% of the original.\" will be displayed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+msgid "The WeBWorK Project"
+msgstr "A WeBWorK projekt"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+msgid ""
+"The adjusted status of a problem is the larger of the problem's status and "
+"the weighted average of the status of those problems which count towards the"
+" parent grade."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:190
+msgid ""
+"The amount of time (in minutes) after the due date that the Answers are "
+"available to student to view.  You can change this for individual homework, "
+"but WeBWorK will use this value when a set is created."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
+msgid ""
+"The amount of time (in minutes) before the due date when the assignment is "
+"opened.  You can change this for individual homework, but WeBWorK will use "
+"this value when a set is created. "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+msgid "The answer above is NOT correct."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+msgid "The answer above is correct."
+msgstr "A fenti válasz helyes"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+msgid "The answer will be graded later."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
+msgid ""
+"The child problems for this problem will become visible to the student when "
+"they either have more incorrect attempts than is specified here, or when "
+"they run out of attempts, whichever comes first.  If \"max\" is specified "
+"here then child problems will only be available after a student runs out of "
+"attempts."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+msgid ""
+"The configuration module did not find the data it needs to function.  Have "
+"your site administrator check that Constants.pm is up to date."
+msgstr ""
+
+#. ($archive_courseID, $archive_path)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+msgid ""
+"The course '%1' has already been archived at '%2'. This earlier archive will"
+" be erased.  This cannot be undone."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
+msgid "The default display mode"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
+msgid ""
+"The default number of attempts before the problem is re-randomized. ( 0 => "
+"never )"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:275
+msgid ""
+"The default number of attempts between re-randomization of the problems ( 0 "
+"=> never)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:249
+msgid "The directory you specified doesn't exist"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1361
+msgid "The display was already cleared."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:390
+msgid ""
+"The e-mail verbosity level controls how much information is automatically "
+"added to feedback e-mails.  Levels are<ol><li value=\"Simple\"> Simple: send"
+" only the feedback comment and context link<li value=\"Standard\"> Standard:"
+" as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
+"Debug: as in Standard, plus the problem environment (debugging data)</ol>"
+msgstr ""
+
+#. ($achievementName, $self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+msgid "The evaluator for %1 has been renamed to '%2'."
+msgstr ""
+
+#. ($emailDirectory, $openfilename)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+msgid ""
+"The file %1/%2 already exists and cannot be overwritten. The message was not"
+" saved"
+msgstr ""
+
+#. ($emailDirectory, $openfilename)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+msgid "The file %1/%2 cannot be found."
+msgstr ""
+
+#. ($emailDirectory,$openfilename)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+msgid "The file %1/%2 is not readable by the webserver."
+msgstr ""
+
+#. ($self->shortPath($inputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+msgid "The file '%1' cannot be found."
+msgstr ""
+
+#. ($self->shortPath($editFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+msgid "The file '%1' cannot be read!"
+msgstr ""
+
+#. ($self->shortPath($inputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+msgid "The file '%1' is a blank problem!"
+msgstr ""
+
+#. ($self->shortPath($editFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+msgid "The file '%1' is a directory!"
+msgstr ""
+
+#. ($self->shortPath($inputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+msgid "The file '%1' is protected!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
+msgid "The file does not appear to be a text file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:94
+msgid "The file you are trying to download doesn't exist"
+msgstr ""
+
+#. (@succeeded_courses)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+msgid "The following courses were successfully hidden: %1"
+msgstr ""
+
+#. (@succeeded_courses)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+msgid "The following courses were successfully unhidden: %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+msgid "The following upgrades are available for your WeBWorK system:"
+msgstr ""
+
+#. (CGI::b(join(", ", @unassignedUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+msgid ""
+"The following users are NOT assigned to this set and will be ignored: %1"
+msgstr ""
+
+#. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+msgid ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the score of problem %1."
+msgstr ""
+
+#. (join(', ', map({join('.', @{$problemSeqs[$_]})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+msgid ""
+"The grade for this problem is the larger of the score for this problem, or "
+"the weighted average of the problems: %1."
+msgstr ""
+
+#. ($setName, $self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
+msgid "The hardcopy header for set %1 has been renamed to '%2'."
+msgstr ""
+
+#. ($rename_oldCourseID, $rename_oldCourseInstitution,
+#. $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+msgid ""
+"The institution associated with the course %1 has been changed from %2 to %3"
+msgstr ""
+
+#. ($rename_newCourseID, $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+msgid "The institution associated with the course %1 is now %2"
+msgstr ""
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+msgid ""
+"The instructor account with user id %1 does not exist.  Please create the "
+"account manually via WeBWorK."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+msgid ""
+"The library index is older than the library, you need to run OPL-update."
+msgstr ""
+
+#. ($r->param('new_set_name')
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
+msgid ""
+"The name '%1' is not a valid set name.  Use only letters, digits, -, _, and "
+"."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
+msgid ""
+"The name of course information file (located in the templates directory). "
+"Its contents are displayed in the right panel next to the list of homework "
+"sets."
+msgstr ""
+
+#. ($openDate, $dueDate, $answerDate)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+msgid ""
+"The open date: %1, close date: %2, and answer date: %3 must be defined and "
+"in chronological order."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+msgid "The password and password confirmation for the instructor must match."
+msgstr ""
+
+#. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
+msgid ""
+"The password you entered in the %1 field does not match your current "
+"password. Please retype your current password and try again."
+msgstr ""
+
+#. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
+msgid ""
+"The passwords you entered in the %1 and %2 fields don't match. Please retype"
+" your new password and try again."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+msgid "The path to the original file should be absolute"
+msgstr "Az állomány eredeti elérési útvonala legyen abszolút"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:505
+msgid ""
+"The percentage of active students with correct answers for each problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
+msgid ""
+"The percentage of students receiving at least these scores. The median score"
+" is in the 50% column."
+msgstr ""
+
+#. ($recScore,$totPossible)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+msgid "The recorded score for this test is  %1/%2."
+msgstr ""
+
+#. ($recScore, $totPossible)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+msgid "The recorded score for this test is %1/%2."
+msgstr ""
+
+#. ($openDate, $dueDate)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+msgid ""
+"The reduced credit date should be between the open date %1 and close date %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1142
+msgid ""
+"The reduced scoring date should be between the open date and close date."
+msgstr ""
+
+#. (join('.',@seq)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+msgid "The score for this problem can count towards score of problem %1."
+msgstr ""
+
+#. ($setName,$effectiveUser)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+msgid "The selected problem set (%1) is not a valid set for %2"
+msgstr "A kiválasztott feladatsor (%1) nem érvényes sor a  %2 -hoz(höz)"
+
+#. ($setID, $userCountMessage)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+msgid "The set %1 is assigned to %2."
+msgstr ""
+
+#. ($setName, $self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
+msgid "The set header for set %1 has been renamed to '%2'."
+msgstr ""
+
+#. ($newSetName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
+msgid ""
+"The set name '%1' is already in use.  Pick a different name if you would "
+"like to start a new set."
+msgstr ""
+
+#. ($setID, $editingSetVersion, $editForUser[0])
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+msgid "The set-version (%1, version %2) is not assigned to user %3."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
+msgid "The solution has been removed."
+msgstr ""
+
+#. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
+msgid ""
+"The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
+msgstr ""
+
+#. ($versionNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+msgid "The test (which is number %1) may  no longer be submitted for a grade."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
+msgid ""
+"The time limit on this assignment was exceeded. The assignment may be "
+"checked, but the result will not be counted."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:178
+msgid ""
+"The time of the day that the assignment is due.  This can be changed on an "
+"individual basis, but WeBWorK will use this value for default when a set is "
+"created."
+msgstr ""
+
+#. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+msgid "The title of the course %1 has been changed from %2 to %3"
+msgstr ""
+
+#. ($rename_newCourseID, $rename_newCourseTitle)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+msgid "The title of the course %1 is now %2"
+msgstr ""
+
+#. ($editForUser[0], $setCountMessage)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+msgid "The user %1 has been assigned %2."
+msgstr ""
+
+#. ($enableReducedScoring)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+msgid ""
+"The value %1 for enableReducedScoring is not valid; it will be replaced with"
+" 'N'."
+msgstr ""
+
+#. ($timeCap)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+msgid ""
+"The value %1 for the capTimeLimit option is not valid; it will be replaced "
+"with '0'."
+msgstr ""
+
+#. ($hideScore)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+msgid ""
+"The value %1 for the hideScore option is not valid; it will be replaced with"
+" 'N'."
+msgstr ""
+
+#. ($hideWork)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+msgid ""
+"The value %1 for the hideWork option is not valid; it will be replaced with "
+"'N'."
+msgstr ""
+
+#. ($relaxRestrictIP)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+msgid ""
+"The value %1 for the relaxRestrictIP option is not valid; it will be "
+"replaced with 'No'."
+msgstr ""
+
+#. ($restrictIP)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+msgid ""
+"The value %1 for the restrictIP option is not valid; it will be replaced "
+"with 'No'."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+msgid ""
+"The webwork server must be able to write to these directories. Please "
+"correct the permssion errors."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:128
+msgid "Theme (refresh page after saving changes to reveal new theme.)"
+msgstr ""
+
+# Context is "Sort by ____ Then by _____"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+msgid "Then by"
+msgstr "aztán e szerint"
+
+#. ($count_line)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:578
+msgid "There are %1 matching WeBWorK problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:154
+msgid ""
+"There are currently two hardcopy themes to choose from: One Column and Two "
+"Columns.  The Two Columns theme is the traditional hardcopy format.  The One"
+" Column theme uses the full page width for each column"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
+msgid ""
+"There are currently two themes (or skins) to choose from: math3 and math4.  "
+"The theme specifies a unified look and feel for the WeBWorK course web "
+"pages."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+msgid ""
+"There are extra database fields  which are not defined in the schema for at "
+"least one table.  They can only be removed manually from the database."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+msgid ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+msgid ""
+"There are extra database tables which are not defined in the schema.  They "
+"can only be removed manually from the database. They will not be renamed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:576
+msgid "There are no matching WeBWorK problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+msgid ""
+"There are tables or fields missing from the database.  The database must be "
+"upgraded before archiving this course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+msgid "There are upgrades available for the Open Problem Library."
+msgstr ""
+
+#. ($PGBranch, $PGRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+msgid ""
+"There are upgrades available for your current branch of PG from branch %1 in"
+" remote %2."
+msgstr ""
+
+#. ($WeBWorKBranch, $WeBWorKRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+msgid ""
+"There are upgrades available for your current branch of WeBWorK from branch "
+"%1 in remote %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
+msgid ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for achievement $achievementID for "
+"this student."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
+msgid ""
+"There is NO undo for this function.  Do not use it unless you know what you "
+"are doing!  When you unassign a student using this button, or by unchecking "
+"their name, you destroy all of the data for homework set $setID for this "
+"student."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:276
+msgid "There is NO undo for unassigning a set."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:127
+msgid "There is NO undo for unassigning students."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+msgid "There is a new version of PG available."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+msgid "There is a new version of WeBWorK available."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:472
+msgid "There is a written solution available"
+msgstr ""
+
+#. ($message_file, $merge_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
+msgid ""
+"There is no additional grade information.  A message about additional grades"
+" can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. "
+"These files can be edited using the \"Email\" link and the \"File Manager\" "
+"link in the left margin."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+msgid ""
+"There is no library tree file for the library, you will need to run OPL-"
+"update."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:734
+msgid "There is no undo for deleting files or directories!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:474
+msgid ""
+"There is no written solution available for this problem, but you can still "
+"view the correct answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:476
+msgid "There is no written solution available for this problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+msgid ""
+"There may be something wrong with this question. Please inform your "
+"instructor including the warning messages below."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+msgid ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator if this recurs."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+msgid ""
+"There was an error during the login process.  Please speak to your "
+"instructor or system administrator."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:316
+msgid ""
+"These users and higher get the \"Show Past Answers\" button on the problem "
+"page."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
+msgid "This action can take a long time if there are many students."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
+msgid "This action will not overwrite existing users."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+msgid "This answer is NOT completely correct."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+msgid "This answer is NOT correct."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+msgid "This answer is correct."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
+msgid ""
+"This course supports guest logins. Click %1 to log into this course as a "
+"guest."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+msgid "This homework set contains no problems."
+msgstr "Ez a feladatgysor nem tartalmaz feladatokat."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+msgid "This homework set is closed."
+msgstr "Ez a feladatsor zárolva van."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+msgid "This homework set is not yet open."
+msgstr "Ez a feladatsor jelenleg nincs nyitva."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+msgid ""
+"This is a blank problem template file and can not be edited directly. Use "
+"the 'NewVersion' action below to create a local copy of the file and add it "
+"to the current problem set."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
+msgid ""
+"This is a table showing the current Homework sets for this class.  The "
+"fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned "
+"Users, Visibility to students, Reduced Credit Enabled, Date it was opened, "
+"Date it is due, and the Date during which the answers are posted.  The Edit "
+"Set Data field contains checkboxes for selection and a link to the set data "
+"editing page.  The cells in the Edit Problems fields contain links which "
+"take you to a page where you can edit the containing problems, and the cells"
+" in the edit assigned users field contains links which take you to a page "
+"where you can edit what students the set is assigned to."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:93
+msgid ""
+"This is the Achievement Editor.  It is used to edit the achievements "
+"available to students.  Please keep in mind the following facts: Achievments"
+" are displayed, and evaluated, in the order they are listed. The \"secret\" "
+"category creates achievements which are not visible to students until they "
+"are earned.  The \"level\" category is used for the achievements associated "
+"to a users level."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:91
+msgid ""
+"This is the classlist editor page, where you can view and edit the records "
+"of all the students currently enrolled in this course.  The top of the page "
+"contains forms which allow you to filter which students to view, sort your "
+"students in a chosen order, edit student records, give new passwords to "
+"students, import/export student records from/to external files, or "
+"add/delete students.  To use, please select the action you would like to "
+"perform, enter in the relevant information in the fields below, and hit the "
+"\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
+"page contains a table containing the student usernames and their "
+"information."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:90
+msgid ""
+"This is the homework sets editor page where you can view and edit the "
+"homework sets that exist in this course and the problems that they contain. "
+"The top of the page contains forms which allow you to filter which sets to "
+"display in the table, sort the sets in a chosen order, edit homework sets, "
+"publish homework sets, import/export sets from/to an external file, score "
+"sets, or create/delete sets.  To use, please select the action you would "
+"like to perform, enter in the relevant information in the fields below, and "
+"hit the \\\"Take Action!\\\" button at the bottom of the form.  The bottom "
+"of the page contains a table displaying the sets and several pieces of "
+"relevant information."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:203
+msgid ""
+"This is the number of achievement points given to each user for completing a"
+" problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+msgid ""
+"This problem has open subproblems.  You can visit them by using the links to"
+" the left or visiting the set page."
+msgstr ""
+
+#. ($shownYet{$problemFile})
+#. ($prettyID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+msgid "This problem uses the same source file as number %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+msgid "This problem will not count towards your grade."
+msgstr "Ez a feladatsor nem számít be az értékelésbe."
+
+#. ($EMAIL)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+msgid "This sample mail would be sent to %1"
+msgstr ""
+
+#. (join('.',@seq)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+msgid ""
+"This score for this problem does not count for the score of problem %1 or "
+"for the set."
+msgstr ""
+
+#. ($message_file, $merge_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
+msgid ""
+"This scoring message is generated from [TMPL]/email/%1. It is merged with "
+"the file [Scoring]/%2. These files can be edited using the \"Email\" link "
+"and the \"File Manager\" link in the left margin."
+msgstr ""
+
+#. (CGI::strong($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+msgid "This set %1 is assigned to %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+msgid "This set doesn't contain any problems yet."
+msgstr ""
+
+#. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+msgid ""
+"This set had a reduced scoring period that started on %1 and ended on %2.  "
+"During that period all work counted for %3% of its value."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:271
+msgid ""
+"This set has a set-level proctor password to authorize logins. Enter the "
+"password below."
+msgstr ""
+
+#. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
+# Context is "This set is visible" or "This set is hidden"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
+msgid "This set is %1"
+msgstr "Ez a feladatsor %1"
+
+#. ($reducedScoringPerCent)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+msgid ""
+"This set is in its reduced scoring period.  All work counts for %1% of its "
+"value."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:178
+msgid "This set needs to be assigned to you before you can grade it."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:182
+msgid ""
+"This set will be unavailable to students until they have earned a certain "
+"score on the sets specified in this field.  The sets should be written as a "
+"comma separated list.  The minimum score required on the sets is specified "
+"in the following field."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:218
+msgid ""
+"This sets whether the Reduced Scoring system will be enabled.  If enabled "
+"you will need to set the default length of the reduced scoring period and "
+"the value of work done in the reduced scoring period below.  <p> To use "
+"this, you also have to enable Reduced Scoring for individual assignments and"
+" set their Reduced Scoring Dates by editing the set data.<p> This works with"
+" the avg_problem_grader (which is the the default grader) and the  "
+"std_problem_grader (the all or nothing grader).  It will work with custom "
+"graders if they are written appropriately."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+msgid "This source file does not exist!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+msgid "This source file is a directory!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+msgid "This source file is not a plain file!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+msgid "This source file is not readable!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:382
+msgid ""
+"This specifies the rerandomization period: the number of attempts before a "
+"new version of the problem is generated by changing the Seed value. The "
+"value of -1 uses the default from course configuration. The value of 0 "
+"disables rerandomization."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:257
+msgid ""
+"This table lists out the available homework sets for this class, along with "
+"its current status. Click on the link on the name of the homework sets to "
+"take you to the problems in that homework set.  Clicking on the links in the"
+" table headings will sort the table by the field it corresponds to.  You can"
+" also select sets for download to PDF or TeX format using the linkx next to "
+"the problem set names, and then clicking on the 'Download PDF or TeX "
+"Hardcopy for Selected Sets' button at the end of the table.  There is also a"
+" clear button and an Email instructor button at the end of the table."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+msgid ""
+"This table shows the problems that are in this problem set.  The columns "
+"from left to right are: name of the problem, current number of attempts "
+"made, number of attempts remaining, the point worth, and the completion "
+"status.  Click on the link on the name of the problem to take you to the "
+"problem page."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+msgid "Time"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
+msgid "Time Interval for New Test Versions (min; 0=infty)"
+msgstr ""
+
+#. ($elapsedTime,$allowed)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+msgid "Time taken on test: %1 min (%2 min allowed)."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:221
+msgid "Timestamp"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:146
+msgid "Timezone for the course"
+msgstr ""
+
+#. (sprintf("%.0f",$restriction)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+msgid "To access this set you must score at least %1% on set %2."
+msgstr ""
+
+#. (sprintf("%.0f",$restriction)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+msgid ""
+"To access this set you must score at least %1% on the following sets: %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+msgid ""
+"To add an additional instructor to the new course, specify user information "
+"below. The user ID may contain only numbers, letters, hyphens, periods "
+"(dots), commas,and underscores.\n"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+msgid ""
+"To add the WeBWorK administrators to the new course (as administrators) "
+"check the box below."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:278
+msgid ""
+"To change status (scores or grades) for this student for one set, click on "
+"the individual set link."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+msgid ""
+"To copy problem templates from an existing course, select the course below."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+msgid ""
+"To edit a specific student version of this set, edit (all of) her/his "
+"assigned sets."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+msgid ""
+"To edit this text you must first make a copy of this file using the "
+"'NewVersion' action below."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+msgid ""
+"To edit this text you must use the 'NewVersion' action below to save it to "
+"another file."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
+msgid "To this Problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+msgid "To:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+msgid "Totals"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
+msgid "Totals only (not problem scores)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:299
+msgid "Totals only, only after answer date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
+msgid "Transfer"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+msgid "True"
+msgstr "Igaz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2266
+msgid "Try it"
+msgstr "Próbáld ki"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:189
+msgid "Tunic of Extension"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:105
+msgid "Two Columns"
+msgstr "Két oszlop"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+msgid "Type"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+msgid "URI"
+msgstr ""
+
+#. ($achievementName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+msgid "Unable to change the evaluator for set %1. Unknown error."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+msgid "Unable to obtain error messages from within the PG question."
+msgstr ""
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+msgid "Unable to write to '%1': %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+msgid "Unarchive"
+msgstr ""
+
+#. ($unarchive_courseID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+msgid "Unarchive %1 to course:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+msgid "Unarchive Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+msgid "Unarchive Next Course"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
+msgid "Unassign from All Users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
+msgid "Unassign selected sets from selected users"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
+msgid ""
+"Unassignments were not done.  You need to both click to \"Allow unassign\" "
+"and click on the Unassign button."
+msgstr ""
+
+#. ($unattempted,$num_of_problems)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+msgid "Unattempted: %1/%2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
+msgid "Unclassified Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+msgid "Ungraded"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+msgid "Unhide Courses"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
+msgid ""
+"Unlock an additional version of a Gateway Test.  If used before the close "
+"date of the Gateway Test this will allow you to generate a new version of "
+"the test."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:163
+msgid "Unpack"
+msgstr "Kicsomagol"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:385
+msgid "Unpack archives automatically"
+msgstr "Az archívumok automatikus kicsomagolása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+msgid "Unselect all courses"
+msgstr "Az összes kurzus kijelölésének megszüntetése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
+msgid "Unselect all sets"
+msgstr "Az összes feladatsor kijelölésének visszavonása "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+msgid "Unselect all users"
+msgstr "Az összes felhasználó kijelölésének visszavonása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+msgid "Update"
+msgstr "Frissítés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:803
+msgid "Update Display"
+msgstr "A képernyő frissítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:724
+msgid "Update Menus"
+msgstr "A menük frissítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+msgid "Update settings and refresh page"
+msgstr "A beállítások majd az oldal frissítése "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+msgid "Update the checked directories?"
+msgstr "A bejelölt könyvtárak frissítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+msgid "Updated location description."
+msgstr "A frissített elhelyezkedés leírása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+msgid "Upgrade"
+msgstr "Frissítés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+msgid "Upgrade Course Tables"
+msgstr "A kurzustáblák frissítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+msgid "Upgrade Courses"
+msgstr "A kurzusok frissítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+msgid "Upgrade process completed"
+msgstr "A frissítési folyamat befejezve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:370
+msgid "Upload"
+msgstr "Feltöltés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:161
+msgid "Use Date Picker"
+msgstr "Dátumválasztó használata"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+msgid "Use Default Header File"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+msgid "Use Equation Editor?"
+msgstr "Egyenletszerkesztő használata"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:239
+msgid "Use Item"
+msgstr "Elem használata"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+msgid "Use System Default"
+msgstr "Rendszerbeállítások használata"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+msgid "Use browser back button to return from preview mode"
+msgstr "Használja a böngészője vissza gombját a kilépéshez az előnézeti módból."
+
+#. (CGI::b("$achievementID")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+msgid "Use in achievement %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+msgid "Use in new achievement:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
+msgid "Use log base 10 instead of base <i>e</i>"
+msgstr "10-es alapú logaritmust használj <i>e</i> alapú helyett"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:370
+msgid "Use older answer checkers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
+msgid ""
+"Use the interface below to quickly access commonly-used instructor tools, or"
+" select a tool from the list to the left."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+msgid ""
+"Use this form to report to your professor a problem with the WeBWorK system "
+"or an error in a problem you are attempting. Along with your message, "
+"additional information about the state of the system will be included."
+msgstr "Használja ezt a tanárának szóló űrlapot WebWork rendszerben vagy az valamely feladatnál előállt hiba bejelentésére. Az üzenettel el lesznek küldve további információk a rendszer állapotáról is."
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+msgid ""
+"User '%1' will not be copied from admin course as it is the initial "
+"instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
+msgid "User ID"
+msgstr "Felhasználói azonosító"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
+msgid "User Settings"
+msgstr "Felhasználói beállíttások"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
+msgid "User Values"
+msgstr "Felhasználói értékek"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
+msgid "User's name is:"
+msgstr "A felhasználó neve ez:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
+msgid "User's username is:"
+msgstr "A felhasználó felhasználóneve ez:"
+
+#. ($user, $setID, $sortme[$j][0])
+#. ($user, $setID, $j)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
+msgid ""
+"UserProblem missing for user=%1 set=%2 problem=%3. This may indicate "
+"database corruption."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
+msgid "Username"
+msgstr "Felhasználónév"
+
+#. ($user_id)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
+msgid "Username presented:  %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
+msgid "Users"
+msgstr "Felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
+msgid "Users Assigned to Set %2"
+msgstr "A felhasználó ki lett jelölve a %2 feladatsorhoz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+msgid "Users List"
+msgstr "Felhasználói lista"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:311
+msgid ""
+"Users at this level and higher are allowed to change their e-mail address. "
+"Normally guest users are not allowed to change the e-mail address since it "
+"does not make sense to send e-mail to anonymous accounts."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:287
+msgid ""
+"Users at this level and higher are allowed to change their password. "
+"Normally guest users are not allowed to change their password."
+msgstr ""
+
+#. ($names{$primary}, $names{$secondary}, $names{$ternary})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+msgid "Users sorted by %1, then by %2, then by %3"
+msgstr "A felhasználók előbb %1, aztán %2 és végül %3 szerint rendezve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:306
+msgid ""
+"Users with at least this permission level get a link in the left panel for "
+"reporting bugs to the bug tracking system in Rochester"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:405
+msgid ""
+"Users with this permssion level or greater will automatically be sent "
+"feedback from students (generated when they use the \"Contact instructor\" "
+"button on any problem page).  In addition the feedback message will be sent "
+"to addresses listed below.  To send ONLY to addresses listed below set "
+"permission level to \"nobody\"."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
+msgid "Using contents of the default message $default_msg_file instead."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+msgid "Using what display mode?: "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+msgid "Using what seed?: "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:222
+msgid "Value of work done in Reduced Scoring Period"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+msgid "Variable Documentation:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+msgid "Versions of a set can only be edited for one user at a time."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+msgid "View"
+msgstr "Megjelenítés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
+msgid "View Problems"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+msgid "View equations as"
+msgstr "Mutasd az egyenletet mint"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
+msgid "View it"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
+msgid "View statistics by set"
+msgstr "Mutasd a statisztikákat feladatsoronként"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
+msgid "View statistics by student"
+msgstr "A diák statisztikájának megjelenítése"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
+msgid "View student progress by set"
+msgstr "A diákok előmenetelének megtekintése feladatsoronként."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
+msgid "View student progress by student"
+msgstr "A diákok előmenetelének megtekintése diákonként"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
+msgid "View/Edit"
+msgstr "Mutat/szerkeszt"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
+msgid "Viewing temporary file:"
+msgstr "Átmeneti állomány mutatása:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:829
+msgid "Visibility"
+msgstr "Láthatóság"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
+msgid "Visible"
+msgstr "Látható"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
+msgid "Visible to Students"
+msgstr "Látható diákok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
+msgid "Warning"
+msgstr "Figyelmeztetés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+msgid "Warning messages"
+msgstr "Figyelmeztető üzenet"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+msgid "Warning: Deletion destroys all user-related data and is not undoable!"
+msgstr "Vigyázat: a törléssel minden felhaszálóval kapcsolatos adat visszavonhatatlanul törlődik!"
+
+#. ($problem_desc , CGI::br()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1223
+msgid "Warnings encountered while processing %1. Error text: %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+msgid "WeBWorK Error"
+msgstr "WeBWorK hiba"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+msgid "WeBWorK Warnings"
+msgstr "WeBWorK figyelmeztetés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
+msgid ""
+"WeBWorK currently has translations for four languages: \"English en\", "
+"\"Turkish tr\", \"Spanish es\", and \"French fr\" "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:86
+msgid ""
+"WeBWorK has encountered a software error while attempting to process this "
+"problem. It is likely that there is an error in the problem itself. If you "
+"are a student, report this error message to your professor to have it "
+"corrected. If you are a professor, please consult the error output below for"
+" more information."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+msgid ""
+"WeBWorK has encountered warnings while processing your request. If this "
+"occured when viewing a problem, it was likely caused by an error or "
+"ambiguity in that problem. Otherwise, it may indicate a problem with the "
+"WeBWorK system itself. If you are a student, report these warnings to your "
+"professor to have them corrected. If you are a professor, please consult the"
+" warning output below for more information."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:491
+msgid ""
+"WeBWorK was unable to generate a different version of this problem; close "
+"this tab, and return to the original problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:309
+msgid ""
+"WeBWorK was unable to generate a paper copy of this homework set.  Please "
+"inform your instructor. "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:344
+msgid "Weight"
+msgstr "Súly"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
+msgid "Welcome to WeBWorK!"
+msgstr "Üdvözöl a WeBWork!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1289
+msgid "What could be inside?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+msgid "What field should filtered users match on?"
+msgstr "A felhasználók mely mezőjére kíván szűrési feltételt megadni? "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:370
+msgid ""
+"When a student has more attempts than is specified here they will be able to"
+" view another version of this problem.  If set to -1 the feature is disabled"
+" and if set to -2 the course default is used."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:301
+msgid ""
+"When acting as a student, this permission level and higher can submit "
+"answers for that student."
+msgstr ""
+
+#. (CGI::em($r->maketext("before")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2307
+msgid ""
+"When changing problem numbers, we will move the problem to be %1 the chosen "
+"number."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:384
+msgid ""
+"When students click the <em>Email Instructor</em> button to send feedback, "
+"WeBWorK fills in the subject line.  Here you can set the subject line.  In "
+"it, you can have various bits of information filled in with the following "
+"escape sequences.<p><ul><li> %c = course ID<li> %u = user ID<li> %s = set "
+"ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal"
+" percent sign</ul>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:167
+msgid ""
+"When this is on students will see a line on the Grades page which has their "
+"total cumulative homework score.  This score includes all sets assigned to "
+"the student."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:333
+msgid ""
+"When viewing a problem, WeBWorK usually puts the previously submitted answer"
+" in the answer blank.  Below this level, old answers are never shown.  "
+"Typically, that is the desired behaviour for guest accounts."
+msgstr ""
+
+#. (CGI::b($achievementID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:153
+msgid ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for achievement %1 for this student. Make sure this is what you want to"
+" do."
+msgstr ""
+
+#. (CGI::b($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:128
+msgid ""
+"When you unassign by unchecking a student's name, you destroy all of the "
+"data for homework set %1 for this student. You will then need to reassign "
+"the set to these students and they will receive new versions of the "
+"problems. Make sure this is what you want to do before unchecking students."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:280
+msgid ""
+"When you uncheck a homework set (and save the changes), you destroy all of "
+"the data for that set for this student.   If you reassign the set, the "
+"student will receive a new version of each problem. Make sure this is what "
+"you want to do before unchecking sets."
+msgstr ""
+
+#. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
+msgid "Will open on %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+msgid "Worth"
+msgstr "Megéri"
+
+#. ($self->shortPath($outputFilePath)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+msgid ""
+"Write permissions have not been enabled for '%1'.  Changes must be saved to "
+"another file for viewing."
+msgstr ""
+
+#. ($self->shortPath($currentDirectory)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+msgid ""
+"Write permissions have not been enabled in '%1'.  Changes must be saved to a"
+" different directory for viewing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+msgid ""
+"Write permissions have not been enabled in the templates directory.  No "
+"changes can be made."
+msgstr "Az átmeneti könyvtárnak nincsenek engedényezve az írási jogosultságok. Nem történik változás."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+msgid "Yes"
+msgstr "Igen"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:455
+msgid ""
+"You are currently checking answers to a different version of your problem - "
+"these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:460
+msgid ""
+"You are currently previewing answers to a different version of your problem "
+"- these will not be recorded, and you should remember to return to your "
+"original problem once you are done here."
+msgstr ""
+
+#. ($userSet->set_id, $r->connection->remote_ip)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:253
+msgid ""
+"You are not allowed to generate a hardcopy for %1 from your IP address, %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
+msgid "You are not authorized to access the Instructor tools"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+msgid "You are not authorized to access the Instructor tools."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+msgid "You are not authorized to access the instructor tools."
+msgstr "Ön nem jogosult hozzaférni az oktatói eszközökhöz."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
+msgid "You are not authorized to modify homework sets."
+msgstr "Ön nem jogosult módosítani a feladatsort."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+msgid "You are not authorized to modify problems."
+msgstr "Önnek nincs jogosultsága módosítani a feladatot."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
+msgid "You are not authorized to modify set definition files."
+msgstr "Ön nem jogosult módosítani a feladatsor definíciós állományait."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+msgid "You are not authorized to modify student data"
+msgstr "Ön nem jogosult módosítani a diák adatait"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+msgid "You are not authorized to perform this action."
+msgstr "Ön nem jogosult végrehajtani ezt a műveletet."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:246
+msgid ""
+"You are not permitted to generate a hardcopy for a set with hidden work."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:234
+msgid "You are not permitted to generate a hardcopy for an unopened set."
+msgstr ""
+
+#. ($showMeAnother{MaxReps},$solutionShown)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:484
+msgid ""
+"You are only allowed to click on Show Me Another %quant(%1,time,times) per "
+"problem. %2 Close this tab, and return to the original problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+msgid "You are out of time.  Press grade now!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:316
+msgid "You can also examine the following temporary files: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGanswermacros.pl:1693
+msgid "You can earn partial credit on this problem."
+msgstr "Ezért a feladatért részpontokat kaphat. "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
+msgid "You can not specify an absolute path"
+msgstr ""
+
+#. ($action)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
+msgid "You can only %1 one file at a time."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:98
+msgid "You can only download regular files."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:508
+msgid "You can only edit text files"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:786
+msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
+msgstr ""
+
+#. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+msgid ""
+"You can use this feature %quant(%1,more time,more times,as many times as you"
+" want) on this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:866
+msgid "You can't download directories"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:867
+msgid "You can't download files of that type"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
+msgid "You can't edit a directory"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
+msgid "You can't view files of that type"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+msgid "You cannot archive the course you are currently using."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+msgid "You cannot delete the course you are currently using."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+msgid "You cannot delete yourself!"
+msgstr "Nem törölheti önmagát!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1842
+msgid ""
+"You cannot use this version of Set Detail to edit just-in-time type sets.  "
+"You must use Set Detail 2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
+msgid "You did not specify a new set name."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+msgid "You didn't enter any message."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
+msgid "You do not have permission to change email addresses."
+msgstr "Önnek nincs jogosultsága változtatni az e-mail címeket."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
+msgid "You do not have permission to change the hardcopy theme."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
+msgid "You do not have permission to change your password."
+msgstr "Önnek nincs jogosultsága megváltoztatni a jelszavát."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
+msgid "You do not have permission to edit this file."
+msgstr ""
+
+#. ($hardcopy_format)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
+msgid "You do not have permission to generate hardcopy in %1 format."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+msgid "You do not have permission to view the details of this error."
+msgstr "Nincsen engedélye a hiba részleteinek megtekintéséhez."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
+msgid "You don't have any items!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+msgid "You exceeded the allowed time."
+msgstr ""
+
+#. ($numLeft)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+msgid "You have %1 attempt(s) remaining on this test."
+msgstr ""
+
+#. ($attemptsLeft)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
+msgstr "Önnek %negquant(%1,korlátlan próbálkozás,próbálkozás,próbálkozás) maradt."
+
+#. ($attempts_before_rr)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+msgid ""
+"You have %quant(%1,attempt,attempts) left before new version will be "
+"requested."
+msgstr ""
+
+#. ($attempts)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+msgid "You have attempted this problem %quant(%1,time,times)."
+msgstr "Ön ezt a feladatot %quant(%1,-szor(ször),-szor(ször)) próbálta."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
+msgid "You have been logged out of WeBWorK."
+msgstr "Ön kijelentkezett WebWork-ből."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+msgid "You have less than 1 minute to complete this test."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:882
+msgid "You have not chosen a file to upload."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
+msgid "You have requested that the following items be deleted"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1005
+msgid "You have specified an illegal file"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1237
+msgid "You have specified an illegal path"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:465
+msgid ""
+"You may check your answers to this problem without affecting the maximum "
+"number of tries to your original problem."
+msgstr ""
+
+#. ($phrase_for_privileged_users)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:575
+msgid ""
+"You may choose to show any of the following data. Correct answers, hints, "
+"and solutions are only available %1 after the answer date of the homework "
+"set."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+msgid "You may not change your own password here!"
+msgstr "Ön nem tudja megváltoztatni itt a jelszavát!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+msgid "You may still check your answers."
+msgstr ""
+
+#. ($showMeAnother{TriesNeeded})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
+msgid ""
+"You must attempt this problem %quant(%1,time,times) before Show Me Another "
+"is available."
+msgstr ""
+
+#. ($showMeAnother{TriesNeeded})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+msgid ""
+"You must attempt this problem %quant(%1,time,times) before this feature is "
+"available"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+msgid "You must confirm the password for the initial instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:488
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:541
+msgid ""
+"You must log into this set via your Learning Management System (e.g. "
+"Blackboard, Moodle, etc...)."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
+msgid "You must provide a student ID, a set ID, and a problem number."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+msgid "You must select a course to rename."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
+msgid "You must select at least one file for the archive"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
+msgid "You must select at least one file to delete"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+msgid "You must select one or more sets for scoring"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+msgid "You must specify a course ID."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+msgid "You must specify a course name."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
+msgid "You must specify a file name"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+msgid "You must specify a first name for the initial instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+msgid "You must specify a last name for the initial instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+msgid "You must specify a new institution for the course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+msgid "You must specify a new name for the course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+msgid "You must specify a new title for the course."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+msgid "You must specify a password for the initial instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+msgid "You must specify a user ID."
+msgstr "Meg kell adni egy felhasználói azonosítót (ID)."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+msgid "You must specify an email address for the initial instructor."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+msgid "You must specify an file name in order to save a new file."
+msgstr "Meg kell adnia egy fájlnevet, hogy mentsen egy új fájlt."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:488
+msgid ""
+"You must use your Learning Managment System (E.G. Blackboard, Moodle, "
+"Canvas, etc...) to access this set.  Try logging in to the Learning "
+"Managment System and visiting the set from there."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1260
+msgid "You need to select a \"Target Set\" before you can edit it."
+msgstr ""
+
+#. ($action)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
+msgid "You need to select a file to %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
+msgid "You need to select a set definition file to view."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
+msgid "You need to select a set from this course to view."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1369
+msgid "You need to select a set to view."
+msgstr ""
+
+#. (wwRound(0, $pg->{result}->{score} * 100)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+msgid "You received a score of %1 for this attempt."
+msgstr "Ön %1 pontot kapott ezért a próbálkozásért."
+
+#. (join('.',@{$problemSeqs[$next_id]})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+msgid ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem and its graded subproblems."
+msgstr ""
+
+#. (join('.',@{$problemSeqs[$next_id]})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+msgid ""
+"You will not be able to proceed to problem %1 until you have completed, or "
+"run out of attempts, for this problem."
+msgstr ""
+
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1213
+msgid "Your %1 name contains illegal characters"
+msgstr ""
+
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1214
+msgid "Your %1 name may not begin with a dot"
+msgstr ""
+
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1215
+msgid "Your %1 name may not contain a path component"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:495
+msgid ""
+"Your LTI OAuth verification failed.  If this recurs, please speak with your "
+"instructor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:494
+msgid ""
+"Your authentication failed.  Please return to Oncourse and login again."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:237
+msgid ""
+"Your authentication failed.  Please try again. Please speak with your "
+"instructor if you need help."
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#. ($PGBranch, $PGRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+msgid "Your current branch of PG is up to date with branch %1 in remote %2."
+msgstr ""
+
+#. ($WeBWorKBranch, $WeBWorKRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+msgid ""
+"Your current branch of WeBWorK is up to date with branch %1 in remote %2."
+msgstr ""
+
+#. ($LibraryBranch, $LibraryRemote)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+msgid "Your current branch of the Open Problem Library is up to date."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+msgid "Your display options have been saved."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
+msgid "Your email address has been changed."
+msgstr "Az Ön e-mail címe megváltozott."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1239
+msgid "Your file name contains illegal characters"
+msgstr ""
+
+#. ($lastScore,$notCountedMessage)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+msgid "Your overall recorded score is %1.  %2"
+msgstr "Az Ön teljes pontszáma %1. %2"
+
+#. ($versionNumber, wwRound(2,$recordedScore)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+msgid "Your recorded score on this test (number %1) is %2/%3."
+msgstr ""
+
+#. ($testNounNum)
+# $testNounNum is either "test (#)" or "submission (#)"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+msgid "Your score on this %1 WAS recorded."
+msgstr ""
+
+#. ($testNoun,$attemptScore,$totPossible)
+# $testNoun is either "test" or "submission"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+msgid "Your score on this %1 is %2/%3."
+msgstr ""
+
+#. ($testNounNum)
+# $testNounNum is either "test (#)" or "submission (#)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+msgid "Your score on this %1 was NOT recorded."
+msgstr ""
+
+#. ($attemptScore,$totPossible)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+msgid "Your score on this (checked, not recorded) submission is %1/%2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+msgid "Your score on this problem was recorded."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+msgid ""
+"Your score was not recorded because there was a failure in storing the "
+"problem record to the database."
+msgstr "Az Ön pontszáma nem lett elmentve, mert a feladat pontszámának adatbázisba írása hibába ütközött."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+msgid "Your score was not recorded because this homework set is closed."
+msgstr "Pontjai nem lettek elmentve, mivel ez a feladatsor zárva van."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+msgid ""
+"Your score was not recorded because this problem has not been assigned to "
+"you."
+msgstr "Pontjai nem lettek elmentve, mivel ez a feladat nincs hozzárendelve Önhöz."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+msgid ""
+"Your score was not recorded because this problem set version is not open."
+msgstr ""
+
+#. ($elapsed, $allowed)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+msgid ""
+"Your score was not recorded because you have exceeded the time limit for "
+"this test. (Time taken: %1 min; allowed: %2 min.)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+msgid ""
+"Your score was not recorded because you have no attempts remaining on this "
+"set version."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+msgid "Your score was not recorded."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+msgid "Your score was not successfully sent to the LMS"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+msgid "Your score was recorded."
+msgstr "Az eredmény el lett mentve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+msgid "Your score was successfully sent to the LMS"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+msgid "Your session has timed out due to inactivity. Please log in again."
+msgstr "A időkorlátja lejárt inaktivitás miatt. Kérjük, jelentkezzen be újra."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+msgid "Your systems are up to date!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
+msgid "[Edit]"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
+msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
+msgid "_ANSWER_LOG_DESCRIPTION"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+msgid "_CLASSLIST_EDITOR_DESCRIPTION"
+msgstr "Ezen az oldalon megtekintheti és szerkesztheti a kurzushoz hozzárendelt diákok nyilvántartását. Az oldal felső részén szűrési, rendezési eszközöket talál, valamint a diákok bejegyzeseit lehet szerkeszteni, új jelszavakat szolgáltatni, importálni és exportálni, illetve hozzáadni és törölni a diákokat. A használathoz válassza ki a végrehajtandó művelete, majd kattintson a \"Csináld!\" gombra a tennivalók felsorolása alatt. Ezek alatt a diákok felhasználói nevei és adadatait tartalmazó táblázatok találhatók. "
+
+#. (CGI::strong($r->maketext($course)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
+msgid "_EXTERNAL_AUTH_MESSAGE"
+msgstr "1% külső hitelesítési rendszert használ. Önt ez a rendszer hitelesítette, de nem engedélyezi a belépését ebbe a kurzusba."
+
+#. (CGI::b($r->maketext("Guest Login")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
+msgid "_GUEST_LOGIN_MESSAGE"
+msgstr "Ez a kurzus támogatja vendég bejelentkezést. Kattintson a % 1 -ra(re) vendégként való bejelentkezéshez."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
+msgid "_HMWKSETS_EDITOR_DESCRIPTION"
+msgstr "Ez a házi feladatok (HF) - feladatsorok szerkesztőjének oldala, ahol megtekintehi és szerkeszheti az egyes kurzusokhoz tartozó feladatsorokat valamit a tartalmazott feladatokat. Az oldal felső részén olyan kapcsolókat talál, amelyekkel szűrheti, rendezheti, szerkesztheti, importálhatja/exportálhatja, publikálhatja, létrehozhatja/törölheti a feladatsorokat. Válassza ki a végrehajtandó tevékenységet, majd a \"Csináld!\" gombbal végrehajtatja azt. Ezek alatt egy táblázatot talál a a feladatsor feladataival és annak információival."
+
+#. (CGI::b($r->maketext("Remember Me")
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
+msgid "_LOGIN_MESSAGE"
+msgstr "A(z) % 1 megjelölésével az Ön bejelentkezési adatait megjegyzi az Ön által használt böngésző, ami lehetővé teszi a WeBWoRK oldalra bejelentkezését anélkül, hogy beírná a felhasználói nevét és jelszavát (míg a munkamenet le nem jár). Ez a lehetőség nem ajánlott, nem biztonságos nyilvános, nem megbízható munkaállomásokon, számítógépeken, és olyan számítógépeken, amelyek felett nincs közvetlen ellenőrzési lehetősége."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+msgid "_PROBLEM_SET_SUMMARY"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+msgid "_REQUEST_ERROR"
+msgstr "A WeBWoRK szoftverhibába ütközött, miközben megpróbálta feldolgozni ezt a feladatot. Valószínű, hogy a hiba az Ön feladatában van. Ha Ön diák, jelentse ezt a hibaüzenetet a tanárának, hogy orvosolni tudja. Ha Ön tanár, kérjük, olvassa el a hiba kimenetét a részletekért."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+msgid "_USER_TABLE_SUMMARY"
+msgstr ""
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
+msgid "a duplicate of the first selected set"
+msgstr "másolat az első kijelölt feladatsorról"
+
+# Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
+msgid "a new empty set"
+msgstr "új, üres feladatsor"
+
+# Context is "Save to a new file named:"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+msgid "a new file named:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
+msgid "a single set"
+msgstr "egyetlen feladatsor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+msgid "active"
+msgstr "aktív"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
+msgid "add problems"
+msgstr "feladat hozzáadása"
+
+#. ($setName, $@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+msgid "addGlobalSet %1 in ProblemSetList:  %2"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+msgid "added missing permission level for user"
+msgstr ""
+
+# #short for administrator
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "admin"
+msgstr "admin"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+msgid "all achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
+msgid "all current users"
+msgstr "az összes jelenlegi felhasználó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
+msgid "all set dates for one <b>user</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:657
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1362
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:682
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:982
+msgid "all sets"
+msgstr "az összes feladatsor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
+msgid "all students"
+msgstr "minden diák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+msgid "all users"
+msgstr "az összes felhasználó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
+msgid "all users for one <b>set</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+msgid "alphabetically"
+msgstr "abc-sorrendben"
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+msgid "answer"
+msgstr "válasz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+msgid "any users"
+msgstr "bármely felhasználó"
+
+# Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
+msgid "as"
+msgstr "mint"
+
+# Context is "Import achievements from ____ assigning the achievements to ___"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
+msgid "assigning the achievements to"
+msgstr ""
+
+# Context is "Import set from ____ assigning this set to ____"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
+msgid "assigning this set to"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
+msgid "avg attempts"
+msgstr ""
+
+# Context is "Append ____ blank problem template(s) to end of homework set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+msgid "blank problem template(s) to end of homework set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+msgid "by last login date"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
+msgid "changes abandoned"
+msgstr "változások elhagyása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
+msgid "changes saved"
+msgstr "változások mentve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
+msgid "class list data"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
+msgid "class list data for selected <b>users</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
+msgid "close"
+msgstr "bezár"
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+msgid "column"
+msgstr "oszlop"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+msgid "columns:"
+msgstr "oszlopok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+msgid "correct"
+msgstr "helyes"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
+msgid "course files"
+msgstr "kurzusállomány"
+
+#. ($num)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
+msgid "deleted %1 sets"
+msgstr "törölve %1 feladatsor"
+
+#. ($num)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+msgid "deleted %1 users"
+msgstr "törölve %1 felhasználó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
+msgid "editing all achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
+msgid "editing all sets"
+msgstr "az összes feladatsor módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+msgid "editing all users"
+msgstr "az összes felhasználó módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
+msgid "editing selected achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
+msgid "editing selected sets"
+msgstr "a kiválasztott feladatsorok módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+msgid "editing selected users"
+msgstr "a kiválasztott felhasználók módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
+msgid "editing visible sets"
+msgstr "a látható feladatsorok módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+msgid "editing visible users"
+msgstr "a látható felhasználók módosítása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
+msgid "email:"
+msgstr "e-mail:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+msgid "empty"
+msgstr "üres"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
+msgid "enter matching set IDs below"
+msgstr "adja meg alább a megfelelő feladatsor azonosítóját (ID) "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
+msgid "entry rows."
+msgstr "üres sor"
+
+#. ($restrictLoc, $setName, $@)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+msgid "error adding set location %1 for set %2: %3"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
+msgid "export abandoned"
+msgstr "az export elhagyva"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+msgid "exporting all achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
+msgid "exporting all sets"
+msgstr "az összes feladatsor exportálása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+msgid "exporting selected achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
+msgid "exporting selected sets"
+msgstr "a kiválasztott feladatsorok exportálása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
+msgid "exporting visible sets"
+msgstr "a látható feladatsorok exportálása"
+
+#. ($userName, $editForUserID, $setCount)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
+msgid "for  %1 (%2) who has been assigned %3 sets."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
+msgid "for one <b>set</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
+msgid "for one <b>user</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
+msgid "for students"
+msgstr "diákoknak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
+msgid "from"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+msgid "giving new passwords to all users"
+msgstr "új jelszót minden felhasználónak "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+msgid "giving new passwords to selected users"
+msgstr "új jelszót minden kijelölt felhasználónak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+msgid "giving new passwords to visible users"
+msgstr "új jelszót minden látható felhasználónak"
+
+#. ($j, $setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
+msgid "global %1 for set %2 not found."
+msgstr ""
+
+#. ($setName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
+msgid "global set %1  not found."
+msgstr ""
+
+#. ($setID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
+msgid "global set %1 not found."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "grade_proctor"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "guest"
+msgstr "vendég"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
+msgid "hidden"
+msgstr "rejtve"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
+msgid "hidden from"
+msgstr "rejtve innen:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
+msgid "hidden from students"
+msgstr "rejtve a diákoktól"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
+msgid "hidden sets"
+msgstr "rejtett feladatsorok"
+
+#. ('j','k','_0')
+#. ('j','k')
+# doe snot need to be translated
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
+#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/macros/contextLimitedVector.pl:94
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+msgid "illegal character in input: '/'"
+msgstr ""
+
+# Context is " Show users who match _____ in their _____"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+msgid "in their"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+msgid "inactive"
+msgstr "inaktív"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+msgid "incorrect"
+msgstr "helytelen"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+msgid "index"
+msgstr ""
+
+#. ($restrictLoc, $setName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+msgid "input set location %1 already exists for set %2."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+msgid "list of insertable macros"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+msgid "locations selected below"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
+msgid "login"
+msgstr "bejelentkezés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+msgid "login ID"
+msgstr "bejelentkezési azonosító"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
+msgid "login/studentID:"
+msgstr "bejelentkezési/diák azonosító"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "login_proctor"
+msgstr ""
+
+# Context is "Set _____ made visibile for _____ users"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
+msgid "made visible for"
+msgstr "tedd láthatóvá"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
+msgid "max"
+msgstr "max."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
+msgid "multiple sets"
+msgstr "többszörös feladatsor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
+msgid "new set:"
+msgstr "új feladatsor:"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
+msgid "new users"
+msgstr "új felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+msgid "no achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+msgid "no achievements."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+msgid "no location"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1073
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:981
+msgid "no sets"
+msgstr "nincs feladatsor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
+msgid "no students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+msgid "no users"
+msgstr "nincs felhasználó"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "nobody"
+msgstr "senki"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+msgid "nth colum of merge file"
+msgstr "n-edik oszlopa az összevont állománynak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+msgid "number of students not defined"
+msgstr "a diákok száma nincs definiálva"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
+msgid "one <b>set</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
+msgid "one <b>set</b> for  <b>users</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
+msgid "one <b>user</b> (on one <b>set</b>)"
+msgstr ""
+
+# Context is Assign this set to which users?  "only ____"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
+msgid "only"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
+msgid "only best scores"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
+msgid "or"
+msgstr "vagy"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
+msgid "or Problems from"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+msgid "out of"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+msgid "overwrite all data"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+msgid "part"
+msgstr ""
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+msgid "permissions for %1 not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+msgid "pg debug"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+msgid "pg internal errors"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+msgid "pg warning"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+msgid "point"
+msgstr "pont"
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+msgid "points"
+msgstr "pontok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+msgid "preserve existing data"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+msgid "preview answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+msgid "problem"
+msgstr "feladat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
+msgid "problems"
+msgstr "feladatok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "professor"
+msgstr "tanár"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
+msgid "progress"
+msgstr ""
+
+#. ($line)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+msgid "readSetDef error, can't read the line: ||%1||"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
+msgid "recitation #"
+msgstr ""
+
+#. ($studentName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
+msgid "record for user %1 not found"
+msgstr ""
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+msgid "record for visible user %1 not found"
+msgstr ""
+
+#. ($restrictLoc)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+msgid ""
+"restriction location %1 does not exist.  IP restrictions have been ignored."
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+msgid "row"
+msgstr "sor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
+msgid "section #"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
+msgid "section:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
+msgid "selected <b>sets</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
+msgid "selected <b>users</b> to selected <b>sets</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+msgid "selected achievements"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+msgid "selected achievements."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:868
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:983
+msgid "selected sets"
+msgstr "kiválasztott feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+msgid "selected users"
+msgstr "kiválasztott felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
+msgid "separate multiple IDs with commas"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
+msgid "set"
+msgstr "feladatsor"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
+msgid "sets"
+msgstr "feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
+msgid "sets checked below"
+msgstr "az alább bejelölt feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
+msgid "sets hidden from students"
+msgstr "diákok elől elrejtett feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
+msgid "sets visible to students"
+msgstr "a diákok számára látható feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
+msgid "sets with matching set IDs:"
+msgstr "Az azonosítójukban egyező feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
+msgid "showing all sets"
+msgstr "mutasd az összes feladatsort"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+msgid "showing all users"
+msgstr "mutasd az összes felhasználót"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
+msgid "showing hidden sets"
+msgstr "a rejtett feladatsorok mutatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
+msgid "showing matching sets"
+msgstr "a megfelelő feladatsorok mutatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+msgid "showing matching users"
+msgstr "mutasd az összes megfelelő felhasználót"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
+msgid "showing no sets"
+msgstr "ne mutasd a feladatsorokat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+msgid "showing no users"
+msgstr "ne mutasd a felhasználókat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
+msgid "showing selected sets"
+msgstr "mutasd a kiválaszott feladatsorokat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+msgid "showing selected users"
+msgstr "mutasd a kiválasztott felhasználókat"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
+msgid "showing visible sets"
+msgstr "a látható feladatsorok mutatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
+msgid "still open"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "student"
+msgstr "diák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
+msgid "students"
+msgstr "diákok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+msgid "submission"
+msgstr ""
+
+#. ($versionNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+msgid "submission (test %1)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+msgid "summary"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+msgid "ta"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+msgid "test"
+msgstr "teszt"
+
+#. ($versionNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+msgid "test (%1)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
+msgid "test date"
+msgstr "a teszt dátuma"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
+msgid "test time"
+msgstr "a teszt időpontja "
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+msgid "the following file"
+msgstr "a következő állomány"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1253
+msgid "the following file(s)"
+msgstr "a következő állományok"
+
+#. ($forcedSourceFile)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+msgid "the original path to the file is %1"
+msgstr ""
+
+# Context is "Sort by ___ then by ___"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+msgid "then by"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
+msgid "then delete them"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+msgid "time"
+msgstr "idő"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
+msgid "time limit exceeded"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+msgid "times"
+msgstr "idők"
+
+# Context is Assign ____ to _____
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+msgid "to"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
+msgid "to all users, create global data, and"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
+msgid "to one <b>set</b>"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
+msgid "top score"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+msgid "total"
+msgstr ""
+
+#. ($ce->{webworkDirs}{logs})
+#. ($ce->{webworkDirs}{tmp})
+#. ($ce->{webworkDirs}{DATA})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+msgid "unable to write to directory %1"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+msgid "unlimited"
+msgstr "korlátlan"
+
+#. ($userID)
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
+msgid "userID: %1 --"
+msgstr "felhasználói azonosító: %1 --"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+msgid ""
+"username, last name, first name, section, achievement level, achievement "
+"score,"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+msgid "users"
+msgstr "felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+msgid "users who match on selected field"
+msgstr "a kiválasztott mezőknek megfelelő felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+msgid "users who match:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
+msgid "visible"
+msgstr "látható"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1363
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:851
+msgid "visible sets"
+msgstr "látható feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
+msgid "visible to students"
+msgstr "látható a diákoknak"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+msgid "visible users"
+msgstr "látható felhasználók"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
+msgid "with set name(s):"
+msgstr ""
+
+#. ($dir, $fileName)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
+msgid "your students"
+msgstr ""

--- a/lib/WeBWorK/Localize/hu.po
+++ b/lib/WeBWorK/Localize/hu.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # pcsiba <pcsiba@gmail.com>, 2014,2016-2017
 msgid ""
@@ -10,18 +10,24 @@ msgstr ""
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2018-10-07 12:04+0000\n"
 "Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
-"Language-Team: Hungarian (http://www.transifex.com/webwork/webwork2/language/hu/)\n"
+"Language-Team: Hungarian (http://www.transifex.com/webwork/webwork2/language/"
+"hu/)\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "minden diák"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr ""
 
@@ -34,20 +40,20 @@ msgid "% correct with review"
 msgstr "% ellenőrzéssel helyes "
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr "% diák"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr "%1 (régi szerkesztő)"
 
-#. ($display_name, $vnum)
 # Gateway (test 3)
+#. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
 msgid "%1 (test %2)"
 msgstr "%1 (%2 teszt)"
@@ -65,49 +71,61 @@ msgstr "%1 feladat"
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr "%1 feladatsor hozzáadva, %2 feladatsor átugorva. Az átugrott feladatsorok: (%3)"
+msgstr ""
+"%1 feladatsor hozzáadva, %2 feladatsor átugorva. Az átugrott feladatsorok: "
+"(%3)"
 
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
-msgstr "%1 feladatsor exportálva, %2 feladatsor átugorva. Az átugrott feladatsorok: (%3) "
+msgstr ""
+"%1 feladatsor exportálva, %2 feladatsor átugorva. Az átugrott feladatsorok: "
+"(%3) "
 
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
 msgid "%1 students out of %2"
 msgstr "%1 diák a %2 közül"
 
-#. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle,
-#. $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
-msgstr "A %1 kurzus címe %2 -ról(ről) %3 - ra(re) és intézménye %4 -ról(ről) %5 - ra(re) változott "
+msgstr ""
+"A %1 kurzus címe %2 -ról(ről) %3 - ra(re) és intézménye %4 -ról(ről) %5 - "
+"ra(re) változott "
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 felhasználó exportálva a %2/%3 állományba"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
-msgstr "%1 felhasználó cserélve, %2 hozzáadva, %3 átugorva. Az átugrott feladatsorok: (%4) "
+msgstr ""
+"%1 felhasználó cserélve, %2 hozzáadva, %3 átugorva. Az átugrott "
+"feladatsorok: (%4) "
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:197
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:202
 msgid ""
 "%1 uses an external authentication system (e.g., Oncourse,  CAS,  "
-"Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try"
-" again."
-msgstr "%1 külső autentikációs  rendszert (pl. Oncourse, CAS, Blackboard, Moodle, Canvas, etc.) használ. Kérem térjen vissza a használt rendszerbe és próbálja meg újra."
+"Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try "
+"again."
+msgstr ""
+"%1 külső autentikációs  rendszert (pl. Oncourse, CAS, Blackboard, Moodle, "
+"Canvas, etc.) használ. Kérem térjen vissza a használt rendszerbe és próbálja "
+"meg újra."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:97
 msgid ""
 "%1 uses an external authentication system.  You've authenticated through "
 "that system, but aren't allowed to log in to this course."
-msgstr "%1 külső autentikációs  rendszert használ. Önt ez a rendszer hitelesítette, de nincs engedélyezve a belépése ebbe a kurzusba."
+msgstr ""
+"%1 külső autentikációs  rendszert használ. Önt ez a rendszer hitelesítette, "
+"de nincs engedélyezve a belépése ebbe a kurzusba."
 
 #. ($levelpercentage)
 #. ($percentage)
@@ -118,8 +136,8 @@ msgstr "%1% teljesítve"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr "%1% helyes"
 
@@ -156,7 +174,7 @@ msgstr "%1 jelszava megváltozott."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: %2 feladata"
 
@@ -166,12 +184,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr "%1: Ennek a kurzusnak a könyvtára nem található."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -186,50 +204,49 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
-msgid ""
-"%quant(%1,of the questions remains,of the questions remain) unanswered."
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
+msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "%quant(%1,kérdés maradt,kérdés maradt) megválaszolatlan."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr "(Minden nem mentett változtatás el fog veszni.)"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(Ez a feladat nem számít be az értékelésbe.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
-#. ($testNoun, $self->formatDateTime($set->answer_date)
 # $testNoun is either "test" or "submission"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#. ($testNoun, $self->formatDateTime($set->answer_date)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr ""
 
-#. ($testNoun)
 # $testNoun is either "test" or "submission"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#. ($testNoun)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr ""
 
@@ -274,15 +291,14 @@ msgstr ""
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
 "formulas via an options box in the left panel. Here, you can adjust what "
-"display modes are listed.</p><p>Some display modes require other software to"
-" be installed on the server. Be sure to check that all display modes "
-"selected here work from your server.</p><p>The display modes are <ul><li> "
-"plainText: shows the raw LaTeX srings for formulas.<li> images: produces "
-"images using the external programs LaTeX and dvipng.<li> MathJax: a "
-"successor to jsMath, uses javascript to place render "
-"mathematics.</ul></p></p>You must use at least one display mode. If you "
-"select only one, then the options box will not give a choice of modes (since"
-" there will only be one active).</p>"
+"display modes are listed.</p><p>Some display modes require other software to "
+"be installed on the server. Be sure to check that all display modes selected "
+"here work from your server.</p><p>The display modes are <ul><li> plainText: "
+"shows the raw LaTeX srings for formulas.<li> images: produces images using "
+"the external programs LaTeX and dvipng.<li> MathJax: a successor to jsMath, "
+"uses javascript to place render mathematics.</ul></p></p>You must use at "
+"least one display mode. If you select only one, then the options box will "
+"not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
 
 # Leave HTML in place
@@ -294,26 +310,42 @@ msgid ""
 "problem</i> when Show Me Another is clicked; a check is done first to make "
 "sure that a solution exists </li><li><b>SMAshowCorrect</b>: correct answers "
 "<i>for the new problem</i> can be viewed when Show Me Another is clicked; "
-"note that <b>SMAcheckAnswers</b> needs to be enabled at the same "
-"time</li><li><b>SMAshowHints</b>: show hints <i>for the new problem</i> "
-"(assuming they exist)</li></ul>Note: there is very little point enabling the"
-" button unless you check at least one of these options - the students would "
-"simply see a new version that they can not attempt or learn from.</p>"
+"note that <b>SMAcheckAnswers</b> needs to be enabled at the same time</"
+"li><li><b>SMAshowHints</b>: show hints <i>for the new problem</i> (assuming "
+"they exist)</li></ul>Note: there is very little point enabling the button "
+"unless you check at least one of these options - the students would simply "
+"see a new version that they can not attempt or learn from.</p>"
 msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr "Ezzel az azonosítóvall (ID %1) már létezik kurzus!"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
-msgstr "Ezzel a névvel (%1) már létezik könyvtár. Önnek előbb törölnie kell ezt a létező kurzust, mielőtt vissza tudná állítani az archívumból."
+msgstr ""
+"Ezzel a névvel (%1) már létezik könyvtár. Önnek előbb törölnie kell ezt a "
+"létező kurzust, mielőtt vissza tudná állítani az archívumból."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
@@ -322,32 +354,32 @@ msgstr "Ilyen nevű állomány már létezik."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
-"A hardcopy file was generated, but it may not be complete or correct. Please"
-" check that no problems are missing and that they are all legible. If not, "
+"A hardcopy file was generated, but it may not be complete or correct. Please "
+"check that no problems are missing and that they are all legible. If not, "
 "please inform your instructor."
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
-"A location with the name %1 already exists in the database.  Did you mean to"
-" edit that location instead?"
+"A location with the name %1 already exists in the database.  Did you mean to "
+"edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
-"A message with the subject line \"%1\" has been sent to %quant(%2,recipient)"
-" in the class %3.  There were %4 message(s) that could not be sent."
+"A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
+"in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
@@ -356,8 +388,8 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
-"A period (.) indicates a problem has not been attempted, and a number from 0"
-" to 100 indicates the grade earned. The number on the second line gives the "
+"A period (.) indicates a problem has not been attempted, and a number from 0 "
+"to 100 indicates the grade earned. The number on the second line gives the "
 "number of incorrect attempts."
 msgstr ""
 
@@ -380,44 +412,44 @@ msgid ""
 "corresponds to. The Login Name fields contain checkboxes for selecting the "
 "user.  Clicking the link of the name itself will allow you to act as the "
 "selected user.  There will also be an image link following the name which "
-"will take you to a page where you can edit the selected user's information."
-"  Clicking the emails will allow you to email the corresponding user.  "
-"Clicking the links in the entries in the assigned sets columns will take you"
-" to a page where you can view and reassign the sets for the selected user."
+"will take you to a page where you can edit the selected user's information.  "
+"Clicking the emails will allow you to email the corresponding user.  "
+"Clicking the links in the entries in the assigned sets columns will take you "
+"to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr "A VÁLASZ NINCS ELMENTVE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr "A VÁLASZ NINCS ELMENTVE --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "A VÁLASZ CSAK ELLENŐRIZVE LETT --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "A VÁLASZ CSAK ELLENŐRIZVE - A VÁLASZ NICS RÖGZÍTVE"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "A változások elhagyása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Az export elhagyása"
@@ -427,12 +459,12 @@ msgid "Achievement"
 msgstr "Eredmény"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr "'%2' értékelő létrehozta a %1 eredményt."
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "%1 eredmény már létezik. Az eredmény-típus nem lett létrehozva"
 
@@ -449,13 +481,13 @@ msgstr "Eredmény-értékelő szerkesztő"
 msgid "Achievement Evaluator for achievement %1"
 msgstr "%1 eredmény értékelője"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr "Eredmény-azonosító"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr "Ez az eredmény-azonosító már létezik! Nem lett új eredmény-katégória  "
 
@@ -471,12 +503,17 @@ msgstr "Felhasználói eredményszerkesztő"
 msgid "Achievement has been assigned to all users."
 msgstr "Az eredmény hozzá lett rendelve az összes felhasználóhoz"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "Az eredmény hozzá lett rendelve az összes felhasználóhoz"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr "Az eredmény-hozzárendelés vissza lett vonva az összes diáknál"
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr "Az eredmények pontszáma el lett mentve ehhez: %1 "
 
@@ -496,17 +533,17 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr ""
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Aktív"
 
@@ -525,7 +562,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Hozzáadás"
@@ -534,9 +571,9 @@ msgstr "Hozzáadás"
 msgid "Add All"
 msgstr "Mindet add hozzá"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr "Kurzus hozzáadása"
 
@@ -548,7 +585,7 @@ msgstr "Diák hozzáadása"
 msgid "Add Users"
 msgstr "Felhasználók hozzáadása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr "Add hozzá az új kurzushoz annak WeBWorK adminisztrátorait"
 
@@ -556,12 +593,12 @@ msgstr "Add hozzá az új kurzushoz annak WeBWorK adminisztrátorait"
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "Milyen állomány(fájl)típusként adja hozzá?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Hány diákot adjon hozzá?"
 
@@ -569,43 +606,41 @@ msgstr "Hány diákot adjon hozzá?"
 msgid "Add problems to"
 msgstr "A feladat hozzáadása ehhez:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr "Melyik feladatsorhoz adja hozzá?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Hány felhasználót adjon hozzá?"
 
-#. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ?
-#. join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ?
-#. join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
+#. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr ""
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -614,56 +649,56 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr "Címek"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
-"Addresses for new location.  Enter one per line, as single IP addresses "
-"e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges "
-"(e.g., 192.168.1.101-192.168.1.150)):"
+"Addresses for new location.  Enter one per line, as single IP addresses e."
+"g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
+"g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
-"addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP"
-" ranges (e.g., 192.168.1.101-192.168.1.150)):"
+"addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
+"ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:190
@@ -674,7 +709,7 @@ msgstr "A házi feladat lezárásának meghosszabbítása 24 órával"
 msgid "Adds 48 hours to the close date of a homework."
 msgstr "A házi feladat lezárásának meghosszabbítása 48 órával"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -687,10 +722,9 @@ msgid "After set answer date"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
-"After the reduced scoring period begins all work counts for %1% of its "
-"value."
+"After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:715
@@ -701,15 +735,15 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr "Az összes fenti válasz helyes."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -719,7 +753,8 @@ msgstr "Az összes kiválasztott feladatsor elrejtve az összes diák elől"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
 msgid "All selected sets made visible for all students"
-msgstr "Az összes kiválasztott feladatsor láthatóvá téve az összes diák számára"
+msgstr ""
+"Az összes kiválasztott feladatsor láthatóvá téve az összes diák számára"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
 msgid "All sets hidden from all students"
@@ -729,7 +764,7 @@ msgstr "Az összes feladatsor elrejtve az összes diák elől"
 msgid "All sets made visible for all students"
 msgstr "Az összes feladatsor láthatóvá téve az összes diák számára"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr "A kurzus összes diákja"
 
@@ -793,25 +828,25 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
@@ -829,8 +864,8 @@ msgstr "A válasz dátuma"
 msgid "Answer Log"
 msgstr "A válaszok naplója"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "A válasz megmutatása"
 
@@ -843,12 +878,12 @@ msgid "Answer:"
 msgstr "Válasz:"
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -870,15 +905,21 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "Bármely fenti változás a feladatsorban alkalmazódik az összes diákra."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "Bármely fenti változás a feladatsorban alkalmazódik az összes diákra."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -886,23 +927,23 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
-"Any time problem numbers are intentionally changed, the problems will always"
-" be renumbered consecutively, starting from one.  When deleting problems, "
+"Any time problem numbers are intentionally changed, the problems will always "
+"be renumbered consecutively, starting from one.  When deleting problems, "
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr ""
 
@@ -916,26 +957,26 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr ""
 
@@ -945,22 +986,26 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
+msgstr ""
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
@@ -985,17 +1030,17 @@ msgstr ""
 msgid "Assigned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Hozzárendelt feladatsorok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr ""
 
@@ -1003,7 +1048,12 @@ msgstr ""
 msgid "Assignment type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "Hozzárendelt feladatsorok"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr ""
 
@@ -1012,7 +1062,7 @@ msgstr ""
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1024,7 +1074,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Próbálkozások"
 
@@ -1032,13 +1082,14 @@ msgstr "Próbálkozások"
 msgid "Audit"
 msgstr "ellenőrzés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "Szerző adatai"
 
@@ -1046,12 +1097,12 @@ msgstr "Szerző adatai"
 msgid "Automatic"
 msgstr "Automatikus"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1079,8 +1130,8 @@ msgstr "Keresés innen:"
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
 msgid ""
 "By default, feeback is always sent to all users specified to recieve "
-"feedback.  This variable sets the system to only email feedback to users who"
-" have the same section as the user initiating the feedback.  I.E.  Feedback "
+"feedback.  This variable sets the system to only email feedback to users who "
+"have the same section as the user initiating the feedback.  I.E.  Feedback "
 "will only be sent to section leaders."
 msgstr ""
 
@@ -1091,16 +1142,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr "A lezárás dátuma"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr "A lezárás ideje"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1127,10 +1178,11 @@ msgstr "Nem tudja a %1 állományt másolni"
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
 msgid "Can't create archive '%1': command returned %2"
-msgstr "Nem lehet létrehozni a '%1' archívumot: a parancs %2 hibaüzenetet adott"
+msgstr ""
+"Nem lehet létrehozni a '%1' archívumot: a parancs %2 hibaüzenetet adott"
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr "Nem lehet létrehozni %1 számára a kurzuskörnyezetet, mert %2 "
 
@@ -1165,17 +1217,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "Nem kapható meg %1 felhasználó jelszó rekordját: %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr "Nem lehet megnyitni ezt: %1"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr "Nem lehet megnyitni a %1 állományt"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr "A %1 egyesített állomány nem olvasható. Nem lett üzenet küldve"
 
@@ -1184,7 +1236,7 @@ msgstr "A %1 egyesített állomány nem olvasható. Nem lett üzenet küldve"
 msgid "Can't rename file: %1"
 msgstr "Nem lehet átnevezni a %1 állományt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr "Nem lehet átnevezni  ugyanarra a névre"
 
@@ -1193,11 +1245,11 @@ msgstr "Nem lehet átnevezni  ugyanarra a névre"
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr "Nem lehet írni a %1 állományba"
 
@@ -1208,7 +1260,7 @@ msgstr "Nem lehet írni a %1 állományba"
 msgid "Cancel"
 msgstr "Mégse"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr ""
 
@@ -1221,8 +1273,8 @@ msgstr "Nem lehet megnyitni %1 -t"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr "Kategória"
 
@@ -1234,19 +1286,19 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1164
 msgid ""
-"Causes a homework problem to become a clone of another problem from the same"
-" set."
+"Causes a homework problem to become a clone of another problem from the same "
+"set."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:649
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr "A kurzus címének változtatása erre:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr "A kurzusazonosító megváltoztatása erre:"
 
@@ -1260,7 +1312,7 @@ msgstr "A megjelenítési beállítások megváltoztatása "
 msgid "Change Email Address"
 msgstr "Az e-mai cím változtatása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr "Az intézmény megváltoztatása erre:"
 
@@ -1269,32 +1321,32 @@ msgstr "Az intézmény megváltoztatása erre:"
 msgid "Change Password"
 msgstr "A jelszó változtatása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr "A felhasználói beállítások megváltoztatása"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr "Az kurzus intézményének %1 -ról(ről) %2 -ra(re) változtatása"
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr "A cím %1 -ról(ről) %2 -ra(re) változtatása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "A változtatások elhagyása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Az állomány változásait jelenleg nem menthetőek véglegesen."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "A változtatások mentve"
 
@@ -1309,26 +1361,27 @@ msgstr ""
 msgid "Chapter:"
 msgstr "Fejezet"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "A válaszok ellenőrzése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr "A teszt ellenőrzése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr "Ellenőrizze, hogy a jogosultságai helyesen lettek beállítva"
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
-msgstr "Ellenőrizze, hogy létezik-e és olvasható-e a webszerveren a %1 könyvtár."
+msgstr ""
+"Ellenőrizze, hogy létezik-e és olvasható-e a webszerveren a %1 könyvtár."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "További hibaüzenetek ellenőrzése"
 
@@ -1343,7 +1396,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1382,12 +1435,14 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
-msgstr "Kattintson a bejelentkezési névre ezen diákok feladatsorainak adatainak egyéni módosításához (pl. határidők)."
+msgstr ""
+"Kattintson a bejelentkezési névre ezen diákok feladatsorainak adatainak "
+"egyéni módosításához (pl. határidők)."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:552
@@ -1398,7 +1453,7 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr "Lezárás"
 
@@ -1435,9 +1490,8 @@ msgstr "Lezárva"
 msgid "Closes"
 msgstr "Lezárás"
 
-#. ($self->formatDateTime($set->due_date,undef,
-#. $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr "Lezárás ekkor: %1"
 
@@ -1446,39 +1500,39 @@ msgstr "Lezárás ekkor: %1"
 msgid "Closes:"
 msgstr "Lezárás:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Megjegyzés"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1486,7 +1540,7 @@ msgstr ""
 msgid "Completed."
 msgstr "Teljesítve."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr "Megerősít"
 
@@ -1496,7 +1550,7 @@ msgstr "Megerősít"
 msgid "Confirm %1's New Password"
 msgstr "%1 új jelszavának jóváhagyása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr "Erősítse meg a jelszót:"
 
@@ -1510,8 +1564,8 @@ msgid "Continue"
 msgstr "Folytatás"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr ""
 
@@ -1525,7 +1579,7 @@ msgstr "Másol"
 msgid "Copy file as:"
 msgstr "Másolja az állományt mint:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1533,8 +1587,8 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Helyes"
@@ -1543,7 +1597,7 @@ msgstr "Helyes"
 msgid "Correct Adjusted Status"
 msgstr "Helyes módosított állapot"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr "Helyes válasz"
 
@@ -1560,20 +1614,22 @@ msgid "Correct answers"
 msgstr "Helyes válaszok"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr "Helyes: %1/%2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr "HelyesVálasz"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
-msgstr "Nem lehet hozzáadni %1 feladatot ehhez a feladatsorhoz. A számnak 1 és %2 között kell lennie."
+msgstr ""
+"Nem lehet hozzáadni %1 feladatot ehhez a feladatsorhoz. A számnak 1 és %2 "
+"között kell lennie."
 
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
@@ -1587,48 +1643,49 @@ msgid "Couldn't change your email address: %1"
 msgstr "Nem lehet változtatni az Ön %1 e-mail címén"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr "Számláló"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1638,13 +1695,14 @@ msgstr "Kurzus adminisztráció"
 msgid "Course Configuration"
 msgstr "Kurzus konfiguráció"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
-msgstr "A kurzusazonosító csak betűt, számot, kötőjelet és alulvonást tartalmazhat."
+msgstr ""
+"A kurzusazonosító csak betűt, számot, kötőjelet és alulvonást tartalmazhat."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr "Kurzus azonosító"
 
@@ -1653,13 +1711,13 @@ msgstr "Kurzus azonosító"
 msgid "Course Info"
 msgstr "Kurzus infó"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr "A kurzus neve:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr "A kurzus címe"
 
@@ -1667,15 +1725,15 @@ msgstr "A kurzus címe"
 msgid "Course archived."
 msgstr "A kurzus archiválva lett."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Kurzusok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1693,7 +1751,7 @@ msgstr "Létrehozás"
 msgid "Create CSV"
 msgstr "CSV létrehozása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr "Elhelyezkedés létrehozása"
 
@@ -1701,7 +1759,7 @@ msgstr "Elhelyezkedés létrehozása"
 msgid "Create a New Set in This Course:"
 msgstr "Új feladatsor létrehozása ebben a kurzusban:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1709,12 +1767,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "Milyen típusú feladatsort kíván létrehozni?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1727,34 +1785,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr "A jelenleg meghatározott elhelyezkedés alább van felsorolva."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr "Adat"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr "Az adatbázis táblák rendben vannak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr "Az adatbázis táblákat frissíteni kell"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr "Az adatbázis táblák rendben vannak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr "Adatbázis:"
 
@@ -1766,7 +1824,7 @@ msgstr "Dátum"
 msgid "Debug"
 msgstr "Hibakeresés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1791,77 +1849,79 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Törlés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr "Kurzus törlése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr "Törli az összes létező címet"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
-msgstr "Az archiválás után törli a kurzust. Vigyázat nincs utólagos visszavonási lehetőség!"
+msgstr ""
+"Az archiválás után törli a kurzust. Vigyázat nincs utólagos visszavonási "
+"lehetőség!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr "Ezen kurzusok törlése"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "Mennyit töröljön?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr "Törli?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr "Törli az elhelyezkedést:"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr ""
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr "Törli az elhelyezkedés(eke)t: %1 "
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr "Törli a %1 címeket az elhelyezkedésből."
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
 
@@ -1869,7 +1929,7 @@ msgstr ""
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 
@@ -1877,13 +1937,13 @@ msgstr ""
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -1901,47 +1961,48 @@ msgstr "%1 könyvtár nem lett törölve: %2"
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr "%1 könyvtár törölve (a törölt elemek száma: %2)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr "Hiba a könyvtárhoz való hozzáféréssel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr "Könyvtárstruktúra"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
-"Directory structure is missing directories or the webserver lacks sufficient"
-" privileges."
+"Directory structure is missing directories or the webserver lacks sufficient "
+"privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr "A könyvtárstruktúra OK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
-msgstr "Az archiválás előtt a könyvtárstruktúrát kézileg helyre kell állítani. "
+msgstr ""
+"Az archiválás előtt a könyvtárstruktúrát kézileg helyre kell állítani. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr "Az átnevezés előtt a könyvtárstruktúrát kézileg helyre kell állítani."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr "A könyvtárstruktúrát vagy jogosultságait helyre kell állítani."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr "Megjelenítési mód:"
@@ -1949,6 +2010,10 @@ msgstr "Megjelenítési mód:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
 msgstr "Mutasd a legutóbbi választ"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
@@ -1971,29 +2036,29 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr ""
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr ""
 
@@ -2002,17 +2067,17 @@ msgstr ""
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2040,10 +2105,12 @@ msgstr ""
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr "A kiválasztott %plural(%1,sor,sorok) PDF vagy TeX kimeneti állományainak letöltése"
+msgstr ""
+"A kiválasztott %plural(%1,sor,sorok) PDF vagy TeX kimeneti állományainak "
+"letöltése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "A jelenlegi sor PDF vagy TeX kimeneti állományainak mentése "
 
@@ -2064,6 +2131,16 @@ msgstr ""
 msgid "Drop"
 msgstr "Dobd"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr "Készitse el a feladatsor másolatát és nevezze el"
@@ -2075,16 +2152,16 @@ msgid ""
 "functions in student answers, and behave better in certain cases.  Some "
 "problems are specifically coded to use new (or old) answer checkers.  "
 "However, for the bulk of the problems, you can choose what the default will "
-"be here.  <p>Choosing <i>false</i> here means that the newer answer checkers"
-" will be used by default, and choosing <i>true</i> means that the old answer"
-" checkers will be used by default."
+"be here.  <p>Choosing <i>false</i> here means that the newer answer checkers "
+"will be used by default, and choosing <i>true</i> means that the old answer "
+"checkers will be used by default."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "e-mail a tanárnak"
 
@@ -2102,7 +2179,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr "e-mail:"
 
@@ -2110,26 +2187,25 @@ msgstr "e-mail:"
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Módosít"
 
-#. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual
-#. versions')
+#. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr ""
 
@@ -2142,19 +2218,19 @@ msgstr "Az összes feladatsor adatainak módosÍtása"
 msgid "Edit Assigned Users"
 msgstr "A hozzárendelt felhasználók módosítása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr ""
 
@@ -2176,7 +2252,7 @@ msgstr "A feladotsor adatainak módosítása"
 msgid "Edit Target Set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Mely felhasználókat módosítja?"
 
@@ -2192,20 +2268,20 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
-"Edit the current value of the location description, if desired, then add and"
-" select addresses to delete, and then click the \"Take Action\" button to "
+"Edit the current value of the location description, if desired, then add and "
+"select addresses to delete, and then click the \"Take Action\" button to "
 "make all of your changes.  Or, click \"Manage Locations\" above to make no "
 "changes and return to the Manage Locations page."
 msgstr ""
@@ -2215,23 +2291,23 @@ msgid "Edit which sets?"
 msgstr "Mely feladatsorokat módosítja?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr ""
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr ""
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr ""
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr ""
 
@@ -2241,44 +2317,44 @@ msgid "Editing achievement in file '%1'"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "e-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "E-mail cím"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr ""
 
@@ -2286,29 +2362,29 @@ msgstr ""
 msgid "Email Instructor On Failed Attempt"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "e-mail a tanárnak"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2348,8 +2424,8 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr ""
 
@@ -2365,8 +2441,8 @@ msgid ""
 "Enables the use of the conditional release system.  To use conditional "
 "release you need to specify a list of set names on the Problem Set Detail "
 "Page, along with a minimum score.  Students will not be able to access that "
-"homework set until they have achieved the minimum score on all of the listed"
-" sets."
+"homework set until they have achieved the minimum score on all of the listed "
+"sets."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:162
@@ -2386,22 +2462,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "beiratkozott"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Regisztrációs állapot"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Írja be lent a fájlnevet"
 
@@ -2415,8 +2491,8 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Belépve"
 
@@ -2446,7 +2522,7 @@ msgstr ""
 msgid "Error message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr ""
 
@@ -2468,7 +2544,7 @@ msgid ""
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr ""
@@ -2487,6 +2563,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2502,7 +2582,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2510,58 +2590,58 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Export"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr ""
 
@@ -2569,7 +2649,7 @@ msgstr ""
 msgid "Export selected sets"
 msgstr "A kiválasztott feladatsorok exportja"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Mely fájlokat akarja exportálni?"
 
@@ -2577,12 +2657,12 @@ msgstr "Mely fájlokat akarja exportálni?"
 msgid "Export which sets?"
 msgstr "Mely feladatsorokat akarja exportálni?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Mely felhasználókat akarja exportálni?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr ""
 
@@ -2596,16 +2676,16 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr ""
 
@@ -2618,7 +2698,7 @@ msgstr "Nem sikerült létrehozni a %1 új feladatsort"
 msgid "Failed to create new set: no set name specified!"
 msgstr "Nem sikerült létrehozni az új feladatsort: nincs megadva a feladatnév!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
@@ -2630,17 +2710,20 @@ msgstr "Nem sikerült létrehozni a %1 feladatsor másolatát."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
-msgstr "Nem sikerült létrehozni a feladatsor másolatát: nincs megadva a feladatnév!"
+msgstr ""
+"Nem sikerült létrehozni a feladatsor másolatát: nincs megadva a feladatnév!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
-msgstr "Nem sikerült létrehozni a feladatsor másolatát: nincs kiválaszva feladatsor!"
+msgstr ""
+"Nem sikerült létrehozni a feladatsor másolatát: nincs kiválaszva feladatsor!"
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
 msgid "Failed to duplicate set: set %1 already exists!"
-msgstr "Nem sikerült létrehozni a feladatsor másolatát: a %1 feladatsor már létezik!"
+msgstr ""
+"Nem sikerült létrehozni a feladatsor másolatát: a %1 feladatsor már létezik!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
 msgid "Failed to enter student:"
@@ -2649,10 +2732,10 @@ msgstr ""
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr ""
 
@@ -2662,11 +2745,11 @@ msgid "Failed to save: %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr ""
 
@@ -2678,39 +2761,39 @@ msgstr "Visszacsatolás"
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
-"File '%1' exists. File not saved. No changes have been made.  You can change"
-" the file path for this problem manually from the 'Hmwk Sets Editor' page"
+"File '%1' exists. File not saved. No changes have been made.  You can change "
+"the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
 
 #. ($file,$!)
@@ -2753,7 +2836,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Fájlnév"
 
@@ -2762,7 +2845,7 @@ msgstr "Fájlnév"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "Melyik szöveg alapján szűrjek?"
 
@@ -2776,28 +2859,28 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "Keresztnév"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -2805,7 +2888,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -2813,6 +2896,10 @@ msgstr ""
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
@@ -2824,19 +2911,24 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "Ez a feladatgysor nem tartalmaz feladatokat."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "Feladó"
 
@@ -2864,7 +2956,7 @@ msgid "General"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr ""
 
@@ -2884,11 +2976,16 @@ msgstr ""
 msgid "Get Target Set Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Melyik felhasználónak kér új jelszót?"
 
@@ -2915,7 +3012,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -2923,21 +3020,31 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr ""
 
@@ -2965,7 +3072,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "Vendég felhasználó"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr ""
 
@@ -2992,12 +3099,16 @@ msgstr "Fejléc másolata"
 msgid "Hardcopy Theme"
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Súgó"
 
@@ -3009,12 +3120,12 @@ msgstr ""
 msgid "Hidden"
 msgstr "Rejtett"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr ""
 
@@ -3026,8 +3137,8 @@ msgstr ""
 msgid "Hide Hints from Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr ""
 
@@ -3039,7 +3150,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr ""
 
@@ -3053,13 +3164,13 @@ msgstr "Tippek"
 msgid "Hmwk Sets Editor"
 msgstr "HF-sor szerkesztő"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Feladatsorok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr ""
 
@@ -3067,15 +3178,15 @@ msgstr ""
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3092,24 +3203,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
-"emails will be notified whenever a student runs out of attempts on a problem"
-" and its children without receiving an adjusted status of 100%"
+"emails will be notified whenever a student runs out of attempts on a problem "
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
 msgid ""
-"If you check %1 your login information will be remembered by the browser you"
-" are using, allowing you to visit WeBWorK pages without typing your user "
-"name and password (until your session expires). This feature is not safe for"
-" public workstations, untrusted machines, and machines over which you do not"
-" have direct control."
+"If you check %1 your login information will be remembered by the browser you "
+"are using, allowing you to visit WeBWorK pages without typing your user name "
+"and password (until your session expires). This feature is not safe for "
+"public workstations, untrusted machines, and machines over which you do not "
+"have direct control."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
 msgstr ""
 
 #. ($file)
@@ -3117,7 +3232,7 @@ msgstr ""
 msgid "Illegal file '%1' specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3125,8 +3240,9 @@ msgstr ""
 msgid "Import"
 msgstr "Import"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -3141,21 +3257,21 @@ msgstr "Hány feladatsort importálni?"
 msgid "Import sets with names"
 msgstr "Ezen nevű feladatsorok importálása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Mely állományból akar felhasználókat importálni?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Inaktív"
 
@@ -3163,17 +3279,17 @@ msgstr "Inaktív"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr ""
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr ""
 
@@ -3182,7 +3298,7 @@ msgstr ""
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr ""
 
@@ -3190,16 +3306,16 @@ msgstr ""
 msgid "Instructor Tools"
 msgstr "Oktatói eszközök"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3208,7 +3324,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3223,16 +3339,20 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr ""
 
@@ -3244,7 +3364,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3265,28 +3385,28 @@ msgstr ""
 msgid "Last Answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Vezetéknév"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr ""
 
@@ -3313,18 +3433,18 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Könyvtár böngésző"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Könyvtár böngésző 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr ""
@@ -3340,8 +3460,8 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
 msgid ""
 "List of e-mail addresses to which e-mail can be sent by a problem. "
-"Professors need to be added to this list if questionaires are used, or other"
-" WeBWorK problems which send e-mail as part of their answer mechanism."
+"Professors need to be added to this list if questionaires are used, or other "
+"WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
@@ -3358,33 +3478,33 @@ msgstr ""
 msgid "Local Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
-"Location %1 does not exist in the WeBWorK database.  Please check your input"
-" (perhaps you need to reload the location management page?)."
+"Location %1 does not exist in the WeBWorK database.  Please check your input "
+"(perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr ""
 
@@ -3392,8 +3512,8 @@ msgstr ""
 msgid "Log In Again"
 msgstr "Újra bejelentkezni"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Kijelentkezés"
 
@@ -3401,20 +3521,20 @@ msgstr "Kijelentkezés"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr "Bejelentkezés"
 
@@ -3426,23 +3546,23 @@ msgstr "Bejelentkezési információk"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Bejelentkezési név"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Bejelentkezési állapot"
 
@@ -3450,7 +3570,7 @@ msgstr "Bejelentkezési állapot"
 msgid "Logout"
 msgstr "Kijelentkezés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Főmenü"
 
@@ -3463,20 +3583,20 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr ""
@@ -3490,7 +3610,7 @@ msgid "Mark Correct"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr ""
 
@@ -3498,8 +3618,9 @@ msgstr ""
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "Találatok (többszörös azonosítók szétválasztása vesszővel)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Mat. objektumok"
 
@@ -3512,53 +3633,52 @@ msgid "Max. Shown:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
-msgid ""
-"Maximum times Show me Another can be used per problem (-1 => unlimited)"
+msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr ""
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Üzenetek"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
-"Missing required input data. Please check that you have filled in all of the"
-" create location fields and resubmit."
+"Missing required input data. Please check that you have filled in all of the "
+"create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
-#. ($recipient, $ur->email_address)
 # Msg is short for message
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#. ($recipient, $ur->email_address)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -3571,17 +3691,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3622,12 +3742,12 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "Új jelszó"
 
@@ -3639,13 +3759,13 @@ msgstr ""
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "Az új jelszó mentve"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3653,15 +3773,17 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Új feladat"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3669,20 +3791,26 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "Nem"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "Az eredmény hozzá lett rendelve az összes felhasználóhoz"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3701,7 +3829,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "Egy feladatsorban sem történt változás"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3712,7 +3840,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr ""
 
@@ -3722,38 +3850,38 @@ msgstr ""
 msgid "No data exists for set %1 and problem %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3761,22 +3889,22 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr ""
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr ""
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -3789,22 +3917,24 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr "Nincsenek feladatsorok kiválasztva értékelésre"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
-msgstr "Nem jeleníthetőek meg feladatsorok. Válasszon fent egy lehetőséget a kurzus feladatsorainak jegyzékéért. "
+msgstr ""
+"Nem jeleníthetőek meg feladatsorok. Válasszon fent egy lehetőséget a kurzus "
+"feladatsorainak jegyzékéért. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -3821,15 +3951,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -3843,26 +3977,32 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Nincs bejelentkezve."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "Megjegyzés"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr ""
 
@@ -3878,8 +4018,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -3911,7 +4051,7 @@ msgid ""
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr ""
 
@@ -3929,13 +4069,13 @@ msgstr "A kezdés dátuma"
 msgid "Open Problem Library"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -3949,9 +4089,9 @@ msgstr ""
 msgid "Open, complete by %1."
 msgstr ""
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -3974,12 +4114,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr ""
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4003,70 +4143,73 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "A kezdés dátumaCSAK MEGTEKINTÉS - A VÁLASZOK NINCSENEK MENTVE"
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Betét mező"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr "Az oldal generálva: %1"
 
@@ -4079,7 +4222,7 @@ msgstr "Jelszó"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr ""
 
@@ -4088,7 +4231,7 @@ msgstr ""
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4102,24 +4245,24 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Hozzáférési szint"
 
@@ -4127,11 +4270,11 @@ msgstr "Hozzáférési szint"
 msgid "Permissions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
-"will not show up in the courses list on the WeBWorK home page. It will still"
-" appear in the Course Administration listing."
+"will not show up in the courses list on the WeBWorK home page. It will still "
+"appear in the Course Administration listing."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1016
@@ -4164,7 +4307,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4177,7 +4320,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "Kérjük adja meg alább %1 felhasználói nevét és jelszavát:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4195,49 +4338,50 @@ msgstr ""
 msgid "Please select at least one user and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Kérjük válassza ki a mentendő állományt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Előző feladat"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr ""
@@ -4246,12 +4390,12 @@ msgstr ""
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr ""
 
@@ -4268,20 +4412,20 @@ msgstr ""
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr "%1. feladat"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr ""
 
@@ -4299,8 +4443,8 @@ msgstr ""
 msgid "Problem Editor3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Feladatlista"
 
@@ -4316,28 +4460,29 @@ msgstr ""
 msgid "Problem Number "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Feladat-technikák"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "Feladat-néző"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Feladatok"
 
@@ -4385,11 +4530,11 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Közzététel"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -4403,28 +4548,28 @@ msgid "Really delete the items listed above?"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "Előadás"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "A pontszámok mentése az adott feladatsorhoz"
 
@@ -4438,26 +4583,15 @@ msgid "Reduced Scoring Date"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
-msgstr ""
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,
-#. $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr ""
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
 msgstr ""
 
 # Short for "Reduced Scoring:"
@@ -4475,12 +4609,12 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr ""
 
@@ -4489,7 +4623,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Maradék"
 
@@ -4501,7 +4635,7 @@ msgstr "Emlékezz rám!"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4511,13 +4645,13 @@ msgid "Rename"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr ""
 
@@ -4525,27 +4659,27 @@ msgstr ""
 msgid "Rename file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
-"Reopens any gateway test for an additional 24 hours. This allows you to take"
-" a test even if the close date has past. This item does not allow you to "
-"take additional versions of the test."
+"Reopens any gateway test for an additional 24 hours. This allows you to take "
+"a test even if the close date has past. This item does not allow you to take "
+"additional versions of the test."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2326
@@ -4553,53 +4687,54 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Mely felhasználókat cseréli?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Hiba bejelentése"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr ""
 
@@ -4621,8 +4756,8 @@ msgstr ""
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
 msgid ""
-"Requested set '%1' is a proctored test/quiz assignment, but no valid proctor"
-" authorization has been obtained."
+"Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
+"authorization has been obtained."
 msgstr ""
 
 #. ($setName,$node_name)
@@ -4662,8 +4797,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -4671,11 +4806,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4704,23 +4835,22 @@ msgstr ""
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Eredmények"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr ""
 
-#. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams,
-#. \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr "Az utolsó művelet eredményei: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -4732,19 +4862,27 @@ msgstr "Az utolsó művelet eredményei"
 msgid "Results of last action performed: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "Visszaállít"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr ""
@@ -4757,19 +4895,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr "Diák azonosító (ID)"
 
@@ -4778,86 +4916,86 @@ msgstr "Diák azonosító (ID)"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "mentés"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Mentés mint"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "mentés mint"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "A változások mentése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr ""
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -4872,11 +5010,11 @@ msgstr ""
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "A kiválasztott feladatsor(ok) pontozása és mentése ide:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -4901,14 +5039,14 @@ msgid "Scoring Tools"
 msgstr "Pontozási eszközök"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -4918,24 +5056,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Fejezet"
@@ -4950,11 +5088,16 @@ msgstr ""
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Feladatsorok"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -4964,36 +5107,36 @@ msgstr ""
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
-"contain alphanumeric characters and underscores. The course title appears on"
-" the course home page and can be any string."
+"contain alphanumeric characters and underscores. The course title appears on "
+"the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr ""
 
@@ -5001,27 +5144,27 @@ msgstr ""
 msgid "Select all sets"
 msgstr "Az összes feladatsor kiválasztása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Az öszes felhasználó kiválasztása"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Válassza ki a végrehajtandó művelet"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr ""
 
@@ -5035,7 +5178,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5059,23 +5202,23 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Feladatsor/Beállítás"
 
@@ -5109,7 +5252,7 @@ msgid "Set Definition Files"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr ""
 
@@ -5122,7 +5265,7 @@ msgid "Set Detail for set %2"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5136,12 +5279,12 @@ msgstr "A feladatsor fejléce"
 msgid "Set ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Feladatsor infó"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "Feladatsor lista"
 
@@ -5169,8 +5312,12 @@ msgid "Set Name "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -5188,15 +5335,15 @@ msgstr ""
 msgid ""
 "Set to true to display the \"Entered\" column which automatically shows the "
 "evaluated student answer, e.g. 1 if student input is sin(pi/2). If this is "
-"set to false, e.g. to save space in the response area, the student can still"
-" see their evaluated answer by hovering the mouse pointer over the typeset "
+"set to false, e.g. to save space in the response area, the student can still "
+"see their evaluated answer by hovering the mouse pointer over the typeset "
 "version of their answer."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Feladatsorok"
 
@@ -5208,7 +5355,7 @@ msgstr ""
 msgid "Sets assigned to %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr ""
 
@@ -5217,11 +5364,11 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -5229,7 +5376,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "Tippek megjelenítése"
 
@@ -5237,8 +5384,8 @@ msgstr "Tippek megjelenítése"
 msgid "Show Me Another"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Az utolsó válasz megjelenítése"
 
@@ -5250,8 +5397,8 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "A megoldás megjelenítése"
 
@@ -5259,7 +5406,7 @@ msgstr "A megoldás megjelenítése"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Mely felhasználók megjelenítése?"
 
@@ -5268,17 +5415,17 @@ msgstr "Mely felhasználók megjelenítése?"
 msgid "Show all paths"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "A helyes válasz megjelenítése"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr ""
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr ""
 
@@ -5287,7 +5434,7 @@ msgstr ""
 msgid "Show path ..."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr ""
 
@@ -5298,17 +5445,17 @@ msgstr "Mely feladatsorok megjelenítése"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Az oldal leírásának megjelnítése/rejtése"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Mutasd:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr ""
 
@@ -5318,7 +5465,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "%2 feladatsorból %1 megjelenítve."
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr "%2 felhasználóból %1 megjelenítve"
 
@@ -5334,13 +5481,13 @@ msgstr ""
 msgid "Site Information"
 msgstr "Oldal-információ"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr ""
 
@@ -5349,7 +5496,7 @@ msgstr ""
 msgid "Solutions"
 msgstr "Megoldások"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -5360,14 +5507,24 @@ msgid ""
 "the wrong thing."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
 msgid ""
 "Some servers handle courses taking place in different timezones.  If this "
 "course is not showing the correct timezone, enter the correct value here.  "
-"The format consists of unix times, such as "
-"\"America/New_York\",\"America/Chicago\", \"America/Denver\", "
-"\"America/Phoenix\" or \"America/Los_Angeles\". Complete list: <a "
-"href=\"http://en.wikipedia.org/wiki/List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
+"The format consists of unix times, such as \"America/New_York\",\"America/"
+"Chicago\", \"America/Denver\", \"America/Phoenix\" or \"America/Los_Angeles"
+"\". Complete list: <a href=\"http://en.wikipedia.org/wiki/"
+"List_of_zoneinfo_time_zones\">TimeZoneFiles</a>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:484
@@ -5376,14 +5533,14 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "rendezés"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "E szerint rendezve"
 
@@ -5412,7 +5569,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5435,8 +5592,7 @@ msgstr "Statisztikák"
 msgid "Statistics for"
 msgstr ""
 
-#. ($self->{ce}->{courseName}, $self->{setName},
-#. $self->formatDateTime($self->{set_due_date})
+#. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
 msgid "Statistics for %1 set %2. Closes %3"
 msgstr ""
@@ -5446,46 +5602,46 @@ msgstr ""
 msgid "Statistics for %1 student %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Állapot"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "A tevékenység befejezése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "Diák ID"
 
@@ -5501,8 +5657,7 @@ msgstr ""
 msgid "Student Progress"
 msgstr "Diákok előmenetele"
 
-#. ($self->{ce}->{courseName}, $self->{setName},
-#. $self->formatDateTime($self->{set_due_date})
+#. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
 msgid "Student Progress for %1 set %2. Closes %3"
 msgstr ""
@@ -5516,14 +5671,14 @@ msgstr ""
 msgid "Student answers"
 msgstr "Hallgató válaszai"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -5535,31 +5690,35 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "A válasz elküldése"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
 msgstr "%1 válaszainak jóváhagyása"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "Sikeres"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr ""
 
@@ -5569,42 +5728,42 @@ msgid "Successfully created new set %1"
 msgstr "Sikeresen létrehozva a(z) %1 új feladatsor"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -5622,16 +5781,16 @@ msgstr "Hajtsd végre a %1 tesztet"
 msgid "Take %1 test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "Csináld!"
 
@@ -5686,8 +5845,8 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:248
 msgid ""
 "The Reduced Scoring Period is the default period before the due date during "
-"which all additional work done by the student counts at a reduced rate. When"
-" enabling reduced scoring for a set the reduced scoring date will be set to "
+"which all additional work done by the student counts at a reduced rate. When "
+"enabling reduced scoring for a set the reduced scoring date will be set to "
 "the due date minus this number. The reduced scoring date can then be "
 "changed. If the Reduced Scoring is enabled and if it is after the reduced "
 "scoring date, but before the due date, a message like \"This assignment has "
@@ -5696,15 +5855,15 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "A WeBWorK projekt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
-"the weighted average of the status of those problems which count towards the"
-" parent grade."
+"the weighted average of the status of those problems which count towards the "
+"parent grade."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:190
@@ -5721,15 +5880,15 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "A fenti válasz helyes"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr ""
 
@@ -5742,17 +5901,17 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
-"The course '%1' has already been archived at '%2'. This earlier archive will"
-" be erased.  This cannot be undone."
+"The course '%1' has already been archived at '%2'. This earlier archive will "
+"be erased.  This cannot be undone."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
@@ -5782,61 +5941,61 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:390
 msgid ""
 "The e-mail verbosity level controls how much information is automatically "
-"added to feedback e-mails.  Levels are<ol><li value=\"Simple\"> Simple: send"
-" only the feedback comment and context link<li value=\"Standard\"> Standard:"
-" as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
+"added to feedback e-mails.  Levels are<ol><li value=\"Simple\"> Simple: send "
+"only the feedback comment and context link<li value=\"Standard\"> Standard: "
+"as in Simple, plus user, set, problem, and PG data<li value=\"Debug\"> "
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
-"The file %1/%2 already exists and cannot be overwritten. The message was not"
-" saved"
+"The file %1/%2 already exists and cannot be overwritten. The message was not "
+"saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr ""
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr ""
 
@@ -5849,66 +6008,65 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr ""
 
-#. ($rename_oldCourseID, $rename_oldCourseInstitution,
-#. $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -5916,8 +6074,7 @@ msgstr ""
 #. ($r->param('new_set_name')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1443
 msgid ""
-"The name '%1' is not a valid set name.  Use only letters, digits, -, _, and "
-"."
+"The name '%1' is not a valid set name.  Use only letters, digits, -, _, and ."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:123
@@ -5928,13 +6085,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -5948,40 +6105,39 @@ msgstr ""
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 msgid ""
-"The passwords you entered in the %1 and %2 fields don't match. Please retype"
-" your new password and try again."
+"The passwords you entered in the %1 and %2 fields don't match. Please retype "
+"your new password and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "Az állomány eredeti elérési útvonala legyen abszolút"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:659
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:505
-msgid ""
-"The percentage of active students with correct answers for each problem"
+msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
-"The percentage of students receiving at least these scores. The median score"
-" is in the 50% column."
+"The percentage of students receiving at least these scores. The median score "
+"is in the 50% column."
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr ""
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr ""
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -5993,23 +6149,23 @@ msgid ""
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr ""
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "A kiválasztott feladatsor (%1) nem érvényes sor a  %2 -hoz(höz)"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr ""
@@ -6023,7 +6179,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr ""
 
@@ -6032,15 +6188,21 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
@@ -6057,64 +6219,66 @@ msgid ""
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr ""
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
-"The value %1 for enableReducedScoring is not valid; it will be replaced with"
-" 'N'."
+"The value %1 for enableReducedScoring is not valid; it will be replaced with "
+"'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
-"The value %1 for the hideScore option is not valid; it will be replaced with"
-" 'N'."
+"The value %1 for the hideScore option is not valid; it will be replaced with "
+"'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6126,8 +6290,8 @@ msgstr ""
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "aztán e szerint"
 
@@ -6139,35 +6303,34 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:154
 msgid ""
 "There are currently two hardcopy themes to choose from: One Column and Two "
-"Columns.  The Two Columns theme is the traditional hardcopy format.  The One"
-" Column theme uses the full page width for each column"
+"Columns.  The Two Columns theme is the traditional hardcopy format.  The One "
+"Column theme uses the full page width for each column"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
 msgid ""
 "There are currently two themes (or skins) to choose from: math3 and math4.  "
-"The theme specifies a unified look and feel for the WeBWorK course web "
-"pages."
+"The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6177,36 +6340,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
-"There are upgrades available for your current branch of PG from branch %1 in"
-" remote %2."
+"There are upgrades available for your current branch of PG from branch %1 in "
+"remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -6227,11 +6390,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -6242,13 +6405,13 @@ msgstr ""
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
 msgid ""
-"There is no additional grade information.  A message about additional grades"
-" can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. "
-"These files can be edited using the \"Email\" link and the \"File Manager\" "
-"link in the left margin."
+"There is no additional grade information.  A message about additional grades "
+"can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. These "
+"files can be edited using the \"Email\" link and the \"File Manager\" link "
+"in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6268,25 +6431,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6306,15 +6469,15 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr ""
 
@@ -6324,24 +6487,28 @@ msgid ""
 "guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "Ez a feladatgysor nem tartalmaz feladatokat."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "Ez a feladatsor zárolva van."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "Ez a feladatsor jelenleg nincs nyitva."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
@@ -6352,16 +6519,16 @@ msgid ""
 "Date it is due, and the Date during which the answers are posted.  The Edit "
 "Set Data field contains checkboxes for selection and a link to the set data "
 "editing page.  The cells in the Edit Problems fields contain links which "
-"take you to a page where you can edit the containing problems, and the cells"
-" in the edit assigned users field contains links which take you to a page "
+"take you to a page where you can edit the containing problems, and the cells "
+"in the edit assigned users field contains links which take you to a page "
 "where you can edit what students the set is assigned to."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:93
 msgid ""
 "This is the Achievement Editor.  It is used to edit the achievements "
-"available to students.  Please keep in mind the following facts: Achievments"
-" are displayed, and evaluated, in the order they are listed. The \"secret\" "
+"available to students.  Please keep in mind the following facts: Achievments "
+"are displayed, and evaluated, in the order they are listed. The \"secret\" "
 "category creates achievements which are not visible to students until they "
 "are earned.  The \"level\" category is used for the achievements associated "
 "to a users level."
@@ -6373,12 +6540,11 @@ msgid ""
 "of all the students currently enrolled in this course.  The top of the page "
 "contains forms which allow you to filter which students to view, sort your "
 "students in a chosen order, edit student records, give new passwords to "
-"students, import/export student records from/to external files, or "
-"add/delete students.  To use, please select the action you would like to "
+"students, import/export student records from/to external files, or add/"
+"delete students.  To use, please select the action you would like to "
 "perform, enter in the relevant information in the fields below, and hit the "
 "\\\"Take Action!\\\" button at the bottom of the form.  The bottom of the "
-"page contains a table containing the student usernames and their "
-"information."
+"page contains a table containing the student usernames and their information."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:90
@@ -6397,39 +6563,43 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:203
 msgid ""
-"This is the number of achievement points given to each user for completing a"
-" problem."
+"This is the number of achievement points given to each user for completing a "
+"problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
-msgid ""
-"This problem has open subproblems.  You can visit them by using the links to"
-" the left or visiting the set page."
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
 msgstr ""
 
-#. ($shownYet{$problemFile})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
+msgid ""
+"This problem has open subproblems.  You can visit them by using the links to "
+"the left or visiting the set page."
+msgstr ""
+
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "Ez a feladatsor nem számít be az értékelésbe."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
@@ -6445,17 +6615,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6467,15 +6637,15 @@ msgid ""
 "password below."
 msgstr ""
 
-#. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 # Context is "This set is visible" or "This set is hidden"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr "Ez a feladatsor %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -6498,30 +6668,30 @@ msgid ""
 "This sets whether the Reduced Scoring system will be enabled.  If enabled "
 "you will need to set the default length of the reduced scoring period and "
 "the value of work done in the reduced scoring period below.  <p> To use "
-"this, you also have to enable Reduced Scoring for individual assignments and"
-" set their Reduced Scoring Dates by editing the set data.<p> This works with"
-" the avg_problem_grader (which is the the default grader) and the  "
+"this, you also have to enable Reduced Scoring for individual assignments and "
+"set their Reduced Scoring Dates by editing the set data.<p> This works with "
+"the avg_problem_grader (which is the the default grader) and the  "
 "std_problem_grader (the all or nothing grader).  It will work with custom "
 "graders if they are written appropriately."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -6537,15 +6707,15 @@ msgstr ""
 msgid ""
 "This table lists out the available homework sets for this class, along with "
 "its current status. Click on the link on the name of the homework sets to "
-"take you to the problems in that homework set.  Clicking on the links in the"
-" table headings will sort the table by the field it corresponds to.  You can"
-" also select sets for download to PDF or TeX format using the linkx next to "
+"take you to the problems in that homework set.  Clicking on the links in the "
+"table headings will sort the table by the field it corresponds to.  You can "
+"also select sets for download to PDF or TeX format using the linkx next to "
 "the problem set names, and then clicking on the 'Download PDF or TeX "
-"Hardcopy for Selected Sets' button at the end of the table.  There is also a"
-" clear button and an Email instructor button at the end of the table."
+"Hardcopy for Selected Sets' button at the end of the table.  There is also a "
+"clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6554,8 +6724,8 @@ msgid ""
 "problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr ""
 
@@ -6564,7 +6734,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -6577,24 +6747,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -6606,27 +6776,27 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -6636,11 +6806,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -6657,7 +6827,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr "Igaz"
 
@@ -6673,46 +6844,46 @@ msgstr ""
 msgid "Two Columns"
 msgstr "Két oszlop"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr ""
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr ""
 
@@ -6732,7 +6903,7 @@ msgid ""
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr ""
 
@@ -6740,13 +6911,13 @@ msgstr ""
 msgid "Unclassified Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr ""
 
@@ -6765,7 +6936,7 @@ msgstr "Kicsomagol"
 msgid "Unpack archives automatically"
 msgstr "Az archívumok automatikus kicsomagolása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr "Az összes kurzus kijelölésének megszüntetése"
 
@@ -6773,12 +6944,12 @@ msgstr "Az összes kurzus kijelölésének megszüntetése"
 msgid "Unselect all sets"
 msgstr "Az összes feladatsor kijelölésének visszavonása "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Az összes felhasználó kijelölésének visszavonása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr "Frissítés"
 
@@ -6790,37 +6961,37 @@ msgstr "A képernyő frissítése"
 msgid "Update Menus"
 msgstr "A menük frissítése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr "A beállítások majd az oldal frissítése "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr "A bejelölt könyvtárak frissítése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr "A frissített elhelyezkedés leírása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr "Frissítés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr "A kurzustáblák frissítése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr "A kurzusok frissítése"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr "A frissítési folyamat befejezve"
 
@@ -6834,11 +7005,12 @@ msgid "Use Date Picker"
 msgstr "Dátumválasztó használata"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr "Egyenletszerkesztő használata"
 
@@ -6846,20 +7018,21 @@ msgstr "Egyenletszerkesztő használata"
 msgid "Use Item"
 msgstr "Elem használata"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Rendszerbeállítások használata"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
-msgstr "Használja a böngészője vissza gombját a kilépéshez az előnézeti módból."
+msgstr ""
+"Használja a böngészője vissza gombját a kilépéshez az előnézeti módból."
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr ""
 
@@ -6873,25 +7046,28 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
 msgid ""
-"Use the interface below to quickly access commonly-used instructor tools, or"
-" select a tool from the list to the left."
+"Use the interface below to quickly access commonly-used instructor tools, or "
+"select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
 "additional information about the state of the system will be included."
-msgstr "Használja ezt a tanárának szóló űrlapot WebWork rendszerben vagy az valamely feladatnál előállt hiba bejelentésére. Az üzenettel el lesznek küldve további információk a rendszer állapotáról is."
+msgstr ""
+"Használja ezt a tanárának szóló űrlapot WebWork rendszerben vagy az valamely "
+"feladatnál előállt hiba bejelentésére. Az üzenettel el lesznek küldve "
+"további információk a rendszer állapotáról is."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr "Felhasználói azonosító"
@@ -6913,8 +7089,8 @@ msgstr "A felhasználó neve ez:"
 msgid "User's username is:"
 msgstr "A felhasználó felhasználóneve ez:"
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -6932,7 +7108,7 @@ msgid "Username presented:  %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -6942,7 +7118,7 @@ msgstr "Felhasználók"
 msgid "Users Assigned to Set %2"
 msgstr "A felhasználó ki lett jelölve a %2 feladatsorhoz"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Felhasználói lista"
 
@@ -6960,7 +7136,7 @@ msgid ""
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "A felhasználók előbb %1, aztán %2 és végül %3 szerint rendezve"
 
@@ -6979,17 +7155,18 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -6997,21 +7174,21 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "Megjelenítés"
 
@@ -7024,7 +7201,7 @@ msgstr "Megjelenítés"
 msgid "View Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "Mutasd az egyenletet mint"
 
@@ -7055,8 +7232,8 @@ msgstr "A diákok előmenetelének megtekintése diákonként"
 msgid "View/Edit"
 msgstr "Mutat/szerkeszt"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr "Átmeneti állomány mutatása:"
@@ -7079,30 +7256,37 @@ msgstr "Látható"
 msgid "Visible to Students"
 msgstr "Látható diákok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr "Figyelmeztető üzenet"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
-msgstr "Vigyázat: a törléssel minden felhaszálóval kapcsolatos adat visszavonhatatlanul törlődik!"
+msgstr ""
+"Vigyázat: a törléssel minden felhaszálóval kapcsolatos adat "
+"visszavonhatatlanul törlődik!"
 
 #. ($problem_desc , CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1223
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr "WeBWorK hiba"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK figyelmeztetés"
 
@@ -7117,18 +7301,18 @@ msgid ""
 "WeBWorK has encountered a software error while attempting to process this "
 "problem. It is likely that there is an error in the problem itself. If you "
 "are a student, report this error message to your professor to have it "
-"corrected. If you are a professor, please consult the error output below for"
-" more information."
+"corrected. If you are a professor, please consult the error output below for "
+"more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
 "ambiguity in that problem. Otherwise, it may indicate a problem with the "
 "WeBWorK system itself. If you are a student, report these warnings to your "
-"professor to have them corrected. If you are a professor, please consult the"
-" warning output below for more information."
+"professor to have them corrected. If you are a professor, please consult the "
+"warning output below for more information."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:491
@@ -7155,15 +7339,15 @@ msgstr "Üdvözöl a WeBWork!"
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "A felhasználók mely mezőjére kíván szűrési feltételt megadni? "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:370
 msgid ""
-"When a student has more attempts than is specified here they will be able to"
-" view another version of this problem.  If set to -1 the feature is disabled"
-" and if set to -2 the course default is used."
+"When a student has more attempts than is specified here they will be able to "
+"view another version of this problem.  If set to -1 the feature is disabled "
+"and if set to -2 the course default is used."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:301
@@ -7185,8 +7369,8 @@ msgid ""
 "WeBWorK fills in the subject line.  Here you can set the subject line.  In "
 "it, you can have various bits of information filled in with the following "
 "escape sequences.<p><ul><li> %c = course ID<li> %u = user ID<li> %s = set "
-"ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal"
-" percent sign</ul>"
+"ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
+"percent sign</ul>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:167
@@ -7198,8 +7382,8 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:333
 msgid ""
-"When viewing a problem, WeBWorK usually puts the previously submitted answer"
-" in the answer blank.  Below this level, old answers are never shown.  "
+"When viewing a problem, WeBWorK usually puts the previously submitted answer "
+"in the answer blank.  Below this level, old answers are never shown.  "
 "Typically, that is the desired behaviour for guest accounts."
 msgstr ""
 
@@ -7207,8 +7391,8 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:153
 msgid ""
 "When you unassign by unchecking a student's name, you destroy all of the "
-"data for achievement %1 for this student. Make sure this is what you want to"
-" do."
+"data for achievement %1 for this student. Make sure this is what you want to "
+"do."
 msgstr ""
 
 #. (CGI::b($setID)
@@ -7234,42 +7418,46 @@ msgstr ""
 msgid "Will open on %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Megéri"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
-"Write permissions have not been enabled in '%1'.  Changes must be saved to a"
-" different directory for viewing."
+"Write permissions have not been enabled in '%1'.  Changes must be saved to a "
+"different directory for viewing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
-msgstr "Az átmeneti könyvtárnak nincsenek engedényezve az írási jogosultságok. Nem történik változás."
+msgstr ""
+"Az átmeneti könyvtárnak nincsenek engedényezve az írási jogosultságok. Nem "
+"történik változás."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Igen"
 
@@ -7297,15 +7485,15 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "Ön nem jogosult hozzaférni az oktatói eszközökhöz."
 
@@ -7315,7 +7503,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "Ön nem jogosult módosítani a feladatsort."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "Önnek nincs jogosultsága módosítani a feladatot."
 
@@ -7324,13 +7512,13 @@ msgstr "Önnek nincs jogosultsága módosítani a feladatot."
 msgid "You are not authorized to modify set definition files."
 msgstr "Ön nem jogosult módosítani a feladatsor definíciós állományait."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "Ön nem jogosult módosítani a diák adatait"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "Ön nem jogosult végrehajtani ezt a műveletet."
 
@@ -7350,7 +7538,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -7361,6 +7549,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "Ezért a feladatért részpontokat kaphat. "
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -7384,10 +7576,10 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
-"You can use this feature %quant(%1,more time,more times,as many times as you"
-" want) on this problem"
+"You can use this feature %quant(%1,more time,more times,as many times as you "
+"want) on this problem"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:866
@@ -7406,15 +7598,15 @@ msgstr ""
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "Nem törölheti önmagát!"
 
@@ -7428,7 +7620,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -7455,37 +7647,42 @@ msgstr ""
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "Nincsen engedélye a hiba részleteinek megtekintéséhez."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr ""
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr "Önnek %negquant(%1,korlátlan próbálkozás,próbálkozás,próbálkozás) maradt."
+msgstr ""
+"Önnek %negquant(%1,korlátlan próbálkozás,próbálkozás,próbálkozás) maradt."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Ön ezt a feladatot %quant(%1,-szor(ször),-szor(ször)) próbálta."
 
@@ -7493,7 +7690,7 @@ msgstr "Ön ezt a feladatot %quant(%1,-szor(ször),-szor(ször)) próbálta."
 msgid "You have been logged out of WeBWorK."
 msgstr "Ön kijelentkezett WebWork-ből."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -7527,11 +7724,16 @@ msgid ""
 "set."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Ön nem tudja megváltoztatni itt a jelszavát!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "Ön nem tudja megváltoztatni itt a jelszavát!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr ""
 
@@ -7543,13 +7745,13 @@ msgid ""
 msgstr ""
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -7564,7 +7766,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr ""
 
@@ -7576,20 +7778,27 @@ msgstr ""
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr ""
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+#, fuzzy
+msgid "You must select one or more sets for scoring!"
+msgstr "Nincsenek feladatsorok kiválasztva értékelésre"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Meg kell adni egy felhasználói azonosítót (ID)."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr ""
 
@@ -7597,41 +7806,41 @@ msgstr ""
 msgid "You must specify a file name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Meg kell adni egy felhasználói azonosítót (ID)."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "Meg kell adnia egy fájlnevet, hogy mentsen egy új fájlt."
 
@@ -7664,19 +7873,19 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr "Ön %1 pontot kapott ezért a próbálkozásért."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -7705,8 +7914,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:483
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:494
-msgid ""
-"Your authentication failed.  Please return to Oncourse and login again."
+msgid "Your authentication failed.  Please return to Oncourse and login again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:237
@@ -7715,27 +7923,28 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr ""
 
@@ -7747,112 +7956,128 @@ msgstr "Az Ön e-mail címe megváltozott."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Az Ön teljes pontszáma %1. %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr ""
 
-#. ($testNounNum)
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 # $testNounNum is either "test (#)" or "submission (#)"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#. ($testNounNum)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr ""
 
-#. ($testNoun,$attemptScore,$totPossible)
 # $testNoun is either "test" or "submission"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#. ($testNoun,$attemptScore,$totPossible)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr ""
 
-#. ($testNounNum)
 # $testNounNum is either "test (#)" or "submission (#)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#. ($testNounNum)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr ""
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
-msgstr "Az Ön pontszáma nem lett elmentve, mert a feladat pontszámának adatbázisba írása hibába ütközött."
+msgstr ""
+"Az Ön pontszáma nem lett elmentve, mert a feladat pontszámának adatbázisba "
+"írása hibába ütközött."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Pontjai nem lettek elmentve, mivel ez a feladatsor zárva van."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
-msgstr "Pontjai nem lettek elmentve, mivel ez a feladat nincs hozzárendelve Önhöz."
+msgstr ""
+"Pontjai nem lettek elmentve, mivel ez a feladat nincs hozzárendelve Önhöz."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Az eredmény el lett mentve"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "A időkorlátja lejárt inaktivitás miatt. Kérjük, jelentkezzen be újra."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr ""
@@ -7865,42 +8090,77 @@ msgstr ""
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
-msgstr "Ezen az oldalon megtekintheti és szerkesztheti a kurzushoz hozzárendelt diákok nyilvántartását. Az oldal felső részén szűrési, rendezési eszközöket talál, valamint a diákok bejegyzeseit lehet szerkeszteni, új jelszavakat szolgáltatni, importálni és exportálni, illetve hozzáadni és törölni a diákokat. A használathoz válassza ki a végrehajtandó művelete, majd kattintson a \"Csináld!\" gombra a tennivalók felsorolása alatt. Ezek alatt a diákok felhasználói nevei és adadatait tartalmazó táblázatok találhatók. "
+msgstr ""
+"Ezen az oldalon megtekintheti és szerkesztheti a kurzushoz hozzárendelt "
+"diákok nyilvántartását. Az oldal felső részén szűrési, rendezési eszközöket "
+"talál, valamint a diákok bejegyzeseit lehet szerkeszteni, új jelszavakat "
+"szolgáltatni, importálni és exportálni, illetve hozzáadni és törölni a "
+"diákokat. A használathoz válassza ki a végrehajtandó művelete, majd "
+"kattintson a \"Csináld!\" gombra a tennivalók felsorolása alatt. Ezek alatt "
+"a diákok felhasználói nevei és adadatait tartalmazó táblázatok találhatók. "
 
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
-msgstr "1% külső hitelesítési rendszert használ. Önt ez a rendszer hitelesítette, de nem engedélyezi a belépését ebbe a kurzusba."
+msgstr ""
+"1% külső hitelesítési rendszert használ. Önt ez a rendszer hitelesítette, de "
+"nem engedélyezi a belépését ebbe a kurzusba."
 
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
-msgstr "Ez a kurzus támogatja vendég bejelentkezést. Kattintson a % 1 -ra(re) vendégként való bejelentkezéshez."
+msgstr ""
+"Ez a kurzus támogatja vendég bejelentkezést. Kattintson a % 1 -ra(re) "
+"vendégként való bejelentkezéshez."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
-msgstr "Ez a házi feladatok (HF) - feladatsorok szerkesztőjének oldala, ahol megtekintehi és szerkeszheti az egyes kurzusokhoz tartozó feladatsorokat valamit a tartalmazott feladatokat. Az oldal felső részén olyan kapcsolókat talál, amelyekkel szűrheti, rendezheti, szerkesztheti, importálhatja/exportálhatja, publikálhatja, létrehozhatja/törölheti a feladatsorokat. Válassza ki a végrehajtandó tevékenységet, majd a \"Csináld!\" gombbal végrehajtatja azt. Ezek alatt egy táblázatot talál a a feladatsor feladataival és annak információival."
+msgstr ""
+"Ez a házi feladatok (HF) - feladatsorok szerkesztőjének oldala, ahol "
+"megtekintehi és szerkeszheti az egyes kurzusokhoz tartozó feladatsorokat "
+"valamit a tartalmazott feladatokat. Az oldal felső részén olyan kapcsolókat "
+"talál, amelyekkel szűrheti, rendezheti, szerkesztheti, importálhatja/"
+"exportálhatja, publikálhatja, létrehozhatja/törölheti a feladatsorokat. "
+"Válassza ki a végrehajtandó tevékenységet, majd a \"Csináld!\" gombbal "
+"végrehajtatja azt. Ezek alatt egy táblázatot talál a a feladatsor "
+"feladataival és annak információival."
 
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
-msgstr "A(z) % 1 megjelölésével az Ön bejelentkezési adatait megjegyzi az Ön által használt böngésző, ami lehetővé teszi a WeBWoRK oldalra bejelentkezését anélkül, hogy beírná a felhasználói nevét és jelszavát (míg a munkamenet le nem jár). Ez a lehetőség nem ajánlott, nem biztonságos nyilvános, nem megbízható munkaállomásokon, számítógépeken, és olyan számítógépeken, amelyek felett nincs közvetlen ellenőrzési lehetősége."
+msgstr ""
+"A(z) % 1 megjelölésével az Ön bejelentkezési adatait megjegyzi az Ön által "
+"használt böngésző, ami lehetővé teszi a WeBWoRK oldalra bejelentkezését "
+"anélkül, hogy beírná a felhasználói nevét és jelszavát (míg a munkamenet le "
+"nem jár). Ez a lehetőség nem ajánlott, nem biztonságos nyilvános, nem "
+"megbízható munkaállomásokon, számítógépeken, és olyan számítógépeken, "
+"amelyek felett nincs közvetlen ellenőrzési lehetősége."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
-msgstr "A WeBWoRK szoftverhibába ütközött, miközben megpróbálta feldolgozni ezt a feladatot. Valószínű, hogy a hiba az Ön feladatában van. Ha Ön diák, jelentse ezt a hibaüzenetet a tanárának, hogy orvosolni tudja. Ha Ön tanár, kérjük, olvassa el a hiba kimenetét a részletekért."
+msgstr ""
+"A WeBWoRK szoftverhibába ütközött, miközben megpróbálta feldolgozni ezt a "
+"feladatot. Valószínű, hogy a hiba az Ön feladatában van. Ha Ön diák, "
+"jelentse ezt a hibaüzenetet a tanárának, hogy orvosolni tudja. Ha Ön tanár, "
+"kérjük, olvassa el a hiba kimenetét a részletekért."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "másolat az első kijelölt feladatsorról"
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -7909,13 +8169,19 @@ msgid "a duplicate of the first selected set"
 msgstr "másolat az első kijelölt feladatsorról"
 
 # Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "új, üres feladatsor"
+
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "új, üres feladatsor"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -7924,7 +8190,7 @@ msgstr ""
 msgid "a single set"
 msgstr "egyetlen feladatsor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr "aktív"
 
@@ -7933,11 +8199,11 @@ msgid "add problems"
 msgstr "feladat hozzáadása"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -7947,13 +8213,13 @@ msgid "admin"
 msgstr "admin"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -7982,14 +8248,14 @@ msgstr "az összes feladatsor"
 msgid "all students"
 msgstr "minden diák"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "az összes felhasználó"
 
@@ -7997,31 +8263,37 @@ msgstr "az összes felhasználó"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr "abc-sorrendben"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr "válasz"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "bármely felhasználó"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr "mint"
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
-msgstr ""
 
 # Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
@@ -8035,22 +8307,22 @@ msgstr ""
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "változások elhagyása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "változások mentve"
@@ -8067,17 +8339,17 @@ msgstr ""
 msgid "close"
 msgstr "bezár"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr "oszlop"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr "oszlopok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "helyes"
 
@@ -8091,7 +8363,7 @@ msgid "deleted %1 sets"
 msgstr "törölve %1 feladatsor"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr "törölve %1 felhasználó"
 
@@ -8103,7 +8375,7 @@ msgstr ""
 msgid "editing all sets"
 msgstr "az összes feladatsor módosítása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "az összes felhasználó módosítása"
 
@@ -8115,7 +8387,7 @@ msgstr ""
 msgid "editing selected sets"
 msgstr "a kiválasztott feladatsorok módosítása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "a kiválasztott felhasználók módosítása"
 
@@ -8123,7 +8395,7 @@ msgstr "a kiválasztott felhasználók módosítása"
 msgid "editing visible sets"
 msgstr "a látható feladatsorok módosítása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "a látható felhasználók módosítása"
 
@@ -8132,7 +8404,7 @@ msgstr "a látható felhasználók módosítása"
 msgid "email:"
 msgstr "e-mail:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr "üres"
 
@@ -8145,16 +8417,16 @@ msgid "entry rows."
 msgstr "üres sor"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "az export elhagyva"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr ""
 
@@ -8162,7 +8434,7 @@ msgstr ""
 msgid "exporting all sets"
 msgstr "az összes feladatsor exportálása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr ""
 
@@ -8196,15 +8468,15 @@ msgstr "diákoknak"
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "új jelszót minden felhasználónak "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "új jelszót minden kijelölt felhasználónak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "új jelszót minden látható felhasználónak"
 
@@ -8233,9 +8505,9 @@ msgstr ""
 msgid "guest"
 msgstr "vendég"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "rejtve"
@@ -8244,7 +8516,7 @@ msgstr "rejtve"
 msgid "hidden from"
 msgstr "rejtve innen:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "rejtve a diákoktól"
@@ -8253,48 +8525,52 @@ msgstr "rejtve a diákoktól"
 msgid "hidden sets"
 msgstr "rejtett feladatsorok"
 
+# doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-# doe snot need to be translated
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr "inaktív"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "helytelen"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr ""
 
@@ -8302,7 +8578,7 @@ msgstr ""
 msgid "login"
 msgstr "bejelentkezés"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr "bejelentkezési azonosító"
 
@@ -8337,15 +8613,15 @@ msgstr "új feladatsor:"
 msgid "new users"
 msgstr "új felhasználók"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr ""
 
@@ -8364,28 +8640,32 @@ msgstr "nincs feladatsor"
 msgid "no students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "nincs felhasználó"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr "senki"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr "n-edik oszlopa az összevont állománynak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
 msgstr "a diákok száma nincs definiálva"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
@@ -8409,7 +8689,7 @@ msgstr ""
 msgid "only best scores"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8421,53 +8701,57 @@ msgstr "vagy"
 msgid "or Problems from"
 msgstr ""
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr "pont"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr "pontok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr "feladat"
 
@@ -8485,8 +8769,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -8500,18 +8784,18 @@ msgid "record for user %1 not found"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr ""
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr "sor"
 
@@ -8533,13 +8817,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr ""
 
@@ -8558,17 +8842,17 @@ msgstr ""
 msgid "selected sets"
 msgstr "kiválasztott feladatsorok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "kiválasztott felhasználók"
 
@@ -8606,7 +8890,7 @@ msgstr "Az azonosítójukban egyező feladatsorok"
 msgid "showing all sets"
 msgstr "mutasd az összes feladatsort"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "mutasd az összes felhasználót"
 
@@ -8621,7 +8905,7 @@ msgstr "a rejtett feladatsorok mutatása"
 msgid "showing matching sets"
 msgstr "a megfelelő feladatsorok mutatása"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "mutasd az összes megfelelő felhasználót"
 
@@ -8629,7 +8913,7 @@ msgstr "mutasd az összes megfelelő felhasználót"
 msgid "showing no sets"
 msgstr "ne mutasd a feladatsorokat"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "ne mutasd a felhasználókat"
 
@@ -8637,13 +8921,17 @@ msgstr "ne mutasd a felhasználókat"
 msgid "showing selected sets"
 msgstr "mutasd a kiválaszott feladatsorokat"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "mutasd a kiválasztott felhasználókat"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
 msgstr "a látható feladatsorok mutatása"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
@@ -8659,16 +8947,16 @@ msgstr "diák"
 msgid "students"
 msgstr "diákok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -8676,12 +8964,12 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr "teszt"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr ""
 
@@ -8693,7 +8981,7 @@ msgstr "a teszt dátuma"
 msgid "test time"
 msgstr "a teszt időpontja "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr "a következő állomány"
 
@@ -8702,14 +8990,14 @@ msgid "the following file(s)"
 msgstr "a következő állományok"
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr ""
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr ""
 
@@ -8717,7 +9005,11 @@ msgstr ""
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "idő"
 
@@ -8725,43 +9017,40 @@ msgstr "idő"
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "idők"
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "korlátlan"
 
@@ -8770,27 +9059,27 @@ msgstr "korlátlan"
 msgid "userID: %1 --"
 msgstr "felhasználói azonosító: %1 --"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr "felhasználók"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "a kiválasztott mezőknek megfelelő felhasználók"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "látható"
@@ -8803,20 +9092,25 @@ msgstr "látható"
 msgid "visible sets"
 msgstr "látható feladatsorok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "látható a diákoknak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "látható felhasználók"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -8824,8 +9118,12 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411

--- a/lib/WeBWorK/Localize/ko.po
+++ b/lib/WeBWorK/Localize/ko.po
@@ -17,12 +17,17 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "선택된 문제집"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 #, fuzzy
 msgid "#corr"
 msgstr "수정"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 #, fuzzy
 msgid "#incorr"
 msgstr "실패"
@@ -36,16 +41,16 @@ msgstr "%1 맞음"
 msgid "% correct with review"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 #, fuzzy
 msgid "% students"
 msgstr "학생들에게 보임"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -86,18 +91,18 @@ msgid "%1 students out of %2"
 msgstr "학생들에게 보임"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 #, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "파일 %2/%3으로 넘어간 %1 사용자"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 #, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
@@ -129,8 +134,8 @@ msgstr "완료됨."
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 #, fuzzy
 msgid "%1% correct"
 msgstr "%1 맞음"
@@ -174,7 +179,7 @@ msgstr "%1님의 비밀번호가 변경되었습니다"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: 문제 %2"
 
@@ -185,13 +190,13 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1: 문제 %2"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 #, fuzzy
 msgid "%1: The directory for the course not found."
 msgstr "파일 '[_1]'을 찾을 수 없음."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -206,50 +211,50 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 #, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "%quant(%1, 전체 문제 중)문제가 입력되지 않았습니다."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 #, fuzzy
 msgid "%score"
 msgstr "점수"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(이 문제는 성적에 들어가지 않습니다.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 #, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "총점은 %1입니다. %2"
 
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 #, fuzzy
 msgid "(Your score on this %1 is not available.)"
 msgstr "총점은 %1입니다. %2"
@@ -325,17 +330,31 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 #, fuzzy
 msgid "A course with ID %1 already exists."
 msgstr "문제집 복사 실패 : 문제집 %1이 이미 존재합니다!"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
@@ -352,27 +371,27 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 #, fuzzy
 msgid "A new file has been created at '%1'"
 msgstr "문제집 %1 존재함. 생성된 문제집 없음."
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 #, fuzzy
 msgid ""
@@ -413,40 +432,40 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 #, fuzzy
 msgid "ANSWERS NOT RECORDED"
 msgstr "미리보기만 -- 답이 입력되지 않았습니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 #, fuzzy
 msgid "ANSWERS NOT RECORDED --"
 msgstr "미리보기만 -- 답이 입력되지 않았습니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 #, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "답안만 체크됨 -- 답안 기록되지 않음"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "답안만 체크됨 -- 답안 기록되지 않음"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "변경사항 취소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "저장후 내보내기 취소"
@@ -457,12 +476,12 @@ msgid "Achievement"
 msgstr "선택된 문제집"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 #, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "문제집 %1 존재함. 생성된 문제집 없음."
@@ -480,13 +499,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -503,12 +522,17 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 #, fuzzy
 msgid "Achievement scores saved to %1"
 msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
@@ -530,19 +554,19 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 #, fuzzy
 msgid "Acting as %1."
 msgstr "%1 실행중"
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 #, fuzzy
 msgid "Action %1 not found"
 msgstr "파일 '[_1]'을 찾을 수 없음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "활성화"
 
@@ -561,7 +585,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "추가"
@@ -570,9 +594,9 @@ msgstr "추가"
 msgid "Add All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 #, fuzzy
 msgid "Add Course"
 msgstr "수업내역"
@@ -587,7 +611,7 @@ msgstr "학생들에게 보임"
 msgid "Add Users"
 msgstr "사용자 추가"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -595,13 +619,13 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 #, fuzzy
 msgid "Add as what filetype?"
 msgstr "어떤 파일형식으로 추가하시겠습니까?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "몇 명을 추가하시겠습니까?"
 
@@ -610,45 +634,45 @@ msgstr "몇 명을 추가하시겠습니까?"
 msgid "Add problems to"
 msgstr "문제 추가"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 #, fuzzy
 msgid "Add to what set?"
 msgstr "추가할 문제집은?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "어떤 사용자를 추가하시겠습니까?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 #, fuzzy
 msgid "Added %1 to %2 as problem %3"
 msgstr "[_2]에 문제 [_3]으로 덧붙여진 [_1]"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 #, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "[_2]에 새로운 문제집 헤더로 추가된 '[_1]'"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 #, fuzzy
 msgid "Added '%1' to %2 as new set header"
 msgstr "[_2]에 새로운 문제집 헤더로 추가된 '[_1]'"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -657,53 +681,53 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Addresses"
 msgstr "이메일 주소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -718,7 +742,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -732,7 +756,7 @@ msgid "After set answer date"
 msgstr "대답한 날짜"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -745,17 +769,17 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 #, fuzzy
 msgid "All of the answers above are correct."
 msgstr "위의 답안은 모두 정답입니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 #, fuzzy
 msgid "All of the gradeable answers above are correct."
 msgstr "위의 답안은 모두 정답입니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -779,7 +803,7 @@ msgstr "학생들로부터 숨김"
 msgid "All sets made visible for all students"
 msgstr "학생들에게 보임"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -851,26 +875,26 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 #, fuzzy
 msgid "An error occured while archiving the course %1:"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 #, fuzzy
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
@@ -890,8 +914,8 @@ msgstr "대답한 날짜"
 msgid "Answer Log"
 msgstr "정답 확인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "정답 미리보기"
 
@@ -904,11 +928,11 @@ msgstr ""
 msgid "Answer:"
 msgstr "정답 확인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -932,15 +956,21 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "아래에 변경된 사항은 모든 학생들 문제집에 반영됩니다."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "아래에 변경된 사항은 모든 학생들 문제집에 반영됩니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 #, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
@@ -954,19 +984,19 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 #, fuzzy
 msgid "Append to end of %1 set"
 msgstr "문제집 [_1] 끝에 덧붙임"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 #, fuzzy
 msgid "Archive"
 msgstr "수업내역"
@@ -981,29 +1011,29 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 #, fuzzy
 msgid "Archive Courses"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 #, fuzzy
 msgid "Archive next course"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 #, fuzzy
 msgid "Archive this Course"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 #, fuzzy
 msgid "Archived Courses"
 msgstr "수업내역"
@@ -1014,24 +1044,28 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 #, fuzzy
 msgid "Assign"
 msgstr "할당된 문제집"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1057,18 +1091,18 @@ msgstr ""
 msgid "Assigned"
 msgstr "할당된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "할당된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 #, fuzzy
 msgid "Assigned achievements to users"
 msgstr "이 문제집을 할당할 사용자는?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 #, fuzzy
 msgid "Assigned to"
 msgstr "할당된 문제집"
@@ -1078,7 +1112,12 @@ msgstr "할당된 문제집"
 msgid "Assignment type"
 msgstr "할당된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "할당된 문제집"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 #, fuzzy
 msgid "At least one of the answers above is NOT correct."
 msgstr "제출 답안 중 최소 한 개가 %1 올바르지 않습니다. "
@@ -1087,7 +1126,7 @@ msgstr "제출 답안 중 최소 한 개가 %1 올바르지 않습니다. "
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1100,7 +1139,7 @@ msgstr "시도"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "시도"
 
@@ -1108,13 +1147,14 @@ msgstr "시도"
 msgid "Audit"
 msgstr "감사"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "작성자 정보"
 
@@ -1122,12 +1162,12 @@ msgstr "작성자 정보"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1167,16 +1207,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1211,7 +1251,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1252,19 +1292,19 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "사용자 '%1'를 위한 비밀번호 기록이 없음: %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 #, fuzzy
 msgid "Can't open %1"
 msgstr "파일 '[_1]'로 저장하기"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 #, fuzzy
 msgid "Can't open file %1"
 msgstr "파일 '[_1]'로 저장하기"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 #, fuzzy
 msgid "Can't read merge file %1. No message sent"
 msgstr "파일 '[_1]'로 저장하기"
@@ -1275,7 +1315,7 @@ msgstr "파일 '[_1]'로 저장하기"
 msgid "Can't rename file: %1"
 msgstr "파일 '[_1]'로 저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1284,11 +1324,11 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 #, fuzzy
 msgid "Can't write to file %1"
 msgstr "파일 '[_1]'로 저장하기"
@@ -1301,7 +1341,7 @@ msgstr "파일 '[_1]'로 저장하기"
 msgid "Cancel"
 msgstr "편집 취소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 #, fuzzy
 msgid "Cancel E-mail"
 msgstr "이메일 취소"
@@ -1316,8 +1356,8 @@ msgstr "파일 '[_1]'로 저장하기"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1337,11 +1377,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1356,7 +1396,7 @@ msgstr "디스플레이 옵션"
 msgid "Change Email Address"
 msgstr "이메일주소 변경"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1365,33 +1405,33 @@ msgstr ""
 msgid "Change Password"
 msgstr "비밀번호 변경"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 #, fuzzy
 msgid "Change User Settings"
 msgstr "사용자 설정 바꾸기"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "변경 취소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "이 파일의 변경사항이 영구적으로 저장되지 않았습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "변경사항 저장"
 
@@ -1406,27 +1446,27 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "정답 확인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 #, fuzzy
 msgid "Check Test"
 msgstr "정답 확인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "추가 오류 메시지 확인"
 
@@ -1441,7 +1481,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1481,8 +1521,8 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1498,7 +1538,7 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 #, fuzzy
 msgid "Close"
 msgstr "닫기"
@@ -1543,7 +1583,7 @@ msgid "Closes"
 msgstr "닫기"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 #, fuzzy
 msgid "Closes %1"
 msgstr "[_1]로 돌아가기"
@@ -1554,39 +1594,39 @@ msgstr "[_1]로 돌아가기"
 msgid "Closes:"
 msgstr "닫기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "코멘트"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1595,7 +1635,7 @@ msgstr ""
 msgid "Completed."
 msgstr "완료됨."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1606,7 +1646,7 @@ msgstr ""
 msgid "Confirm %1's New Password"
 msgstr "%1님의 새 비밀번호 확인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 #, fuzzy
 msgid "Confirm Password:"
 msgstr "%1님의 새 비밀번호 확인"
@@ -1621,8 +1661,8 @@ msgid "Continue"
 msgstr "계속"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 #, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "[_1]에서 새 위치 [_2]로 복사된 보조파일"
@@ -1637,7 +1677,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1646,8 +1686,8 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr "이 문제 수정하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "수정"
@@ -1656,7 +1696,7 @@ msgstr "수정"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 #, fuzzy
 msgid "Correct Answer"
 msgstr "답안 수정"
@@ -1676,19 +1716,19 @@ msgid "Correct answers"
 msgstr "답안 수정"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 #, fuzzy
 msgid "Correct: %1/%2"
 msgstr "문제집 [_1]/ 문제 [_2]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 #, fuzzy
 msgid "CorrectAnswers"
 msgstr "답안 수정"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1707,49 +1747,50 @@ msgid "Couldn't change your email address: %1"
 msgstr "이메일주소를 변경할 수 없습니다: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 #, fuzzy
 msgid "Couldn't save your display options: %1"
 msgstr "이메일주소를 변경할 수 없습니다: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1759,13 +1800,13 @@ msgstr "수업 관리"
 msgid "Course Configuration"
 msgstr "환경설정"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 #, fuzzy
 msgid "Course ID:"
 msgstr "수업 정보"
@@ -1775,14 +1816,14 @@ msgstr "수업 정보"
 msgid "Course Info"
 msgstr "수업 정보"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 #, fuzzy
 msgid "Course Name:"
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 #, fuzzy
 msgid "Course Title:"
 msgstr "수업내역"
@@ -1792,15 +1833,15 @@ msgstr "수업내역"
 msgid "Course archived."
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1819,7 +1860,7 @@ msgstr "생성하기"
 msgid "Create CSV"
 msgstr "생성하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 #, fuzzy
 msgid "Create Location:"
 msgstr "설명"
@@ -1828,7 +1869,7 @@ msgstr "설명"
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1836,12 +1877,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "어떤 종류의 문제집으로 생성?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1854,34 +1895,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 #, fuzzy
 msgid "Database:"
 msgstr "내보내기 취소"
@@ -1895,7 +1936,7 @@ msgstr "날짜 열기"
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1920,84 +1961,84 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 #, fuzzy
 msgid "Delete Course"
 msgstr "삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 #, fuzzy
 msgid "Delete course:"
 msgstr "삭제"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "삭제할 개수는?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 #, fuzzy
 msgid "Delete it?"
 msgstr "삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 #, fuzzy
 msgid "Delete location:"
 msgstr "삭제"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 #, fuzzy
 msgid "Deleted %quant(%1,achievement)"
 msgstr "선택된 문제집"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 #, fuzzy
 msgid "Deleting temp file at %1"
 msgstr "[_1]에서 임시 파일 삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 #, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구되지 않습니다!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 #, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구되지 않습니다!"
@@ -2007,7 +2048,7 @@ msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구되지 않습니다!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 #, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구되지 않습니다!"
@@ -2016,14 +2057,14 @@ msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 #, fuzzy
 msgid "Description"
 msgstr "설명"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -2042,48 +2083,48 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 #, fuzzy
 msgid "Directory structure"
 msgstr "프록터"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 #, fuzzy
 msgid "Display Mode:"
@@ -2093,6 +2134,11 @@ msgstr "디스플레이 모드"
 #, fuzzy
 msgid "Display Past Answers"
 msgstr "지난 정답 보기"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+#, fuzzy
+msgid "Display of scores for this set is not allowed."
+msgstr "총점은 %1입니다. %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 #, fuzzy
@@ -2117,33 +2163,33 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 #, fuzzy
 msgid "Don't Unarchive"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 #, fuzzy
 msgid "Don't Upgrade"
 msgstr "삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #, fuzzy
 msgid "Don't delete"
 msgstr "삭제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 #, fuzzy
 msgid "Don't make changes"
 msgstr "변경사항 저장"
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 #, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "알려지지 않은 저장모드: |[_1]|. 알려지지 않은 오류."
@@ -2153,18 +2199,18 @@ msgstr "알려지지 않은 저장모드: |[_1]|. 알려지지 않은 오류."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 #, fuzzy
 msgid "Don't use in an achievement"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2197,8 +2243,8 @@ msgstr "Hardcopy 생성"
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "선택된 %plural(%1, Set, Sets)에 Hardcopy 다운로드"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "PDF 다운로드 혹은 현재 문제집을 TeX Hardcopy"
 
@@ -2221,6 +2267,16 @@ msgstr "점수 다운로드"
 msgid "Drop"
 msgstr "중단"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr "이 문제집 복사 후 이름 바꾸기"
@@ -2241,7 +2297,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "강사에게 이메일 전송"
 
@@ -2259,7 +2315,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 #, fuzzy
 msgid "E-mail:"
 msgstr "이메일"
@@ -2268,25 +2324,25 @@ msgstr "이메일"
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "편집"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 #, fuzzy
 msgid "Edit %1 of set %2."
 msgstr "파일 '[_2]'에 [_1]을 편집"
@@ -2300,21 +2356,21 @@ msgstr "모든 문제집 데이터 수정"
 msgid "Edit Assigned Users"
 msgstr "배정된 사용자 편집하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 #, fuzzy
 msgid "Edit Header"
 msgstr "문제집 헤더"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 #, fuzzy
 msgid "Edit Location:"
 msgstr "설명"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #, fuzzy
 msgid "Edit Problem"
 msgstr "문제 수정하기"
@@ -2339,7 +2395,7 @@ msgstr "문제집 데이터 편집"
 msgid "Edit Target Set"
 msgstr "문제집 데이터 편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "수정할 사용자는?"
 
@@ -2356,17 +2412,17 @@ msgstr "편집"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2378,24 +2434,24 @@ msgstr ""
 msgid "Edit which sets?"
 msgstr "수정할 문제집은?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 #, fuzzy
 msgid "Edit1"
 msgstr "편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 #, fuzzy
 msgid "Edit2"
 msgstr "편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 #, fuzzy
 msgid "Edit3"
 msgstr "편집"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 #, fuzzy
 msgid "Editing %1 in file '%2'"
 msgstr "파일 '[_2]'에 [_1]을 편집"
@@ -2407,46 +2463,46 @@ msgid "Editing achievement in file '%1'"
 msgstr "파일 '[_2]'에 [_1]을 편집"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 #, fuzzy
 msgid "Editor"
 msgstr "편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 #, fuzzy
 msgid "Editor rows:"
 msgstr "문제 수정하기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "이메일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "이메일 주소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 #, fuzzy
 msgid "Email Body:"
 msgstr "이메일:"
@@ -2456,31 +2512,31 @@ msgstr "이메일:"
 msgid "Email Instructor On Failed Attempt"
 msgstr "강사에게 이메일 전송"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 #, fuzzy
 msgid "Email Link"
 msgstr "이메일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 #, fuzzy
 msgid "Email address"
 msgstr "이메일 주소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "강사에게 이메일 전송"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2524,8 +2580,8 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 #, fuzzy
 msgid "Enabled"
 msgstr "사용 가능"
@@ -2563,22 +2619,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "등록됨"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "등록 현황"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "아래에 파일명을 입력해주세요"
 
@@ -2592,8 +2648,8 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "접속됨"
 
@@ -2625,7 +2681,7 @@ msgstr ""
 msgid "Error message:"
 msgstr "메시지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 #, fuzzy
 msgid "Error messages"
 msgstr "메시지"
@@ -2648,7 +2704,7 @@ msgid ""
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 #, fuzzy
 msgid "Error: The original file %1 cannot be read."
@@ -2668,6 +2724,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2683,7 +2743,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2691,58 +2751,58 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "저장 후 내보내기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 #, fuzzy
 msgid "Export selected achievements."
 msgstr "선택된 문제집 저장 후 내보내기"
@@ -2751,7 +2811,7 @@ msgstr "선택된 문제집 저장 후 내보내기"
 msgid "Export selected sets"
 msgstr "선택된 문제집 저장 후 내보내기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "저장 후 내보낼 파일 종류?"
 
@@ -2759,12 +2819,12 @@ msgstr "저장 후 내보낼 파일 종류?"
 msgid "Export which sets?"
 msgstr "저장 후 내보낼 문제집은?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "저장 후 내보낼 사용자는?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 #, fuzzy
 msgid "Exported achievements to %1"
 msgstr "선택된 문제집 저장 후 내보내기"
@@ -2779,17 +2839,17 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 #, fuzzy
 msgid "Failed to create new achievement: %1"
 msgstr "새로운 문제집:%1 생성 실패"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 #, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "새로운 문제집 생성 실패: 문제집 이름 없음!"
@@ -2804,7 +2864,7 @@ msgstr "새로운 문제집:%1 생성 실패"
 msgid "Failed to create new set: no set name specified!"
 msgstr "새로운 문제집 생성 실패: 문제집 이름 없음!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 #, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
@@ -2839,10 +2899,10 @@ msgstr "새로운 문제집:%1 생성 실패"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 #, fuzzy
 msgid "Failed to open %1"
 msgstr "파일 '[_1]'로 저장하기"
@@ -2854,11 +2914,11 @@ msgid "Failed to save: %1"
 msgstr "파일 '[_1]'로 저장하기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid "Feature exhausted for this problem"
 msgstr "이 문제의 오류 보고하기"
@@ -2872,36 +2932,36 @@ msgstr "피드백"
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 #, fuzzy
 msgid "FeedbackMessage"
 msgstr "피드백"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 #, fuzzy
 msgid ""
@@ -2955,7 +3015,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "파일명"
 
@@ -2964,7 +3024,7 @@ msgstr "파일명"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "어떤 문자열을 필터하시겠습니까?"
 
@@ -2980,29 +3040,29 @@ msgstr "필터"
 msgid "First"
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 #, fuzzy
 msgid "First name"
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3010,7 +3070,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -3019,6 +3079,11 @@ msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+#, fuzzy
+msgid "Format"
+msgstr "Hardcopy 포맷:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
@@ -3030,20 +3095,25 @@ msgstr ""
 msgid "Format:"
 msgstr "Hardcopy 포맷:"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "이 문제집에는 문제가 없습니다."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 #, fuzzy
 msgid "From field must contain one valid email address."
 msgstr "이메일주소를 변경할 수 없습니다: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "From:"
 
@@ -3072,7 +3142,7 @@ msgid "General"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 #, fuzzy
 msgid "General Information"
 msgstr "사이트 정보"
@@ -3095,12 +3165,18 @@ msgstr "다음 문제"
 msgid "Get Target Set Problems"
 msgstr "문제집 데이터 편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+#, fuzzy
+msgid "Get a new version of this problem"
+msgstr "이 문제의 오류 보고하기"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 #, fuzzy
 msgid "Give new password to"
 msgstr "새 비밀번호를 부여할 사용자는?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "새 비밀번호를 부여할 사용자는?"
 
@@ -3128,7 +3204,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "파일 '[_1]'을 찾을 수 없음."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -3136,24 +3212,34 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 #, fuzzy
 msgid "Grade"
 msgstr "성적"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 #, fuzzy
 msgid "Grade Problem"
 msgstr "다음 문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 #, fuzzy
 msgid "Grade Test"
 msgstr "성적"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 #, fuzzy
 msgid "Grader"
 msgstr "성적"
@@ -3183,7 +3269,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "게스트 로그인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 #, fuzzy
 msgid "HTTP Headers"
 msgstr "문제집 헤더"
@@ -3212,13 +3298,17 @@ msgstr "Hardcopy Header"
 msgid "Hardcopy Theme"
 msgstr "Hardcopy Header"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 #, fuzzy
 msgid "Headers"
 msgstr "문제집 헤더"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "도움말"
 
@@ -3230,12 +3320,12 @@ msgstr ""
 msgid "Hidden"
 msgstr "숨김"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Hide Courses"
 msgstr "수업내역"
@@ -3250,8 +3340,8 @@ msgstr "힌트"
 msgid "Hide Hints from Students"
 msgstr "학생들로부터 숨김"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 #, fuzzy
 msgid "Hide Inactive Courses"
 msgstr "수업내역"
@@ -3265,7 +3355,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr "힌트"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 #, fuzzy
 msgid "Hint:"
 msgstr "힌트"
@@ -3279,13 +3369,13 @@ msgstr "힌트"
 msgid "Hmwk Sets Editor"
 msgstr "문제집 에디터"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 #, fuzzy
 msgid "Homework Totals"
 msgstr "문제집"
@@ -3294,15 +3384,15 @@ msgstr "문제집"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3320,14 +3410,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3339,13 +3429,17 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 #, fuzzy
 msgid "Illegal file '%1' specified"
 msgstr "파일 [_1]이 보호되었습니다!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3353,10 +3447,11 @@ msgstr ""
 msgid "Import"
 msgstr "가져오기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
 #, fuzzy
-msgid "Import achievements from"
-msgstr "선택된 문제집 저장 후 내보내기"
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "이 문제집을 할당할 사용자는?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
@@ -3370,22 +3465,22 @@ msgstr "가져올 문제집 개수는?"
 msgid "Import sets with names"
 msgstr "새로운 이름으로 문제집 가져오기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "어떤 파일에서 사용자를 가져오겠습니까?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 #, fuzzy
 msgid "Imported %quant(%1,achievement)"
 msgstr "선택된 문제집 저장 후 내보내기"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "비활성화"
 
@@ -3393,19 +3488,19 @@ msgstr "비활성화"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 #, fuzzy
 msgid "Include Success Index"
 msgstr "인덱스 포함"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 #, fuzzy
 msgid "Incorrect"
 msgstr "실패"
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 #, fuzzy
 msgid "Incorrect: %1/%2"
 msgstr "실패"
@@ -3414,7 +3509,7 @@ msgstr "실패"
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 #, fuzzy
 msgid "Institution:"
 msgstr "설명"
@@ -3423,16 +3518,16 @@ msgstr "설명"
 msgid "Instructor Tools"
 msgstr "강사 전용 도구"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3441,7 +3536,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3456,17 +3551,21 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 #, fuzzy
 msgid "Jump to Page:"
 msgstr "다음 문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 #, fuzzy
 msgid "Jump to Problem:"
 msgstr "다음 문제"
@@ -3479,7 +3578,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3502,28 +3601,28 @@ msgstr "성"
 msgid "Last Answer"
 msgstr "지난 정답 보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "성"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 #, fuzzy
 msgid "Last name"
 msgstr "성"
@@ -3552,18 +3651,18 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "라이브러리 브라우저"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "라이브러리 브라우저 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 #, fuzzy
 msgid "Library Browser 3"
@@ -3602,36 +3701,36 @@ msgstr ""
 msgid "Local Problems"
 msgstr "문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Location"
 msgstr "설명"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 #, fuzzy
 msgid "Location %1 has been created, with addresses %2."
 msgstr "문제집 %1 존재함. 생성된 문제집 없음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 #, fuzzy
 msgid "Location description:"
 msgstr "사이트 설명 보이기/감추기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 #, fuzzy
 msgid "Location name:"
 msgstr "동작 멈춤"
@@ -3640,8 +3739,8 @@ msgstr "동작 멈춤"
 msgid "Log In Again"
 msgstr "다시 로그인해주세요"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "로그아웃"
 
@@ -3649,21 +3748,21 @@ msgstr "로그아웃"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 #, fuzzy
 msgid "Logged in as %1."
 msgstr "%1으로 로그인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 #, fuzzy
 msgid "Login"
 msgstr "로그인"
@@ -3676,23 +3775,23 @@ msgstr "로그인 정보"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "로그인 이름"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "로그인 상태"
 
@@ -3700,7 +3799,7 @@ msgstr "로그인 상태"
 msgid "Logout"
 msgstr "로그아웃"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "메   뉴"
 
@@ -3713,21 +3812,21 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 #, fuzzy
 msgid "Make changes"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 #, fuzzy
 msgid "Manual Grader"
@@ -3743,7 +3842,7 @@ msgid "Mark Correct"
 msgstr "수정"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 #, fuzzy
 msgid "Mark Correct?"
 msgstr "수정"
@@ -3752,8 +3851,9 @@ msgstr "수정"
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "무엇과 대응됩니까? (여러개의 ID를 콤마로 구별하시오) "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "수학 문제"
 
@@ -3771,52 +3871,52 @@ msgstr "보이기:"
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 #, fuzzy
 msgid "Merge file:"
 msgstr "헤더 파일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 #, fuzzy
 msgid "Message"
 msgstr "메시지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 #, fuzzy
 msgid "Message file:"
 msgstr "헤더 파일"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 #, fuzzy
 msgid "Message:"
 msgstr "메시지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "메시지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -3829,17 +3929,17 @@ msgstr "문제"
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3883,13 +3983,13 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 #, fuzzy
 msgid "New Name:"
 msgstr "문제집 이름"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "새 비밀번호"
 
@@ -3902,12 +4002,12 @@ msgstr "파일명"
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "새 비밀번호 저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3915,15 +4015,17 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "다음 문제"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3931,21 +4033,27 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "아니오"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 #, fuzzy
 msgid "No Description"
 msgstr "사이트 설명 보이기/감추기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3965,7 +4073,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "문제집에 변화없음"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3977,7 +4085,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 #, fuzzy
 msgid "No course id defined"
 msgstr "수업내역"
@@ -3989,39 +4097,39 @@ msgstr "수업내역"
 msgid "No data exists for set %1 and problem %2"
 msgstr "문제집 [_1]/ 문제 [_2]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 #, fuzzy
 msgid "No merge data file"
 msgstr "헤더 파일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -4029,25 +4137,25 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 #, fuzzy
 msgid "No record for global set %1."
 msgstr "문제집 [_1]의 헤더"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 #, fuzzy
 msgid "No record for user %1."
 msgstr "문제집 [_1]의 헤더"
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 #, fuzzy
 msgid "No record found for problem %1."
 msgstr "문제집 [_1]의 헤더"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -4060,22 +4168,22 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr "점수기록할 문제집이 선택되지 않음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr "문제집이 없습니다. 기입할 문제집을 위해 강좌에서 옵션을 선택해주세요."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 #, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
@@ -4094,15 +4202,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -4116,26 +4228,32 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "로그인 실패"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "공지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "공지"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 #, fuzzy
 msgid "Number"
 msgstr "문제 뷰어"
@@ -4152,8 +4270,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -4186,7 +4304,7 @@ msgid ""
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 #, fuzzy
 msgid "Open"
 msgstr "날짜 열기"
@@ -4206,13 +4324,13 @@ msgstr "날짜 열기"
 msgid "Open Problem Library"
 msgstr "문제 리스트"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -4228,11 +4346,10 @@ msgstr "열림, 기한"
 msgid "Open, complete by %1."
 msgstr "열기: 1% 완료"
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
-msgid "Open, reduced scoring starts on %1."
-msgstr "감점 시작: %1"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 #, fuzzy
@@ -4257,12 +4374,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr "문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 #, fuzzy
 msgid "Orig. Lib. Browser"
 msgstr "라이브러리 브라우저"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4286,64 +4403,67 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "미리보기만 -- 답이 입력되지 않았습니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "필드 삽입"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 #, fuzzy
 msgid "Page generated at %1"
 msgstr "페이지 생성 1% "
@@ -4357,7 +4477,7 @@ msgstr "비밀번호"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 #, fuzzy
 msgid "Password:"
 msgstr "비밀번호"
@@ -4368,7 +4488,7 @@ msgstr "비밀번호"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "[_2]에 문제 [_3]으로 덧붙여진 [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4382,24 +4502,24 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "허용 레벨"
 
@@ -4408,7 +4528,7 @@ msgstr "허용 레벨"
 msgid "Permissions"
 msgstr "허용 레벨"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4445,7 +4565,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4458,7 +4578,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "사용자이름과 비밀번호를 입력해주세요 %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4478,55 +4598,56 @@ msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요.
 msgid "Please select at least one user and try again."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "저장할 파일을 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #, fuzzy
 msgid "Points"
 msgstr "힌트"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview Message"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 #, fuzzy
 msgid "Preview My Answers"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 #, fuzzy
 msgid "Preview Test"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview message"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 #, fuzzy
 msgid "Preview set to:"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "이전 문제"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 #, fuzzy
 msgid "Previous page"
@@ -4536,11 +4657,11 @@ msgstr "이전 문제"
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #, fuzzy
 msgid "Prob"
 msgstr "문제"
@@ -4560,21 +4681,21 @@ msgstr "문제 %1"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 #, fuzzy
 msgid "Problem %1"
 msgstr "문제 %1"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 #, fuzzy
 msgid "Problem %1."
 msgstr "문제 %1"
@@ -4593,8 +4714,8 @@ msgstr "문제 편집기"
 msgid "Problem Editor3"
 msgstr "문제 편집기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "문제 리스트"
 
@@ -4612,29 +4733,30 @@ msgstr "문제 뷰어"
 msgid "Problem Number "
 msgstr "문제 뷰어"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "기술적 문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 #, fuzzy
 msgid "Problem Viewer"
 msgstr "문제 편집기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "문제"
 
@@ -4684,11 +4806,11 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "출판"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -4702,28 +4824,28 @@ msgid "Really delete the items listed above?"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "설명"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "개별 문제집에 대해 점수 기록"
 
@@ -4738,7 +4860,7 @@ msgid "Reduced Scoring Date"
 msgstr "감점 불가능"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Disabled"
 msgstr "감점 불가능"
@@ -4746,22 +4868,10 @@ msgstr "감점 불가능"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Enabled"
 msgstr "감점 가능"
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
-msgid "Reduced Scoring Starts %1"
-msgstr "감점 시작: %1"
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
-msgid "Reduced scoring started on %1."
-msgstr "감점 시작: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
@@ -4777,12 +4887,12 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Refresh Listing"
 msgstr "사용자 리스트"
@@ -4791,7 +4901,7 @@ msgstr "사용자 리스트"
 msgid "Relax IP restrictions when?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "시도 횟수"
 
@@ -4803,7 +4913,7 @@ msgstr "나를 기억해주세요"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4814,13 +4924,13 @@ msgid "Rename"
 msgstr "파일명"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 #, fuzzy
 msgid "Rename Course"
 msgstr "수업내역"
@@ -4830,20 +4940,20 @@ msgstr "수업내역"
 msgid "Rename file as:"
 msgstr "헤더 파일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 #, fuzzy
 msgid "Render Problem"
 msgstr "다음 문제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 #, fuzzy
 msgid "Renumber Problems"
 msgstr "문제"
@@ -4860,55 +4970,56 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "바꿀 사용자는?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "오류 보고"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 #, fuzzy
 msgid "Report for course %1:"
 msgstr "문제집 [_1]의 헤더"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 #, fuzzy
 msgid "Request information"
 msgstr "사이트 정보"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 #, fuzzy
 msgid "Request new version now."
 msgstr "사이트 정보"
@@ -4977,8 +5088,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -4986,11 +5097,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -5021,24 +5128,24 @@ msgstr "설명"
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "결과"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 #, fuzzy
 msgid "Result of last action performed"
 msgstr "마지막으로 실행된 결과"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 #, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "마지막으로 실행된 결과: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -5051,19 +5158,27 @@ msgstr "마지막으로 실행된 결과"
 msgid "Results of last action performed: "
 msgstr "마지막으로 실행된 결과"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "되돌아가기"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 #, fuzzy
 msgid "Revert to %1"
@@ -5077,19 +5192,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -5098,93 +5213,93 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "저장"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 #, fuzzy
 msgid "Save %1"
 msgstr "저장"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 #, fuzzy
 msgid "Save Changes"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 #, fuzzy
 msgid "Save as"
 msgstr "저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 #, fuzzy
 msgid "Save as Default"
 msgstr "시스템 초기값 사용"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "변경사항 저장"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 #, fuzzy
 msgid "Save file to:"
 msgstr "편집 저장"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 #, fuzzy
 msgid "Save to %1 and View"
 msgstr "[_1]을 저장하고 보여주기"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 #, fuzzy
 msgid "Saved to file '%1'"
 msgstr "파일 '[_1]'로 저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5200,11 +5315,11 @@ msgstr "점수"
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "선택된 문제집 점수 부여하고 저장:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -5233,14 +5348,14 @@ msgid "Scoring Tools"
 msgstr "점수 도구"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5250,24 +5365,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "섹션"
@@ -5283,11 +5398,16 @@ msgstr "섹션"
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "문제집"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 #, fuzzy
@@ -5298,41 +5418,41 @@ msgstr "아래의 동작 선택"
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 #, fuzzy
 msgid "Select a course to delete."
 msgstr "아래의 동작 선택"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 #, fuzzy
 msgid "Select a course to unarchive."
 msgstr "아래의 동작 선택"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 #, fuzzy
 msgid "Select a database layout below."
 msgstr "아래의 동작 선택"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 #, fuzzy
 msgid "Select a listing format:"
 msgstr "실행할 동작을 선택하세요"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 #, fuzzy
 msgid "Select above then:"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 #, fuzzy
 msgid "Select all eligible courses"
 msgstr "모든 사용자 선택"
@@ -5341,28 +5461,28 @@ msgstr "모든 사용자 선택"
 msgid "Select all sets"
 msgstr "모든 문제집 선택"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "모든 사용자 선택"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "실행할 동작을 선택하세요"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 #, fuzzy
 msgid "Select an action to perform:"
 msgstr "실행할 동작을 선택하세요"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 #, fuzzy
 msgid "Select course(s) to hide or unhide."
 msgstr "아래의 동작 선택"
@@ -5377,7 +5497,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5401,27 +5521,27 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 #, fuzzy
 msgid "Selected students"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 #, fuzzy
 msgid "Send E-mail"
 msgstr "이메일 전송:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 #, fuzzy
 msgid "Send Email"
 msgstr "이메일 전송:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 #, fuzzy
 msgid "Send to:"
 msgstr "이메일 전송:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "문제집"
 
@@ -5460,7 +5580,7 @@ msgid "Set Definition Files"
 msgstr "문제집 정의 파일명"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 #, fuzzy
 msgid "Set Description"
 msgstr "사이트 설명 보이기/감추기"
@@ -5474,7 +5594,7 @@ msgid "Set Detail for set %2"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5489,12 +5609,12 @@ msgstr "문제집 헤더"
 msgid "Set ID"
 msgstr "학생 ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "문제집 정보"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "문제집 리스트"
 
@@ -5523,8 +5643,12 @@ msgid "Set Name "
 msgstr "문제집 이름"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -5550,7 +5674,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "문제집"
 
@@ -5564,7 +5688,7 @@ msgstr "배정된 사용자 편집하기"
 msgid "Sets assigned to %1"
 msgstr "배정된 사용자 편집하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #, fuzzy
 msgid "Setting"
 msgstr "사용자 설정 바꾸기"
@@ -5574,12 +5698,12 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 #, fuzzy
 msgid "Show"
 msgstr "보이기:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -5587,7 +5711,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "힌트보여주기"
 
@@ -5596,8 +5720,8 @@ msgstr "힌트보여주기"
 msgid "Show Me Another"
 msgstr "새 창에서 보이기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "지난 정답 보기"
 
@@ -5609,8 +5733,8 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "풀이 보기"
 
@@ -5618,7 +5742,7 @@ msgstr "풀이 보기"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "보여줄 사용자는?"
 
@@ -5628,18 +5752,18 @@ msgstr "보여줄 사용자는?"
 msgid "Show all paths"
 msgstr "선택된 모든 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "정답 보기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 #, fuzzy
 msgid "Show me another"
 msgstr "새 창에서 보이기"
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 #, fuzzy
 msgid "Show me another %1"
 msgstr "새 창에서 보이기"
@@ -5650,7 +5774,7 @@ msgstr "새 창에서 보이기"
 msgid "Show path ..."
 msgstr "선택된 모든 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 #, fuzzy
 msgid "Show saved answers?"
 msgstr "지난 정답 보기"
@@ -5662,17 +5786,17 @@ msgstr "보여줄 문제집은?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "사이트 설명 보이기/감추기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "보이기:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "Showing"
 msgstr "힌트보여주기"
@@ -5684,7 +5808,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "2% 문제집 중에 1% 보이기"
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 #, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "2% 사용자 중에 1% 보이기"
@@ -5701,13 +5825,13 @@ msgstr ""
 msgid "Site Information"
 msgstr "사이트 정보"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 #, fuzzy
 msgid "Solution:"
 msgstr "풀이"
@@ -5717,7 +5841,7 @@ msgstr "풀이"
 msgid "Solutions"
 msgstr "풀이"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -5726,6 +5850,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -5744,15 +5878,15 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 #, fuzzy
 msgid "Sort"
 msgstr "분류"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "분류"
 
@@ -5783,7 +5917,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5819,48 +5953,48 @@ msgstr "[_2]에 문제 [_3]으로 덧붙여진 [_1]"
 msgid "Statistics for %1 student %2"
 msgstr "학생별 진행상황 통계 보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "상태"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "동작 중지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 #, fuzzy
 msgid "Stop Archiving"
 msgstr "동작 중지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 #, fuzzy
 msgid "Stop archiving courses"
 msgstr "수업내역"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "학생 ID"
 
@@ -5893,14 +6027,14 @@ msgstr "[_1]의 학생 진행상황"
 msgid "Student answers"
 msgstr "학생 답안"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -5914,34 +6048,38 @@ msgstr "답안 제출하기"
 msgid "Submit"
 msgstr "정답 제출하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "정답 제출하기"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 #, fuzzy
 msgid "Submit Answers for %1"
 msgstr "답안 %1 제출하기"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "성공"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 #, fuzzy
 msgid "Success Index"
 msgstr "성공"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 #, fuzzy
 msgid "Successfully archived the course %1."
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 #, fuzzy
 msgid "Successfully created new achievement %1"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
@@ -5953,46 +6091,46 @@ msgid "Successfully created new set %1"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 #, fuzzy
 msgid "Successfully created the course %1"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 #, fuzzy
 msgid "Successfully deleted the course %1."
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 #, fuzzy
 msgid "Successfully renamed the course %1 to %2"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 #, fuzzy
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "새로운 문제집 %1이 성공적으로 생성되었습니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -6012,16 +6150,16 @@ msgstr "%1 시험 보기"
 msgid "Take %1 test."
 msgstr "%1 시험 보기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "실행!"
 
@@ -6089,11 +6227,11 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "WeBWorK 프로젝트"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6114,16 +6252,16 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 #, fuzzy
 msgid "The answer above is NOT correct."
 msgstr "위의 답안은 %1 틀립니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "정답입니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 #, fuzzy
 msgid "The answer will be graded later."
 msgstr "정답입니다"
@@ -6137,14 +6275,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6185,60 +6323,60 @@ msgid ""
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 #, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "문제집 [_1]의 hardcopy 헤더가 '[_2]'로 이름이 바뀌었습니다. "
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 #, fuzzy
 msgid "The file %1/%2 cannot be found."
 msgstr "오류: 원본파일 [_1]을 읽을 수 없습니다."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 #, fuzzy
 msgid "The file '%1' cannot be found."
 msgstr "오류: 원본파일 [_1]을 읽을 수 없습니다."
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 #, fuzzy
 msgid "The file '%1' cannot be read!"
 msgstr "오류: 원본파일 [_1]을 읽을 수 없습니다."
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid "The file '%1' is a blank problem!"
 msgstr "파일 '[_1]'에 문제가 없습니다!"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 #, fuzzy
 msgid "The file '%1' is a directory!"
 msgstr "파일 '[_1]이 디렉토리입니다!"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 #, fuzzy
 msgid "The file '%1' is protected!"
 msgstr "파일 [_1]이 보호되었습니다!"
@@ -6252,28 +6390,28 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 #, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
@@ -6281,38 +6419,38 @@ msgid ""
 msgstr "이 문제는 성적에 들어가지 않습니다."
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 #, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "문제집 [_1]의 hardcopy 헤더가 '[_2]'로 이름이 바뀌었습니다. "
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6331,13 +6469,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -6365,8 +6503,8 @@ msgstr ""
 "\t\t\t\t\t\t\t\t필드에 맞지 않습니다. 새로운 비밀번호를 입력해주시고 \n"
 "\t\t\t\t\t\t\t\t 다시 시도해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "파일의 초기경로는 완전합니다"
 
@@ -6375,7 +6513,7 @@ msgstr "파일의 초기경로는 완전합니다"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -6383,19 +6521,19 @@ msgid ""
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 #, fuzzy
 msgid "The recorded score for this test is  %1/%2."
 msgstr "총점은 %1입니다. %2"
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #, fuzzy
 msgid "The recorded score for this test is %1/%2."
 msgstr "총점은 %1입니다. %2"
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -6407,26 +6545,26 @@ msgid ""
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 #, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "이 문제는 성적에 들어가지 않습니다."
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 #, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "선택된 문제집(%1)이 유효한 문제집 %2이 아닙니다"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 #, fuzzy
 msgid "The set %1 is assigned to %2."
 msgstr "WeBWorK 숙제 [_1]의 기한은 [_2]까지 입니다."
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 #, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
@@ -6441,7 +6579,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 #, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "WeBWorK 숙제 [_1]의 기한은 [_2]까지 입니다."
@@ -6451,7 +6589,7 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 #, fuzzy
 msgid ""
@@ -6460,9 +6598,17 @@ msgstr ""
 "'문제집 [_1] / 문제 [_2]'의 소스 파일이 [_3]에서 '[_4]'로 바뀌었습니다."
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"테스트 박스가 초기 문제의 소스를 가지고 있습니다. 브라우저에서 뒤로가기 버튼"
+"을 눌러 잃어버린 편집본을 복구할 수 있습니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6478,14 +6624,14 @@ msgid ""
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 #, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
 "'문제집 [_1] / 문제 [_2]'의 소스 파일이 [_3]에서 '[_4]'로 바뀌었습니다."
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 #, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr ""
@@ -6493,54 +6639,56 @@ msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 #, fuzzy
 msgid "The user %1 has been assigned %2."
 msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6551,8 +6699,8 @@ msgid "Theme (refresh page after saving changes to reveal new theme.)"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "그러면"
 
@@ -6574,24 +6722,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6601,36 +6749,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -6651,11 +6799,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -6672,7 +6820,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6692,25 +6840,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6730,17 +6878,17 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 #, fuzzy
 msgid "This answer is NOT completely correct."
 msgstr "위의 답안은 %1 틀립니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 #, fuzzy
 msgid "This answer is NOT correct."
 msgstr "위의 답안은 %1 틀립니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 #, fuzzy
 msgid "This answer is correct."
 msgstr "정답입니다"
@@ -6751,20 +6899,20 @@ msgid ""
 "guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "이 문제집에는 문제가 없습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "이 문제집은 닫혔습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "이 문제집은 아직 열리지 않습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 #, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
@@ -6773,6 +6921,10 @@ msgid ""
 msgstr ""
 "이것은 빈 문제 템플릿 파일이고 즉시 편집되지 않습니다. 아래의 '저장하기'를 사"
 "용하여 파일의 로컬 사본을 만들고 현재 문제집에 추가해주세요."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6830,35 +6982,39 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "이 문제는 성적에 들어가지 않습니다."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 #, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
@@ -6875,19 +7031,19 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 #, fuzzy
 msgid "This set %1 is assigned to %2."
 msgstr "문제집 [_1]의 헤더가 '[_2]'로 이름이 바뀌었습니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 #, fuzzy
 msgid "This set doesn't contain any problems yet."
 msgstr "이 문제집에는 문제가 없습니다."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6900,14 +7056,14 @@ msgid ""
 msgstr ""
 
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 #, fuzzy
 msgid "This set is %1"
 msgstr "이 문제집은 %1입니다"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -6938,23 +7094,23 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 #, fuzzy
 msgid "This source file is a directory!"
 msgstr "파일 '[_1]이 디렉토리입니다!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -6978,7 +7134,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6987,8 +7143,8 @@ msgid ""
 "problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 #, fuzzy
 msgid "Time"
 msgstr "시험 날짜"
@@ -6998,7 +7154,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -7011,24 +7167,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7040,20 +7196,20 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 #, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
@@ -7062,8 +7218,8 @@ msgstr ""
 "이 문자열을 수정하려면 아래의 '저장하기' 버튼을 이용해 파일을 먼저 복사해주세"
 "요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
@@ -7076,11 +7232,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "이 문제 수정하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -7097,7 +7253,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -7113,50 +7270,50 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 #, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "문제집 [_1]의 문제집 헤더를 바꿀 수 없습니다. 알려지지 않은 오류."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 #, fuzzy
 msgid "Unable to write to '%1': %2"
 msgstr "파일 '[_1]'로 저장하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 #, fuzzy
 msgid "Unarchive"
 msgstr "수업내역"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 #, fuzzy
 msgid "Unarchive %1 to course:"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 #, fuzzy
 msgid "Unarchive Next Course"
 msgstr "수업내역"
@@ -7179,7 +7336,7 @@ msgid ""
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 #, fuzzy
 msgid "Unattempted: %1/%2"
 msgstr "'[_1]'로 쓸 수 없음: [_2]"
@@ -7189,13 +7346,13 @@ msgstr "'[_1]'로 쓸 수 없음: [_2]"
 msgid "Unclassified Problems"
 msgstr "문제 수정하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 #, fuzzy
 msgid "Unhide Courses"
 msgstr "수업내역"
@@ -7215,7 +7372,7 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 #, fuzzy
 msgid "Unselect all courses"
 msgstr "모든 사용자 선택 해제"
@@ -7224,12 +7381,12 @@ msgstr "모든 사용자 선택 해제"
 msgid "Unselect all sets"
 msgstr "모든 문제집 선택 해제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "모든 사용자 선택 해제"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -7241,39 +7398,39 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 #, fuzzy
 msgid "Upgrade"
 msgstr "성적"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 #, fuzzy
 msgid "Upgrade Courses"
 msgstr "수업내역"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -7287,11 +7444,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -7299,21 +7457,21 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "시스템 초기값 사용"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 #, fuzzy
 msgid "Use in achievement %1"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 #, fuzzy
 msgid "Use in new achievement:"
 msgstr "선택된 문제집"
@@ -7332,7 +7490,7 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -7342,13 +7500,13 @@ msgstr ""
 "시오. 메시지 뿐 아니라, 시스템 상황에 대한 부가 정보도 포함."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -7373,8 +7531,8 @@ msgstr "파일명"
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -7393,7 +7551,7 @@ msgid "Username presented:  %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 #, fuzzy
@@ -7405,7 +7563,7 @@ msgstr "사용자 추가"
 msgid "Users Assigned to Set %2"
 msgstr "배정된 사용자 편집하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "사용자 리스트"
 
@@ -7423,7 +7581,7 @@ msgid ""
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 #, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "%1로, %2로, %3로 분류된 사용자, "
@@ -7443,18 +7601,19 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 #, fuzzy
 msgid "Using what display mode?: "
 msgstr "디스플레이 모드"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -7462,21 +7621,21 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "보기"
 
@@ -7490,7 +7649,7 @@ msgstr "보기"
 msgid "View Problems"
 msgstr "문제 수정하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "방정식은 다음과 같습니다;"
 
@@ -7523,8 +7682,8 @@ msgstr "학생별 진행상황 보기"
 msgid "View/Edit"
 msgstr "편집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 #, fuzzy
 msgid "Viewing temporary file:"
@@ -7549,19 +7708,19 @@ msgstr "보임"
 msgid "Visible to Students"
 msgstr "학생들에게 보임"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 #, fuzzy
 msgid "Warning"
 msgstr "시도 횟수"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 #, fuzzy
 msgid "Warning messages"
 msgstr "점수 도구"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구되지 않습니다!"
 
@@ -7570,12 +7729,17 @@ msgstr "경고: 삭제시 모든 사용자 관련 정보가 사라지고, 복구
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 #, fuzzy
 msgid "WeBWorK Error"
 msgstr "WeBWorK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 #, fuzzy
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK"
@@ -7595,7 +7759,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7629,7 +7793,7 @@ msgstr "WeBWorK에 오신 걸 환영합니다!"
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "어떤 필드에 필터된 사용자가 맞습니까?"
 
@@ -7709,12 +7873,12 @@ msgstr ""
 msgid "Will open on %1."
 msgstr "%1후에 열립니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "점수"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
@@ -7723,7 +7887,7 @@ msgstr ""
 "'[_1]'에서 허가되지 않았습니다. 변경사항은 다른 디렉토리에 저장되어야 합니다."
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
@@ -7731,24 +7895,26 @@ msgid ""
 msgstr ""
 "'[_1]'에서 허가되지 않았습니다. 변경사항은 다른 디렉토리에 저장되어야 합니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "템플릿 디렉토리에서 허가되지 않음. 변경할 수 없음."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "예"
 
@@ -7777,16 +7943,16 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr "강사 전용 도구입니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 #, fuzzy
 msgid "You are not authorized to access the Instructor tools."
 msgstr "강사 전용 도구입니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "강사 전용 도구입니다."
 
@@ -7796,7 +7962,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "문제집을 변경할 권한이 없습니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "문제를 변경할 권한이 없습니다."
 
@@ -7805,13 +7971,13 @@ msgstr "문제를 변경할 권한이 없습니다."
 msgid "You are not authorized to modify set definition files."
 msgstr "문제집 정의 파일을 변경할 권한이 없습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "학생 데이터를 변경할 권한이 없습니다."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "이 동작을 취할 권한이 없습니다."
 
@@ -7831,7 +7997,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -7842,6 +8008,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "이 문제의 부분 점수를 받았습니다."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 #, fuzzy
@@ -7866,7 +8036,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -7889,16 +8059,16 @@ msgstr "파일 '[_1]이 디렉토리입니다!"
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 #, fuzzy
 msgid "You cannot delete the course you are currently using."
 msgstr "본인을 삭제할 수 없습니다!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "본인을 삭제할 수 없습니다!"
 
@@ -7913,7 +8083,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "사용자 ID를 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -7943,39 +8113,43 @@ msgstr "자세한 오류를 볼 권한이 없습니다."
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "비밀번호를 변경할 권한이 없습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "자세한 오류를 볼 권한이 없습니다."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 #, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "%1 %2 남았습니다."
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 #, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "무제한으로 시도할 수 있습니다."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 #, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "이 문제를 %quant(%1, 번) 시도했습니다."
@@ -7984,7 +8158,7 @@ msgstr "이 문제를 %quant(%1, 번) 시도했습니다."
 msgid "You have been logged out of WeBWorK."
 msgstr "WeBWorK에서 로그아웃되었습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -8021,11 +8195,16 @@ msgstr ""
 "다음 데이터를 보려면 선택하시오. 정답과 풀이는 문제집의 answer date 후에 볼 "
 "수 있음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "여기서 비밀번호를 바꿀 수 없습니다!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "여기서 비밀번호를 바꿀 수 없습니다!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 #, fuzzy
 msgid "You may still check your answers."
 msgstr "여기서 비밀번호를 바꿀 수 없습니다!"
@@ -8039,14 +8218,14 @@ msgid ""
 msgstr "이 문제를 %quant(%1, 번) 시도했습니다."
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "이 문제를 %quant(%1, 번) 시도했습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -8061,7 +8240,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 #, fuzzy
 msgid "You must select a course to rename."
 msgstr "사용자 ID를 명시해주세요."
@@ -8075,22 +8254,28 @@ msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요.
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
 #, fuzzy
-msgid "You must select one or more sets for scoring"
+msgid "You must select one or more sets for scoring!"
 msgstr "점수기록할 문제집이 선택되지 않음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "사용자 ID를 명시해주세요."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 #, fuzzy
 msgid "You must specify a course ID."
 msgstr "사용자 ID를 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 #, fuzzy
 msgid "You must specify a course name."
 msgstr "사용자 ID를 명시해주세요."
@@ -8100,47 +8285,47 @@ msgstr "사용자 ID를 명시해주세요."
 msgid "You must specify a file name"
 msgstr "사용자 ID를 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 #, fuzzy
 msgid "You must specify a first name for the initial instructor."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 #, fuzzy
 msgid "You must specify a last name for the initial instructor."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 #, fuzzy
 msgid "You must specify a new institution for the course."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 #, fuzzy
 msgid "You must specify a new name for the course."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 #, fuzzy
 msgid "You must specify a new title for the course."
 msgstr "사용자 ID를 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "사용자 ID를 명시해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 #, fuzzy
 msgid "You must specify an email address for the initial instructor."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 #, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "새로운 파일을 저장하기 위해 파일명을 입력해주세요."
@@ -8176,20 +8361,20 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 #, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "이번 시도로 %1의 점수를 얻었습니다."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8227,27 +8412,28 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 #, fuzzy
 msgid "Your display options have been saved."
 msgstr "이메일 주소가 변경되었습니다."
@@ -8260,120 +8446,133 @@ msgstr "이메일 주소가 변경되었습니다."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 #, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "총점은 %1입니다. %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 #, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "총점은 %1입니다. %2"
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 #, fuzzy
 msgid "Your score on this %1 WAS recorded."
 msgstr "점수가 기록되었습니다."
 
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 #, fuzzy
 msgid "Your score on this %1 is %2/%3."
 msgstr "총점은 %1입니다. %2"
 
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 #, fuzzy
 msgid "Your score on this %1 was NOT recorded."
 msgstr "점수가 기록되었습니다."
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 #, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "점수가 기록되었습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 #, fuzzy
 msgid "Your score on this problem was recorded."
 msgstr "점수가 기록되었습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr "점수가 기록되지 않았습니다; 데이터베이스에 문제를 저장하는데 실패함."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "점수가 입력되지 않았습니다; 문제집이 닫힘"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "점수가 기록되지 않았습니다. 이 문제가 할당되지 않았음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 #, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr "점수가 기록되지 않았습니다. 이 문제가 할당되지 않았음."
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr "점수가 기록되지 않았습니다. 이 문제가 할당되지 않았음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr "점수가 기록되지 않았습니다. 이 문제가 할당되지 않았음."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 #, fuzzy
 msgid "Your score was not recorded."
 msgstr "점수가 기록되었습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "점수가 기록되었습니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "로그인 시간이 지났습니다. 다시 로그인해 주세요."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 #, fuzzy
 msgid "[Edit]"
@@ -8389,7 +8588,7 @@ msgstr "_문제집_편집자_정보"
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr "_문제집_편집자_정보"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr "_CLASSLIST_편집자_설명"
 
@@ -8412,31 +8611,41 @@ msgstr "_문제집_편집자_정보"
 msgid "_LOGIN_MESSAGE"
 msgstr "_로그인_메시지"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr "_오류_보고"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "첫번쨰 선택된 문제집 사본"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
 msgstr "첫번쨰 선택된 문제집 사본"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "새로운 빈 문제집"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "새로운 빈 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -8445,7 +8654,7 @@ msgstr ""
 msgid "a single set"
 msgstr "문제집 하나"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "active"
 msgstr "비활성화"
@@ -8456,11 +8665,11 @@ msgid "add problems"
 msgstr "문제 추가"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -8469,13 +8678,13 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 #, fuzzy
@@ -8506,14 +8715,14 @@ msgstr "모든 문제집"
 msgid "all students"
 msgstr "모든 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "모든 사용자"
 
@@ -8521,31 +8730,37 @@ msgstr "모든 사용자"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 #, fuzzy
 msgid "answer"
 msgstr "대답한 날짜"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "모든 사용자"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
-msgid "assigning the achievements to"
-msgstr "이 문제집을 할당할 사용자는?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 #, fuzzy
@@ -8559,22 +8774,22 @@ msgid "avg attempts"
 msgstr "시도"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "변경사항 취소됨"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "변경사항 저장"
@@ -8593,17 +8808,17 @@ msgstr ""
 msgid "close"
 msgstr "닫기"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "수정"
 
@@ -8619,7 +8834,7 @@ msgid "deleted %1 sets"
 msgstr "삭제된 문제집 %1"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 #, fuzzy
 msgid "deleted %1 users"
 msgstr "삭제된 사용자 %1"
@@ -8633,7 +8848,7 @@ msgstr "모든 문제집 수정"
 msgid "editing all sets"
 msgstr "모든 문제집 수정"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "모든 사용자 수정"
 
@@ -8646,7 +8861,7 @@ msgstr "선택된 문제집"
 msgid "editing selected sets"
 msgstr "선택된 문제집 수정"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "선택된 사용자 수정"
 
@@ -8654,7 +8869,7 @@ msgstr "선택된 사용자 수정"
 msgid "editing visible sets"
 msgstr "보이는 문제집 수정"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "보이는 사용자 수정"
 
@@ -8664,7 +8879,7 @@ msgstr "보이는 사용자 수정"
 msgid "email:"
 msgstr "이메일"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 #, fuzzy
 msgid "empty"
 msgstr "시도"
@@ -8679,16 +8894,16 @@ msgid "entry rows."
 msgstr "문제 수정하기"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "내보내기 취소"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 #, fuzzy
 msgid "exporting all achievements"
 msgstr "모든 문제집 내보내기"
@@ -8697,7 +8912,7 @@ msgstr "모든 문제집 내보내기"
 msgid "exporting all sets"
 msgstr "모든 문제집 내보내기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 #, fuzzy
 msgid "exporting selected achievements"
 msgstr "선택된 문제집 저장 후 내보내기"
@@ -8734,15 +8949,15 @@ msgstr "학생들로부터 숨김"
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "모든 사용자에게 새 비밀번호 부여"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "선택된 사용자에게 새 비밀번호 부여"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "보이는 사용자에게 새 비밀번호 부여"
 
@@ -8774,9 +8989,9 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "숨김"
@@ -8785,7 +9000,7 @@ msgstr "숨김"
 msgid "hidden from"
 msgstr "숨겨짐"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "학생들로부터 숨김"
@@ -8796,45 +9011,49 @@ msgstr "숨겨진 문제집"
 
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "inactive"
 msgstr "비활성화"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "실패"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 #, fuzzy
 msgid "locations selected below"
 msgstr "선택된 문제집 저장 후 내보내기"
@@ -8844,7 +9063,7 @@ msgstr "선택된 문제집 저장 후 내보내기"
 msgid "login"
 msgstr "로그인"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 #, fuzzy
 msgid "login ID"
 msgstr "로그인"
@@ -8883,16 +9102,16 @@ msgstr "없는 문제집입니다"
 msgid "new users"
 msgstr "없는 사용자입니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 #, fuzzy
 msgid "no achievements"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 #, fuzzy
 msgid "no location"
 msgstr "풀이"
@@ -8913,27 +9132,31 @@ msgstr "없는 문제집입니다"
 msgid "no students"
 msgstr "없는 문제집입니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "없는 사용자입니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -8958,7 +9181,7 @@ msgstr ""
 msgid "only best scores"
 msgstr "시험 점수"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8972,56 +9195,60 @@ msgstr "분류"
 msgid "or Problems from"
 msgstr "문제"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 #, fuzzy
 msgid "point"
 msgstr "힌트"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 #, fuzzy
 msgid "points"
 msgstr "힌트"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 #, fuzzy
 msgid "preview answers"
 msgstr "정답 미리보기"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 #, fuzzy
 msgid "problem"
 msgstr "문제 %1"
@@ -9041,8 +9268,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -9058,19 +9285,19 @@ msgid "record for user %1 not found"
 msgstr "파일 '[_1]'을 찾을 수 없음."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 #, fuzzy
 msgid "record for visible user %1 not found"
 msgstr "파일 '[_1]'을 찾을 수 없음."
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -9095,14 +9322,14 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 #, fuzzy
 msgid "selected achievements"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 #, fuzzy
 msgid "selected achievements."
 msgstr "선택된 문제집"
@@ -9122,17 +9349,17 @@ msgstr "선택된 문제집"
 msgid "selected sets"
 msgstr "선택된 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "선택된 사용자"
 
@@ -9176,7 +9403,7 @@ msgstr "아래에 맞는 문제집 ID 입력"
 msgid "showing all sets"
 msgstr "선택된 모든 문제집"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "선택된 모든 사용자"
 
@@ -9193,7 +9420,7 @@ msgstr "어떤 문제집도 보이지않기"
 msgid "showing matching sets"
 msgstr "알맞는 사용자 보이기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "알맞는 사용자 보이기"
 
@@ -9201,7 +9428,7 @@ msgstr "알맞는 사용자 보이기"
 msgid "showing no sets"
 msgstr "어떤 문제집도 보이지않기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "사용자 감추기"
 
@@ -9209,7 +9436,7 @@ msgstr "사용자 감추기"
 msgid "showing selected sets"
 msgstr "선택된 문제집 감추기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "선택된 사용자 보이기"
 
@@ -9217,6 +9444,10 @@ msgstr "선택된 사용자 보이기"
 #, fuzzy
 msgid "showing visible sets"
 msgstr "보이는 문제집 저장 후 내보내기"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 #, fuzzy
@@ -9235,18 +9466,18 @@ msgstr "학생 ID"
 msgid "students"
 msgstr "학생 ID"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "submission"
 msgstr "답안 제출하기"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "submission (test %1)"
 msgstr "답안 제출하기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -9254,13 +9485,13 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "test"
 msgstr "%1 시험"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "test (%1)"
 msgstr "%1 시험"
@@ -9275,7 +9506,7 @@ msgstr "시험 날짜"
 msgid "test time"
 msgstr "%1 시험"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -9284,14 +9515,14 @@ msgid "the following file(s)"
 msgstr ""
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 #, fuzzy
 msgid "the original path to the file is %1"
 msgstr "파일의 초기 경로는[_1]입니다."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 #, fuzzy
 msgid "then by"
 msgstr "그러면"
@@ -9300,7 +9531,11 @@ msgstr "그러면"
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "시간"
 
@@ -9308,44 +9543,41 @@ msgstr "시간"
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "번"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 #, fuzzy
 msgid "top score"
 msgstr "시험 점수"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 #, fuzzy
 msgid "unable to write to directory %1"
 msgstr "파일 '[_1]'로 저장하기"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "무제한"
 
@@ -9355,29 +9587,29 @@ msgstr "무제한"
 msgid "userID: %1 --"
 msgstr "[_1]을 바꾸기"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "users"
 msgstr "없는 사용자입니다"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "선택된 필드에 부합한 사용자"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 #, fuzzy
 msgid "users who match:"
 msgstr "선택된 필드에 부합한 사용자"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "보임"
@@ -9390,20 +9622,25 @@ msgstr "보임"
 msgid "visible sets"
 msgstr "풀이집 보임"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "학생들에게 보임"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "알아볼 수 있는 사용자"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -9411,14 +9648,34 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #, fuzzy
 msgid "your students"
 msgstr "학생들에게 보임"
+
+#, fuzzy
+#~ msgid "Import achievements from"
+#~ msgstr "선택된 문제집 저장 후 내보내기"
+
+#, fuzzy
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "감점 시작: %1"
+
+#, fuzzy
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "감점 시작: %1"
+
+#, fuzzy
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "감점 시작: %1"
 
 #, fuzzy
 #~ msgid "answer "
@@ -9492,10 +9749,6 @@ msgstr "학생들에게 보임"
 
 #~ msgid "No sets selected for scoring."
 #~ msgstr "점수기록할 문제집이 선택되지 않음."
-
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "공지"
 
 #, fuzzy
 #~ msgid "Recitation:"
@@ -9698,13 +9951,6 @@ msgstr "학생들에게 보임"
 
 #~ msgid "Published"
 #~ msgstr "출판됨"
-
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "테스트 박스가 초기 문제의 소스를 가지고 있습니다. 브라우저에서 뒤로가기 버"
-#~ "튼을 눌러 잃어버린 편집본을 복구할 수 있습니다."
 
 #~ msgid ""
 #~ "Documentation from source code for PG modules and macro files. Often the "

--- a/lib/WeBWorK/Localize/ru_RU.po
+++ b/lib/WeBWorK/Localize/ru_RU.po
@@ -15,13 +15,19 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "выбранные задания"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 #, fuzzy
 msgid "#corr"
 msgstr "верно"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 #, fuzzy
 msgid "#incorr"
 msgstr "неверно"
@@ -37,16 +43,16 @@ msgid "% correct with review"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 #, fuzzy
 msgid "% students"
 msgstr "выдимы студентам"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -94,20 +100,20 @@ msgid "%1 students out of %2"
 msgstr "выдимы студентам"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 #, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 пользователей экспортировано в файл %2/%3"
 
 #
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 #, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
@@ -142,8 +148,8 @@ msgstr "завершено."
 #
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 #, fuzzy
 msgid "%1% correct"
 msgstr "%1% верно"
@@ -194,7 +200,7 @@ msgstr "Новый пароль для %1 установлен."
 #
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "Задание %1: Задача %2"
 
@@ -207,13 +213,13 @@ msgstr "Задание %1: Задача %2"
 
 #
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 #, fuzzy
 msgid "%1: The directory for the course not found."
 msgstr "Файл '[_1]' не найден."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -229,7 +235,7 @@ msgstr ""
 
 #
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 #, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
@@ -237,48 +243,48 @@ msgstr ""
 "все ответы даны)."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
 # The last symbol "ы" is displayed incorrectly on the button on the "Instructor tools" page 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 #, fuzzy
 msgid "%score"
 msgstr "Баллы"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(Эта задача не будет Вам засчитана.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 #
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 #, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "Ваши баллы записаны"
 
 #
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 #, fuzzy
 msgid "(Your score on this %1 is not available.)"
 msgstr "Ваши баллы записаны"
@@ -359,17 +365,31 @@ msgstr ""
 #
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 #, fuzzy
 msgid "A course with ID %1 already exists."
 msgstr "Не удалось создать дубликат задания: задание %1 уже существует!"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #
@@ -387,14 +407,14 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -402,14 +422,14 @@ msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 #, fuzzy
 msgid "A new file has been created at '%1'"
 msgstr "Задание %1 уже имеется. Новое задание не создано"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 #, fuzzy
 msgid ""
@@ -450,46 +470,46 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 #, fuzzy
 msgid "ANSWERS NOT RECORDED"
 msgstr "ПРЕДВАРИТЕЛЬНВЙ ПРОСМОТР -- ОТВЕТЫ НЕ ЗАПИСАНЫ"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 #, fuzzy
 msgid "ANSWERS NOT RECORDED --"
 msgstr "ПРЕДВАРИТЕЛЬНВЙ ПРОСМОТР -- ОТВЕТЫ НЕ ЗАПИСАНЫ"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 #, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "ОТВЕТЫ ПРОВЕРЕНЫ, НО ОНИ НЕ ЗАПИСАНЫ"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "ОТВЕТЫ ПРОВЕРЕНЫ, НО ОНИ НЕ ЗАПИСАНЫ"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "Не сохранять изменений"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Не делать экспортирование"
@@ -501,13 +521,13 @@ msgid "Achievement"
 msgstr "выбранные задания"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 #, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "Задание %1 уже имеется. Новое задание не создано"
@@ -525,13 +545,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -549,13 +569,19 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 #, fuzzy
 msgid "Achievement scores saved to %1"
 msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
@@ -579,7 +605,7 @@ msgstr ""
 
 #
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 #, fuzzy
 msgid "Acting as %1."
 msgstr "Действуете как %1. "
@@ -587,13 +613,13 @@ msgstr "Действуете как %1. "
 #
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 #, fuzzy
 msgid "Action %1 not found"
 msgstr "Файл '[_1]' не найден."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Активен"
 
@@ -613,7 +639,7 @@ msgstr ""
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Добавить"
@@ -623,9 +649,9 @@ msgid "Add All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 #, fuzzy
 msgid "Add Course"
 msgstr "Курсы"
@@ -642,7 +668,7 @@ msgstr "выдимы студентам"
 msgid "Add Users"
 msgstr "Добавить пользователей"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -651,14 +677,14 @@ msgid "Add a new test for which Gateway?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 #, fuzzy
 msgid "Add as what filetype?"
 msgstr "Дрбавить как файл какого типа?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Сколько студентов добавить?"
 
@@ -669,49 +695,49 @@ msgid "Add problems to"
 msgstr "Добавить задачу"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 #, fuzzy
 msgid "Add to what set?"
 msgstr "В какое из заданий добавить?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Каких новых пользователей добавить?"
 
 #
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 #, fuzzy
 msgid "Added %1 to %2 as problem %3"
 msgstr "Задача [_1] добавлена в задание [_2] как хадача [_3]"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 #, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "'[_1]' добавлен к [_2] в качестве заголовка задания"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 #, fuzzy
 msgid "Added '%1' to %2 as new set header"
 msgstr "'[_1]' добавлен к [_2] в качестве заголовка задания"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -720,54 +746,54 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Addresses"
 msgstr "Адрес e-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -782,7 +808,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -797,7 +823,7 @@ msgid "After set answer date"
 msgstr "Дата ответа"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -811,18 +837,18 @@ msgid "All assignments were made successfully."
 msgstr ""
 
 # I have translated this string, however it is displayed untranslated.
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 #, fuzzy
 msgid "All of the answers above are correct."
 msgstr "Все вышеперечисленные ответы верны."
 
 # I have translated this string, however it is displayed untranslated.
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 #, fuzzy
 msgid "All of the gradeable answers above are correct."
 msgstr "Все вышеперечисленные ответы верны."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -850,7 +876,7 @@ msgstr "скрыто от студентов"
 msgid "All sets made visible for all students"
 msgstr "выдимы студентам"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -930,26 +956,26 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 #, fuzzy
 msgid "An error occured while archiving the course %1:"
 msgstr "Успешно создано новое задание"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 #, fuzzy
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "Успешно создано новое задание"
@@ -972,8 +998,8 @@ msgid "Answer Log"
 msgstr "Дата ответа"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Предварительный просмсотр ответа"
 
@@ -987,11 +1013,11 @@ msgstr ""
 msgid "Answer:"
 msgstr "Дата ответа"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -1018,8 +1044,16 @@ msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr ""
+"Все сделанные нимже изменения будут отражаться в задании для ВСЕХ студентов."
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
@@ -1028,7 +1062,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 #, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
@@ -1043,21 +1077,21 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 #, fuzzy
 msgid "Append to end of %1 set"
 msgstr "Дописать в конец задания [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 #, fuzzy
 msgid "Archive"
 msgstr "Курсы"
@@ -1072,33 +1106,33 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 #, fuzzy
 msgid "Archive Courses"
 msgstr "Курсы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 #, fuzzy
 msgid "Archive next course"
 msgstr "Курсы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 #, fuzzy
 msgid "Archive this Course"
 msgstr "Курсы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 #, fuzzy
 msgid "Archived Courses"
 msgstr "Курсы"
@@ -1109,25 +1143,29 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 #, fuzzy
 msgid "Assign"
 msgstr "Назначенные задания"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1157,20 +1195,20 @@ msgid "Assigned"
 msgstr "Назначенные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Назначенные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 #, fuzzy
 msgid "Assigned achievements to users"
 msgstr "Кому из пользователей назначить это задание?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 #, fuzzy
 msgid "Assigned to"
 msgstr "Назначенные задания"
@@ -1182,7 +1220,13 @@ msgid "Assignment type"
 msgstr "Назначенные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "Назначенные задания"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 #, fuzzy
 msgid "At least one of the answers above is NOT correct."
 msgstr "По крайней мере один из ответов выше НЕ %1 верен."
@@ -1191,7 +1235,7 @@ msgstr "По крайней мере один из ответов выше НЕ 
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1206,7 +1250,7 @@ msgstr "Попытки"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Попытки"
 
@@ -1215,14 +1259,15 @@ msgstr "Попытки"
 msgid "Audit"
 msgstr "Аудит"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "Информация об авторе"
 
@@ -1230,12 +1275,12 @@ msgstr "Информация об авторе"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1275,16 +1320,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #
@@ -1324,7 +1369,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1372,21 +1417,21 @@ msgstr "Не удается получить пароль пользовател
 
 #
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 #, fuzzy
 msgid "Can't open %1"
 msgstr "Сохранени в файл '[_1]'"
 
 #
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 #, fuzzy
 msgid "Can't open file %1"
 msgstr "Сохранени в файл '[_1]'"
 
 #
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 #, fuzzy
 msgid "Can't read merge file %1. No message sent"
 msgstr "Сохранени в файл '[_1]'"
@@ -1398,7 +1443,7 @@ msgstr "Сохранени в файл '[_1]'"
 msgid "Can't rename file: %1"
 msgstr "Сохранени в файл '[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1408,11 +1453,11 @@ msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
 #
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 #, fuzzy
 msgid "Can't write to file %1"
 msgstr "Сохранени в файл '[_1]'"
@@ -1427,7 +1472,7 @@ msgid "Cancel"
 msgstr "Отменить редактирование"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 #, fuzzy
 msgid "Cancel E-mail"
 msgstr "Отменить отправку e-mail"
@@ -1443,8 +1488,8 @@ msgstr "Сохранени в файл '[_1]'"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1464,11 +1509,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1485,7 +1530,7 @@ msgstr "Опции отображения"
 msgid "Change Email Address"
 msgstr "Сменить адрес e-mail"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1496,36 +1541,36 @@ msgid "Change Password"
 msgstr "Сменить пароль"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 #, fuzzy
 msgid "Change User Settings"
 msgstr "Изменить опции пользователя"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "Изменения отменены"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Изменения в этом файле ещё не были сохранены."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "Изменения сохранены"
 
@@ -1541,29 +1586,29 @@ msgid "Chapter:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "Проверить ответы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 #, fuzzy
 msgid "Check Test"
 msgstr "Проверить ответы"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "Проверяются дополнительные сообщения об ошибках"
 
@@ -1578,7 +1623,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1624,8 +1669,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1643,7 +1688,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 #, fuzzy
 msgid "Close"
 msgstr "Закрыто"
@@ -1695,7 +1740,7 @@ msgstr "Закрыто"
 
 #
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 #, fuzzy
 msgid "Closes %1"
 msgstr "Задача [_1]"
@@ -1707,11 +1752,11 @@ msgstr "Задача [_1]"
 msgid "Closes:"
 msgstr "Закрыто"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
@@ -1719,28 +1764,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Комментарий"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1750,7 +1795,7 @@ msgstr ""
 msgid "Completed."
 msgstr "завершено."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1763,7 +1808,7 @@ msgid "Confirm %1's New Password"
 msgstr "Подтвердите новый пароль для %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 #, fuzzy
 msgid "Confirm Password:"
 msgstr "Подтвердите новый пароль для %1"
@@ -1780,8 +1825,8 @@ msgstr "Продолжить"
 
 #
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 #, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "Вспомогательные файлы скопированы из [_1] в новое место [_2]"
@@ -1796,7 +1841,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1807,8 +1852,8 @@ msgid "Copy this Problem"
 msgstr "Редактировать данную задачу"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Верно"
@@ -1818,7 +1863,7 @@ msgid "Correct Adjusted Status"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr "Правильные ответы"
 
@@ -1841,20 +1886,20 @@ msgstr "Правильные ответы"
 
 #
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 #, fuzzy
 msgid "Correct: %1/%2"
 msgstr "задание [_1]/задача [_2]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 #, fuzzy
 msgid "CorrectAnswers"
 msgstr "Правильные ответы"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1875,51 +1920,52 @@ msgid "Couldn't change your email address: %1"
 msgstr "Не удаётся сменить адрес e-mail для %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 #, fuzzy
 msgid "Couldn't save your display options: %1"
 msgstr "Не удаётся сменить адрес e-mail для %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1930,14 +1976,14 @@ msgstr "Администрирование курса"
 msgid "Course Configuration"
 msgstr "Конфигурация курса. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 #, fuzzy
 msgid "Course ID:"
 msgstr "Сведения о курсе"
@@ -1949,15 +1995,15 @@ msgid "Course Info"
 msgstr "Сведения о курсе"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 #, fuzzy
 msgid "Course Name:"
 msgstr "Имя"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 #, fuzzy
 msgid "Course Title:"
 msgstr "Курсы"
@@ -1969,15 +2015,15 @@ msgid "Course archived."
 msgstr "Имя"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Курсы"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1999,7 +2045,7 @@ msgid "Create CSV"
 msgstr "Создать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 #, fuzzy
 msgid "Create Location:"
 msgstr "Подразделение"
@@ -2008,7 +2054,7 @@ msgstr "Подразделение"
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -2017,12 +2063,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "Создать как задание какого типа?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -2035,35 +2081,35 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 #, fuzzy
 msgid "Database:"
 msgstr "экспортирование отменено"
@@ -2078,7 +2124,7 @@ msgstr "Дата открытия"
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -2104,85 +2150,85 @@ msgid "Default Time that the Assignment is Due"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Удалить"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 #, fuzzy
 msgid "Delete Course"
 msgstr "Удалить"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 #, fuzzy
 msgid "Delete course:"
 msgstr "Удалить"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "Удалить кого?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 #, fuzzy
 msgid "Delete it?"
 msgstr "Удалить"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 #, fuzzy
 msgid "Delete location:"
 msgstr "Удалить"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 #, fuzzy
 msgid "Deleted %quant(%1,achievement)"
 msgstr "выбранные задания"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 #, fuzzy
 msgid "Deleting temp file at %1"
 msgstr "Удаляется временый файл в  [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 #, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
@@ -2192,7 +2238,7 @@ msgstr ""
 "необратимо!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 #, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
@@ -2208,7 +2254,7 @@ msgstr ""
 "необратимо!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 #, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
@@ -2220,14 +2266,14 @@ msgid "Deny From"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 #, fuzzy
 msgid "Description"
 msgstr "Подразделение"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -2247,50 +2293,50 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 #, fuzzy
 msgid "Directory structure"
 msgstr "Смотритель"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 #, fuzzy
 msgid "Display Mode:"
@@ -2301,6 +2347,12 @@ msgstr "Способ отображения"
 #, fuzzy
 msgid "Display Past Answers"
 msgstr "Отобразить предыдущие ответы"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+#, fuzzy
+msgid "Display of scores for this set is not allowed."
+msgstr "Ваши баллы записаны"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -2327,38 +2379,38 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 #, fuzzy
 msgid "Don't Unarchive"
 msgstr "Сохранить изменения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 #, fuzzy
 msgid "Don't Upgrade"
 msgstr "Удалить"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #, fuzzy
 msgid "Don't delete"
 msgstr "Удалить"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 #, fuzzy
 msgid "Don't make changes"
 msgstr "Сохранить изменения"
 
 #
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 #, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "Неопознанная saveMode: |[_1]|. Причина ошибки неизвестна."
@@ -2368,19 +2420,19 @@ msgstr "Неопознанная saveMode: |[_1]|. Причина ошибки �
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 #, fuzzy
 msgid "Don't use in an achievement"
 msgstr "Сохранить изменения"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2418,8 +2470,8 @@ msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Скачать печатную версию для %1 заданий"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Скачать PDF или TeX файл для данного задания"
 
@@ -2446,6 +2498,16 @@ msgstr "Скачать баллы"
 msgid "Drop"
 msgstr "Пропустить"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2468,7 +2530,7 @@ msgid "E-Mail"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "Написать e-mail инструктору"
 
@@ -2487,7 +2549,7 @@ msgid "E-mail verbosity level"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 #, fuzzy
 msgid "E-mail:"
 msgstr "Email"
@@ -2497,26 +2559,26 @@ msgid "Earned"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Редактировать"
 
 #
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 #, fuzzy
 msgid "Edit %1 of set %2."
 msgstr "Редактирование [_1] в файле '[_2]'"
@@ -2532,24 +2594,24 @@ msgstr "Редактировать все настройки задания"
 msgid "Edit Assigned Users"
 msgstr "Редактировать список студентов, которым назначено задание"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 #, fuzzy
 msgid "Edit Header"
 msgstr "Заголовок задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 #, fuzzy
 msgid "Edit Location:"
 msgstr "Подразделение"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #, fuzzy
 msgid "Edit Problem"
 msgstr "Редактировать задачи"
@@ -2579,7 +2641,7 @@ msgid "Edit Target Set"
 msgstr "Редактировать настройки задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Кого из пользователей редактировать?"
 
@@ -2599,17 +2661,17 @@ msgstr "Редактировать"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2623,27 +2685,27 @@ msgid "Edit which sets?"
 msgstr "Какие из заданий редактировать?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 #, fuzzy
 msgid "Edit1"
 msgstr "Редактировать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 #, fuzzy
 msgid "Edit2"
 msgstr "Редактировать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 #, fuzzy
 msgid "Edit3"
 msgstr "Редактировать"
 
 #
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 #, fuzzy
 msgid "Editing %1 in file '%2'"
 msgstr "Редактирование [_1] в файле '[_2]'"
@@ -2657,52 +2719,52 @@ msgstr "Редактирование [_1] в файле '[_2]'"
 
 #
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 #, fuzzy
 msgid "Editing location %1"
 msgstr "Статистика для [_1]"
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 #, fuzzy
 msgid "Editor"
 msgstr "Редактировать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 #, fuzzy
 msgid "Editor rows:"
 msgstr "Редактировать задачи"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "Email"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "Адрес e-mail"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 #, fuzzy
 msgid "Email Body:"
 msgstr "E-mail:"
@@ -2714,33 +2776,33 @@ msgid "Email Instructor On Failed Attempt"
 msgstr "Написать e-mail инструктору"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 #, fuzzy
 msgid "Email Link"
 msgstr "Email"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 #, fuzzy
 msgid "Email address"
 msgstr "Адрес e-mail"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "Написать e-mail инструктору"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2789,8 +2851,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 #, fuzzy
 msgid "Enabled"
 msgstr "Включить"
@@ -2829,24 +2891,24 @@ msgstr ""
 msgid "Enrolled"
 msgstr "Включен в списки"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Статус участия"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Напечатайте имя файла "
 
@@ -2862,8 +2924,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Введено"
 
@@ -2898,7 +2960,7 @@ msgid "Error message:"
 msgstr "Сообщения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 #, fuzzy
 msgid "Error messages"
 msgstr "Сообщения"
@@ -2922,7 +2984,7 @@ msgstr ""
 
 #
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 #, fuzzy
 msgid "Error: The original file %1 cannot be read."
@@ -2942,6 +3004,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2957,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2965,60 +3031,60 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Экспортировать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 #, fuzzy
 msgid "Export selected achievements."
 msgstr "Экспортировать выделенные задания"
@@ -3029,7 +3095,7 @@ msgid "Export selected sets"
 msgstr "Экспортировать выделенные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Экспортировать в какой файл?"
 
@@ -3039,13 +3105,13 @@ msgid "Export which sets?"
 msgstr "Какие из заданий экспортировать?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Кого из пользователей экспортировать?"
 
 #
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 #, fuzzy
 msgid "Exported achievements to %1"
 msgstr "Экспортировать выделенные задания"
@@ -3060,19 +3126,19 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 #, fuzzy
 msgid "Failed to create new achievement: %1"
 msgstr "Не удаётся слздать новое задание: %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 #, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "Не укдаётся создать новое задание: не указано название для задания! "
@@ -3090,7 +3156,7 @@ msgid "Failed to create new set: no set name specified!"
 msgstr "Не укдаётся создать новое задание: не указано название для задания! "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 #, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
@@ -3133,10 +3199,10 @@ msgstr "Не удаётся слздать новое задание: %1"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 #, fuzzy
 msgid "Failed to open %1"
 msgstr "Сохранени в файл '[_1]'"
@@ -3149,12 +3215,12 @@ msgid "Failed to save: %1"
 msgstr "Сохранени в файл '[_1]'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid "Feature exhausted for this problem"
 msgstr "сообщить об ошибке в этой задача"
@@ -3170,37 +3236,37 @@ msgid "Feedback by Section."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 #, fuzzy
 msgid "FeedbackMessage"
 msgstr "Обратная связь"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 #, fuzzy
 msgid ""
@@ -3259,7 +3325,7 @@ msgid "File successfully renamed"
 msgstr "Успешно создано новое задание"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Имя файла"
 
@@ -3269,7 +3335,7 @@ msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "По какому тексту ыильтровать?"
 
@@ -3288,30 +3354,30 @@ msgid "First"
 msgstr "Имя"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "Имя"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 #, fuzzy
 msgid "First name"
 msgstr "Имя"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3319,7 +3385,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -3328,6 +3394,12 @@ msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+#, fuzzy
+msgid "Format"
+msgstr "Формат печатной версии:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
@@ -3340,22 +3412,28 @@ msgstr ""
 msgid "Format:"
 msgstr "Формат печатной версии:"
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "Это задане не содержит задач."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 #, fuzzy
 msgid "From field must contain one valid email address."
 msgstr "Не удаётся сменить адрес e-mail для %1"
 
 # При отправке e-mail инструктору
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "От:"
 
@@ -3386,7 +3464,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 #, fuzzy
 msgid "General Information"
 msgstr "Информация о сайте"
@@ -3413,13 +3491,20 @@ msgid "Get Target Set Problems"
 msgstr "Редактировать настройки задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+#, fuzzy
+msgid "Get a new version of this problem"
+msgstr "сообщить об ошибке в этой задача"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 #, fuzzy
 msgid "Give new password to"
 msgstr "Кому из пользователей назначить новый пароль?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Кому из пользователей назначить новый пароль?"
 
@@ -3448,7 +3533,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "Файл '[_1]' не найден."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -3456,28 +3541,38 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 #, fuzzy
 msgid "Grade"
 msgstr "Баллы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 #, fuzzy
 msgid "Grade Problem"
 msgstr "Следующая задача"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 #, fuzzy
 msgid "Grade Test"
 msgstr "Баллы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 #, fuzzy
 msgid "Grader"
 msgstr "Баллы"
@@ -3510,7 +3605,7 @@ msgid "Guest Login"
 msgstr "Гостевой вход"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 #, fuzzy
 msgid "HTTP Headers"
 msgstr "Заголовок задания"
@@ -3543,15 +3638,19 @@ msgstr "Заголовок печатной версии залания"
 msgid "Hardcopy Theme"
 msgstr "Заголовок печатной версии залания"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 #, fuzzy
 msgid "Headers"
 msgstr "Заголовок задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Помощь"
 
@@ -3564,13 +3663,13 @@ msgstr ""
 msgid "Hidden"
 msgstr "Скрытое"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Hide Courses"
 msgstr "Курсы"
@@ -3588,8 +3687,8 @@ msgid "Hide Hints from Students"
 msgstr "скрыто от студентов"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 #, fuzzy
 msgid "Hide Inactive Courses"
 msgstr "Курсы"
@@ -3605,7 +3704,7 @@ msgid "Hide path:"
 msgstr "Подсказки"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 #, fuzzy
 msgid "Hint:"
 msgstr "Подсказки"
@@ -3622,14 +3721,14 @@ msgid "Hmwk Sets Editor"
 msgstr "Редактор заданий"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 #, fuzzy
 msgid "Homework Totals"
 msgstr "Задания"
@@ -3638,16 +3737,16 @@ msgstr "Задания"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3667,14 +3766,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3686,6 +3785,10 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
@@ -3693,7 +3796,7 @@ msgstr ""
 msgid "Illegal file '%1' specified"
 msgstr "Файл '[_1]' зашищён от записи!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3702,8 +3805,9 @@ msgstr ""
 msgid "Import"
 msgstr "Импортировать"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
 msgstr ""
 
 #
@@ -3722,24 +3826,24 @@ msgid "Import sets with names"
 msgstr "Импортировать задания с именами"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Из какого файла импортировать пользователей?"
 
 #
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 #, fuzzy
 msgid "Imported %quant(%1,achievement)"
 msgstr "Экспортировать выделенные задания"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Не активен"
 
@@ -3748,13 +3852,13 @@ msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 #, fuzzy
 msgid "Include Success Index"
 msgstr "Включить оглавление"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 #, fuzzy
 msgid "Incorrect"
@@ -3762,7 +3866,7 @@ msgstr "неверно"
 
 #
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 #, fuzzy
 msgid "Incorrect: %1/%2"
 msgstr "неверно"
@@ -3772,7 +3876,7 @@ msgid "Init"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 #, fuzzy
 msgid "Institution:"
 msgstr "Подразделение"
@@ -3782,16 +3886,16 @@ msgstr "Подразделение"
 msgid "Instructor Tools"
 msgstr "Инструменты инструктора"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3800,7 +3904,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3816,17 +3920,21 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 #, fuzzy
 msgid "Jump to Problem:"
 msgstr "Следующая задача"
@@ -3839,7 +3947,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3865,29 +3973,29 @@ msgid "Last Answer"
 msgstr "Отобразить предыдущие ответы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Фамилия"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 #, fuzzy
 msgid "Last name"
 msgstr "Фамилия"
@@ -3918,20 +4026,20 @@ msgid "Level:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Подбор задач"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Подбор задач 2"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 #, fuzzy
 msgid "Library Browser 3"
@@ -3975,14 +4083,14 @@ msgid "Local Problems"
 msgstr "Задачи"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Location"
 msgstr "Подразделение"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -3990,24 +4098,24 @@ msgstr ""
 
 #
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 #, fuzzy
 msgid "Location %1 has been created, with addresses %2."
 msgstr "Задание %1 уже имеется. Новое задание не создано"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 #, fuzzy
 msgid "Location description:"
 msgstr "Показать/Скрыть описание сайта"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 #, fuzzy
 msgid "Location name:"
 msgstr "бездействие"
@@ -4018,8 +4126,8 @@ msgid "Log In Again"
 msgstr "Войти снова"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "выйти"
 
@@ -4027,23 +4135,23 @@ msgstr "выйти"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 #, fuzzy
 msgid "Logged in as %1."
 msgstr "Вы вошли как  %1. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 #, fuzzy
 msgid "Login"
 msgstr "Логин"
@@ -4058,24 +4166,24 @@ msgstr "Информация о вошедшем"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Логин"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Статус вошедшего"
 
@@ -4085,7 +4193,7 @@ msgid "Logout"
 msgstr "Выйти"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Главное меню"
 
@@ -4099,22 +4207,22 @@ msgid "Make Archive"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 #, fuzzy
 msgid "Make changes"
 msgstr "Сохранить изменения"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 #, fuzzy
 msgid "Manual Grader"
@@ -4132,7 +4240,7 @@ msgstr "Верно"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 #, fuzzy
 msgid "Mark Correct?"
 msgstr "Верно"
@@ -4143,8 +4251,9 @@ msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "Совпадение с кем? (разделяйте идентификаторы запятыми)"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Math Objects"
 
@@ -4165,56 +4274,56 @@ msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 #, fuzzy
 msgid "Merge file:"
 msgstr "файл заголовка"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 #, fuzzy
 msgid "Message"
 msgstr "Сообщения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 #, fuzzy
 msgid "Message file:"
 msgstr "Сообщения"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 #, fuzzy
 msgid "Message:"
 msgstr "Сообщения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Сообщения"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -4228,18 +4337,18 @@ msgstr "Задачи"
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -4288,14 +4397,14 @@ msgid "New Folder"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 #, fuzzy
 msgid "New Name:"
 msgstr "Имя задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "Новый пароль"
 
@@ -4310,12 +4419,12 @@ msgid "New folder name:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "Новый пароль сохранён"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -4324,16 +4433,18 @@ msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Следующая задача"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4341,22 +4452,29 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "Нет"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 #, fuzzy
 msgid "No Description"
 msgstr "Показать/Скрыть описание сайта"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -4378,7 +4496,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "Ни одно из заданий не изменено"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -4392,7 +4510,7 @@ msgid "No changes were saved!"
 msgstr "изменения сохранены"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 #, fuzzy
 msgid "No course id defined"
 msgstr "Курсы"
@@ -4405,40 +4523,40 @@ msgstr "Курсы"
 msgid "No data exists for set %1 and problem %2"
 msgstr "задание [_1]/задача [_2]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 #, fuzzy
 msgid "No merge data file"
 msgstr "файл заголовка"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -4447,7 +4565,7 @@ msgstr ""
 #
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 #, fuzzy
 msgid "No record for global set %1."
 msgstr "Заголовок задания для [_1]"
@@ -4455,19 +4573,19 @@ msgstr "Заголовок задания для [_1]"
 #
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 #, fuzzy
 msgid "No record for user %1."
 msgstr "Заголовок задания для [_1]"
 
 #
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 #, fuzzy
 msgid "No record found for problem %1."
 msgstr "Заголовок задания для [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -4482,7 +4600,7 @@ msgid "No sets selected for scoring"
 msgstr "Не выбраны задания для подсчёта баллов по ним"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -4491,16 +4609,16 @@ msgstr ""
 "отобразить список заданий в курсе."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 #, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
@@ -4522,15 +4640,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -4544,29 +4666,36 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Вы не вошли"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Замечание"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "Замечание"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 #, fuzzy
 msgid "Number"
 msgstr "Просмотр задач"
@@ -4583,8 +4712,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -4620,7 +4749,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 #, fuzzy
 msgid "Open"
 msgstr "Дата открытия"
@@ -4642,13 +4771,13 @@ msgstr "Дата открытия"
 msgid "Open Problem Library"
 msgstr "Список задач"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -4666,12 +4795,10 @@ msgstr "Задача [_1]"
 msgid "Open, complete by %1."
 msgstr "открыто: завершите решение до %1"
 
-#
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
-msgid "Open, reduced scoring starts on %1."
-msgstr "Начинается уменьшените баллов: %1"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 msgid "Open:"
@@ -4694,12 +4821,12 @@ msgid "Order Problems Randomly"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 #, fuzzy
 msgid "Orig. Lib. Browser"
 msgstr "Подбор задач"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4724,67 +4851,70 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "ПРЕДВАРИТЕЛЬНВЙ ПРОСМОТР -- ОТВЕТЫ НЕ ЗАПИСАНЫ"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Заполненые поля"
 
 #
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 #, fuzzy
 msgid "Page generated at %1"
 msgstr "Страница сгенерирована %1"
@@ -4800,7 +4930,7 @@ msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 #, fuzzy
 msgid "Password:"
 msgstr "Пароль"
@@ -4812,7 +4942,7 @@ msgstr "Пароль"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "Задача [_1] добавлена в задание [_2] как хадача [_3]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4826,25 +4956,25 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Уровень допуска"
 
@@ -4854,7 +4984,7 @@ msgstr "Уровень допуска"
 msgid "Permissions"
 msgstr "Уровень допуска"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4891,7 +5021,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4905,7 +5035,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "Введите ниже Ваш логин и  пароль для %1:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4929,20 +5059,20 @@ msgid "Please select at least one user and try again."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Укажите файл, в который следует сохранитиь. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #, fuzzy
 msgid "Points"
 msgstr "Подсказки"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
@@ -4950,42 +5080,43 @@ msgid "Preflight Log"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview Message"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 #, fuzzy
 msgid "Preview My Answers"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 #, fuzzy
 msgid "Preview Test"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview message"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 #, fuzzy
 msgid "Preview set to:"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Предыдущая задача"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 #, fuzzy
 msgid "Previous page"
@@ -4995,12 +5126,12 @@ msgstr "Предыдущая задача"
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #, fuzzy
 msgid "Prob"
 msgstr "Задачи"
@@ -5023,22 +5154,22 @@ msgstr "Задача %1"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 #, fuzzy
 msgid "Problem %1"
 msgstr "Задача %1"
 
 #
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 #, fuzzy
 msgid "Problem %1."
 msgstr "Задача %1"
@@ -5061,8 +5192,8 @@ msgid "Problem Editor3"
 msgstr "Редактор задач"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Список задач"
 
@@ -5083,31 +5214,32 @@ msgid "Problem Number "
 msgstr "Просмотр задач"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Техника программирования задач. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 #, fuzzy
 msgid "Problem Viewer"
 msgstr "Редактор задач"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Задачи"
 
@@ -5160,11 +5292,11 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Опубликовать"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -5179,29 +5311,29 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "Подразделение"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Записать баллы для отдельных заданий"
 
@@ -5218,7 +5350,7 @@ msgstr "Уменьшение баллов отключено"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Disabled"
 msgstr "Уменьшение баллов отключено"
@@ -5227,24 +5359,10 @@ msgstr "Уменьшение баллов отключено"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Enabled"
 msgstr "Уменьшение баллов включено"
-
-#
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
-msgid "Reduced Scoring Starts %1"
-msgstr "Начинается уменьшените баллов: %1"
-
-#
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
-msgid "Reduced scoring started on %1."
-msgstr "Начинается уменьшените баллов: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
@@ -5261,12 +5379,12 @@ msgid "Refresh Display"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Refresh Listing"
 msgstr "Список пользователей"
@@ -5276,7 +5394,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Остаётся"
 
@@ -5290,7 +5408,7 @@ msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -5301,14 +5419,14 @@ msgid "Rename"
 msgstr "Имя файла"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 #, fuzzy
 msgid "Rename Course"
 msgstr "Курсы"
@@ -5319,22 +5437,22 @@ msgstr "Курсы"
 msgid "Rename file as:"
 msgstr "файл заголовка"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 #, fuzzy
 msgid "Render Problem"
 msgstr "Следующая задача"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 #, fuzzy
 msgid "Renumber Problems"
 msgstr "Задачи"
@@ -5351,60 +5469,61 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Кого из пользователей заменить?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Сообщить об ошибках"
 
 #
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 #, fuzzy
 msgid "Report for course %1:"
 msgstr "Заголовок задания для [_1]"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 #, fuzzy
 msgid "Request information"
 msgstr "Информация о сайте"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 #, fuzzy
 msgid "Request new version now."
 msgstr "Информация о сайте"
@@ -5474,8 +5593,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -5483,11 +5602,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -5519,26 +5634,26 @@ msgid "Restrict release by set(s)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Результат"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 #, fuzzy
 msgid "Result of last action performed"
 msgstr "Результат последнего из выполненых действий"
 
 #
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 #, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "Результат последнего из выполненых действий: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -5553,21 +5668,29 @@ msgstr "Результат последнего из выполненых дей
 msgid "Results of last action performed: "
 msgstr "Результат последнего из выполненых действий"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "Вернуть"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 #, fuzzy
 msgid "Revert to %1"
@@ -5581,19 +5704,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -5603,103 +5726,103 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "Сохранить"
 
 #
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 #, fuzzy
 msgid "Save %1"
 msgstr "Сохранить"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Сохранить как"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 #, fuzzy
 msgid "Save Changes"
 msgstr "Сохранить изменения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 #, fuzzy
 msgid "Save as"
 msgstr "Сохранить как"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 #, fuzzy
 msgid "Save as Default"
 msgstr "Использовать системные настройки по умолчанию"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "Сохранить изменения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 #, fuzzy
 msgid "Save file to:"
 msgstr "Сохранить изменения"
 
 #
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 #, fuzzy
 msgid "Save to %1 and View"
 msgstr "Сохранить [_1] и просмотреть"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 #, fuzzy
 msgid "Saved to file '%1'"
 msgstr "Сохранени в файл '[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
 # The last symbol "ы" is displayed incorrectly on the button on the "Instructor tools" page 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5717,11 +5840,11 @@ msgid "Score required for release"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Выставить баллы по выбранным заданиям и согранить их в:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -5755,14 +5878,14 @@ msgid "Scoring Tools"
 msgstr "Инструменты для подсчёта баллов"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5773,24 +5896,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Отдел"
@@ -5807,11 +5930,17 @@ msgstr "Отдел"
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Задания"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
@@ -5824,12 +5953,12 @@ msgid "Select a Set from this Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 #, fuzzy
 msgid "Select a course to delete."
 msgstr "Выбарите действие нмже"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5837,33 +5966,33 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 #, fuzzy
 msgid "Select a course to unarchive."
 msgstr "Выбарите действие нмже"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 #, fuzzy
 msgid "Select a database layout below."
 msgstr "Выбарите действие нмже"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 #, fuzzy
 msgid "Select a listing format:"
 msgstr "Выбрать действите для выполнения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 #, fuzzy
 msgid "Select above then:"
 msgstr "выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 #, fuzzy
 msgid "Select all eligible courses"
 msgstr "Выбрать всех пользователей"
@@ -5874,31 +6003,31 @@ msgid "Select all sets"
 msgstr "Выбрать все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Выбрать всех пользователей"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Выбрать действите для выполнения"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 #, fuzzy
 msgid "Select an action to perform:"
 msgstr "Выбрать действите для выполнения"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 #, fuzzy
 msgid "Select course(s) to hide or unhide."
 msgstr "Выбарите действие нмже"
@@ -5913,7 +6042,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5938,31 +6067,31 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 #, fuzzy
 msgid "Selected students"
 msgstr "выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 #, fuzzy
 msgid "Send E-mail"
 msgstr "Отправить e-mail:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 #, fuzzy
 msgid "Send Email"
 msgstr "Отправить e-mail:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 #, fuzzy
 msgid "Send to:"
 msgstr "Отправить e-mail:"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Задание"
 
@@ -6006,7 +6135,7 @@ msgstr "Имя файла, определяющего задание"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 #, fuzzy
 msgid "Set Description"
 msgstr "Показать/Скрыть описание сайта"
@@ -6021,7 +6150,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -6038,13 +6167,13 @@ msgid "Set ID"
 msgstr "ID студента"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Информация о задании"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "Список заданий"
 
@@ -6075,8 +6204,12 @@ msgid "Set Name "
 msgstr "Имя задания"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -6103,7 +6236,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Задания"
 
@@ -6120,7 +6253,7 @@ msgid "Sets assigned to %1"
 msgstr "Редактировать список студентов, которым назначено задание"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #, fuzzy
 msgid "Setting"
 msgstr "Изменить опции пользователя"
@@ -6131,12 +6264,12 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 #, fuzzy
 msgid "Show"
 msgstr "Показать:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -6145,7 +6278,7 @@ msgid "Show Date & Size"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "Отобразить подсказки"
 
@@ -6156,8 +6289,8 @@ msgid "Show Me Another"
 msgstr "Показать в другом окне"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Отобразить предыдущие ответы"
 
@@ -6170,8 +6303,8 @@ msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "Показать решения"
 
@@ -6180,7 +6313,7 @@ msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Кого из пользователей показать"
 
@@ -6192,20 +6325,20 @@ msgid "Show all paths"
 msgstr "оторажены все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Показать правильные ответы"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 #, fuzzy
 msgid "Show me another"
 msgstr "Показать в другом окне"
 
 #
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 #, fuzzy
 msgid "Show me another %1"
 msgstr "Показать в другом окне"
@@ -6218,7 +6351,7 @@ msgid "Show path ..."
 msgstr "оторажены все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 #, fuzzy
 msgid "Show saved answers?"
 msgstr "Отобразить предыдущие ответы"
@@ -6232,19 +6365,19 @@ msgstr "Какие из заданий отобразить?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Показать/Скрыть описание сайта"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Показать:"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "Showing"
 msgstr "Отобразить подсказки"
@@ -6258,7 +6391,7 @@ msgstr "Отображено %1 изf %2 заданий."
 
 #
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 #, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "Отображено %1 из %2 пользователей"
@@ -6276,14 +6409,14 @@ msgstr ""
 msgid "Site Information"
 msgstr "Информация о сайте"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 #, fuzzy
 msgid "Solution:"
 msgstr "Решения"
@@ -6294,7 +6427,7 @@ msgstr "Решения"
 msgid "Solutions"
 msgstr "Решения"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -6303,6 +6436,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -6322,16 +6465,16 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 #, fuzzy
 msgid "Sort"
 msgstr "Сортировать"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "Сортировать по полю"
 
@@ -6364,7 +6507,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -6405,52 +6548,52 @@ msgid "Statistics for %1 student %2"
 msgstr "Посмотреть статистику по студентам"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Статус"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Прекратить действие"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 #, fuzzy
 msgid "Stop Archiving"
 msgstr "Прекратить действие"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 #, fuzzy
 msgid "Stop archiving courses"
 msgstr "Курсы"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "ID студента"
 
@@ -6488,14 +6631,14 @@ msgstr "Текущие результаты студентов по [_1]"
 msgid "Student answers"
 msgstr "Ответы студента"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -6512,16 +6655,20 @@ msgid "Submit"
 msgstr "Отправить ответы"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "Отправить ответы"
 
 #
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 #, fuzzy
 msgid "Submit Answers for %1"
 msgstr "Отправтьь ответы на %1"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
@@ -6529,20 +6676,20 @@ msgid "Success"
 msgstr "Успешно"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 #, fuzzy
 msgid "Success Index"
 msgstr "Успешно"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 #, fuzzy
 msgid "Successfully archived the course %1."
 msgstr "Успешно создано новое задание"
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 #, fuzzy
 msgid "Successfully created new achievement %1"
 msgstr "Успешно создано новое задание"
@@ -6554,46 +6701,46 @@ msgid "Successfully created new set %1"
 msgstr "Успешно создано новое задание"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 #, fuzzy
 msgid "Successfully created the course %1"
 msgstr "Успешно создано новое задание"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 #, fuzzy
 msgid "Successfully deleted the course %1."
 msgstr "Успешно создано новое задание"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 #, fuzzy
 msgid "Successfully renamed the course %1 to %2"
 msgstr "Успешно создано новое задание"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 #, fuzzy
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "Успешно создано новое задание"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -6616,16 +6763,16 @@ msgid "Take %1 test."
 msgstr "Выполнить тест %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "Выполнить действие!"
 
@@ -6697,11 +6844,11 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "Проект WebWork"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6723,18 +6870,18 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 #, fuzzy
 msgid "The answer above is NOT correct."
 msgstr "Приведённый выше ответ не %1 верен."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "Приведённый выше ответ верен."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 #, fuzzy
 msgid "The answer will be graded later."
 msgstr "Приведённый выше ответ верен."
@@ -6748,14 +6895,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6796,13 +6943,13 @@ msgstr ""
 
 #
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 #, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "Заголовок задания [_1] был переименован в  '[_2]'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
@@ -6810,52 +6957,52 @@ msgstr ""
 
 #
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 #, fuzzy
 msgid "The file %1/%2 cannot be found."
 msgstr "Ошибка: Первоначсальный файл [_1] не удаётся прочесть."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 #, fuzzy
 msgid "The file '%1' cannot be found."
 msgstr "Ошибка: Первоначсальный файл [_1] не удаётся прочесть."
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 #, fuzzy
 msgid "The file '%1' cannot be read!"
 msgstr "Ошибка: Первоначсальный файл [_1] не удаётся прочесть."
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid "The file '%1' is a blank problem!"
 msgstr "Файл '[_1]' это пустая задача!"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 #, fuzzy
 msgid "The file '%1' is a directory!"
 msgstr "Afqk '[_1]' является папкой!"
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 #, fuzzy
 msgid "The file '%1' is protected!"
 msgstr "Файл '[_1]' зашищён от записи!"
@@ -6869,29 +7016,29 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 #, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
@@ -6899,7 +7046,7 @@ msgid ""
 msgstr "Эта задача не будет засчитана в ваших баллах. "
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -6907,31 +7054,31 @@ msgstr ""
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 #, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "Заголовок задания [_1] был переименован в  '[_2]'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6950,13 +7097,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -6987,8 +7134,8 @@ msgstr ""
 "\t\t\t\t\t\tНаберите пароли попробуйте ещё раз."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "Путь к первоначальному файлу должен быть абсолютным"
 
@@ -6997,7 +7144,7 @@ msgstr "Путь к первоначальному файлу должен бы�
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -7005,19 +7152,19 @@ msgid ""
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr ""
 
 #
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #, fuzzy
 msgid "The recorded score for this test is %1/%2."
 msgstr "Ваши баллы записаны"
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -7030,14 +7177,14 @@ msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 #, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "Эта задача не будет засчитана в ваших баллах. "
 
 #
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 #, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "Выбранное задание (%1) не назначено %2"
@@ -7045,14 +7192,14 @@ msgstr "Выбранное задание (%1) не назначено %2"
 #
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 #, fuzzy
 msgid "The set %1 is assigned to %2."
 msgstr "Задание WeBWorK [_1] закрыто: [_2]."
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 #, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
@@ -7067,7 +7214,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr ""
 
@@ -7077,7 +7224,7 @@ msgstr ""
 
 #
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 #, fuzzy
 msgid ""
@@ -7087,9 +7234,18 @@ msgstr ""
 "'[_4]'."
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"Текстовое окно теперь содержит код исходной задачи. Вы можете восстановить "
+"сделанные ранее изменения при момощи кнопки Назад в Вашем браузере."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -7106,7 +7262,7 @@ msgstr ""
 
 #
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 #, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
@@ -7115,7 +7271,7 @@ msgstr ""
 
 #
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 #, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr ""
@@ -7125,54 +7281,56 @@ msgstr ""
 #
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 #, fuzzy
 msgid "The user %1 has been assigned %2."
 msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -7184,8 +7342,8 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "Затем по полю"
 
@@ -7207,24 +7365,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -7234,36 +7392,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -7284,11 +7442,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -7305,7 +7463,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -7325,25 +7483,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -7364,19 +7522,19 @@ msgid "This action will not overwrite existing users."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 #, fuzzy
 msgid "This answer is NOT completely correct."
 msgstr "Приведённый выше ответ не %1 верен."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 #, fuzzy
 msgid "This answer is NOT correct."
 msgstr "Приведённый выше ответ не %1 верен."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 #, fuzzy
 msgid "This answer is correct."
 msgstr "Приведённый выше ответ верен."
@@ -7388,23 +7546,23 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "Это задане не содержит задач."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "Это задание закрыто. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "Это задание пока не открыто. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 #, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
@@ -7414,6 +7572,10 @@ msgstr ""
 "Это файо шаблона для задачи, его нелтзя редактировать напрямую. Выполните "
 "коменду 'сохранить как' ниже для того, чтобы изготовить локальную копию "
 "задачи и добавить её к текущему заданию."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7471,37 +7633,41 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "Эта задача не будет засчитана в ваших баллах. "
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 #, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
@@ -7519,20 +7685,20 @@ msgstr ""
 #
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 #, fuzzy
 msgid "This set %1 is assigned to %2."
 msgstr "Заголовок для задания [_1] был перпеименован в  '[_2]'."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 #, fuzzy
 msgid "This set doesn't contain any problems yet."
 msgstr "Это задане не содержит задач."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -7546,14 +7712,14 @@ msgstr ""
 
 #
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 #, fuzzy
 msgid "This set is %1"
 msgstr "Это задание %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -7584,24 +7750,24 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 #, fuzzy
 msgid "This source file is a directory!"
 msgstr "Afqk '[_1]' является папкой!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -7625,7 +7791,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -7635,8 +7801,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 #, fuzzy
 msgid "Time"
 msgstr "Дата тестирования"
@@ -7646,7 +7812,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -7659,24 +7825,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7688,21 +7854,21 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 #, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
@@ -7712,8 +7878,8 @@ msgstr ""
 "действие 'Сохранить как' ниже."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
@@ -7728,11 +7894,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "Редактировать данную задачу"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -7749,7 +7915,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -7765,55 +7932,55 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 #, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "Не удалось изменить заголовок для задания [_1]. Неизвестная ошибка."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 #, fuzzy
 msgid "Unable to write to '%1': %2"
 msgstr "Сохранени в файл '[_1]'"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 #, fuzzy
 msgid "Unarchive"
 msgstr "Курсы"
 
 #
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 #, fuzzy
 msgid "Unarchive %1 to course:"
 msgstr "Курсы"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 #, fuzzy
 msgid "Unarchive Next Course"
 msgstr "Курсы"
@@ -7839,7 +8006,7 @@ msgstr ""
 
 #
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 #, fuzzy
 msgid "Unattempted: %1/%2"
 msgstr "Не удалось записать в '[_1]': [_2]"
@@ -7850,14 +8017,14 @@ msgstr "Не удалось записать в '[_1]': [_2]"
 msgid "Unclassified Problems"
 msgstr "Редактировать задачи"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 #, fuzzy
 msgid "Unhide Courses"
 msgstr "Курсы"
@@ -7878,7 +8045,7 @@ msgid "Unpack archives automatically"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 #, fuzzy
 msgid "Unselect all courses"
 msgstr "Отменить выбор всех пользователей"
@@ -7889,12 +8056,12 @@ msgid "Unselect all sets"
 msgstr "Отменить выбр всех заданий"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Отменить выбор всех пользователей"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -7906,41 +8073,41 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 #, fuzzy
 msgid "Upgrade"
 msgstr "Баллы"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 #, fuzzy
 msgid "Upgrade Courses"
 msgstr "Курсы"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -7954,11 +8121,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -7967,23 +8135,23 @@ msgid "Use Item"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Использовать системные настройки по умолчанию"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 #, fuzzy
 msgid "Use in achievement %1"
 msgstr "выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 #, fuzzy
 msgid "Use in new achievement:"
 msgstr "выбранные задания"
@@ -8003,7 +8171,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -8014,13 +8182,13 @@ msgstr ""
 "сообщением будет отправлена дополнительная информация о состоянии системы."
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -8048,8 +8216,8 @@ msgstr "Имя файла"
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -8070,7 +8238,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 #, fuzzy
@@ -8084,7 +8252,7 @@ msgid "Users Assigned to Set %2"
 msgstr "Редактировать список студентов, которым назначено задание"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Список пользователей"
 
@@ -8103,7 +8271,7 @@ msgstr ""
 
 #
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 #, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr ""
@@ -8124,17 +8292,18 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -8142,22 +8311,22 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "Просмотреть"
 
@@ -8173,7 +8342,7 @@ msgid "View Problems"
 msgstr "Редактировать задачи"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "Просматривать уравнения как"
 
@@ -8213,8 +8382,8 @@ msgid "View/Edit"
 msgstr "Редактировать"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 #, fuzzy
 msgid "Viewing temporary file:"
@@ -8243,21 +8412,21 @@ msgid "Visible to Students"
 msgstr "выдимы студентам"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 #, fuzzy
 msgid "Warning"
 msgstr "Остаётся"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 #, fuzzy
 msgid "Warning messages"
 msgstr "Инструменты для подсчёта баллов"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "Предупреждаем: Удаление уничтожит все данные пользователя и это действие "
@@ -8268,14 +8437,19 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 #, fuzzy
 msgid "WeBWorK Error"
 msgstr "WeBWorK"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 #, fuzzy
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK"
@@ -8295,7 +8469,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -8331,7 +8505,7 @@ msgid "What could be inside?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "По какому из полей сделапть выборку пользователей."
 
@@ -8413,13 +8587,13 @@ msgid "Will open on %1."
 msgstr "откроется %1"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Ценность"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
@@ -8430,7 +8604,7 @@ msgstr ""
 
 #
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
@@ -8440,25 +8614,27 @@ msgstr ""
 "папку для посмотра."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "Папка templates закрыта для записи.  Изменения не могут быть записаны."
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Да"
 
@@ -8489,9 +8665,9 @@ msgid "You are not authorized to access the Instructor tools"
 msgstr "У вас нет прав доступа к инструментам инструктора. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 #, fuzzy
 msgid "You are not authorized to access the Instructor tools."
 msgstr "У вас нет прав доступа к инструментам инструктора. "
@@ -8499,7 +8675,7 @@ msgstr "У вас нет прав доступа к инструментам и�
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "У вас нет прав доступа к инструментам инструктора. "
 
@@ -8511,7 +8687,7 @@ msgstr "У вас нет прав доступа для изменения за�
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "У вас нет прав доступа для изменения задач."
 
@@ -8522,14 +8698,14 @@ msgid "You are not authorized to modify set definition files."
 msgstr "У вас нет прав доступа для изменения файлов отпределения заданий. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "У вас нет прав доступа для изменения данных студентов. "
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "У вас нет прав доступа для выполнения этого действия. "
 
@@ -8549,7 +8725,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -8561,6 +8737,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "Балл за эту задачу может дробиться. "
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
@@ -8586,7 +8766,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -8610,18 +8790,18 @@ msgstr "Afqk '[_1]' является папкой!"
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 #, fuzzy
 msgid "You cannot delete the course you are currently using."
 msgstr "Вы не можете удалить самого себя! "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "Вы не можете удалить самого себя! "
 
@@ -8637,7 +8817,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "Надо указать ID пользователя. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -8673,34 +8853,38 @@ msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "У вас нет прав доступа для изменеия Вашего пароля. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "У вас нет оазрешений посмотреть детали этой ошибки."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 #, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "У вас осталось %1 %2."
 
 #
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 #, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "У вас осталось %1 попыток."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
@@ -8708,7 +8892,7 @@ msgstr ""
 
 #
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 #, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Вы пробовали решить эту задачу %1 раз."
@@ -8718,7 +8902,7 @@ msgstr "Вы пробовали решить эту задачу %1 раз."
 msgid "You have been logged out of WeBWorK."
 msgstr "Вы вышли из WebWork. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -8757,12 +8941,18 @@ msgstr ""
 "быть доступны только после даты закрытия задания."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Здесь Вы не можете поменять Ваш собственный пароль. "
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "Здесь Вы не можете поменять Ваш собственный пароль. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 #, fuzzy
 msgid "You may still check your answers."
 msgstr "Здесь Вы не можете поменять Ваш собственный пароль. "
@@ -8778,14 +8968,14 @@ msgstr "Вы пробовали решить эту задачу %1 раз."
 
 #
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "Вы пробовали решить эту задачу %1 раз."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -8801,7 +8991,7 @@ msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 #, fuzzy
 msgid "You must select a course to rename."
 msgstr "Надо указать ID пользователя. "
@@ -8817,24 +9007,31 @@ msgid "You must select at least one file to delete"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
 #, fuzzy
-msgid "You must select one or more sets for scoring"
+msgid "You must select one or more sets for scoring!"
 msgstr "Не выбраны задания для подсчёта баллов по ним"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Надо указать ID пользователя. "
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 #, fuzzy
 msgid "You must specify a course ID."
 msgstr "Надо указать ID пользователя. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 #, fuzzy
 msgid "You must specify a course name."
 msgstr "Надо указать ID пользователя. "
@@ -8846,54 +9043,54 @@ msgid "You must specify a file name"
 msgstr "Надо указать ID пользователя. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 #, fuzzy
 msgid "You must specify a first name for the initial instructor."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 #, fuzzy
 msgid "You must specify a last name for the initial instructor."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 #, fuzzy
 msgid "You must specify a new institution for the course."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 #, fuzzy
 msgid "You must specify a new name for the course."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 #, fuzzy
 msgid "You must specify a new title for the course."
 msgstr "Надо указать ID пользователя. "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Надо указать ID пользователя. "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 #, fuzzy
 msgid "You must specify an email address for the initial instructor."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 #, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "Вам надо указать имя файла для того, чтобы сохранить новый файл."
@@ -8932,20 +9129,20 @@ msgstr ""
 
 #
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 #, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "Вы получили оценку %1 за эту попытку. "
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8983,28 +9180,29 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 #, fuzzy
 msgid "Your display options have been saved."
 msgstr "Ваш адрес e-mail изменён."
@@ -9018,59 +9216,72 @@ msgstr "Ваш адрес e-mail изменён."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 #, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Ваш общий итог %1 баллов. %2"
 
 #
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 #, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "Ваши баллы записаны"
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 #, fuzzy
 msgid "Your score on this %1 WAS recorded."
 msgstr "Ваши баллы записаны"
 
 #
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 #, fuzzy
 msgid "Your score on this %1 is %2/%3."
 msgstr "Ваши баллы записаны"
 
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 #, fuzzy
 msgid "Your score on this %1 was NOT recorded."
 msgstr "Ваши баллы записаны"
 
 #
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 #, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "Ваши баллы записаны"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 #, fuzzy
 msgid "Your score on this problem was recorded."
 msgstr "Ваши баллы записаны"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -9079,19 +9290,19 @@ msgstr ""
 "результатов по задаче в базу данных."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Ваши баллы не записаны, поскольку задание закрыто."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "Ваши баллы не записаны, поскольку эта задача вам не назначена."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 #, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
@@ -9099,7 +9310,7 @@ msgstr "Ваши баллы не записаны, поскольку эта з�
 
 #
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
@@ -9107,7 +9318,7 @@ msgid ""
 msgstr "Ваши баллы не записаны, поскольку эта задача вам не назначена."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
@@ -9115,44 +9326,44 @@ msgid ""
 msgstr "Ваши баллы не записаны, поскольку эта задача вам не назначена."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 #, fuzzy
 msgid "Your score was not recorded."
 msgstr "Ваши баллы записаны"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Ваши баллы записаны"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr ""
 "Ваша сессия закрыта по причине длительного отсутствия обращений к серверу. "
 "Пожалуйста, авторизуйтесь повтрно."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 #, fuzzy
 msgid "[Edit]"
@@ -9171,7 +9382,7 @@ msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr "_ОПИСАНИЕ_РЕДАКТОРА_ЗАДАНИЙ"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr "_ОПИСАНИЕ_РЕДАКТОРА_СПИСКОВ_ПОЛЬЗОВАЕЛЕЙ"
 
@@ -9198,8 +9409,8 @@ msgstr "_ОПИСАНИЕ_РЕДАКТОРА_ЗАДАНИЙ"
 msgid "_LOGIN_MESSAGE"
 msgstr "_СООБЩЕНИЕ_ОБ_АВТОРИЗАЦИИ"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 "This is a table showing the current Homework sets for this class.  The "
@@ -9213,12 +9424,12 @@ msgstr ""
 "where you can edit what students the set is assigned to."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr "_ОШИБКА_ЗАПРОСА"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
 "A table showing all the current users along with several fields of user "
@@ -9235,10 +9446,22 @@ msgstr ""
 "to a page where you can view and reassign the sets for the selected user."
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "дубликат первого из выбраных заданий"
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
 msgstr "дубликат первого из выбраных заданий"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "новое пустое задание"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
@@ -9246,7 +9469,7 @@ msgstr "дубликат первого из выбраных заданий"
 msgid "a new empty set"
 msgstr "новое пустое задание"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -9257,7 +9480,7 @@ msgid "a single set"
 msgstr "одно задаие"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "active"
 msgstr "Не активен"
@@ -9269,11 +9492,11 @@ msgid "add problems"
 msgstr "Добавить задачу"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -9282,14 +9505,14 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 #, fuzzy
@@ -9323,14 +9546,14 @@ msgid "all students"
 msgstr "все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "всех пользователей"
 
@@ -9338,31 +9561,38 @@ msgstr "всех пользователей"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 #, fuzzy
 msgid "answer"
 msgstr "Дата ответа"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "любых пользователей"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
 msgstr ""
 
 #
@@ -9379,24 +9609,24 @@ msgid "avg attempts"
 msgstr "попытки"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "изменение не сохранены"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "изменения сохранены"
@@ -9417,18 +9647,18 @@ msgstr ""
 msgid "close"
 msgstr "Закрыто"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "верно"
 
@@ -9447,7 +9677,7 @@ msgstr "удалено %1 заданий"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 #, fuzzy
 msgid "deleted %1 users"
 msgstr "удалено %1 пользователей"
@@ -9464,7 +9694,7 @@ msgid "editing all sets"
 msgstr "редактороваать все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "редактировать всех пользователей"
 
@@ -9480,7 +9710,7 @@ msgid "editing selected sets"
 msgstr "редактировать выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "редактировать выбранных пользователей"
 
@@ -9490,7 +9720,7 @@ msgid "editing visible sets"
 msgstr "редактировать видимые задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "редактировать видимых пользоваателей"
 
@@ -9502,7 +9732,7 @@ msgid "email:"
 msgstr "Email"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 #, fuzzy
 msgid "empty"
 msgstr "попытка"
@@ -9519,18 +9749,18 @@ msgid "entry rows."
 msgstr "Редактировать задачи"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "экспортирование отменено"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 #, fuzzy
 msgid "exporting all achievements"
 msgstr "экспортировать все задания"
@@ -9541,7 +9771,7 @@ msgid "exporting all sets"
 msgstr "экспортировать все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 #, fuzzy
 msgid "exporting selected achievements"
 msgstr "Экспортировать выделенные задания"
@@ -9583,17 +9813,17 @@ msgid "from"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "назначить новый пароль всем пользователям"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "назначить новый пароль выбранным пользователям"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "назначить новый пароль видимым пользователям"
 
@@ -9629,9 +9859,9 @@ msgid "guest"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "скрыто"
@@ -9642,7 +9872,7 @@ msgid "hidden from"
 msgstr "скрыто от"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "скрыто от студентов"
@@ -9654,48 +9884,52 @@ msgstr "скрытые задания"
 
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "inactive"
 msgstr "Не активен"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "неверно"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 #, fuzzy
 msgid "locations selected below"
 msgstr "экспортировать выбранные задания"
@@ -9707,7 +9941,7 @@ msgid "login"
 msgstr "Логин"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 #, fuzzy
 msgid "login ID"
 msgstr "Логин"
@@ -9752,17 +9986,17 @@ msgid "new users"
 msgstr "никого из пользователей"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 #, fuzzy
 msgid "no achievements"
 msgstr "выбранные задания"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 #, fuzzy
 msgid "no location"
 msgstr "Решения"
@@ -9786,27 +10020,31 @@ msgid "no students"
 msgstr "ни одного задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "никого из пользователей"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -9833,7 +10071,7 @@ msgid "only best scores"
 msgstr "Баллы за тестирование"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -9848,60 +10086,64 @@ msgstr "Сортировать"
 msgid "or Problems from"
 msgstr "Задачи"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 #, fuzzy
 msgid "point"
 msgstr "Подсказки"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 #, fuzzy
 msgid "points"
 msgstr "Подсказки"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 #, fuzzy
 msgid "preview answers"
 msgstr "Предварительный просмотр ответов. "
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 #, fuzzy
 msgid "problem"
 msgstr "Задачи"
@@ -9922,8 +10164,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -9942,19 +10184,19 @@ msgstr "Файл '[_1]' не найден."
 
 #
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 #, fuzzy
 msgid "record for visible user %1 not found"
 msgstr "Файл '[_1]' не найден."
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -9983,15 +10225,15 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 #, fuzzy
 msgid "selected achievements"
 msgstr "выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 #, fuzzy
 msgid "selected achievements."
 msgstr "выбранные задания"
@@ -10013,17 +10255,17 @@ msgid "selected sets"
 msgstr "выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "выбранных пользователей"
 
@@ -10075,7 +10317,7 @@ msgid "showing all sets"
 msgstr "оторажены все задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "отображены все пользователи"
 
@@ -10095,7 +10337,7 @@ msgid "showing matching sets"
 msgstr "отображены пользователи, удовлетворяющие критерию выбрки"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "отображены пользователи, удовлетворяющие критерию выбрки"
 
@@ -10105,7 +10347,7 @@ msgid "showing no sets"
 msgstr "ни одного задания не показано"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "ни одного пользователя не показано"
 
@@ -10115,7 +10357,7 @@ msgid "showing selected sets"
 msgstr "отображены выбранные задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "отображены выбраные пользователи"
 
@@ -10124,6 +10366,10 @@ msgstr "отображены выбраные пользователи"
 #, fuzzy
 msgid "showing visible sets"
 msgstr "экспортировать видимые задания"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -10146,19 +10392,19 @@ msgid "students"
 msgstr "ID студента"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "submission"
 msgstr "submitAnswers"
 
 #
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "submission (test %1)"
 msgstr "submitAnswers"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -10167,14 +10413,14 @@ msgid "ta"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "test"
 msgstr "%1 тест"
 
 #
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "test (%1)"
 msgstr "%1 тест"
@@ -10191,7 +10437,7 @@ msgstr "Дата тестирования"
 msgid "test time"
 msgstr "%1 тест"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -10201,15 +10447,15 @@ msgstr ""
 
 #
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 #, fuzzy
 msgid "the original path to the file is %1"
 msgstr "первоначальный путь к файлу - это [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 #, fuzzy
 msgid "then by"
 msgstr "Затем по полю"
@@ -10218,8 +10464,12 @@ msgstr "Затем по полю"
 msgid "then delete them"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "время"
 
@@ -10228,16 +10478,13 @@ msgid "time limit exceeded"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "раз"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
@@ -10245,13 +10492,13 @@ msgid "to one <b>set</b>"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 #, fuzzy
 msgid "top score"
 msgstr "Баллы за тестирование"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
@@ -10259,16 +10506,16 @@ msgstr ""
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 #, fuzzy
 msgid "unable to write to directory %1"
 msgstr "Сохранени в файл '[_1]'"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "неогр. кол-во"
 
@@ -10277,33 +10524,33 @@ msgstr "неогр. кол-во"
 msgid "userID: %1 --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "users"
 msgstr "никого из пользователей"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "пользователи, которые соответствуют условию выборки по выбранному полю"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 #, fuzzy
 msgid "users who match:"
 msgstr "пользователи, которые соответствуют условию выборки по выбранному полю"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "видимый"
@@ -10318,21 +10565,26 @@ msgid "visible sets"
 msgstr "видимые задания"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "выдимы студентам"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "видимых пользователей"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -10340,8 +10592,12 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #
@@ -10349,6 +10605,21 @@ msgstr ""
 #, fuzzy
 msgid "your students"
 msgstr "выдимы студентам"
+
+#
+#, fuzzy
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "Начинается уменьшените баллов: %1"
+
+#
+#, fuzzy
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "Начинается уменьшените баллов: %1"
+
+#
+#, fuzzy
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "Начинается уменьшените баллов: %1"
 
 #
 #, fuzzy
@@ -10441,11 +10712,6 @@ msgstr "выдимы студентам"
 #
 #~ msgid "No sets selected for scoring."
 #~ msgstr "Не выбраны задания для подсчёта баллов по ним."
-
-#
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "Замечание"
 
 #
 #, fuzzy
@@ -10696,15 +10962,6 @@ msgstr "выдимы студентам"
 #
 #~ msgid "Published"
 #~ msgstr "Опукбликовано"
-
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "Текстовое окно теперь содержит код исходной задачи. Вы можете "
-#~ "восстановить сделанные ранее изменения при момощи кнопки Назад в Вашем "
-#~ "браузере."
 
 #
 #~ msgid ""

--- a/lib/WeBWorK/Localize/tr.po
+++ b/lib/WeBWorK/Localize/tr.po
@@ -17,11 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "Kaç öğrenci eklenecek?"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr ""
 
@@ -34,15 +39,15 @@ msgid "% correct with review"
 msgstr ""
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr ""
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -78,17 +83,17 @@ msgid "%1 students out of %2"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 kullanıcı %2/%3 dosyasına aktarıldı."
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -119,8 +124,8 @@ msgstr ""
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr "%1% doğru"
 
@@ -157,7 +162,7 @@ msgstr "%1 adlı kullanıcının şifresi değiştirildi."
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1: Soru %2."
 
@@ -167,12 +172,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr ""
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -187,49 +192,49 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "Soruların %1 tanesi yanıtsız bırakıldı."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(Bu soru notunuzu etkilemeyecektir.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr ""
 
@@ -302,16 +307,30 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr ""
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
@@ -327,26 +346,26 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
@@ -386,37 +405,37 @@ msgid ""
 msgstr ""
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "Değişiklikleri kaydetme"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Dışa aktarımı iptal et"
@@ -426,12 +445,12 @@ msgid "Achievement"
 msgstr ""
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr ""
 
@@ -448,13 +467,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -470,12 +489,17 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "seçili kullanıcılara yeni şifre veriliyor"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr ""
 
@@ -495,17 +519,17 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr ""
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "Aktif"
 
@@ -524,7 +548,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "Ekle"
@@ -533,9 +557,9 @@ msgstr "Ekle"
 msgid "Add All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr ""
 
@@ -547,7 +571,7 @@ msgstr ""
 msgid "Add Users"
 msgstr "Kullanıcı Ekle"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -555,12 +579,12 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr "Hangi dosya tipi olarak eklenecek?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "Kaç öğrenci eklenecek?"
 
@@ -568,41 +592,41 @@ msgstr "Kaç öğrenci eklenecek?"
 msgid "Add problems to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "Hangi yeni kullanıcılar eklenecek?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr ""
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -611,52 +635,52 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -671,7 +695,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -684,7 +708,7 @@ msgid "After set answer date"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -697,15 +721,15 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr "Yanıtların tümü doğru"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -725,7 +749,7 @@ msgstr ""
 msgid "All sets made visible for all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -789,25 +813,25 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
@@ -825,8 +849,8 @@ msgstr "Cevap tarihi"
 msgid "Answer Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "Gösterim"
 
@@ -839,12 +863,12 @@ msgid "Answer:"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -866,15 +890,21 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "Aşağıda yapılan değişiklikler seti çözen HER öğrenci için uygulanacakç"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "Aşağıda yapılan değişiklikler seti çözen HER öğrenci için uygulanacakç"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
@@ -887,18 +917,18 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr ""
 
@@ -912,26 +942,26 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr ""
 
@@ -941,22 +971,26 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
+msgstr ""
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
@@ -981,17 +1015,17 @@ msgstr ""
 msgid "Assigned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "Ödev verilmiş setler"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr ""
 
@@ -999,7 +1033,12 @@ msgstr ""
 msgid "Assignment type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "Ödev verilmiş setler"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr ""
 
@@ -1008,7 +1047,7 @@ msgstr ""
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1020,7 +1059,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "Deneme sayısı"
 
@@ -1028,13 +1067,14 @@ msgstr "Deneme sayısı"
 msgid "Audit"
 msgstr "Denetle"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "Yazar Bilgileri"
 
@@ -1042,12 +1082,12 @@ msgstr "Yazar Bilgileri"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1087,16 +1127,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1126,7 +1166,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1161,17 +1201,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "kullanıcı için şifre bilgileri alınamadı '%1': %2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr ""
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr ""
 
@@ -1180,7 +1220,7 @@ msgstr ""
 msgid "Can't rename file: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1189,11 +1229,11 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr ""
 
@@ -1204,7 +1244,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr ""
 
@@ -1217,8 +1257,8 @@ msgstr ""
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1238,11 +1278,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1256,7 +1296,7 @@ msgstr ""
 msgid "Change Email Address"
 msgstr "E-posta Adresi Değiştir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1265,32 +1305,32 @@ msgstr ""
 msgid "Change Password"
 msgstr "Şifre Değiştir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr ""
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "Değişiklikler kaydedilmedi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Dosyadaki değişiklikler henüz kalıcı olarak kaydedilmedi."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "Değişiklikler kaydedildi"
 
@@ -1305,26 +1345,26 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "Yanıtları kontrol et"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "Diğer hata mesajları kontrol ediliyor"
 
@@ -1339,7 +1379,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1378,8 +1418,8 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1396,7 +1436,7 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr ""
 
@@ -1434,7 +1474,7 @@ msgid "Closes"
 msgstr ""
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr ""
 
@@ -1443,39 +1483,39 @@ msgstr ""
 msgid "Closes:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "Yorum"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1483,7 +1523,7 @@ msgstr ""
 msgid "Completed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1493,7 +1533,7 @@ msgstr ""
 msgid "Confirm %1's New Password"
 msgstr "%1 için Şifre Onayı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr ""
 
@@ -1507,8 +1547,8 @@ msgid "Continue"
 msgstr "Devam"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr ""
 
@@ -1522,7 +1562,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1530,8 +1570,8 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "Doğru yanıt"
@@ -1540,7 +1580,7 @@ msgstr "Doğru yanıt"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr ""
 
@@ -1557,17 +1597,17 @@ msgid "Correct answers"
 msgstr "Doğru yanıtları göster"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr ""
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1584,48 +1624,49 @@ msgid "Couldn't change your email address: %1"
 msgstr "E-posta adresiniz değiştirilemedi: %1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1635,13 +1676,13 @@ msgstr "Ders Yönetimi"
 msgid "Course Configuration"
 msgstr "Ders Seçenekleri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr ""
 
@@ -1650,13 +1691,13 @@ msgstr ""
 msgid "Course Info"
 msgstr "Ders bilgileri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr ""
 
@@ -1664,15 +1705,15 @@ msgstr ""
 msgid "Course archived."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "Dersler"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1690,7 +1731,7 @@ msgstr "Oluştur"
 msgid "Create CSV"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr ""
 
@@ -1698,7 +1739,7 @@ msgstr ""
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1706,12 +1747,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "Ne tip set oluşturulacak?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1724,34 +1765,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr ""
 
@@ -1763,7 +1804,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1788,77 +1829,77 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "Sil"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "Kaç tane silinecek?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr ""
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr ""
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
 
@@ -1866,7 +1907,7 @@ msgstr ""
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 
@@ -1874,13 +1915,13 @@ msgstr ""
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -1898,53 +1939,57 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -1968,29 +2013,29 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr ""
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr ""
 
@@ -1999,17 +2044,17 @@ msgstr ""
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2039,8 +2084,8 @@ msgstr ""
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Seçili Setleri Yazdırmak için dosya indir: [plural,_1,Set,Sets]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Mevcut seti Yazdırmak için dosya indir"
 
@@ -2060,6 +2105,16 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "Bırak"
+
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2081,7 +2136,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "Eğitmene E-posta"
 
@@ -2099,7 +2154,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr "E-posta"
 
@@ -2107,25 +2162,25 @@ msgstr "E-posta"
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "Düzenle"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr ""
 
@@ -2138,19 +2193,19 @@ msgstr "Bütün set bilgilerini düzenle"
 msgid "Edit Assigned Users"
 msgstr "Ödev verilmiş kullanıcıları düzenle"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr ""
 
@@ -2172,7 +2227,7 @@ msgstr "Set Bilgilerini Düzenle"
 msgid "Edit Target Set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "Hangi Kullanıcılar Düzenlenecek?"
 
@@ -2188,17 +2243,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2211,23 +2266,23 @@ msgid "Edit which sets?"
 msgstr "Hangi setler düzenlecek?"
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr ""
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr ""
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr ""
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr ""
 
@@ -2237,44 +2292,44 @@ msgid "Editing achievement in file '%1'"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "E-posta"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "E-posta Adresi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr ""
 
@@ -2282,29 +2337,29 @@ msgstr ""
 msgid "Email Instructor On Failed Attempt"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "Eğitmene E-posta"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2344,8 +2399,8 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr ""
 
@@ -2382,22 +2437,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "Kayıtlı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "Kayıt Durumu"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "Aşağıya dosya adı girin"
 
@@ -2411,8 +2466,8 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Yanıt"
 
@@ -2442,7 +2497,7 @@ msgstr ""
 msgid "Error message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr ""
 
@@ -2464,7 +2519,7 @@ msgid ""
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr ""
@@ -2483,6 +2538,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2498,7 +2557,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2506,58 +2565,58 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "Dışa aktar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr ""
 
@@ -2565,7 +2624,7 @@ msgstr ""
 msgid "Export selected sets"
 msgstr "Şeçili setleri dışarı aktar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "Ne çeşit dosyaya aktarılacak?"
 
@@ -2573,12 +2632,12 @@ msgstr "Ne çeşit dosyaya aktarılacak?"
 msgid "Export which sets?"
 msgstr "Hangı setler dışarı aktarılacak?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "Hangi kullanıcılar dışarı aktarılacak?"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr ""
 
@@ -2592,16 +2651,16 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr ""
 
@@ -2614,7 +2673,7 @@ msgstr "Yeni set yaratılamadı: %1"
 msgid "Failed to create new set: no set name specified!"
 msgstr "Yeni set oluşturulamadı: set adı belirtilmemiş!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
@@ -2645,10 +2704,10 @@ msgstr ""
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr ""
 
@@ -2658,11 +2717,11 @@ msgid "Failed to save: %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr ""
 
@@ -2674,35 +2733,35 @@ msgstr "Geri Bildirim"
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
@@ -2749,7 +2808,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "Dosya adı"
 
@@ -2758,7 +2817,7 @@ msgstr "Dosya adı"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "Hangi metin ile filtrelenecek?"
 
@@ -2772,28 +2831,28 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "İsim"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -2801,7 +2860,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -2809,6 +2868,10 @@ msgstr ""
 msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
@@ -2820,19 +2883,24 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "Bu soru grubunda soru bulunmamaktadır."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "Gönderen:"
 
@@ -2860,7 +2928,7 @@ msgid "General"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr ""
 
@@ -2880,11 +2948,16 @@ msgstr ""
 msgid "Get Target Set Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "Hangi kullanıcılara yeni şifre verilecek?"
 
@@ -2911,7 +2984,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -2919,21 +2992,31 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr ""
 
@@ -2961,7 +3044,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "Misafir Kullanıcı Girişi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr ""
 
@@ -2988,12 +3071,16 @@ msgstr "Çıktı Dosyası Başlığı"
 msgid "Hardcopy Theme"
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "Yardım"
 
@@ -3005,12 +3092,12 @@ msgstr ""
 msgid "Hidden"
 msgstr "Gizli"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr ""
 
@@ -3022,8 +3109,8 @@ msgstr ""
 msgid "Hide Hints from Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr ""
 
@@ -3035,7 +3122,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr ""
 
@@ -3049,13 +3136,13 @@ msgstr "İpuçlarını göster"
 msgid "Hmwk Sets Editor"
 msgstr "Ödev Setleri Düzenleyici"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Soru Grupları"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr ""
 
@@ -3063,15 +3150,15 @@ msgstr ""
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3089,14 +3176,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3108,12 +3195,16 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 msgid "Illegal file '%1' specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3121,8 +3212,9 @@ msgstr ""
 msgid "Import"
 msgstr "İçeri Aktar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -3137,21 +3229,21 @@ msgstr "Kaç set aktarılacak?"
 msgid "Import sets with names"
 msgstr "Setleri isimleriyle beraber aktar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "Kullanıcılar hangi dosyadan aktarılacak?"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "Aktif Değil"
 
@@ -3159,17 +3251,17 @@ msgstr "Aktif Değil"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr ""
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr ""
 
@@ -3178,7 +3270,7 @@ msgstr ""
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr ""
 
@@ -3186,16 +3278,16 @@ msgstr ""
 msgid "Instructor Tools"
 msgstr "Eğitmen Araçları"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3204,7 +3296,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3219,16 +3311,20 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr ""
 
@@ -3240,7 +3336,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3261,28 +3357,28 @@ msgstr ""
 msgid "Last Answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "Soyadı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr ""
 
@@ -3309,18 +3405,18 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Soru Kütüphaneleri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Soru Kütüphane Tarayıcısı 2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr ""
@@ -3354,33 +3450,33 @@ msgstr ""
 msgid "Local Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr ""
 
@@ -3388,8 +3484,8 @@ msgstr ""
 msgid "Log In Again"
 msgstr "Tekrar giriş yap"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "Çıkış Yap"
 
@@ -3397,20 +3493,20 @@ msgstr "Çıkış Yap"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr "Devam et"
 
@@ -3422,23 +3518,23 @@ msgstr "Giriş Bilgileri"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "Kullanıcı adı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "Durumu"
 
@@ -3446,7 +3542,7 @@ msgstr "Durumu"
 msgid "Logout"
 msgstr "Çıkış"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Ana Menü"
 
@@ -3459,20 +3555,20 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr ""
@@ -3486,7 +3582,7 @@ msgid "Mark Correct"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr ""
 
@@ -3496,8 +3592,9 @@ msgstr ""
 "Hangi özellikler eşleştirilecek? (birden fazla kullanıcı adını virgülle "
 "ayırın)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "Matematik Nesneleri"
 
@@ -3513,49 +3610,49 @@ msgstr ""
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr ""
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Mesajlar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -3568,17 +3665,17 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3619,12 +3716,12 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "Yeni Şifre"
 
@@ -3636,13 +3733,13 @@ msgstr ""
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "Yeni şifreler kaydedildi"
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3650,15 +3747,17 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "Sonraki Soru"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3666,20 +3765,25 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "Hayır"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3698,7 +3802,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "Herhangi bir sete değişiklik yapılmadı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3709,7 +3813,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr ""
 
@@ -3719,38 +3823,38 @@ msgstr ""
 msgid "No data exists for set %1 and problem %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -3758,22 +3862,22 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr ""
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr ""
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -3786,7 +3890,7 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr "Notlamak için bir set seçili değil"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -3795,15 +3899,15 @@ msgstr ""
 "birini işaretleyin."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
@@ -3820,15 +3924,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -3842,26 +3950,32 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Giriş yapmadınız."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "Not"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "Not"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr ""
 
@@ -3877,8 +3991,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -3910,7 +4024,7 @@ msgid ""
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr ""
 
@@ -3928,13 +4042,13 @@ msgstr "Açılış tarihi"
 msgid "Open Problem Library"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -3948,9 +4062,9 @@ msgstr ""
 msgid "Open, complete by %1."
 msgstr ""
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -3973,12 +4087,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr ""
 
 # Context is "7 Out Of 10"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4002,70 +4116,73 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "tr: Pad Fields"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr "Sayfa %1de yaratıldı"
 
@@ -4078,7 +4195,7 @@ msgstr "Sifre"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr ""
 
@@ -4087,7 +4204,7 @@ msgstr ""
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4101,24 +4218,24 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "Yetki seviyesi"
 
@@ -4126,7 +4243,7 @@ msgstr "Yetki seviyesi"
 msgid "Permissions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4163,7 +4280,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4176,7 +4293,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "Lütfen %1 dersi için kullanici adi ve sifrenizi giriniz:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4194,49 +4311,50 @@ msgstr ""
 msgid "Please select at least one user and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Lütfen kaydedilecek dosyayın belirtin."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "Önceki Soru"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr ""
@@ -4245,12 +4363,12 @@ msgstr ""
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr ""
 
@@ -4267,20 +4385,20 @@ msgstr ""
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr "Soru %1"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr ""
 
@@ -4298,8 +4416,8 @@ msgstr ""
 msgid "Problem Editor3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "Soru Listesi"
 
@@ -4315,28 +4433,29 @@ msgstr ""
 msgid "Problem Number "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "Soru Teknikleri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr "Soru Görüntüleyici"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "Sorular"
 
@@ -4384,11 +4503,11 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "Yayımla"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -4402,28 +4521,28 @@ msgid "Really delete the items listed above?"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "Problem cozum dersi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Tek set için notları kaydet"
 
@@ -4437,25 +4556,15 @@ msgid "Reduced Scoring Date"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
-msgstr ""
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr ""
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
 msgstr ""
 
 # Short for "Reduced Scoring:"
@@ -4473,12 +4582,12 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr ""
 
@@ -4487,7 +4596,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Kalan hak"
 
@@ -4499,7 +4608,7 @@ msgstr "Beni hatırla"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4509,13 +4618,13 @@ msgid "Rename"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr ""
 
@@ -4523,19 +4632,19 @@ msgstr ""
 msgid "Rename file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr ""
 
@@ -4551,53 +4660,54 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "Hangi kullanıcılar değiştirilecek?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Hataları bildir"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr ""
 
@@ -4660,8 +4770,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -4669,11 +4779,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -4702,22 +4808,22 @@ msgstr ""
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "Sonuç"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr ""
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr "En son gerçekleştilen işlemin sonucu: %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -4729,19 +4835,27 @@ msgstr "En son gerçekleştirilen işlemin sonuçları"
 msgid "Results of last action performed: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "Ters çevir"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr ""
@@ -4754,19 +4868,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -4775,86 +4889,86 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "Kaydet"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "Farklı Kaydet: [TMPL]/"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr "Farklı kaydet"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "Değişiklikleri kaydet"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr ""
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -4869,11 +4983,11 @@ msgstr ""
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Seçili setleri notla ve dosyaya kaydet:"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -4898,14 +5012,14 @@ msgid "Scoring Tools"
 msgstr "Notlama Araçları"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -4915,24 +5029,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "Bölüm"
@@ -4947,11 +5061,16 @@ msgstr ""
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Soru Grupları"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 msgid "Select a Problem Collection"
@@ -4961,36 +5080,36 @@ msgstr ""
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr ""
 
@@ -4998,27 +5117,27 @@ msgstr ""
 msgid "Select all sets"
 msgstr "Bütün setleri seç"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "Bütün kullanıcıları seç"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "Yapılacak işlemi seç"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr ""
 
@@ -5032,7 +5151,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5056,23 +5175,23 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Set"
 
@@ -5106,7 +5225,7 @@ msgid "Set Definition Files"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr ""
 
@@ -5119,7 +5238,7 @@ msgid "Set Detail for set %2"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5133,12 +5252,12 @@ msgstr "Set Başlığı"
 msgid "Set ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Set Bilgileri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "Set Listesi"
 
@@ -5166,8 +5285,12 @@ msgid "Set Name "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -5193,7 +5316,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Setler"
 
@@ -5205,7 +5328,7 @@ msgstr ""
 msgid "Sets assigned to %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr ""
 
@@ -5214,11 +5337,11 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -5226,7 +5349,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "İpuçlarını göster"
 
@@ -5234,8 +5357,8 @@ msgstr "İpuçlarını göster"
 msgid "Show Me Another"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "Önceki Yanıtları Göster"
 
@@ -5247,8 +5370,8 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "Çözümleri göster"
 
@@ -5256,7 +5379,7 @@ msgstr "Çözümleri göster"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "Hangi kullanıcılar gösterilecek?"
 
@@ -5265,17 +5388,17 @@ msgstr "Hangi kullanıcılar gösterilecek?"
 msgid "Show all paths"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Doğru yanıtları göster"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr ""
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr ""
 
@@ -5284,7 +5407,7 @@ msgstr ""
 msgid "Show path ..."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr ""
 
@@ -5295,17 +5418,17 @@ msgstr "Hangi setler gösterilecek?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "Web Alanı Açıklamasını Göster/Gizle"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "Göster"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr ""
 
@@ -5315,7 +5438,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "%2 setin %1 tanesi gösteriliyor."
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr "%2 kullanıcının %1 tanesi gösteriliyor."
 
@@ -5331,13 +5454,13 @@ msgstr ""
 msgid "Site Information"
 msgstr "Web Alanı Bilgileri"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr ""
 
@@ -5346,7 +5469,7 @@ msgstr ""
 msgid "Solutions"
 msgstr "Çözümleri göster"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -5355,6 +5478,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -5373,14 +5506,14 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr "Sırala"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "Kriterlere Göre Sırala"
 
@@ -5409,7 +5542,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5442,46 +5575,46 @@ msgstr ""
 msgid "Statistics for %1 student %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Durumu"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Rol Yapmayı bırak"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "Kullanıcı Adı"
 
@@ -5511,14 +5644,14 @@ msgstr ""
 msgid "Student answers"
 msgstr "Yanıtları Gönder"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -5530,31 +5663,35 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "Yanıtları Gönder"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
 msgstr "%1 için Yanıtları Gönder"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "Başarılı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr ""
 
@@ -5564,42 +5701,42 @@ msgid "Successfully created new set %1"
 msgstr "Yeni set %1 başarıyla yaratıldı"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -5617,16 +5754,16 @@ msgstr "%1 testini çöz"
 msgid "Take %1 test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "İşlemi Gerçekleştir!"
 
@@ -5691,11 +5828,11 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "WeBWorK Projesi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -5716,15 +5853,15 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "Yukarıdaki yanıt doğru."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr ""
 
@@ -5737,14 +5874,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -5784,54 +5921,54 @@ msgid ""
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr ""
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr ""
 
@@ -5844,65 +5981,65 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
 msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -5921,13 +6058,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -5945,8 +6082,8 @@ msgid ""
 "your new password and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "Sorunun özgün yolu kesin olmalı"
 
@@ -5955,7 +6092,7 @@ msgstr "Sorunun özgün yolu kesin olmalı"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -5963,17 +6100,17 @@ msgid ""
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr ""
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr ""
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -5985,23 +6122,23 @@ msgid ""
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr ""
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "Seçtiğiniz soru seti (%1) set %2 için geçerli değil"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr ""
@@ -6015,7 +6152,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr ""
 
@@ -6024,16 +6161,25 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"Şu anda sorunun orijinal hali gösteriliyor. Kaydedilmemiş değişiklikleri "
+"kurtarmak için internet tarayıcınızın \"Geri\" tuşunu kullanın."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6049,64 +6195,66 @@ msgid ""
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr ""
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6118,8 +6266,8 @@ msgstr ""
 
 # Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "sonra"
 
@@ -6141,24 +6289,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6168,36 +6316,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -6218,11 +6366,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -6239,7 +6387,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6259,25 +6407,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6297,15 +6445,15 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr ""
 
@@ -6315,24 +6463,28 @@ msgid ""
 "guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "Bu soru grubunda soru bulunmamaktadır."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "Bu soru grubu kapalı."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "Bu soru grubu henüz açık değil."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
@@ -6391,35 +6543,39 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "Bu soru, notunuzu etkilemeyecektir."
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
@@ -6435,17 +6591,17 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6459,13 +6615,13 @@ msgstr ""
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr "Bu set %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -6496,22 +6652,22 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -6535,7 +6691,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6544,8 +6700,8 @@ msgid ""
 "problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr ""
 
@@ -6554,7 +6710,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -6567,24 +6723,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -6596,27 +6752,27 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
@@ -6626,11 +6782,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -6647,7 +6803,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -6663,46 +6820,46 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr ""
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr ""
 
@@ -6722,7 +6879,7 @@ msgid ""
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr ""
 
@@ -6730,13 +6887,13 @@ msgstr ""
 msgid "Unclassified Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr ""
 
@@ -6755,7 +6912,7 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr ""
 
@@ -6763,12 +6920,12 @@ msgstr ""
 msgid "Unselect all sets"
 msgstr "Bütün setlerdeki seçimi kaldır"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "Bütün kullanıcılardaki seçimi kaldir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -6780,37 +6937,37 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -6824,11 +6981,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -6836,20 +6994,20 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "Varsayılan Ayarları Kullan"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr ""
 
@@ -6867,7 +7025,7 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -6877,13 +7035,13 @@ msgstr ""
 "soruda bir hata olduğunu bildirmek için kullanabilirsiniz. "
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -6905,8 +7063,8 @@ msgstr ""
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -6924,7 +7082,7 @@ msgid "Username presented:  %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
@@ -6934,7 +7092,7 @@ msgstr ""
 msgid "Users Assigned to Set %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "Kullanıcı Listesi"
 
@@ -6952,7 +7110,7 @@ msgid ""
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "Kullanıcılar sırasıyla %1, %2 ve %3 kriterlerine göre sıları"
 
@@ -6971,17 +7129,18 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -6989,21 +7148,21 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "Göster"
 
@@ -7016,7 +7175,7 @@ msgstr "Göster"
 msgid "View Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "Eşitlikler ne şekilde gösterilecek"
 
@@ -7047,8 +7206,8 @@ msgstr "tr: View student progress by student"
 msgid "View/Edit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr ""
@@ -7071,17 +7230,17 @@ msgstr "Görünür"
 msgid "Visible to Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "Dikkat: Silme işlemi kullanıcının bütün bilgilerini yok eder ve bu işlem "
@@ -7092,11 +7251,16 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr ""
 
@@ -7115,7 +7279,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7149,7 +7313,7 @@ msgstr "WeBWorK sitemize hoşgeldiniz!"
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "Seçili kullanıcılar hangi kriterlerde eşleşmeli?"
 
@@ -7228,42 +7392,44 @@ msgstr ""
 msgid "Will open on %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "Değeri"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "Şablon klasörü yazmaya kapalı. Değişiklik yapılamaz."
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "Evet"
 
@@ -7291,15 +7457,15 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "Eğitmen araçlarına erişim yetkiniz yok."
 
@@ -7309,7 +7475,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "Ödev setlerini değiştirme yetkiniz yok."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "Sorularda değişklik yapma yetkiniz yok."
 
@@ -7318,13 +7484,13 @@ msgstr "Sorularda değişklik yapma yetkiniz yok."
 msgid "You are not authorized to modify set definition files."
 msgstr "Set tanım dosyalarını değiştirme yetkiniz yok."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "Öğrenci bilgilerini değiştirme yetkisine sahip değilsiniz."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "Bu işlemi gerçekleştirme yetkiniz yok."
 
@@ -7344,7 +7510,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -7355,6 +7521,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "Bu sorudan kısmi puan alabilirsiniz."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 msgid "You can not specify an absolute path"
@@ -7378,7 +7548,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -7400,15 +7570,15 @@ msgstr ""
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "Kendinizi silemezsiniz!"
 
@@ -7422,7 +7592,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -7449,37 +7619,41 @@ msgstr ""
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "Bu hatanın detaylarını görmeye yetkiniz yok."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr ""
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "[negquant,_1,Sınırsız deneme hakkı,deneme hakkı,deneme hakkı] kaldı."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
 
@@ -7487,7 +7661,7 @@ msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
 msgid "You have been logged out of WeBWorK."
 msgstr "WeBWorK sisteminden çıkış yaptınız."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -7521,11 +7695,16 @@ msgid ""
 "set."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Şifrenizi buradan değiştiremezsiniz!"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "Şifrenizi buradan değiştiremezsiniz!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr ""
 
@@ -7537,13 +7716,13 @@ msgid ""
 msgstr ""
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -7558,7 +7737,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr ""
 
@@ -7570,20 +7749,27 @@ msgstr ""
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
-msgstr ""
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+#, fuzzy
+msgid "You must select one or more sets for scoring!"
+msgstr "Notlamak için bir set seçili değil"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Bir kullanıcı adı girmelisiniz."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr ""
 
@@ -7591,41 +7777,41 @@ msgstr ""
 msgid "You must specify a file name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Bir kullanıcı adı girmelisiniz."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
 
@@ -7658,19 +7844,19 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr "Bu soru için %1 puan aldınız."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -7708,27 +7894,28 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr ""
 
@@ -7740,47 +7927,60 @@ msgstr "E-posta adresiniz değiştirildi."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Ortalama puanınız: %1.  %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr ""
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -7788,66 +7988,66 @@ msgstr ""
 "Notunuz kaydedilemedi, çünkü notun veritabanına kaydı sırasında bir hata "
 "oluştu."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Notunuz kaydedilemedi çünkü bu soru grubu kapalı."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr ""
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Notunuz kaydedildi."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Oturumunuz zaman aşımına uğradı. Lütfen tekrar giriş yapınız."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr ""
@@ -7860,7 +8060,7 @@ msgstr ""
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "Bu sayfa sınıf listesi editörü. Burada derse kayıtlı öğrencilerin "
@@ -7909,12 +8109,12 @@ msgstr ""
 "kullanıma açık bilgisayarlar, güvenli olmayan bilgisayarlar, ve doğrudan "
 "kontrole sahip olmadığınız bilgisayarlarda kullanmak için güvenli değildir."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 " WebWork bu problemi işlerken bir yazılım hatası ile karşılaştı. Problemin "
@@ -7922,10 +8122,16 @@ msgstr ""
 "ilgili kişilere bildiriniz. Eğer yetkili bir kişiyseniz daha fazla bilgi "
 "için alttaki hata raporunu inceleyiniz."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+# Context is "Create set ______ as a duplicate of the first selected set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "İlk seçilen setin bir kopyası"
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -7934,13 +8140,19 @@ msgid "a duplicate of the first selected set"
 msgstr "İlk seçilen setin bir kopyası"
 
 # Context is "Create set ______ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "Boş bir yeni set"
+
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "Boş bir yeni set"
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -7949,7 +8161,7 @@ msgstr ""
 msgid "a single set"
 msgstr "tek bir set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr ""
 
@@ -7958,11 +8170,11 @@ msgid "add problems"
 msgstr ""
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -7972,13 +8184,13 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
@@ -8007,14 +8219,14 @@ msgstr "bütün setler"
 msgid "all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "bütün kullanıcılar"
 
@@ -8022,30 +8234,36 @@ msgstr "bütün kullanıcılar"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "her kullanıcı"
 
 # Context is "Create _____ as a new empty set"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
 msgstr ""
 
 # Context is "Import set from ____ assigning this set to ____"
@@ -8060,22 +8278,22 @@ msgstr ""
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "değişiklikler kaydedilmedi"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "değişiklikler kaydedildi"
@@ -8092,17 +8310,17 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "doğru"
 
@@ -8116,7 +8334,7 @@ msgid "deleted %1 sets"
 msgstr "%1 set silindi."
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr "%1 kullanıcı silindi."
 
@@ -8128,7 +8346,7 @@ msgstr ""
 msgid "editing all sets"
 msgstr "bütün setler düzenleniyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "bütün kullancılar düzenleniyor"
 
@@ -8140,7 +8358,7 @@ msgstr ""
 msgid "editing selected sets"
 msgstr "seçili setler düzenleniyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "seçili kullanıcılar düzenleniyor"
 
@@ -8148,7 +8366,7 @@ msgstr "seçili kullanıcılar düzenleniyor"
 msgid "editing visible sets"
 msgstr "görünür setler düzenleniyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "görünür kullanıcılar düzenleniyor"
 
@@ -8157,7 +8375,7 @@ msgstr "görünür kullanıcılar düzenleniyor"
 msgid "email:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr ""
 
@@ -8170,16 +8388,16 @@ msgid "entry rows."
 msgstr ""
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "dışarı aktarım yapılmadı"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr ""
 
@@ -8187,7 +8405,7 @@ msgstr ""
 msgid "exporting all sets"
 msgstr "bürün setler dışarı aktarılıyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr ""
 
@@ -8221,15 +8439,15 @@ msgstr ""
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "bütün kullanıcılara yeni şifre veriliyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "seçili kullanıcılara yeni şifre veriliyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "görünür kullanıcılara yeni şifre veriliyor"
 
@@ -8258,9 +8476,9 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "gizli"
@@ -8269,7 +8487,7 @@ msgstr "gizli"
 msgid "hidden from"
 msgstr "görüntülenmiyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "öğrenciler tarafından görülemez"
@@ -8281,45 +8499,49 @@ msgstr "gizli setler"
 # doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "yanlış"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr ""
 
@@ -8327,7 +8549,7 @@ msgstr ""
 msgid "login"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr ""
 
@@ -8362,15 +8584,15 @@ msgstr ""
 msgid "new users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr ""
 
@@ -8389,27 +8611,31 @@ msgstr "Set yok"
 msgid "no students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "kullanıcı yok"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -8434,7 +8660,7 @@ msgstr ""
 msgid "only best scores"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8446,53 +8672,57 @@ msgstr ""
 msgid "or Problems from"
 msgstr ""
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr ""
 
@@ -8510,8 +8740,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -8525,18 +8755,18 @@ msgid "record for user %1 not found"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr ""
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -8558,13 +8788,13 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr ""
 
@@ -8583,17 +8813,17 @@ msgstr ""
 msgid "selected sets"
 msgstr "seçili setler"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "seçili kullanıcılar"
 
@@ -8631,7 +8861,7 @@ msgstr ""
 msgid "showing all sets"
 msgstr "bütün setler gösteriliyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "bütün kullanıcılar gösteriliyor"
 
@@ -8646,7 +8876,7 @@ msgstr ""
 msgid "showing matching sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "eşleşen kullanıcılar gösteriliyor"
 
@@ -8654,7 +8884,7 @@ msgstr "eşleşen kullanıcılar gösteriliyor"
 msgid "showing no sets"
 msgstr "hiçbir set gösterilmiyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "hiçbir kullanıcı gösterilmiyor"
 
@@ -8662,12 +8892,16 @@ msgstr "hiçbir kullanıcı gösterilmiyor"
 msgid "showing selected sets"
 msgstr "seçili setler gösteriliyor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "seçili kullanıcılar gösteriliyor"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -8684,16 +8918,16 @@ msgstr ""
 msgid "students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -8701,12 +8935,12 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr ""
 
@@ -8718,7 +8952,7 @@ msgstr ""
 msgid "test time"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -8727,14 +8961,14 @@ msgid "the following file(s)"
 msgstr ""
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr ""
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr ""
 
@@ -8742,7 +8976,11 @@ msgstr ""
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "deneme hakkı"
 
@@ -8750,43 +8988,40 @@ msgstr "deneme hakkı"
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "deneme hakkı"
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "sınırsız"
 
@@ -8795,27 +9030,27 @@ msgstr "sınırsız"
 msgid "userID: %1 --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "seçili alanla eşleşen kullanıcılar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "Görünür"
@@ -8828,20 +9063,25 @@ msgstr "Görünür"
 msgid "visible sets"
 msgstr "görünür setler"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "öğrencilere görüntüleyebilir"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "kullanıcılar görüntüleyebilir"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -8849,8 +9089,12 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
@@ -8859,242 +9103,236 @@ msgstr ""
 
 #
 #, fuzzy
-msgid "Will open on %1"
-msgstr "%1 tarihinde açılacak"
+#~ msgid "Will open on %1"
+#~ msgstr "%1 tarihinde açılacak"
 
 #
 #, fuzzy
-msgid "User ID:"
-msgstr "Kullanıcı Ekle"
+#~ msgid "User ID:"
+#~ msgstr "Kullanıcı Ekle"
 
 #
-msgid "Viewing temporary file"
-msgstr "Geçici dosya gösteriliyor"
-
-#
-#, fuzzy
-msgid "set %1."
-msgstr "%1'e geri dön"
+#~ msgid "Viewing temporary file"
+#~ msgstr "Geçici dosya gösteriliyor"
 
 #
 #, fuzzy
-msgid "Bad Nonce for user "
-msgstr "Set %1 başlığı"
+#~ msgid "set %1."
+#~ msgstr "%1'e geri dön"
 
 #
 #, fuzzy
-msgid "Can't write to file: %1"
-msgstr "'%1' dosyasına kaydedildi"
+#~ msgid "Bad Nonce for user "
+#~ msgstr "Set %1 başlığı"
 
 #
 #, fuzzy
-msgid "Change Display Options"
-msgstr "Görünüm Seçenekleri"
-
-#
-msgid "navNext"
-msgstr "&nbspSonraki"
-
-#
-msgid "navNextGrey"
-msgstr "&nbspSonraki"
-
-#
-msgid "navPrev"
-msgstr "&nbspÖnceki"
-
-#
-msgid "navPrevGrey"
-msgstr "&nbspÖnceki"
-
-#
-msgid "navProbListGrey"
-msgstr "&nbspSorular"
-
-#
-msgid "navUp"
-msgstr "&nbspYukarı"
+#~ msgid "Can't write to file: %1"
+#~ msgstr "'%1' dosyasına kaydedildi"
 
 #
 #, fuzzy
-msgid "Show me another [_1]"
-msgstr "Yani pencerede göster"
+#~ msgid "Change Display Options"
+#~ msgstr "Görünüm Seçenekleri"
 
 #
-msgid "Apply Options"
-msgstr "Seçenekleri Uygula"
+#~ msgid "navNext"
+#~ msgstr "&nbspSonraki"
 
 #
-msgid "Disable"
-msgstr "Devre dişi bırak"
+#~ msgid "navNextGrey"
+#~ msgstr "&nbspSonraki"
 
 #
-msgid "Enable/Disable reduced scoring for selected sets"
-msgstr "Seçili setler için azaltılmış not seçenegini etkinleştir/kaldır"
+#~ msgid "navPrev"
+#~ msgstr "&nbspÖnceki"
 
 #
-msgid "Reduced Credit %1 for all sets"
-msgstr "Bütün setler için notlar %1 azaltıldı"
+#~ msgid "navPrevGrey"
+#~ msgstr "&nbspÖnceki"
 
 #
-msgid "_REDUCED_CREDIT_MESSAGE_1"
-msgstr ""
-"Bu ödev seti için Azaltılmış Not süresi var. Bu süre %1 tarihinde başlıyor "
-"ve %2 tarihinde son buluyor. Bu süre içinde cevaplanan bütün sorular asıl "
-"değerlerinin yüzde %3 değerinde olacak."
+#~ msgid "navProbListGrey"
+#~ msgstr "&nbspSorular"
 
 #
-msgid "_REDUCED_CREDIT_MESSAGE_2"
-msgstr ""
-"Bu ödev seti için Azaltılmış Not süresi vardı. Bu süre %1 tarihinde başladı "
-"ve %2 tarihinde bitti. Bu süre içinde cevaplanan bütün sorular asıl "
-"değerlerinin yüzde %3 değerinde notlandı."
+#~ msgid "navUp"
+#~ msgstr "&nbspYukarı"
 
 #
-msgid "completely"
-msgstr "tamamen"
+#, fuzzy
+#~ msgid "Show me another [_1]"
+#~ msgstr "Yani pencerede göster"
 
 #
-msgid "Course Information for course [_1]"
-msgstr "%1 dersinin bilgileri"
+#~ msgid "Apply Options"
+#~ msgstr "Seçenekleri Uygula"
 
 #
-msgid ""
-"Report bugs in a WeBWorK question/problem using this link. The very first "
-"time you do this you will need to register with an email address so that "
-"information on the bug fix can be reported back to you."
-msgstr ""
-"WebWork veya soruyla ilgili hata bildirmek için bu linki kullanın. Bunu ilk "
-"kez yaparken e-posta adresinizle kayıt olmanız gerekmektedir."
+#~ msgid "Disable"
+#~ msgstr "Devre dişi bırak"
 
 #
-msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-msgstr ""
-"%1 seti için yazdırılabilir dosya başlığı değiştirilemedi. Bilinmeyen hata."
+#~ msgid "Enable/Disable reduced scoring for selected sets"
+#~ msgstr "Seçili setler için azaltılmış not seçenegini etkinleştir/kaldır"
 
 #
-msgid "Unable to make '[_1]' the set header for [_2]"
-msgstr "'%1' set %2 için dosya başlığı yapılamadı"
+#~ msgid "Reduced Credit %1 for all sets"
+#~ msgstr "Bütün setler için notlar %1 azaltıldı"
 
 #
-msgid "Can't determine user of temporary edit file [_1]."
-msgstr "Geçici dosya %1 için kullanıcı belirlenemedi."
+#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
+#~ msgstr ""
+#~ "Bu ödev seti için Azaltılmış Not süresi var. Bu süre %1 tarihinde "
+#~ "başlıyor ve %2 tarihinde son buluyor. Bu süre içinde cevaplanan bütün "
+#~ "sorular asıl değerlerinin yüzde %3 değerinde olacak."
 
 #
-msgid "Top level of author information on the wiki."
-msgstr "Wikide yazar bilgilerinin en üst seviyesi."
+#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
+#~ msgstr ""
+#~ "Bu ödev seti için Azaltılmış Not süresi vardı. Bu süre %1 tarihinde "
+#~ "başladı ve %2 tarihinde bitti. Bu süre içinde cevaplanan bütün sorular "
+#~ "asıl değerlerinin yüzde %3 değerinde notlandı."
 
 #
-msgid "Reverting to original file '[_1]'"
-msgstr "Asıl dosyaya geri dönülüyor ('%1')"
+#~ msgid "completely"
+#~ msgstr "tamamen"
 
 #
-msgid "Wiki summary page for MathObjects"
-msgstr "MathObjects için özet wiki sayfası"
+#~ msgid "Course Information for course [_1]"
+#~ msgstr "%1 dersinin bilgileri"
 
 #
-msgid "Snippets of PG code illustrating specific techniques"
-msgstr "Özel teknikleri gösteren PG yazılımı"
+#~ msgid ""
+#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
+#~ "time you do this you will need to register with an email address so that "
+#~ "information on the bug fix can be reported back to you."
+#~ msgstr ""
+#~ "WebWork veya soruyla ilgili hata bildirmek için bu linki kullanın. Bunu "
+#~ "ilk kez yaparken e-posta adresinizle kayıt olmanız gerekmektedir."
 
 #
-msgid "Error copying [_1] to [_2]"
-msgstr "Dosya %1, %2ye kopyalanarken hata oluştu"
+#~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
+#~ msgstr ""
+#~ "%1 seti için yazdırılabilir dosya başlığı değiştirilemedi. Bilinmeyen "
+#~ "hata."
 
 #
-msgid "blank problem"
-msgstr "boş soru"
+#~ msgid "Unable to make '[_1]' the set header for [_2]"
+#~ msgstr "'%1' set %2 için dosya başlığı yapılamadı"
 
 #
-msgid ""
-"Note: this problem viewer is for viewing purposes only. As of right now, "
-"testing functionality is not possible."
-msgstr ""
-"Not: Bu soru görüntüleyici şu an sadece soruları görüntüleyebilir, soru "
-"çözme fonksiyonu şu an mevcut değil."
+#~ msgid "Can't determine user of temporary edit file [_1]."
+#~ msgstr "Geçici dosya %1 için kullanıcı belirlenemedi."
 
 #
-msgid "webwork"
-msgstr "webwork"
+#~ msgid "Top level of author information on the wiki."
+#~ msgstr "Wikide yazar bilgilerinin en üst seviyesi."
 
 #
-msgid "submit button clicked"
-msgstr "gönder düğmesine basıldı"
+#~ msgid "Reverting to original file '[_1]'"
+#~ msgstr "Asıl dosyaya geri dönülüyor ('%1')"
 
 #
-msgid ""
-"Test snippets of PG code in interactive lab.  Good way to learn PG language."
-msgstr ""
-"Interaktif labaratuarda PG test yazılımları. PG yazılım dilini öğrenmek içi "
-"iyi bir kaynak."
+#~ msgid "Wiki summary page for MathObjects"
+#~ msgstr "MathObjects için özet wiki sayfası"
 
 #
-msgid "View Using Seed Number"
-msgstr "Tohum numarasını kullanarak göster"
+#~ msgid "Snippets of PG code illustrating specific techniques"
+#~ msgstr "Özel teknikleri gösteren PG yazılımı"
 
 #
-msgid ""
-"The text box now contains the source of the original problem. You can "
-"recover lost edits by using the Back button on your browser."
-msgstr ""
-"Şu anda sorunun orijinal hali gösteriliyor. Kaydedilmemiş değişiklikleri "
-"kurtarmak için internet tarayıcınızın \"Geri\" tuşunu kullanın."
+#~ msgid "Error copying [_1] to [_2]"
+#~ msgstr "Dosya %1, %2ye kopyalanarken hata oluştu"
 
 #
-msgid ""
-"Documentation from source code for PG modules and macro files. Often the "
-"most up-to-date information."
-msgstr ""
-"PG modülleri ve makro dosyaları hakkında bilgi dosyası. Genellikle en son "
-"bilgileri içerir."
+#~ msgid "blank problem"
+#~ msgstr "boş soru"
 
 #
-msgid ""
-"PG mark down syntax used to format WeBWorK questions. This interactive lab "
-"can help you to learn the techniques."
-msgstr ""
-"WebWork sorularında kullanılan PG kodu sözdizimi. Bu interaktif labaratuar, "
-"teknikleri öğrenmek için kullanılabilir."
+#~ msgid ""
+#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
+#~ "testing functionality is not possible."
+#~ msgstr ""
+#~ "Not: Bu soru görüntüleyici şu an sadece soruları görüntüleyebilir, soru "
+#~ "çözme fonksiyonu şu an mevcut değil."
 
 #
-msgid ""
-"Error: This path is already in the temporary edit directory -- no new "
-"temporary file is created. path = [_1]"
-msgstr ""
-"Hata: Bu yol belirteci geçici düzenleme klasöründe mevcut -- yeni bir geçici "
-"dosya oluşturuldu. yol = %1"
+#~ msgid "webwork"
+#~ msgstr "webwork"
 
 #
-msgid ""
-"Please use radio buttons to choose the method for saving this file. Can't "
-"recognize saveMode: |[_1]|."
-msgstr "Bu dosya için kaydetme modunu seçin. Kaydetme modu tanınmadı: |%1|."
+#~ msgid "submit button clicked"
+#~ msgstr "gönder düğmesine basıldı"
 
 #
-msgid "Resources"
-msgstr "Kaynaklar"
+#~ msgid ""
+#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
+#~ "language."
+#~ msgstr ""
+#~ "Interaktif labaratuarda PG test yazılımları. PG yazılım dilini öğrenmek "
+#~ "içi iyi bir kaynak."
 
 #
-msgid "Duplicate"
-msgstr "Çoğalt"
+#~ msgid "View Using Seed Number"
+#~ msgstr "Tohum numarasını kullanarak göster"
 
 #
-msgid "This path |[_1]| is not the path to a temporary edit file."
-msgstr "Bu yol belirteci |%1| geçici düzenleme dosyası yolu değil."
+#~ msgid ""
+#~ "Documentation from source code for PG modules and macro files. Often the "
+#~ "most up-to-date information."
+#~ msgstr ""
+#~ "PG modülleri ve makro dosyaları hakkında bilgi dosyası. Genellikle en son "
+#~ "bilgileri içerir."
 
 #
-msgid ""
-"Unable to change the source file path for set [_1], problem [_2]. Unknown "
-"error."
-msgstr ""
-"Set %1, soru %2 için kaynak kodu yolu değiştirilemiyor. Bilinmeyen hata."
+#~ msgid ""
+#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
+#~ "lab can help you to learn the techniques."
+#~ msgstr ""
+#~ "WebWork sorularında kullanılan PG kodu sözdizimi. Bu interaktif "
+#~ "labaratuar, teknikleri öğrenmek için kullanılabilir."
 
 #
-msgid "Save as new independent problem"
-msgstr "Yeni bir soru olarak kaydet"
+#~ msgid ""
+#~ "Error: This path is already in the temporary edit directory -- no new "
+#~ "temporary file is created. path = [_1]"
+#~ msgstr ""
+#~ "Hata: Bu yol belirteci geçici düzenleme klasöründe mevcut -- yeni bir "
+#~ "geçici dosya oluşturuldu. yol = %1"
 
 #
-msgid "Unknown file type"
-msgstr "Bilinmeyen dosya tipi"
+#~ msgid ""
+#~ "Please use radio buttons to choose the method for saving this file. Can't "
+#~ "recognize saveMode: |[_1]|."
+#~ msgstr "Bu dosya için kaydetme modunu seçin. Kaydetme modu tanınmadı: |%1|."
+
+#
+#~ msgid "Resources"
+#~ msgstr "Kaynaklar"
+
+#
+#~ msgid "Duplicate"
+#~ msgstr "Çoğalt"
+
+#
+#~ msgid "This path |[_1]| is not the path to a temporary edit file."
+#~ msgstr "Bu yol belirteci |%1| geçici düzenleme dosyası yolu değil."
+
+#
+#~ msgid ""
+#~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
+#~ "error."
+#~ msgstr ""
+#~ "Set %1, soru %2 için kaynak kodu yolu değiştirilemiyor. Bilinmeyen hata."
+
+#
+#~ msgid "Save as new independent problem"
+#~ msgstr "Yeni bir soru olarak kaydet"
+
+#
+#~ msgid "Unknown file type"
+#~ msgstr "Bilinmeyen dosya tipi"
 
 #, fuzzy
 #~ msgid "answer "
@@ -9143,10 +9381,6 @@ msgstr "Bilinmeyen dosya tipi"
 #, fuzzy
 #~ msgid "No sets selected for scoring."
 #~ msgstr "Notlamak için bir set seçili değil"
-
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "Not"
 
 #, fuzzy
 #~ msgid "Recitation:"

--- a/lib/WeBWorK/Localize/tr.po
+++ b/lib/WeBWorK/Localize/tr.po
@@ -1,50 +1,43 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: WeBWorK Online Homework System\n"
+"Project-Id-Version: webwork2\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2016-03-21 14:37-0500\n"
-"Last-Translator: Geoff Goehle <goehle@gmail.com>\n"
-"Language-Team: Webwork Turkish language team <Ben Walter <benwalt@gmail."
-"com>>\n"
-"Language: tr_TR\n"
+"PO-Revision-Date: 2018-10-07 12:04+0000\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: Turkish (http://www.transifex.com/webwork/webwork2/language/"
+"tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.6.10\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
-#, fuzzy
 msgid "#corr"
-msgstr "doğru"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
-#, fuzzy
 msgid "#incorr"
-msgstr "yanlış"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
-#, fuzzy
 msgid "% correct"
-msgstr "%1% doğru"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:674
 msgid "% correct with review"
 msgstr ""
 
-#
+# Percent students
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
-#, fuzzy
 msgid "% students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
 #. ($prettySetID)
 #. ($prettyProblemID)
@@ -53,64 +46,49 @@ msgstr "öğrencilere görüntüleyebilir"
 msgid "%1 (old editor)"
 msgstr ""
 
-#
+# Gateway (test 3)
 #. ($display_name, $vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:459
-#, fuzzy
 msgid "%1 (test %2)"
 msgstr "%1 (test %2)"
 
-#
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:309
-#, fuzzy
 msgid "%1 Points:"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:431
-#, fuzzy
 msgid "%1 Problems:"
-msgstr "Sorular"
+msgstr ""
 
-#
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1345
-#, fuzzy
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
 msgstr "%1 set eklendi, %2 sets atlandı. Atlanan setler: (%3)"
 
-#
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1453
-#, fuzzy
 msgid "%1 sets exported, %2 sets skipped. Skipped sets: (%3)"
 msgstr "%1 set aktarıldı, %2 set atlandı. Atlanan setler: (%3)"
 
-#
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
-#, fuzzy
 msgid "%1 students out of %2"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
-#
 #. (scalar @userIDsToExport, $dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
-#, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 kullanıcı %2/%3 dosyasına aktarıldı."
 
-#
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
-#, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
@@ -132,87 +110,66 @@ msgid ""
 "that system, but aren't allowed to log in to this course."
 msgstr ""
 
-#
 #. ($levelpercentage)
 #. ($percentage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:192
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:316
-#, fuzzy
 msgid "%1% Complete"
-msgstr "tamamlandı."
+msgstr ""
 
-#
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
-#, fuzzy
 msgid "%1% correct"
 msgstr "%1% doğru"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:187
-#, fuzzy
 msgid "%1's Current Address"
 msgstr "%1 için Mevcut Adres"
 
-#
 #. ($user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:142
-#, fuzzy
 msgid "%1's Current Password"
 msgstr "%1 için Mevcut Şifre"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:191
-#, fuzzy
 msgid "%1's New Address"
 msgstr "%1 için Yeni Adres"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:146
-#, fuzzy
 msgid "%1's New Password"
 msgstr "%1 için Yeni Şifre"
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:121
-#, fuzzy
 msgid "%1's new password cannot be blank."
 msgstr "%1 için yeni şifre boş bırakılamaz."
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:93
-#, fuzzy
 msgid "%1's password has been changed."
 msgstr "%1 adlı kullanıcının şifresi değiştirildi."
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
 msgid "%1: Problem %2"
 msgstr "%1: Soru %2."
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:354
-#, fuzzy
 msgid "%1: Problem %2 Show Me Another"
-msgstr "%1: Soru %2."
+msgstr ""
 
-#
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
-#, fuzzy
 msgid "%1: The directory for the course not found."
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
 #. ($succeeded_count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
@@ -229,10 +186,8 @@ msgstr ""
 msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
-#
 #. ($numBlanks)
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
-#, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "Soruların %1 tanesi yanıtsız bırakıldı."
 
@@ -241,11 +196,9 @@ msgstr "Soruların %1 tanesi yanıtsız bırakıldı."
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
-#, fuzzy
 msgid "%score"
-msgstr "Not"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
@@ -259,7 +212,6 @@ msgid ""
 "of attempts:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
 msgid "(This problem will not count towards your grade.)"
 msgstr "(Bu soru notunuzu etkilemeyecektir.)"
@@ -269,48 +221,38 @@ msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
-#, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
-#, fuzzy
 msgid "(Your score on this %1 is not available.)"
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1261
-#, fuzzy
 msgid "(correct)"
-msgstr "doğru"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:221
 msgid "(gw/quiz) After version answer date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1263
-#, fuzzy
 msgid "(incorrect)"
-msgstr "yanlış"
+msgstr ""
 
-#
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1265
-#, fuzzy
 msgid "(score %1)"
-msgstr "Not"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
-#, fuzzy
 msgid "1 student"
-msgstr "Kullanıcı Adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:223
 msgid ""
@@ -327,6 +269,7 @@ msgid ""
 "graders if they are written appropriately.</p>"
 msgstr ""
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:340
 msgid ""
 "<p>When viewing a problem, users may choose different methods of rendering "
@@ -341,6 +284,7 @@ msgid ""
 "not give a choice of modes (since there will only be one active).</p>"
 msgstr ""
 
+# Leave HTML in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:263
 msgid ""
 "<ul><li><b>SMAcheckAnswers</b>: enables the Check Answers button <i>for the "
@@ -356,14 +300,12 @@ msgid ""
 "see a new version that they can not attempt or learn from.</p>"
 msgstr ""
 
-#
 #. ($add_courseID)
 #. ($rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
-#, fuzzy
 msgid "A course with ID %1 already exists."
-msgstr "Set çoğaltılamadı: set %1 zaten mevcut!"
+msgstr ""
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
@@ -372,12 +314,10 @@ msgid ""
 "existing course before you can unarchive."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
-#, fuzzy
 msgid "A file with that name already exists"
-msgstr "Set çoğaltılamadı: set %1 zaten mevcut!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:303
 msgid ""
@@ -400,23 +340,18 @@ msgid ""
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
-#, fuzzy
 msgid "A new file has been created at '%1'"
-msgstr "Set %1 mevcut. Yeni set oluşturulmadı"
+msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
-#, fuzzy
 msgid ""
 "A new file has been created at '%1' with the contents below.  No changes "
 "have been made to set %2"
 msgstr ""
-"Aşağıdaki içerikle '%1' dosyası yaratıldı. Set %2de değişiklik yapılmadı."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:813
 msgid ""
@@ -425,6 +360,7 @@ msgid ""
 "number of incorrect attempts."
 msgstr ""
 
+# Leave symbol codes in place
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:173
 msgid ""
 "A switch to govern the use of a Progress Bar for the student; this also "
@@ -449,35 +385,28 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
+# Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
 msgid "ADJ STATUS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
-#, fuzzy
 msgid "ANSWERS NOT RECORDED"
-msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
-#, fuzzy
 msgid "ANSWERS NOT RECORDED --"
-msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
-#, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
-msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
@@ -487,29 +416,24 @@ msgstr "YANITLAR SADECE KONTROL EDİLİYOR -- YANITLAR KAYDEDİLMEDİ"
 msgid "Abandon changes"
 msgstr "Değişiklikleri kaydetme"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "Dışa aktarımı iptal et"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:156
-#, fuzzy
 msgid "Achievement"
-msgstr "seçili setler"
+msgstr ""
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
-#
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
-#, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
-msgstr "Set %1 mevcut. Yeni set oluşturulmadı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:716
 msgid "Achievement Editor"
@@ -542,29 +466,23 @@ msgstr ""
 msgid "Achievement User Editor"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:51
-#, fuzzy
 msgid "Achievement has been assigned to all users."
-msgstr "Set %1 başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
-#
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
-#, fuzzy
 msgid "Achievement scores saved to %1"
-msgstr "Set %1 başlığı '%2' olarak değiştirildi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:266
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:286
-#, fuzzy
 msgid "Achievements"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:408
 msgid "Act as"
@@ -576,22 +494,17 @@ msgstr ""
 msgid "Act as:"
 msgstr ""
 
-#
 #. (HTML::Entities::encode_entities($eUserID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
-#, fuzzy
 msgid "Acting as %1."
-msgstr "%1 gibi davranılıyor."
+msgstr ""
 
-#
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
-#, fuzzy
 msgid "Action %1 not found"
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Active"
 msgstr "Aktif"
@@ -609,7 +522,6 @@ msgid ""
 "homework in a limited way."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
@@ -621,23 +533,17 @@ msgstr "Ekle"
 msgid "Add All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
-#, fuzzy
 msgid "Add Course"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
-#, fuzzy
 msgid "Add Students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:466
-#, fuzzy
 msgid "Add Users"
 msgstr "Kullanıcı Ekle"
 
@@ -649,37 +555,28 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
-#, fuzzy
 msgid "Add as what filetype?"
 msgstr "Hangi dosya tipi olarak eklenecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
 msgid "Add how many students?"
 msgstr "Kaç öğrenci eklenecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:855
-#, fuzzy
 msgid "Add problems to"
-msgstr "Soru ekle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
-#, fuzzy
 msgid "Add to what set?"
-msgstr "Hangi sete eklenecek?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
 msgid "Add which new users?"
 msgstr "Hangi yeni kullanıcılar eklenecek?"
 
-#
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_path, $setID, $targetProblemNumber)
@@ -689,25 +586,20 @@ msgstr "Hangi yeni kullanıcılar eklenecek?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
-#, fuzzy
 msgid "Added %1 to %2 as problem %3"
-msgstr "%1 sorusu %2 setine soru %3 olarak eklendi"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
-#, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
-msgstr "'%1' dosyası %2 dosyasına yeni set başlığı olarak eklendi"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
-#, fuzzy
 msgid "Added '%1' to %2 as new set header"
-msgstr "'%1' dosyası %2 dosyasına yeni set başlığı olarak eklendi"
+msgstr ""
 
 #. (join(', ', @toAdd)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
@@ -753,11 +645,9 @@ msgid ""
 "entry and try again."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Addresses"
-msgstr "E-posta Adresi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
 msgid ""
@@ -789,11 +679,9 @@ msgstr ""
 msgid "Advanced Search"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:220
-#, fuzzy
 msgid "After set answer date"
-msgstr "Cevap tarihi"
+msgstr ""
 
 #. ($reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
@@ -809,45 +697,33 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
-#, fuzzy
 msgid "All of the answers above are correct."
 msgstr "Yanıtların tümü doğru"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
-#, fuzzy
 msgid "All of the gradeable answers above are correct."
-msgstr "Yanıtların tümü doğru"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:955
-#, fuzzy
 msgid "All selected sets hidden from all students"
-msgstr "Bütün seçili setler her e %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:954
-#, fuzzy
 msgid "All selected sets made visible for all students"
-msgstr "Bütün seçili setler her e %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:945
-#, fuzzy
 msgid "All sets hidden from all students"
-msgstr "öğrenciler tarafından görülemez"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:944
-#, fuzzy
 msgid "All sets made visible for all students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
 msgid "All students in course"
@@ -857,53 +733,39 @@ msgstr ""
 msgid "All unassignments were made successfully."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:950
-#, fuzzy
 msgid "All visible hidden from all students"
-msgstr "Görünür bütün setler her öğrenciye %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:949
-#, fuzzy
 msgid "All visible sets made visible for all students"
-msgstr "Görünür bütün setler her öğrenciye %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
-#, fuzzy
 msgid "Allow unassign"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:376
 msgid "Allowed error, as a percentage, for numerical comparisons"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:291
-#, fuzzy
 msgid "Allowed to <em>act as</em> another user"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:310
-#, fuzzy
 msgid "Allowed to change their e-mail address"
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:286
-#, fuzzy
 msgid "Allowed to change their password"
-msgstr "%1 adlı kullanıcının şifresi değiştirilemedi: %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:282
-#, fuzzy
 msgid "Allowed to login to the course"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:328
 msgid "Allowed to see solutions before the answer date"
@@ -913,11 +775,9 @@ msgstr ""
 msgid "Allowed to see the correct answers before the answer date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:315
-#, fuzzy
 msgid "Allowed to view past answers"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:320
 msgid "Allowed to view problems in sets which are not open yet"
@@ -931,9 +791,8 @@ msgstr ""
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
-#, fuzzy
 msgid "An error occured while archiving the course %1:"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($rename_oldCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
@@ -949,11 +808,9 @@ msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
-#, fuzzy
 msgid "An error occured while renaming the course %1 to %2:"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:451
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:782
@@ -964,13 +821,10 @@ msgstr "Yeni set %1 başarıyla yaratıldı"
 msgid "Answer Date"
 msgstr "Cevap tarihi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:249
-#, fuzzy
 msgid "Answer Log"
-msgstr "Yanıtları kontrol et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Answer Preview"
@@ -980,31 +834,27 @@ msgstr "Gösterim"
 msgid "Answer(s) submitted:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:38
-#, fuzzy
 msgid "Answer:"
-msgstr "Yanıtları kontrol et"
+msgstr ""
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
 msgid "AnswerGroupInfo"
 msgstr ""
 
+# Leave out spaces
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
 msgid "AnswerHashInfo"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:223
-#, fuzzy
 msgid "Answers"
-msgstr "Yanıtları kontrol et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:134
-#, fuzzy
 msgid "Answers Available"
-msgstr "kapalı, cevaplar açıklandı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1128
@@ -1016,7 +866,6 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
@@ -1024,14 +873,12 @@ msgstr ""
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "Aşağıda yapılan değişiklikler seti çözen HER öğrenci için uygulanacakç"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
-#, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
-msgstr "Aşağıda yapılan değişiklikler seti çözen HER öğrenci için uygulanacakç"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2305
 msgid ""
@@ -1045,19 +892,15 @@ msgstr ""
 msgid "Append"
 msgstr ""
 
-#
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
-#, fuzzy
 msgid "Append to end of %1 set"
-msgstr "Set %1in sonuna ekle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
-#, fuzzy
 msgid "Archive"
-msgstr "Dersler"
+msgstr ""
 
 #. ($archive, $n)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:770
@@ -1075,30 +918,22 @@ msgstr ""
 msgid "Archive Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
-#, fuzzy
 msgid "Archive Courses"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
-#, fuzzy
 msgid "Archive next course"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
-#, fuzzy
 msgid "Archive this Course"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
-#, fuzzy
 msgid "Archived Courses"
-msgstr "Dersler"
+msgstr ""
 
 #. ($courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:201
@@ -1119,24 +954,19 @@ msgid ""
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
-#, fuzzy
 msgid "Assign"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
-#, fuzzy
 msgid "Assign selected sets to selected users"
-msgstr "Bu set hangi kullanıcılara ödev verilecek?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1303
 msgid "Assign this set to which users?"
 msgstr "Bu set hangi kullanıcılara ödev verilecek?"
@@ -1146,44 +976,34 @@ msgstr "Bu set hangi kullanıcılara ödev verilecek?"
 msgid "Assign to All Current Users"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Assigned"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
 msgid "Assigned Sets"
 msgstr "Ödev verilmiş setler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
-#, fuzzy
 msgid "Assigned achievements to users"
-msgstr "Bu set hangi kullanıcılara ödev verilecek?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
-#, fuzzy
 msgid "Assigned to"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:226
-#, fuzzy
 msgid "Assignment type"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
-#, fuzzy
 msgid "At least one of the answers above is NOT correct."
-msgstr "Yanıtların en az bir tanesi %1doğru değil."
+msgstr ""
 
+# Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:437
 msgid "Att. to Open Children"
 msgstr ""
@@ -1192,13 +1012,10 @@ msgstr ""
 msgid "Attempt to upgrade directories"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:399
-#, fuzzy
 msgid "Attempted"
-msgstr "Deneme sayısı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
@@ -1207,7 +1024,6 @@ msgstr "Deneme sayısı"
 msgid "Attempts"
 msgstr "Deneme sayısı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Audit"
 msgstr "Denetle"
@@ -1217,7 +1033,6 @@ msgstr "Denetle"
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
 msgid "Author Info"
@@ -1284,36 +1099,26 @@ msgstr ""
 msgid "Cake of Enlargment"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
-#, fuzzy
 msgid "Can e-mail instructor"
-msgstr "Eğitmene E-posta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:305
-#, fuzzy
 msgid "Can report bugs"
-msgstr "Hataları bildir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:332
-#, fuzzy
 msgid "Can show old answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:300
-#, fuzzy
 msgid "Can submit answers for a student"
-msgstr "%1 için Yanıtları Gönder"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:621
-#, fuzzy
 msgid "Can't copy file: %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
 #. ($archive,systemError($?)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:772
@@ -1325,75 +1130,55 @@ msgstr ""
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:847
-#, fuzzy
 msgid "Can't create directory: %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:929
-#, fuzzy
 msgid "Can't create file '%1': %2"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:826
-#, fuzzy
 msgid "Can't create file: %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($name, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:939
-#, fuzzy
 msgid "Can't delete archive '%1': %2"
-msgstr "kullanıcı için şifre bilgileri alınamadı '%1': %2"
+msgstr ""
 
-#
 #. ($eUserID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:75
-#, fuzzy
 msgid "Can't get password record for effective user '%1': %2"
 msgstr "Mevcut kullanıcı için şifre bilgileri alınamadı '%1': %2"
 
-#
 #. ($userID,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:67
-#, fuzzy
 msgid "Can't get password record for user '%1': %2"
 msgstr "kullanıcı için şifre bilgileri alınamadı '%1': %2"
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
-#, fuzzy
 msgid "Can't open %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
-#, fuzzy
 msgid "Can't open file %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
-#, fuzzy
 msgid "Can't read merge file %1. No message sent"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:646
-#, fuzzy
 msgid "Can't rename file: %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
 msgid "Can't rename to the same name."
@@ -1404,37 +1189,29 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#
 #. ($!)
 #. ($fullPath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
-#, fuzzy
 msgid "Can't write to file %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:585
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:968
-#, fuzzy
 msgid "Cancel"
-msgstr "Düzenlemeyi iptal et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
-#, fuzzy
 msgid "Cancel E-mail"
-msgstr "Düzenlemeyi iptal et"
+msgstr ""
 
-#
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:292
-#, fuzzy
 msgid "Cannot open %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:246
 msgid "Cap Test Time at Set Close Date?"
@@ -1469,15 +1246,12 @@ msgstr ""
 msgid "Change CourseID to:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:203
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:175
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:84
-#, fuzzy
 msgid "Change Display Settings"
-msgstr "Görünüm Seçenekleri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:158
 msgid "Change Email Address"
 msgstr "E-posta Adresi Değiştir"
@@ -1486,17 +1260,14 @@ msgstr "E-posta Adresi Değiştir"
 msgid "Change Institution to:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:391
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:62
 msgid "Change Password"
 msgstr "Şifre Değiştir"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
-#, fuzzy
 msgid "Change User Settings"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr ""
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
@@ -1508,19 +1279,16 @@ msgstr ""
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
 msgid "Changes abandoned"
 msgstr "Değişiklikler kaydedilmedi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "Dosyadaki değişiklikler henüz kalıcı olarak kaydedilmedi."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
 msgid "Changes saved"
@@ -1537,16 +1305,13 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
 msgid "Check Answers"
 msgstr "Yanıtları kontrol et"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
-#, fuzzy
 msgid "Check Test"
-msgstr "Yanıtları kontrol et"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
 msgid "Check that it's permissions are set correctly."
@@ -1559,7 +1324,6 @@ msgid ""
 "webserver."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
 msgid "Checking additional error messages"
 msgstr "Diğer hata mesajları kontrol ediliyor"
@@ -1583,12 +1347,10 @@ msgstr ""
 msgid "Choose the set whose close date you would like to extend."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:908
 msgid "Choose visibility of the sets to be affected"
 msgstr "Etkilenecek setlerin görünürlüğünü seçin"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:890
 msgid "Choose which sets to be affected"
 msgstr "Hangi setlerin etkileneceğini seçin"
@@ -1598,21 +1360,17 @@ msgstr "Hangi setlerin etkileneceğini seçin"
 msgid "Class values"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:375
 msgid "Classlist Editor"
 msgstr "Sınıf Listesi Düzenleyici"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:324
 msgid "Clear"
 msgstr "Temizle"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:945
-#, fuzzy
 msgid "Clear Problem Display"
-msgstr "Soru Listesi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:816
 msgid ""
@@ -1620,7 +1378,6 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
 msgid ""
@@ -1639,13 +1396,10 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
-#, fuzzy
 msgid "Close"
-msgstr "Kapalı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:765
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:781
@@ -1654,55 +1408,40 @@ msgstr "Kapalı"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:804
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:827
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Close Date"
-msgstr "Teslim Tarihi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:554
-#, fuzzy
 msgid "Closed, answers available."
-msgstr "kapalı, cevaplar açıklandı"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->answer_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:550
-#, fuzzy
 msgid "Closed, answers on %1."
-msgstr "kapalı, cevaplar %1 tarihinde"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:552
-#, fuzzy
 msgid "Closed, answers recently available."
-msgstr "kapalı, cevaplar yeni açıklandı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:506
-#, fuzzy
 msgid "Closed."
-msgstr "Kapalı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:85
-#, fuzzy
 msgid "Closes"
-msgstr "Kapalı"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
-#, fuzzy
 msgid "Closes %1"
-msgstr "%1'e geri dön"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:37
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:232
-#, fuzzy
 msgid "Closes:"
-msgstr "Kapalı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
 msgid "Collapse"
@@ -1712,7 +1451,6 @@ msgstr ""
 msgid "Collapse All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
@@ -1741,47 +1479,38 @@ msgstr ""
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:446
-#, fuzzy
 msgid "Completed."
-msgstr "tamamlandı."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "Confirm"
 msgstr ""
 
-#
 #. ($e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:150
-#, fuzzy
 msgid "Confirm %1's New Password"
 msgstr "%1 için Şifre Onayı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
-#, fuzzy
 msgid "Confirm Password:"
-msgstr "%1 için Şifre Onayı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:268
 msgid "Congratulations, you earned a new level!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:260
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:291
 msgid "Continue"
 msgstr "Devam"
 
-#
 #. ($sourceDirectory, $outputDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
-#, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
-msgstr "Ek dosyalar %1 dizininden %2 dizinine kopyalandı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:352
@@ -1797,13 +1526,10 @@ msgstr ""
 msgid "Copy templates from:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1218
-#, fuzzy
 msgid "Copy this Problem"
-msgstr "Bu soruyu düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
@@ -1814,41 +1540,30 @@ msgstr "Doğru yanıt"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
-#, fuzzy
 msgid "Correct Answer"
-msgstr "Doğru yanıtları göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1283
-#, fuzzy
 msgid "Correct Answers:"
-msgstr "Doğru yanıtları göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
-#, fuzzy
 msgid "Correct Status"
-msgstr "Doğru yanıtları göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:587
 msgid "Correct answers"
 msgstr "Doğru yanıtları göster"
 
-#
 #. ($total_correct,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
-#, fuzzy
 msgid "Correct: %1/%2"
-msgstr " set %1/soru %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
-#, fuzzy
 msgid "CorrectAnswers"
-msgstr "Doğru yanıtları göster"
+msgstr ""
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
@@ -1857,18 +1572,14 @@ msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
 
-#
 #. ($e_user_name,$@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:104
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:90
-#, fuzzy
 msgid "Couldn't change %1's password: %2"
 msgstr "%1 adlı kullanıcının şifresi değiştirilemedi: %2"
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:169
-#, fuzzy
 msgid "Couldn't change your email address: %1"
 msgstr "E-posta adresiniz değiştirilemedi: %1"
 
@@ -1887,12 +1598,10 @@ msgstr ""
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
-#, fuzzy
 msgid "Couldn't save your display options: %1"
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
@@ -1916,14 +1625,12 @@ msgstr ""
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
 msgstr "Ders Yönetimi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:484
 msgid "Course Configuration"
 msgstr "Ders Seçenekleri"
@@ -1933,40 +1640,30 @@ msgstr "Ders Seçenekleri"
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
-#, fuzzy
 msgid "Course ID:"
-msgstr "Ders bilgileri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "Course Info"
 msgstr "Ders bilgileri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
-#, fuzzy
 msgid "Course Name:"
-msgstr "İsim"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
-#, fuzzy
 msgid "Course Title:"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:203
-#, fuzzy
 msgid "Course archived."
-msgstr "İsim"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
@@ -1984,23 +1681,18 @@ msgid ""
 "\"hidden\" or \"visible\"."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:170
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "Create"
 msgstr "Oluştur"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:439
-#, fuzzy
 msgid "Create CSV"
-msgstr "Oluştur"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
-#, fuzzy
 msgid "Create Location:"
-msgstr "Problem cozum dersi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:866
 msgid "Create a New Set in This Course:"
@@ -2010,7 +1702,6 @@ msgstr ""
 msgid "Create a new achievement with ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1108
 msgid "Create as what type of set?"
 msgstr "Ne tip set oluşturulacak?"
@@ -2059,18 +1750,14 @@ msgstr ""
 msgid "Database tables ok"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
-#, fuzzy
 msgid "Database:"
-msgstr "dışarı aktarım yapılmadı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:867
-#, fuzzy
 msgid "Date"
-msgstr "Açılış tarihi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:393
 msgid "Debug"
@@ -2101,7 +1788,6 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
@@ -2111,15 +1797,13 @@ msgstr ""
 msgid "Delete"
 msgstr "Sil"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
-#, fuzzy
 msgid "Delete Course"
-msgstr "Sil"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
 msgid "Delete all existing addresses"
@@ -2129,37 +1813,28 @@ msgstr ""
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
-#, fuzzy
 msgid "Delete course:"
-msgstr "Sil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
 msgid "Delete how many?"
 msgstr "Kaç tane silinecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
-#, fuzzy
 msgid "Delete it?"
-msgstr "Sil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
-#, fuzzy
 msgid "Delete location:"
-msgstr "Sil"
+msgstr ""
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
-#, fuzzy
 msgid "Deleted %quant(%1,achievement)"
-msgstr "seçili setler"
+msgstr ""
 
 #. (join(', ', @delLocations)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
@@ -2171,69 +1846,47 @@ msgstr ""
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
-#
 #. ($self->shortPath($self->{tempFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
-#, fuzzy
 msgid "Deleting temp file at %1"
-msgstr "%1 klasörindeki geçici dosya siliniyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
-#, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr ""
-"Dikkat: Silme işlemi kullanıcının bütün bilgilerini yok eder ve bu işlem "
-"geri döndürelemez!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
-#, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
-"Dikkat: Silme işlemi kullanıcının bütün bilgilerini yok eder ve bu işlem "
-"geri döndürelemez!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1079
-#, fuzzy
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
-"Dikkat: Silme işlemi kullanıcının bütün bilgilerini yok eder ve bu işlem "
-"geri döndürelemez!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
-#, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
-"Dikkat: Silme işlemi kullanıcının bütün bilgilerini yok eder ve bu işlem "
-"geri döndürelemez!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:209
 msgid "Deny From"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
-#, fuzzy
 msgid "Description"
-msgstr "Problem cozum dersi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
 msgid "Didn't recognize action"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:154
-#, fuzzy
 msgid "Directory"
-msgstr "Gözetmen"
+msgstr ""
 
 #. ($file, $!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:679
@@ -2249,13 +1902,11 @@ msgstr ""
 msgid "Directory permission errors "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
-#, fuzzy
 msgid "Directory structure"
-msgstr "Gözetmen"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
@@ -2285,32 +1936,24 @@ msgstr ""
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
-#, fuzzy
 msgid "Display Mode:"
-msgstr "Görünüm Modu"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
-#, fuzzy
 msgid "Display Past Answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
-#, fuzzy
 msgid "Display options: Show"
-msgstr "Görünüm Seçenekleri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
-#, fuzzy
 msgid "Display the evaluated student answer"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
@@ -2330,36 +1973,26 @@ msgstr ""
 msgid "Don't Archive"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
-#, fuzzy
 msgid "Don't Unarchive"
-msgstr "Değişiklikleri kaydet"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
-#, fuzzy
 msgid "Don't Upgrade"
-msgstr "Sil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
-#, fuzzy
 msgid "Don't delete"
-msgstr "Sil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
-#, fuzzy
 msgid "Don't make changes"
-msgstr "Değişiklikleri kaydet"
+msgstr ""
 
-#
 #. ($saveMode)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
-#, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
-msgstr "Tanımlanmamış kaydetme modu: |%1|. Bilinmeyen hata."
+msgstr ""
 
 #. ($type)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:168
@@ -2372,17 +2005,14 @@ msgstr ""
 msgid "Don't rename"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
-#, fuzzy
 msgid "Don't use in an achievement"
-msgstr "Değişiklikleri kaydet"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
 msgid "Done"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1001
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:158
@@ -2390,61 +2020,47 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:69
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:990
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:995
-#, fuzzy
 msgid "Download"
-msgstr "Notları İndir"
+msgstr ""
 
-#
 #. ($set->set_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:579
-#, fuzzy
 msgid "Download %1"
-msgstr "Notları İndir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:305
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:261
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:267
-#, fuzzy
 msgid "Download Hardcopy"
-msgstr "Yazdırılabilir dosya oluştur"
+msgstr ""
 
-#
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:317
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Seçili Setleri Yazdırmak için dosya indir: [plural,_1,Set,Sets]"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "Mevcut seti Yazdırmak için dosya indir"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:325
 msgid "Download PDF or TeX Hardcopy for Selected Sets"
 msgstr "Seçili Setleri Yazdırmak için dosya indir"
 
-#
 #. ($selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:560
-#, fuzzy
 msgid "Download hardcopy of set %1 for %2?"
-msgstr "Bu set için yazdırılabilir dosya indirin."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:410
-#, fuzzy
 msgid "Download:"
-msgstr "Notları İndir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Drop"
 msgstr "Bırak"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr "Bu seti çoğalt ve isimlendir"
@@ -2465,7 +2081,6 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
 msgid "E-mail Instructor"
 msgstr "Eğitmene E-posta"
@@ -2484,9 +2099,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
-#, fuzzy
 msgid "E-mail:"
 msgstr "E-posta"
 
@@ -2494,7 +2107,6 @@ msgstr "E-posta"
 msgid "Earned"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
@@ -2511,20 +2123,16 @@ msgstr ""
 msgid "Edit"
 msgstr "Düzenle"
 
-#
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
-#, fuzzy
 msgid "Edit %1 of set %2."
-msgstr "'%2' dosyası içinde %1 düzenleniyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:589
 msgid "Edit All Set Data"
 msgstr "Bütün set bilgilerini düzenle"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:444
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:467
 msgid "Edit Assigned Users"
@@ -2534,49 +2142,36 @@ msgstr "Ödev verilmiş kullanıcıları düzenle"
 msgid "Edit Evaluator"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#, fuzzy
 msgid "Edit Header"
-msgstr "Set Başlığı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
-#, fuzzy
 msgid "Edit Location:"
-msgstr "Problem cozum dersi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
-#, fuzzy
 msgid "Edit Problem"
-msgstr "Soruları Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:443
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:466
 msgid "Edit Problems"
 msgstr "Soruları Düzenle"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:612
-#, fuzzy
 msgid "Edit Set"
-msgstr "Set Bilgilerini Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:446
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:469
 msgid "Edit Set Data"
 msgstr "Set Bilgilerini Düzenle"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:862
-#, fuzzy
 msgid "Edit Target Set"
-msgstr "Set Bilgilerini Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
 msgid "Edit Which Users?"
 msgstr "Hangi Kullanıcılar Düzenlenecek?"
@@ -2586,12 +2181,10 @@ msgstr "Hangi Kullanıcılar Düzenlenecek?"
 msgid "Edit data for %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2264
-#, fuzzy
 msgid "Edit it"
-msgstr "Düzenle"
+msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
@@ -2613,43 +2206,35 @@ msgid ""
 "changes and return to the Manage Locations page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:844
 msgid "Edit which sets?"
 msgstr "Hangi setler düzenlecek?"
 
-#
+# Edit with a number 1 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
-#, fuzzy
 msgid "Edit1"
-msgstr "Düzenle"
+msgstr ""
 
-#
+# Edit with a number 2 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
-#, fuzzy
 msgid "Edit2"
-msgstr "Düzenle"
+msgstr ""
 
-#
+# Edit with a number 3 after with no space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
-#, fuzzy
 msgid "Edit3"
-msgstr "Düzenle"
+msgstr ""
 
-#
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
-#, fuzzy
 msgid "Editing %1 in file '%2'"
-msgstr "'%2' dosyası içinde %1 düzenleniyor"
+msgstr ""
 
-#
 #. ($self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:212
-#, fuzzy
 msgid "Editing achievement in file '%1'"
-msgstr "'%2' dosyası içinde %1 düzenleniyor"
+msgstr ""
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
@@ -2662,27 +2247,21 @@ msgstr ""
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
-#, fuzzy
 msgid "Editor"
-msgstr "Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
-#, fuzzy
 msgid "Editor rows:"
-msgstr "Soruları Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "E-posta"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
@@ -2695,31 +2274,22 @@ msgstr "E-posta"
 msgid "Email Address"
 msgstr "E-posta Adresi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
-#, fuzzy
 msgid "Email Body:"
-msgstr "E-posta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:320
-#, fuzzy
 msgid "Email Instructor On Failed Attempt"
-msgstr "Eğitmene E-posta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
-#, fuzzy
 msgid "Email Link"
-msgstr "E-posta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
-#, fuzzy
 msgid "Email address"
-msgstr "E-posta Adresi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
@@ -2738,39 +2308,31 @@ msgstr ""
 msgid "Emails to be sent to the following:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:207
-#, fuzzy
 msgid "Enable Achievement Items"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Enable Conditional Release"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:197
-#, fuzzy
 msgid "Enable Course Achievements"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:172
 msgid "Enable Progress Bar and current problem highlighting"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:590
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:613
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:217
-#, fuzzy
 msgid "Enable Reduced Scoring"
-msgstr "Azaltılmiş Notu Etkinleştir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:252
-#, fuzzy
 msgid "Enable Show Me Another button"
-msgstr "Yani pencerede göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
 msgid "Enable periodic re-randomization of problems"
@@ -2782,12 +2344,10 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
-#, fuzzy
 msgid "Enabled"
-msgstr "Etkinleştir"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:271
 msgid ""
@@ -2818,7 +2378,6 @@ msgid ""
 "for that problem)."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
 msgid "Enrolled"
 msgstr "Kayıtlı"
@@ -2827,7 +2386,6 @@ msgstr "Kayıtlı"
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
@@ -2839,12 +2397,10 @@ msgstr ""
 msgid "Enrollment Status"
 msgstr "Kayıt Durumu"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
 msgid "Enter filename below"
 msgstr "Aşağıya dosya adı girin"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1266
 msgid "Enter filenames below"
 msgstr "Aşağıya dosya isimlerini girin"
@@ -2855,17 +2411,14 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
 msgid "Entered"
 msgstr "Yanıt"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
-#, fuzzy
 msgid "Entered student:"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:221
 msgid "Equation Display"
@@ -2885,17 +2438,13 @@ msgid ""
 "the password was done."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:81
-#, fuzzy
 msgid "Error message:"
-msgstr "Mesajlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
-#, fuzzy
 msgid "Error messages"
-msgstr "Mesajlar"
+msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1537
@@ -2914,13 +2463,11 @@ msgid ""
 "in set %1"
 msgstr ""
 
-#
 #. ($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
-#, fuzzy
 msgid "Error: The original file %1 cannot be read."
-msgstr "Hata: %1 dosyası okunamıyor."
+msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1086
@@ -3005,44 +2552,35 @@ msgstr ""
 msgid "Expand All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
 msgid "Export"
 msgstr "Dışa aktar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
-#, fuzzy
 msgid "Export selected achievements."
-msgstr "Şeçili setleri dışarı aktar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1423
 msgid "Export selected sets"
 msgstr "Şeçili setleri dışarı aktar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
 msgid "Export to what kind of file?"
 msgstr "Ne çeşit dosyaya aktarılacak?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1356
 msgid "Export which sets?"
 msgstr "Hangı setler dışarı aktarılacak?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
 msgid "Export which users?"
 msgstr "Hangi kullanıcılar dışarı aktarılacak?"
 
-#
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
-#, fuzzy
 msgid "Exported achievements to %1"
-msgstr "Şeçili setleri dışarı aktar"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1485
 msgid "Extend the close date for which Gateway?"
@@ -3058,70 +2596,52 @@ msgstr ""
 msgid "FIRST NAME"
 msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
-#, fuzzy
 msgid "Failed to create new achievement: %1"
-msgstr "Yeni set yaratılamadı: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
-#, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
-msgstr "Yeni set oluşturulamadı: set adı belirtilmemiş!"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1205
-#, fuzzy
 msgid "Failed to create new set: %1"
 msgstr "Yeni set yaratılamadı: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1132
 msgid "Failed to create new set: no set name specified!"
 msgstr "Yeni set oluşturulamadı: set adı belirtilmemiş!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
-#, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
-msgstr "Set çoğaltılamadı: herhangi bir set seçili değil!"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1618
-#, fuzzy
 msgid "Failed to duplicate set: %1"
 msgstr "Set çoğaltılamadı: %1"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1602
 msgid "Failed to duplicate set: no set name specified!"
 msgstr "Set çoğaltılamadı: set adı belirtilmemiş!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1166
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1600
 msgid "Failed to duplicate set: no set selected for duplication!"
 msgstr "Set çoğaltılamadı: herhangi bir set seçili değil!"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1604
-#, fuzzy
 msgid "Failed to duplicate set: set %1 already exists!"
 msgstr "Set çoğaltılamadı: set %1 zaten mevcut!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
-#, fuzzy
 msgid "Failed to enter student:"
-msgstr "Yeni set yaratılamadı: %1"
+msgstr ""
 
-#
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
@@ -3129,31 +2649,24 @@ msgstr "Yeni set yaratılamadı: %1"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
-#, fuzzy
 msgid "Failed to open %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:543
-#, fuzzy
 msgid "Failed to save: %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "False"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid "Feature exhausted for this problem"
-msgstr "Soruda hata olduğunu bildir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:230
-#, fuzzy
 msgid "Feedback"
 msgstr "Geri Bildirim"
 
@@ -3161,11 +2674,9 @@ msgstr "Geri Bildirim"
 msgid "Feedback by Section."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
-#, fuzzy
 msgid "FeedbackMessage"
-msgstr "Geri Bildirim"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
@@ -3190,17 +2701,13 @@ msgstr ""
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
-#, fuzzy
 msgid ""
 "File '%1' exists. File not saved. No changes have been made.  You can change "
 "the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
-"'%1' dosyası mevcut. Dosya kaydedilmedi. Hiçbir değişiklik yapılmadı. Bu "
-"sorunun dosya konumunu \"Set Düzenleyicisi\" sayfasından değiştirebilirsiniz."
 
 #. ($file,$!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:682
@@ -3214,42 +2721,34 @@ msgstr ""
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:935
-#, fuzzy
 msgid "File '%2' uploaded successfully"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "File <b>%1</b> already exists. Overwrite it, or rename it as:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:493
-#, fuzzy
 msgid "File Compare"
-msgstr "Dosya adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:557
 msgid "File Manager"
 msgstr "Dosya Yöneticisi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:544
-#, fuzzy
 msgid "File saved"
-msgstr "Dosya adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:619
 msgid "File successfully copied"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:644
-#, fuzzy
 msgid "File successfully renamed"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
 msgid "Filename"
 msgstr "Dosya adı"
@@ -3259,26 +2758,20 @@ msgstr "Dosya adı"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
 msgid "Filter by what text?"
 msgstr "Hangi metin ile filtrelenecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:174
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:167
-#, fuzzy
 msgid "Filter:"
-msgstr "Filtre"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#, fuzzy
 msgid "First"
-msgstr "İsim"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
@@ -3296,11 +2789,9 @@ msgstr "İsim"
 msgid "First Name"
 msgstr "İsim"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
-#, fuzzy
 msgid "First name"
-msgstr "İsim"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
 msgid ""
@@ -3324,25 +2815,20 @@ msgstr ""
 msgid "Format for the subject line in feedback e-mails"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
-#, fuzzy
 msgid "Format:"
-msgstr "Çıktı Dosyası Başlığı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
-#, fuzzy
 msgid "From field must contain one valid email address."
-msgstr "E-posta adresiniz değiştirilemedi: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
@@ -3354,13 +2840,11 @@ msgstr "Gönderen:"
 msgid "GLOBAL Usage"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1385
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1486
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1587
-#, fuzzy
 msgid "Gateway Name "
-msgstr "Soyadı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:239
 msgid "Gateway Quiz %2"
@@ -3375,14 +2859,11 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
-#, fuzzy
 msgid "General Information"
-msgstr "Web Alanı Bilgileri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:472
 msgid "Generate Hardcopy"
 msgstr "Yazdırılabilir dosya oluştur"
@@ -3391,25 +2872,18 @@ msgstr "Yazdırılabilir dosya oluştur"
 msgid "Generate hardcopy for selected sets and selected users"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:548
-#, fuzzy
 msgid "Get Library Set Problems"
-msgstr "Sonraki Soru"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:539
-#, fuzzy
 msgid "Get Target Set Problems"
-msgstr "Set Bilgilerini Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
-#, fuzzy
 msgid "Give new password to"
-msgstr "Hangi kullanıcılara yeni şifre verilecek?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
 msgid "Give new password to which users?"
 msgstr "Hangi kullanıcılara yeni şifre verilecek?"
@@ -3430,13 +2904,11 @@ msgstr ""
 msgid "Gives half credit on every problem in a set."
 msgstr ""
 
-#
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1402
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1476
-#, fuzzy
 msgid "Global problem %1 for set %2 not found."
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
@@ -3447,35 +2919,25 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#, fuzzy
 msgid "Grade"
-msgstr "Notlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
-#, fuzzy
 msgid "Grade Problem"
-msgstr "Sonraki Soru"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
-#, fuzzy
 msgid "Grade Test"
-msgstr "Notlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
-#, fuzzy
 msgid "Grader"
-msgstr "Notlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:277
-#, fuzzy
 msgid "Grades"
 msgstr "Notlar"
 
@@ -3495,29 +2957,23 @@ msgstr ""
 msgid "Greater Tome of Enlightenment"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:286
 msgid "Guest Login"
 msgstr "Misafir Kullanıcı Girişi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
-#, fuzzy
 msgid "HTTP Headers"
-msgstr "Set Başlığı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:605
 msgid "Hardcopy Format:"
 msgstr "Çıktı Dosyası Başlığı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:295
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:304
 msgid "Hardcopy Generator"
 msgstr "Çıktı Dosyası Başlığı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:763
@@ -3527,21 +2983,16 @@ msgstr "Çıktı Dosyası Başlığı"
 msgid "Hardcopy Header"
 msgstr "Çıktı Dosyası Başlığı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:617
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:153
-#, fuzzy
 msgid "Hardcopy Theme"
-msgstr "Çıktı Dosyası Başlığı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
-#, fuzzy
 msgid "Headers"
-msgstr "Set Başlığı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
 msgid "Help"
 msgstr "Yardım"
@@ -3550,7 +3001,6 @@ msgstr "Yardım"
 msgid "Here is a new version of your problem."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:914
 msgid "Hidden"
 msgstr "Gizli"
@@ -3559,71 +3009,55 @@ msgstr "Gizli"
 msgid "Hide All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Hide Courses"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:478
-#, fuzzy
 msgid "Hide Hints"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:427
-#, fuzzy
 msgid "Hide Hints from Students"
-msgstr "öğrenciler tarafından görülemez"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
-#, fuzzy
 msgid "Hide Inactive Courses"
-msgstr "Dersler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:932
 msgid "Hide all paths"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Hide path:"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
-#, fuzzy
 msgid "Hint:"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:390
 msgid "Hints"
 msgstr "İpuçlarını göster"
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:414
 msgid "Hmwk Sets Editor"
 msgstr "Ödev Setleri Düzenleyici"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Soru Grupları"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
-#, fuzzy
 msgid "Homework Totals"
-msgstr "Soru Grupları"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1308
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
@@ -3637,7 +3071,6 @@ msgstr ""
 msgid "Icon File"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
 msgid ""
 "If a password field is left blank, the student's current password will be "
@@ -3675,61 +3108,49 @@ msgid ""
 "have direct control."
 msgstr ""
 
-#
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
-#, fuzzy
 msgid "Illegal file '%1' specified"
-msgstr "'%1' dosyası korumalı!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
 msgid "Illegal filename contains '..'"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1238
 msgid "Import"
 msgstr "İçeri Aktar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-#, fuzzy
 msgid "Import achievements from"
-msgstr "Şeçili setleri dışarı aktar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
 msgstr "Nereden aktarılacak?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1246
 msgid "Import how many sets?"
 msgstr "Kaç set aktarılacak?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1279
 msgid "Import sets with names"
 msgstr "Setleri isimleriyle beraber aktar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
 msgid "Import users from what file?"
 msgstr "Kullanıcılar hangi dosyadan aktarılacak?"
 
-#
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
-#, fuzzy
 msgid "Imported %quant(%1,achievement)"
-msgstr "Şeçili setleri dışarı aktar"
+msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "In progress: %1/%2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
 msgid "Inactive"
 msgstr "Aktif Değil"
@@ -3738,37 +3159,29 @@ msgstr "Aktif Değil"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
-#, fuzzy
 msgid "Include Success Index"
-msgstr "Indeksi dahil et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
-#, fuzzy
 msgid "Incorrect"
-msgstr "yanlış"
+msgstr ""
 
-#
 #. ($total_incorrect,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
-#, fuzzy
 msgid "Incorrect: %1/%2"
-msgstr "yanlış"
+msgstr ""
 
+# Short for Initial
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:170
 msgid "Init"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
-#, fuzzy
 msgid "Institution:"
-msgstr "Problem cozum dersi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:343
 msgid "Instructor Tools"
 msgstr "Eğitmen Araçları"
@@ -3795,7 +3208,6 @@ msgstr ""
 msgid "Invalid headerType %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:187
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/XMLRPC.pm:41
 msgid "Invalid user ID or password."
@@ -3811,18 +3223,14 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
-#, fuzzy
 msgid "Jump to Page:"
-msgstr "Sonraki Soru"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
-#, fuzzy
 msgid "Jump to Problem:"
-msgstr "Sonraki Soru"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:829
 msgid "Just-In-Time parameters"
@@ -3844,20 +3252,15 @@ msgstr ""
 msgid "Language (refresh page after saving changes to reveal new language.)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:864
-#, fuzzy
 msgid "Last"
-msgstr "Soyadı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:410
-#, fuzzy
 msgid "Last Answer"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
@@ -3879,17 +3282,13 @@ msgstr "Soyadı"
 msgid "Last column of merge file"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
-#, fuzzy
 msgid "Last name"
-msgstr "Soyadı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Latest Answers"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:142
 msgid ""
@@ -3910,37 +3309,29 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "Soru Kütüphaneleri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "Soru Kütüphane Tarayıcısı 2"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
-#, fuzzy
 msgid "Library Browser 3"
-msgstr "Soru Kütüphane Tarayıcısı 2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:512
-#, fuzzy
 msgid "Library Browser no js"
-msgstr "Soru Kütüphane Tarayıcısı 2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:339
-#, fuzzy
 msgid "List of display modes made available to students"
-msgstr "Bu soru grubu öğrenciler tarafından %1."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:400
 msgid ""
@@ -3949,29 +3340,23 @@ msgid ""
 "WeBWorK problems which send e-mail as part of their answer mechanism."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:262
-#, fuzzy
 msgid "List of options for Show Me Another button"
-msgstr "Yani pencerede göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:406
 msgid "Local"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:887
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm:980
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:796
-#, fuzzy
 msgid "Local Problems"
-msgstr "Sorular"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#, fuzzy
 msgid "Location"
-msgstr "Problem cozum dersi"
+msgstr ""
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
@@ -3981,36 +3366,28 @@ msgid ""
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
-#
 #. ($locationID, join(', ', @addresses)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
-#, fuzzy
 msgid "Location %1 has been created, with addresses %2."
-msgstr "Set %1 mevcut. Yeni set oluşturulmadı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
-#, fuzzy
 msgid "Location description:"
-msgstr "Web Alanı Açıklamasını Göster/Gizle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
-#, fuzzy
 msgid "Location name:"
-msgstr "İşlem yapma"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:168
 msgid "Log In Again"
 msgstr "Tekrar giriş yap"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
 msgid "Log Out"
@@ -4027,27 +3404,21 @@ msgstr "Çıkış Yap"
 msgid "Log into %1"
 msgstr ""
 
-#
 #. (HTML::Entities::encode_entities($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
-#, fuzzy
 msgid "Logged in as %1."
-msgstr "%1 olarak giriş yaptınız."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
-#, fuzzy
 msgid "Login"
 msgstr "Devam et"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:95
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:98
 msgid "Login Info"
 msgstr "Giriş Bilgileri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
@@ -4066,18 +3437,15 @@ msgstr "Giriş Bilgileri"
 msgid "Login Name"
 msgstr "Kullanıcı adı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
 msgid "Login Status"
 msgstr "Durumu"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:313
 msgid "Logout"
 msgstr "Çıkış"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
 msgid "Main Menu"
 msgstr "Ana Menü"
@@ -4091,11 +3459,9 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
-#, fuzzy
 msgid "Make changes"
-msgstr "Değişiklikleri kaydet"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
 msgid "Make these changes in  course:"
@@ -4106,89 +3472,68 @@ msgstr ""
 msgid "Manage Locations"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
-#, fuzzy
 msgid "Manual Grader"
-msgstr "Notlar"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:213
 msgid "Mark All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Mark Correct"
-msgstr "Doğru yanıt"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
-#, fuzzy
 msgid "Mark Correct?"
-msgstr "Doğru yanıt"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:698
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr ""
 "Hangi özellikler eşleştirilecek? (birden fazla kullanıcı adını virgülle "
 "ayırın)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
 msgid "Math Objects"
 msgstr "Matematik Nesneleri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:351
-#, fuzzy
 msgid "Max attempts"
-msgstr "deneme hakkı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:384
-#, fuzzy
 msgid "Max. Shown:"
-msgstr "Göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:257
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
-#, fuzzy
 msgid "Merge file:"
-msgstr "Başlık dosyası"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
-#, fuzzy
 msgid "Message"
-msgstr "Mesajlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
-#, fuzzy
 msgid "Message file:"
-msgstr "Başlık dosyası"
+msgstr ""
 
 #. ($emailDirectory, $output_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
-#, fuzzy
 msgid "Message:"
-msgstr "Mesajlar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
 msgid "Messages"
 msgstr "Mesajlar"
@@ -4208,26 +3553,25 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
+# Msg is short for message
 #. ($recipient, $ur->email_address)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:51
-#, fuzzy
 msgid "My Problems"
-msgstr "Sorular"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1288
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
+# Short for Number of Fields
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
 msgid "NO OF FIELDS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
@@ -4240,20 +3584,15 @@ msgstr ""
 msgid "Name"
 msgstr "Grup Adı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:873
-#, fuzzy
 msgid "Name for new set here"
-msgstr "Yeni seti adlandırın"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:122
-#, fuzzy
 msgid "Name of course information file"
-msgstr "Ders Bilgileri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1095
 msgid "Name the new set"
 msgstr "Yeni seti adlandırın"
@@ -4262,13 +3601,11 @@ msgstr "Yeni seti adlandırın"
 msgid "Necromancers Charm"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:380
-#, fuzzy
 msgid "Never"
-msgstr "Ters çevir"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:165
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:356
@@ -4282,33 +3619,28 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
-#, fuzzy
 msgid "New Name:"
-msgstr "Set Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
 msgid "New Password"
 msgstr "Yeni Şifre"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:830
-#, fuzzy
 msgid "New file name:"
-msgstr "Dosya adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:851
 msgid "New folder name:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
 msgid "New passwords saved"
 msgstr "Yeni şifreler kaydedildi"
 
+# No space
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "NewVersion"
@@ -4318,7 +3650,6 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
 msgid "Next Problem"
@@ -4328,7 +3659,6 @@ msgstr "Sonraki Soru"
 msgid "Next page"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4345,22 +3675,18 @@ msgstr ""
 msgid "No"
 msgstr "Hayır"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
-#, fuzzy
 msgid "No Description"
-msgstr "Web Alanı Açıklamasını Göster/Gizle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:63
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:69
-#, fuzzy
 msgid "No action taken"
-msgstr "İşlem yapma"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:151
 msgid ""
@@ -4368,7 +3694,6 @@ msgid ""
 "speak with your instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:940
 msgid "No change made to any set"
 msgstr "Herhangi bir sete değişiklik yapılmadı"
@@ -4379,26 +3704,20 @@ msgid ""
 "changed and enter the change data."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1093
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1166
-#, fuzzy
 msgid "No changes were saved!"
-msgstr "değişiklikler kaydedildi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
-#, fuzzy
 msgid "No course id defined"
-msgstr "Dersler"
+msgstr ""
 
-#
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:624
-#, fuzzy
 msgid "No data exists for set %1 and problem %2"
-msgstr " set %1/soru %2"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
 msgid "No filename was specified for saving!  The message was not saved."
@@ -4417,11 +3736,9 @@ msgstr ""
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
-#, fuzzy
 msgid "No merge data file"
-msgstr "Başlık dosyası"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
 msgid ""
@@ -4439,28 +3756,22 @@ msgid ""
 "below."
 msgstr ""
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
-#, fuzzy
 msgid "No record for global set %1."
-msgstr "Set %1 başlığı"
+msgstr ""
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
-#, fuzzy
 msgid "No record for user %1."
-msgstr "Set %1 başlığı"
+msgstr ""
 
-#
 #. ($prob)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
-#, fuzzy
 msgid "No record found for problem %1."
-msgstr "Set %1 başlığı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
 msgid "No record found."
@@ -4470,13 +3781,11 @@ msgstr ""
 msgid "No sets in this course yet"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1006
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:279
 msgid "No sets selected for scoring"
 msgstr "Notlamak için bir set seçili değil"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
@@ -4494,21 +3803,15 @@ msgstr ""
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
-#, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
-"Hiç set gösterilmiyor. Dersteki setleri görmek için yukarıdaki seçeneklerden "
-"birini işaretleyin."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
-#, fuzzy
 msgid "No tests taken."
-msgstr "İşlem yapma"
+msgstr ""
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:565
@@ -4543,12 +3846,10 @@ msgstr ""
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
 msgid "Not logged in."
 msgstr "Giriş yapmadınız."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
 msgid "Note"
@@ -4559,12 +3860,10 @@ msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
-#, fuzzy
 msgid "Number"
-msgstr "Soru Görüntüleyici"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:253
 msgid "Number of Graded Submissions per Test (0=infty)"
@@ -4587,17 +3886,14 @@ msgstr ""
 msgid "Oil of Cleansing"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:366
-#, fuzzy
 msgid "Old Classlist Editor"
-msgstr "Sınıf Listesi Düzenleyici"
+msgstr ""
 
-#
+# Hmwk is short for Homework
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:405
-#, fuzzy
 msgid "Old Hmwk Sets Editor"
-msgstr "Ödev Setleri Düzenleyici"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:103
 msgid "One Column"
@@ -4614,13 +3910,10 @@ msgid ""
 "instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
-#, fuzzy
 msgid "Open"
-msgstr "Açılış tarihi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:764
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:780
@@ -4631,11 +3924,9 @@ msgstr "Açılış tarihi"
 msgid "Open Date"
 msgstr "Açılış tarihi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:886
-#, fuzzy
 msgid "Open Problem Library"
-msgstr "Soru Listesi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
@@ -4647,38 +3938,28 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:694
-#, fuzzy
 msgid "Open, closes %1."
-msgstr "açık, bitiş tarihi: "
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:692
-#, fuzzy
 msgid "Open, complete by %1."
-msgstr "açık: %1 tarihine kadar tamamlayın"
+msgstr ""
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
 msgid "Open, reduced scoring starts on %1."
-msgstr "Azaltılmiş not başlangıç tarihi: %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
-#, fuzzy
 msgid "Open:"
-msgstr "Açılış tarihi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:114
-#, fuzzy
 msgid "Opens"
-msgstr "Açılış tarihi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
@@ -4688,29 +3969,24 @@ msgstr ""
 msgid "Optional Modules"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:280
-#, fuzzy
 msgid "Order Problems Randomly"
-msgstr "Sorular"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
-#, fuzzy
 msgid "Orig. Lib. Browser"
-msgstr "Soru Kütüphaneleri"
+msgstr ""
 
+# Context is "7 Out Of 10"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:449
-#, fuzzy
 msgid "Over time, closed."
-msgstr "süre bitti: kapalı."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
@@ -4721,6 +3997,7 @@ msgstr ""
 msgid "Overwrite existing files silently"
 msgstr ""
 
+# PG is a WeBWorK abreviation and should stay PG
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:337
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
@@ -4745,52 +4022,53 @@ msgstr ""
 msgid "PG warning messages"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
 msgid "PGInfo"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
 msgid "PGLab"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
 msgid "PGML"
 msgstr ""
 
+# Doesn't need to be translated
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
 msgid "POD"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "GÖSTERİM -- YANITLAR KAYDEDİLMEDİ "
 
+# Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
 msgid "PROB NUMBER"
 msgstr ""
 
+# Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
 msgid "PROB VALUE"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
 msgid "Pad Fields"
 msgstr "tr: Pad Fields"
 
-#
 #. (timestamp($self)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
-#, fuzzy
 msgid "Page generated at %1"
 msgstr "Sayfa %1de yaratıldı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:254
 msgid "Password"
 msgstr "Sifre"
@@ -4800,18 +4078,14 @@ msgstr "Sifre"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
-#, fuzzy
 msgid "Password:"
-msgstr "Sifre"
+msgstr ""
 
-#
 #. ($studentUser, $setName, $prettyProblemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:459
-#, fuzzy
 msgid "Past Answers for %1, set %2, problem %3"
-msgstr "%1 sorusu %2 setine soru %3 olarak eklendi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
 msgid "Percent"
@@ -4833,7 +4107,6 @@ msgid ""
 "number of attempts."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
@@ -4849,11 +4122,9 @@ msgstr ""
 msgid "Permission Level"
 msgstr "Yetki seviyesi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:280
-#, fuzzy
 msgid "Permissions"
-msgstr "Yetki seviyesi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
 msgid ""
@@ -4900,7 +4171,6 @@ msgstr ""
 msgid "Please enter in a value to match in the filter field."
 msgstr ""
 
-#
 #. (CGI::b($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:205
 msgid "Please enter your username and password for %1 below:"
@@ -4910,37 +4180,29 @@ msgstr "Lütfen %1 dersi için kullanici adi ve sifrenizi giriniz:"
 msgid "Please provide a location name to delete."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:221
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:399
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:413
 msgid "Please select action to be performed."
 msgstr "Lütfen gerçekleştirilecek işlemi seçin."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:179
-#, fuzzy
 msgid "Please select at least one set and try again."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:170
-#, fuzzy
 msgid "Please select at least one user and try again."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "Lütfen kaydedilecek dosyayın belirtin."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
-#, fuzzy
 msgid "Points"
-msgstr "İpuçlarını göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
 msgid "Potion of Forgetfullness"
@@ -4950,47 +4212,34 @@ msgstr ""
 msgid "Preflight Log"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview Message"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
-#, fuzzy
 msgid "Preview My Answers"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
-#, fuzzy
 msgid "Preview Test"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
-#, fuzzy
 msgid "Preview message"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
-#, fuzzy
 msgid "Preview set to:"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
 msgid "Previous Problem"
 msgstr "Önceki Soru"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
-#, fuzzy
 msgid "Previous page"
-msgstr "Önceki Soru"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "Primary sort"
@@ -5000,25 +4249,19 @@ msgstr ""
 msgid "Print Test"
 msgstr ""
 
-#
+# Short for Problem
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#, fuzzy
 msgid "Prob"
-msgstr "Sorular"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:508
-#, fuzzy
 msgid "Problem"
-msgstr "Sorular"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:662
-#, fuzzy
 msgid "Problem #"
-msgstr "Soru %1"
+msgstr ""
 
-#
 #. ($prettyProblemID)
 #. (join('.',@seq)
 #. ($problemID)
@@ -5033,74 +4276,59 @@ msgstr "Soru %1"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
-#, fuzzy
 msgid "Problem %1"
 msgstr "Soru %1"
 
-#
 #. ($problemNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
-#, fuzzy
 msgid "Problem %1."
-msgstr "Soru %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:566
 msgid "Problem Editor"
 msgstr "Soru Düzenleyici"
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:575
-#, fuzzy
 msgid "Problem Editor2"
-msgstr "Soru Düzenleyici"
+msgstr ""
 
-#
+# No space before number
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:584
-#, fuzzy
 msgid "Problem Editor3"
-msgstr "Soru Düzenleyici"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
 msgid "Problem List"
 msgstr "Soru Listesi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:220
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:576
-#, fuzzy
 msgid "Problem Number"
-msgstr "Soru Görüntüleyici"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:591
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:702
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:815
-#, fuzzy
 msgid "Problem Number "
-msgstr "Soru Görüntüleyici"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
 msgid "Problem Techniques"
 msgstr "Soru Teknikleri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
-#, fuzzy
 msgid "Problem Viewer"
-msgstr "Soru Düzenleyici"
+msgstr "Soru Görüntüleyici"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
@@ -5124,9 +4352,7 @@ msgstr ""
 msgid "Problems have been assigned to all current users."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:109
-#, fuzzy
 msgid "Proctor"
 msgstr "Gözetmen"
 
@@ -5134,11 +4360,9 @@ msgstr "Gözetmen"
 msgid "Proctor authorization required."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:283
-#, fuzzy
 msgid "Proctor password:"
-msgstr "Sifre"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:264
 msgid "Proctor username:"
@@ -5160,7 +4384,6 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
 msgid "Publish"
 msgstr "Yayımla"
@@ -5178,7 +4401,6 @@ msgstr ""
 msgid "Really delete the items listed above?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
@@ -5201,7 +4423,6 @@ msgstr ""
 msgid "Recitation"
 msgstr "Problem cozum dersi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
 msgid "Record Scores for Single Sets"
 msgstr "Tek set için notları kaydet"
@@ -5210,43 +4431,34 @@ msgstr "Tek set için notları kaydet"
 msgid "Reduced Scoring"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:164
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:473
-#, fuzzy
 msgid "Reduced Scoring Date"
-msgstr "Azaltılmış not etkin değil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Disabled"
-msgstr "Azaltılmış not etkin değil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
-#, fuzzy
 msgid "Reduced Scoring Enabled"
-msgstr "Azaltılmış not etkin"
+msgstr ""
 
-#
 #. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
 msgid "Reduced Scoring Starts %1"
-msgstr "Azaltılmiş not başlangıç tarihi: %1"
+msgstr ""
 
-#
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
 msgid "Reduced scoring started on %1."
-msgstr "Azaltılmiş not başlangıç tarihi: %1"
+msgstr ""
 
+# Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
 msgstr ""
@@ -5261,27 +4473,24 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
-#, fuzzy
 msgid "Refresh Listing"
-msgstr "Kullanıcı Listesi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:214
 msgid "Relax IP restrictions when?"
 msgstr ""
 
-#
+# Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 msgid "Remaining"
 msgstr "Kalan hak"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:257
 msgid "Remember Me"
 msgstr "Beni hatırla"
@@ -5290,35 +4499,29 @@ msgstr "Beni hatırla"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
-#, fuzzy
 msgid "Rename"
-msgstr "Dosya adı"
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
 msgid "Rename %1 to %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
-#, fuzzy
 msgid "Rename Course"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
-#, fuzzy
 msgid "Rename file as:"
-msgstr "Başlık dosyası"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
 msgid "Render"
@@ -5328,17 +4531,13 @@ msgstr ""
 msgid "Render All"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
-#, fuzzy
 msgid "Render Problem"
-msgstr "Sonraki Soru"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
-#, fuzzy
 msgid "Renumber Problems"
-msgstr "Sorular"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1553
 msgid ""
@@ -5357,7 +4556,6 @@ msgstr ""
 msgid "Replace current problem: %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
 msgid "Replace which users?"
 msgstr "Hangi kullanıcılar değiştirilecek?"
@@ -5373,18 +4571,15 @@ msgstr ""
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
 msgid "Report bugs"
 msgstr "Hataları bildir"
 
-#
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
-#, fuzzy
 msgid "Report for course %1:"
-msgstr "Set %1 başlığı"
+msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
@@ -5397,27 +4592,21 @@ msgstr ""
 msgid "Request New Version"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
-#, fuzzy
 msgid "Request information"
-msgstr "Web Alanı Bilgileri"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
-#, fuzzy
 msgid "Request new version now."
-msgstr "Web Alanı Bilgileri"
+msgstr ""
 
-#
 #. ($setName,$effectiveUserName)
 #. ($setName, $effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:407
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:430
-#, fuzzy
 msgid "Requested set '%1' could not be found in the database for user %2."
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:464
@@ -5442,33 +4631,25 @@ msgid ""
 "the problem sets listing page."
 msgstr ""
 
-#
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
-#, fuzzy
 msgid "Requested set '%1' is not assigned to user %2."
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:451
-#, fuzzy
 msgid "Requested set '%1' is not available yet."
-msgstr "Bu soru grubu henüz açık değil."
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:441
-#, fuzzy
 msgid "Requested set '%1' is not yet open."
-msgstr "Bu soru grubu henüz açık değil."
+msgstr ""
 
-#
 #. ($verNum,$setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:403
-#, fuzzy
 msgid "Requested version (%1) of set '%2' is not assigned to user %3."
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:373
 msgid "Rerandomize after"
@@ -5504,44 +4685,35 @@ msgstr ""
 msgid "Restrict Access by IP"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:807
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:891
-#, fuzzy
 msgid "Restrict Locations"
-msgstr "Problem cozum dersi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:310
 msgid "Restrict Problem Progression"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:208
-#, fuzzy
 msgid "Restrict To"
-msgstr "Problem cozum dersi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:174
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Result"
 msgstr "Sonuç"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
-#, fuzzy
 msgid "Result of last action performed"
-msgstr "En son gerçekleştirilen işlemin sonuçları"
+msgstr ""
 
-#
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
-#, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "En son gerçekleştilen işlemin sonucu: %1"
 
@@ -5549,22 +4721,18 @@ msgstr "En son gerçekleştilen işlemin sonucu: %1"
 msgid "Results for this submission"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:403
 msgid "Results of last action performed"
 msgstr "En son gerçekleştirilen işlemin sonuçları"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:213
-#, fuzzy
 msgid "Results of last action performed: "
-msgstr "En son gerçekleştirilen işlemin sonuçları"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
 msgid "Retitled"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
@@ -5572,13 +4740,11 @@ msgstr ""
 msgid "Revert"
 msgstr "Ters çevir"
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
-#, fuzzy
 msgid "Revert to %1"
-msgstr "Ters çevir"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:355
 msgid "Ring of Reduction"
@@ -5604,7 +4770,6 @@ msgstr ""
 msgid "STUDENT ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
@@ -5615,14 +4780,11 @@ msgstr ""
 msgid "Save"
 msgstr "Kaydet"
 
-#
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
-#, fuzzy
 msgid "Save %1"
-msgstr "Kaydet"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
@@ -5630,29 +4792,22 @@ msgstr "Kaydet"
 msgid "Save As"
 msgstr "Farklı Kaydet: [TMPL]/"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
-#, fuzzy
 msgid "Save Changes"
-msgstr "Değişiklikleri kaydet"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
-#, fuzzy
 msgid "Save as"
 msgstr "Farklı kaydet"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
-#, fuzzy
 msgid "Save as Default"
-msgstr "Varsayılan Ayarları Kullan"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
@@ -5665,30 +4820,24 @@ msgstr "Varsayılan Ayarları Kullan"
 msgid "Save changes"
 msgstr "Değişiklikleri kaydet"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
-#, fuzzy
 msgid "Save file to:"
-msgstr "Düzenlemeyi kaydet"
+msgstr ""
 
-#
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
-#, fuzzy
 msgid "Save to %1 and View"
-msgstr "%1 Kaydet ve Görüntüle"
+msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
-#, fuzzy
 msgid "Saved to file '%1'"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
@@ -5702,7 +4851,6 @@ msgstr ""
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
@@ -5713,17 +4861,14 @@ msgstr ""
 msgid "Score"
 msgstr "Not"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#, fuzzy
 msgid "Score (%)"
-msgstr "Not"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:185
 msgid "Score required for release"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
 msgid "Score selected set(s) and save to:"
 msgstr "Seçili setleri notla ve dosyaya kaydet:"
@@ -5732,32 +4877,23 @@ msgstr "Seçili setleri notla ve dosyaya kaydet:"
 msgid "Score summary for last submit:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:975
 msgid "Score which sets?"
 msgstr "Hangi setler notlanacak?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
-#, fuzzy
 msgid "Scores"
-msgstr "Not"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:656
-#, fuzzy
 msgid "Scoring Download"
-msgstr "Notlama Araçları"
+msgstr "Notları İndir"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:162
-#, fuzzy
 msgid "Scoring Message"
-msgstr "Notlama Araçları"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:647
-#, fuzzy
 msgid "Scoring Tools"
 msgstr "Notlama Araçları"
 
@@ -5776,7 +4912,6 @@ msgstr ""
 msgid "Secondary sort"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
@@ -5802,13 +4937,11 @@ msgstr ""
 msgid "Section"
 msgstr "Bölüm"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:541
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:738
-#, fuzzy
 msgid "Section:"
-msgstr "Bölüm"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:385
 msgid "Seed"
@@ -5820,21 +4953,17 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
-#, fuzzy
 msgid "Select a Problem Collection"
-msgstr "Aşağıdan işlem seç"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "Select a Set from this Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
-#, fuzzy
 msgid "Select a course to delete."
-msgstr "Aşağıdan işlem seç"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
 msgid ""
@@ -5843,72 +4972,55 @@ msgid ""
 "the course home page and can be any string."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
-#, fuzzy
 msgid "Select a course to unarchive."
-msgstr "Aşağıdan işlem seç"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
-#, fuzzy
 msgid "Select a database layout below."
-msgstr "Aşağıdan işlem seç"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
-#, fuzzy
 msgid "Select a listing format:"
-msgstr "Yapılacak işlemi seç"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
-#, fuzzy
 msgid "Select above then:"
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
-#, fuzzy
 msgid "Select all eligible courses"
-msgstr "Bütün kullanıcıları seç"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:563
 msgid "Select all sets"
 msgstr "Bütün setleri seç"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
 msgid "Select all users"
 msgstr "Bütün kullanıcıları seç"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
 msgid "Select an action to perform"
 msgstr "Yapılacak işlemi seç"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
-#, fuzzy
 msgid "Select an action to perform:"
-msgstr "Yapılacak işlemi seç"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
 msgid "Select course(s) to archive."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
-#, fuzzy
 msgid "Select course(s) to hide or unhide."
-msgstr "Aşağıdan işlem seç"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:95
 msgid ""
@@ -5944,61 +5056,44 @@ msgid ""
 "choice."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
-#, fuzzy
 msgid "Selected students"
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
-#, fuzzy
 msgid "Send E-mail"
-msgstr "E-posta yolla:"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
-#, fuzzy
 msgid "Send Email"
-msgstr "E-posta yolla:"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
-#, fuzzy
 msgid "Send to:"
-msgstr "E-posta yolla:"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
 msgid "Set"
 msgstr "Set"
 
-#
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1133
-#, fuzzy
 msgid "Set %1 exists.  No set created"
 msgstr "Set %1 mevcut. Yeni set oluşturulmadı"
 
-#
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1486
-#, fuzzy
 msgid "Set %1 has been created."
-msgstr "Set %1 mevcut. Yeni set oluşturulmadı"
+msgstr ""
 
-#
 #. ($newSetName,$userName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1491
-#, fuzzy
 msgid "Set %1 was assigned to %2"
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:475
-#, fuzzy
 msgid "Set Assigner"
-msgstr "Ödev verilmiş setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:445
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:468
@@ -6007,16 +5102,13 @@ msgstr "Set Tanım Dosyası Adı"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:889
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:798
-#, fuzzy
 msgid "Set Definition Files"
-msgstr "Set Tanım Dosyası Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
-#, fuzzy
 msgid "Set Description"
-msgstr "Web Alanı Açıklamasını Göster/Gizle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:433
 msgid "Set Detail 2 for set %2"
@@ -6026,7 +5118,6 @@ msgstr ""
 msgid "Set Detail for set %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
@@ -6038,24 +5129,19 @@ msgstr ""
 msgid "Set Header"
 msgstr "Set Başlığı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
-#, fuzzy
 msgid "Set ID"
-msgstr "Kullanıcı Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 msgid "Set Info"
 msgstr "Set Bilgileri"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
 msgid "Set List"
 msgstr "Set Listesi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:761
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:777
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:781
@@ -6064,7 +5150,6 @@ msgstr "Set Listesi"
 msgid "Set Name"
 msgstr "Set Adı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1105
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1215
@@ -6077,9 +5162,8 @@ msgstr "Set Adı"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:699
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:812
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:904
-#, fuzzy
 msgid "Set Name "
-msgstr "Set Adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
@@ -6106,7 +5190,6 @@ msgid ""
 "version of their answer."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
@@ -6114,34 +5197,26 @@ msgstr ""
 msgid "Sets"
 msgstr "Setler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:393
-#, fuzzy
 msgid "Sets Assigned to User"
-msgstr "Ödev verilmiş kullanıcıları düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:384
-#, fuzzy
 msgid "Sets assigned to %1"
-msgstr "Ödev verilmiş kullanıcıları düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
-#, fuzzy
 msgid "Setting"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1291
 msgid "Shift dates so that the earliest is"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
-#, fuzzy
 msgid "Show"
-msgstr "Göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
 msgid "Show Auxiliary Resources"
@@ -6151,18 +5226,14 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
 msgid "Show Hints"
 msgstr "İpuçlarını göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:797
-#, fuzzy
 msgid "Show Me Another"
-msgstr "Yani pencerede göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
 msgid "Show Past Answers"
@@ -6176,7 +5247,6 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
 msgid "Show Solutions"
@@ -6186,56 +5256,42 @@ msgstr "Çözümleri göster"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
 msgid "Show Which Users?"
 msgstr "Hangi kullanıcılar gösterilecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:928
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:933
-#, fuzzy
 msgid "Show all paths"
-msgstr "bütün setler gösteriliyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
 msgid "Show correct answers"
 msgstr "Doğru yanıtları göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
-#, fuzzy
 msgid "Show me another"
-msgstr "Yani pencerede göster"
+msgstr ""
 
-#
 #. ($exhausted)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
-#, fuzzy
 msgid "Show me another %1"
-msgstr "Yani pencerede göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1113
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1114
-#, fuzzy
 msgid "Show path ..."
-msgstr "bütün setler gösteriliyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
-#, fuzzy
 msgid "Show saved answers?"
-msgstr "Önceki Yanıtları Göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:676
 msgid "Show which sets?"
 msgstr "Hangi setler gösterilecek?"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
@@ -6243,30 +5299,23 @@ msgstr "Hangi setler gösterilecek?"
 msgid "Show/Hide Site Description"
 msgstr "Web Alanı Açıklamasını Göster/Gizle"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
 msgid "Show:"
 msgstr "Göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "Showing"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:616
-#, fuzzy
 msgid "Showing %1 out of %2 sets."
 msgstr "%2 setin %1 tanesi gösteriliyor."
 
-#
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
-#, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "%2 kullanıcının %1 tanesi gösteriliyor."
 
@@ -6274,7 +5323,6 @@ msgstr "%2 kullanıcının %1 tanesi gösteriliyor."
 msgid "Simple"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:64
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:120
@@ -6287,15 +5335,12 @@ msgstr "Web Alanı Bilgileri"
 msgid "Skip archiving this course"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
-#, fuzzy
 msgid "Solution:"
-msgstr "Çözümleri göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:599
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:392
 msgid "Solutions"
@@ -6328,33 +5373,26 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
-#, fuzzy
 msgid "Sort"
 msgstr "Sırala"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
 msgid "Sort by"
 msgstr "Kriterlere Göre Sırala"
 
-#
 #. ($names{$primary}, $names{$secondary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:832
-#, fuzzy
 msgid "Sort by %1 and then by %2"
 msgstr "Önce %1 sonra %2 kriteriyle sırala"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:172
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:161
-#, fuzzy
 msgid "Sort:"
-msgstr "Sırala"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:337
 msgid "Source File"
@@ -6381,7 +5419,6 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:107
@@ -6391,27 +5428,20 @@ msgstr ""
 msgid "Statistics"
 msgstr "İstatistikler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:79
-#, fuzzy
 msgid "Statistics for"
-msgstr "Set %1 istatistikleri"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:83
-#, fuzzy
 msgid "Statistics for %1 set %2. Closes %3"
-msgstr "%1 sorusu %2 setine soru %3 olarak eklendi"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:81
-#, fuzzy
 msgid "Statistics for %1 student %2"
-msgstr "İstatistikleri öğrencilere göre göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
@@ -6426,24 +5456,18 @@ msgstr "İstatistikleri öğrencilere göre göster"
 msgid "Status"
 msgstr "Durumu"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Stop Acting"
 msgstr "Rol Yapmayı bırak"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
-#, fuzzy
 msgid "Stop Archiving"
-msgstr "Rol Yapmayı bırak"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
-#, fuzzy
 msgid "Stop archiving courses"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
@@ -6461,14 +5485,11 @@ msgstr "Dersler"
 msgid "Student ID"
 msgstr "Kullanıcı Adı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
-#, fuzzy
 msgid "Student Name"
-msgstr "Set Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:749
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:758
@@ -6476,21 +5497,16 @@ msgstr "Set Adı"
 msgid "Student Progress"
 msgstr "Öğrenci Gelişimi"
 
-#
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
-#, fuzzy
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr "%1 için öğrencilerin durumu"
+msgstr ""
 
-#
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
-#, fuzzy
 msgid "Student Progress for %1 student %2"
-msgstr "%1 için öğrencilerin durumu"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:581
 msgid "Student answers"
 msgstr "Yanıtları Gönder"
@@ -6506,85 +5522,68 @@ msgstr ""
 msgid "Subject: "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:230
-#, fuzzy
 msgid "Submission time:"
-msgstr "Yanıtları Gönder"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:254
-#, fuzzy
 msgid "Submit"
-msgstr "Yanıtları Gönder"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
 msgid "Submit Answers"
 msgstr "Yanıtları Gönder"
 
-#
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
-#, fuzzy
 msgid "Submit Answers for %1"
 msgstr "%1 için Yanıtları Gönder"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "Başarılı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
-#, fuzzy
 msgid "Success Index"
-msgstr "Başarılı"
+msgstr ""
 
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
-#, fuzzy
 msgid "Successfully archived the course %1."
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($newAchievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
-#, fuzzy
 msgid "Successfully created new achievement %1"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($newSetID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1207
-#, fuzzy
 msgid "Successfully created new set %1"
 msgstr "Yeni set %1 başarıyla yaratıldı"
 
 #. ($add_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
-#, fuzzy
 msgid "Successfully created the course %1"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
-#, fuzzy
 msgid "Successfully deleted the course %1."
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
-#, fuzzy
 msgid "Successfully renamed the course %1 to %2"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
-#, fuzzy
 msgid "Successfully unarchived %1 to the course %2"
-msgstr "Yeni set %1 başarıyla yaratıldı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
@@ -6604,25 +5603,20 @@ msgstr ""
 msgid "Table is ok"
 msgstr ""
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:471
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:473
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:509
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:512
-#, fuzzy
 msgid "Take %1 test"
 msgstr "%1 testini çöz"
 
-#
 #. ($display_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:499
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:503
-#, fuzzy
 msgid "Take %1 test."
-msgstr "%1 testini çöz"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
@@ -6636,27 +5630,21 @@ msgstr "%1 testini çöz"
 msgid "Take Action!"
 msgstr "İşlemi Gerçekleştir!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:856
-#, fuzzy
 msgid "Target Set:"
-msgstr "Set Bilgilerini Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:270
 msgid "Test Date"
 msgstr "Sınav Tarihi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:269
 msgid "Test Score"
 msgstr "Sınav Notu"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:868
-#, fuzzy
 msgid "Test Time"
-msgstr "Sınav Tarihi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:237
 msgid "Test Time Limit (min; 0=Close Date)"
@@ -6670,11 +5658,9 @@ msgstr ""
 msgid "Text chapter:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:760
-#, fuzzy
 msgid "Text section:"
-msgstr "İşlemi Gerçekleştir!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:749
 msgid "Textbook:"
@@ -6705,7 +5691,6 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
 msgid "The WeBWorK Project"
 msgstr "WeBWorK Projesi"
@@ -6731,22 +5716,17 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
-#, fuzzy
 msgid "The answer above is NOT correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
 msgid "The answer above is correct."
 msgstr "Yukarıdaki yanıt doğru."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
-#, fuzzy
 msgid "The answer will be graded later."
-msgstr "Yukarıdaki yanıt doğru."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:445
 msgid ""
@@ -6770,11 +5750,9 @@ msgid ""
 "be erased.  This cannot be undone."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:347
-#, fuzzy
 msgid "The default display mode"
-msgstr "Görünüm Modu"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:276
 msgid ""
@@ -6805,12 +5783,10 @@ msgid ""
 "Debug: as in Standard, plus the problem environment (debugging data)</ol>"
 msgstr ""
 
-#
 #. ($achievementName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
-#, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
-msgstr "Set %1 için yazdırılabilir dosya başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
@@ -6819,57 +5795,45 @@ msgid ""
 "saved"
 msgstr ""
 
-#
 #. ($emailDirectory, $openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
-#, fuzzy
 msgid "The file %1/%2 cannot be found."
-msgstr "Hata: %1 dosyası okunamıyor."
+msgstr ""
 
 #. ($emailDirectory,$openfilename)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
-#, fuzzy
 msgid "The file '%1' cannot be found."
-msgstr "Hata: %1 dosyası okunamıyor."
+msgstr ""
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
-#, fuzzy
 msgid "The file '%1' cannot be read!"
-msgstr "Hata: %1 dosyası okunamıyor."
+msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid "The file '%1' is a blank problem!"
-msgstr "'%1' dosyası boş bir soru!"
+msgstr ""
 
-#
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
-#, fuzzy
 msgid "The file '%1' is a directory!"
-msgstr "'%1' dosyası bir dizin!"
+msgstr ""
 
-#
 #. ($self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
-#, fuzzy
 msgid "The file '%1' is protected!"
-msgstr "'%1' dosyası korumalı!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:513
 msgid "The file does not appear to be a text file"
@@ -6900,14 +5864,12 @@ msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
-#
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
-#, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the score of problem %1."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
@@ -6916,13 +5878,11 @@ msgid ""
 "the weighted average of the problems: %1."
 msgstr ""
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
-#, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
-msgstr "Set %1 için yazdırılabilir dosya başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
@@ -6971,29 +5931,20 @@ msgstr ""
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
-#
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
-#, fuzzy
 msgid ""
 "The password you entered in the %1 field does not match your current "
 "password. Please retype your current password and try again."
 msgstr ""
-"%1 alanına girdiğiniz şifre ile mevcut şifreniz uyuşmamaktadır. Lütfen "
-"şirfenizi girerek tekrar deneyiniz."
 
-#
 #. (CGI::b($r->maketext("[_1]'s New Password",$e_user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:115
-#, fuzzy
 msgid ""
 "The passwords you entered in the %1 and %2 fields don't match. Please retype "
 "your new password and try again."
 msgstr ""
-"%1 ve %2  alanlarına girdiğiniz şifreler uyuşmadı. Yeni şifrenizi girerek "
-"tekrar deneyiniz."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
 msgid "The path to the original file should be absolute"
@@ -7011,19 +5962,15 @@ msgid ""
 "is in the 50% column."
 msgstr ""
 
-#
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
-#, fuzzy
 msgid "The recorded score for this test is  %1/%2."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
-#
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
-#, fuzzy
 msgid "The recorded score for this test is %1/%2."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
@@ -7037,35 +5984,27 @@ msgid ""
 "The reduced scoring date should be between the open date and close date."
 msgstr ""
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
-#, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr ""
 
-#
 #. ($setName,$effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
-#, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "Seçtiğiniz soru seti (%1) set %2 için geçerli değil"
 
-#
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
-#, fuzzy
 msgid "The set %1 is assigned to %2."
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
-#
 #. ($setName, $self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
-#, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
-msgstr "Set %1 için yazdırılabilir dosya başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #. ($newSetName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1455
@@ -7074,26 +6013,22 @@ msgid ""
 "like to start a new set."
 msgstr ""
 
-#
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
-#, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
-msgstr "WebWork Ödevi [_1] teslim tarihi: [_2]"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:483
 msgid "The solution has been removed."
 msgstr ""
 
-#
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
-#, fuzzy
 msgid ""
 "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
-msgstr "'set %1 / soru %2' için kaynak kodu %3'ten '%4'e değiştirildi."
+msgstr ""
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
@@ -7113,27 +6048,21 @@ msgid ""
 "created."
 msgstr ""
 
-#
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
-#, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
-msgstr "'set %1 / soru %2' için kaynak kodu %3'ten '%4'e değiştirildi."
+msgstr ""
 
-#
 #. ($rename_newCourseID, $rename_newCourseTitle)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
-#, fuzzy
 msgid "The title of the course %1 is now %2"
-msgstr "'set %1 / soru %2' için kaynak kodu %3'ten '%4'e değiştirildi."
+msgstr ""
 
-#
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
-#, fuzzy
 msgid "The user %1 has been assigned %2."
-msgstr "Set %1 başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #. ($enableReducedScoring)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
@@ -7187,7 +6116,7 @@ msgstr ""
 msgid "Theme (refresh page after saving changes to reveal new theme.)"
 msgstr ""
 
-#
+# Context is "Sort by ____ Then by _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
@@ -7368,23 +6297,17 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
-#, fuzzy
 msgid "This answer is NOT completely correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
-#, fuzzy
 msgid "This answer is NOT correct."
-msgstr "Yukarıdaki yanıt %1doğru değil."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
-#, fuzzy
 msgid "This answer is correct."
-msgstr "Yukarıdaki yanıt doğru."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:95
 msgid ""
@@ -7392,33 +6315,25 @@ msgid ""
 "guest."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
 msgid "This homework set contains no problems."
 msgstr "Bu soru grubunda soru bulunmamaktadır."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
 msgid "This homework set is closed."
 msgstr "Bu soru grubu kapalı."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
 msgid "This homework set is not yet open."
 msgstr "Bu soru grubu henüz açık değil."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
-#, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
 "the 'NewVersion' action below to create a local copy of the file and add it "
 "to the current problem set."
 msgstr ""
-"Bu boş bir soru şablonu ve üzerinde değişiklik yapılamaz. Aşağıdaki farklı "
-"kaydet işlemini kullarak dosyanın yerel bir kopyasını oluşturdaktan sonra "
-"üzerinde değişiklik yapabilirsiniz."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7494,7 +6409,6 @@ msgstr ""
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 msgid "This problem will not count towards your grade."
 msgstr "Bu soru, notunuzu etkilemeyecektir."
@@ -7504,14 +6418,12 @@ msgstr "Bu soru, notunuzu etkilemeyecektir."
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
-#
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
-#, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
-msgstr "Bu soru, notunuzu etkilemeyecektir."
+msgstr ""
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -7521,20 +6433,16 @@ msgid ""
 "and the \"File Manager\" link in the left margin."
 msgstr ""
 
-#
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
-#, fuzzy
 msgid "This set %1 is assigned to %2."
-msgstr "Set %1 başlığı '%2' olarak değiştirildi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
-#, fuzzy
 msgid "This set doesn't contain any problems yet."
-msgstr "Bu soru grubunda soru bulunmamaktadır."
+msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
@@ -7549,11 +6457,10 @@ msgid ""
 "password below."
 msgstr ""
 
-#
+# Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
-#, fuzzy
 msgid "This set is %1"
 msgstr "Bu set %1"
 
@@ -7593,12 +6500,10 @@ msgstr ""
 msgid "This source file does not exist!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
-#, fuzzy
 msgid "This source file is a directory!"
-msgstr "'%1' dosyası bir dizin!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
@@ -7639,12 +6544,10 @@ msgid ""
 "problem page."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
-#, fuzzy
 msgid "Time"
-msgstr "Sınav Tarihi"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:261
 msgid "Time Interval for New Test Versions (min; 0=infty)"
@@ -7705,33 +6608,23 @@ msgid ""
 "assigned sets."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
-#, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr ""
-"Bu dosyada değişiklik yapmak için önce 'Farklı Kaydet' seçeneğini kullanarak "
-"kaydetmeniz lazım."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
-#, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
 "another file."
 msgstr ""
-"Bu metni düzenlemek için aşağıdaki 'Farklı Kaydet' işlemini kullanarak başka "
-"bir dosya olarak kaydetmeniz gerekiyor."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1220
-#, fuzzy
 msgid "To this Problem"
-msgstr "Bu soruyu düzenle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
 msgid "To:"
@@ -7779,36 +6672,28 @@ msgstr ""
 msgid "URI"
 msgstr ""
 
-#
 #. ($achievementName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
-#, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
-msgstr "Set %1'in başlığı değiştirilemedi. Bilinmeyen hata."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
-#, fuzzy
 msgid "Unable to write to '%1': %2"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
-#, fuzzy
 msgid "Unarchive"
-msgstr "Dersler"
+msgstr ""
 
-#
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
-#, fuzzy
 msgid "Unarchive %1 to course:"
-msgstr "Dersler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
@@ -7817,24 +6702,18 @@ msgstr "Dersler"
 msgid "Unarchive Course"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
-#, fuzzy
 msgid "Unarchive Next Course"
-msgstr "Dersler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
-#, fuzzy
 msgid "Unassign from All Users"
-msgstr "Ödev verilmemiş soru dosyası"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
-#, fuzzy
 msgid "Unassign selected sets from selected users"
-msgstr "Ödev verilmemiş soru dosyası"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
@@ -7842,30 +6721,24 @@ msgid ""
 "and click on the Unassign button."
 msgstr ""
 
-#
 #. ($unattempted,$num_of_problems)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
-#, fuzzy
 msgid "Unattempted: %1/%2"
-msgstr "'%1' dosyasına yazılamadı: %2"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:52
-#, fuzzy
 msgid "Unclassified Problems"
-msgstr "Soruları Düzenle"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
 msgid "Ungraded"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
-#, fuzzy
 msgid "Unhide Courses"
-msgstr "Dersler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1341
 msgid ""
@@ -7882,18 +6755,14 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
-#, fuzzy
 msgid "Unselect all courses"
-msgstr "Bütün kullanıcılardaki seçimi kaldir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:569
 msgid "Unselect all sets"
 msgstr "Bütün setlerdeki seçimi kaldır"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
 msgid "Unselect all users"
 msgstr "Bütün kullanıcılardaki seçimi kaldir"
@@ -7924,26 +6793,22 @@ msgstr ""
 msgid "Updated location description."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
-#, fuzzy
 msgid "Upgrade"
-msgstr "Notlar"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
-#, fuzzy
 msgid "Upgrade Courses"
-msgstr "Dersler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
 msgid "Upgrade process completed"
@@ -7971,7 +6836,6 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
 msgid "Use System Default"
 msgstr "Varsayılan Ayarları Kullan"
@@ -7980,18 +6844,14 @@ msgstr "Varsayılan Ayarları Kullan"
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
-#
 #. (CGI::b("$achievementID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
-#, fuzzy
 msgid "Use in achievement %1"
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
-#, fuzzy
 msgid "Use in new achievement:"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:364
 msgid "Use log base 10 instead of base <i>e</i>"
@@ -8007,7 +6867,6 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
@@ -8029,24 +6888,18 @@ msgstr ""
 msgid "User ID"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:322
-#, fuzzy
 msgid "User Settings"
-msgstr "Kullanıcı bilgilerini güncelle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:462
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:522
-#, fuzzy
 msgid "User Values"
-msgstr "Kullanici adi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:259
-#, fuzzy
 msgid "User's name is:"
-msgstr "Dosya adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:257
 msgid "User's username is:"
@@ -8061,33 +6914,26 @@ msgid ""
 "database corruption."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:252
-#, fuzzy
 msgid "Username"
-msgstr "Dosya adı"
+msgstr "Kullanici adi"
 
 #. ($user_id)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:342
 msgid "Username presented:  %1"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
-#, fuzzy
 msgid "Users"
-msgstr "Kullanıcı Ekle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:443
-#, fuzzy
 msgid "Users Assigned to Set %2"
-msgstr "Ödev verilmiş kullanıcıları düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "Users List"
 msgstr "Kullanıcı Listesi"
@@ -8105,10 +6951,8 @@ msgid ""
 "Normally guest users are not allowed to change their password."
 msgstr ""
 
-#
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
-#, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "Kullanıcılar sırasıyla %1, %2 ve %3 kriterlerine göre sıları"
 
@@ -8131,12 +6975,10 @@ msgstr ""
 msgid "Using contents of the default message $default_msg_file instead."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
-#, fuzzy
 msgid "Using what display mode?: "
-msgstr "Görünüm Modu"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
@@ -8156,7 +6998,6 @@ msgstr ""
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
@@ -8166,66 +7007,52 @@ msgstr ""
 msgid "View"
 msgstr "Göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:453
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:528
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:572
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:684
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:804
-#, fuzzy
 msgid "View Problems"
-msgstr "Soruları Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
 msgid "View equations as"
 msgstr "Eşitlikler ne şekilde gösterilecek"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2093
-#, fuzzy
 msgid "View it"
-msgstr "Göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:210
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:211
 msgid "View statistics by set"
 msgstr "Setlere göre istatistikleri göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:215
 msgid "View statistics by student"
 msgstr "İstatistikleri öğrencilere göre göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
 msgstr "Setlere göre öğrenci gelişimini göster"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
 msgstr "tr: View student progress by student"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
-#, fuzzy
 msgid "View/Edit"
-msgstr "Düzenle"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
-#, fuzzy
 msgid "Viewing temporary file:"
-msgstr "Geçici dosya görüntüleniyor: "
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:767
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:787
@@ -8234,33 +7061,25 @@ msgstr "Geçici dosya görüntüleniyor: "
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:452
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:476
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:915
 msgid "Visible"
 msgstr "Görünür"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:144
-#, fuzzy
 msgid "Visible to Students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
-#, fuzzy
 msgid "Warning"
-msgstr "Kalan hak"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
-#, fuzzy
 msgid "Warning messages"
-msgstr "Notlama Araçları"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
@@ -8273,17 +7092,13 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
-#, fuzzy
 msgid "WeBWorK Error"
-msgstr "WeBWorK"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
-#, fuzzy
 msgid "WeBWorK Warnings"
-msgstr "WeBWorK"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:136
 msgid ""
@@ -8326,7 +7141,6 @@ msgstr ""
 msgid "Weight"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
 msgstr "WeBWorK sitemize hoşgeldiniz!"
@@ -8335,7 +7149,6 @@ msgstr "WeBWorK sitemize hoşgeldiniz!"
 msgid "What could be inside?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
 msgid "What field should filtered users match on?"
 msgstr "Seçili kullanıcılar hangi kriterlerde eşleşmeli?"
@@ -8409,49 +7222,36 @@ msgid ""
 "you want to do before unchecking sets."
 msgstr ""
 
-#
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:463
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:518
-#, fuzzy
 msgid "Will open on %1."
-msgstr "%1 tarihinde açılacak"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Worth"
 msgstr "Değeri"
 
-#
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
 "another file for viewing."
 msgstr ""
-"'%1' için yazma izinleri kapalı. Değişiklikler önce başka bir dosyaya "
-"kaydedilmeli."
 
-#
 #. ($self->shortPath($currentDirectory)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
-#, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr ""
-"'%1' için yazma izinleri kapalı. Değişiklikler önce başka bir dizine "
-"kaydedilmeli."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "Şablon klasörü yazmaya kapalı. Değişiklik yapılamaz."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
@@ -8487,52 +7287,42 @@ msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:139
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools"
-msgstr "Eğitmen araçlarına erişim yetkiniz yok."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
-#, fuzzy
 msgid "You are not authorized to access the Instructor tools."
-msgstr "Eğitmen araçlarına erişim yetkiniz yok."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
 msgid "You are not authorized to access the instructor tools."
 msgstr "Eğitmen araçlarına erişim yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:438
 msgid "You are not authorized to modify homework sets."
 msgstr "Ödev setlerini değiştirme yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
 msgid "You are not authorized to modify problems."
 msgstr "Sorularda değişklik yapma yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:361
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:441
 msgid "You are not authorized to modify set definition files."
 msgstr "Set tanım dosyalarını değiştirme yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
 msgid "You are not authorized to modify student data"
 msgstr "Öğrenci bilgilerini değiştirme yetkisine sahip değilsiniz."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
 msgid "You are not authorized to perform this action."
@@ -8562,16 +7352,13 @@ msgstr ""
 msgid "You can also examine the following temporary files: "
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "Bu sorudan kısmi puan alabilirsiniz."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
-#, fuzzy
 msgid "You can not specify an absolute path"
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:989
@@ -8605,11 +7392,9 @@ msgstr ""
 msgid "You can't download files of that type"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:501
-#, fuzzy
 msgid "You can't edit a directory"
-msgstr "'%1' dosyası bir dizin!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:446
 msgid "You can't view files of that type"
@@ -8619,13 +7404,10 @@ msgstr ""
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
-#, fuzzy
 msgid "You cannot delete the course you are currently using."
-msgstr "Kendinizi silemezsiniz!"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
 msgid "You cannot delete yourself!"
 msgstr "Kendinizi silemezsiniz!"
@@ -8636,48 +7418,37 @@ msgid ""
 "You must use Set Detail 2."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1453
-#, fuzzy
 msgid "You did not specify a new set name."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
 msgid "You didn't enter any message."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
 msgstr "Adres değiştirmek için yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:163
-#, fuzzy
 msgid "You do not have permission to change the hardcopy theme."
-msgstr "Adres değiştirmek için yetkiniz yok."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
 msgstr "Şifre değiştirmek için yetkiniz yok."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:495
-#, fuzzy
 msgid "You do not have permission to edit this file."
-msgstr "Bu hatanın detaylarını görmeye yetkiniz yok."
+msgstr ""
 
-#
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:156
-#, fuzzy
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr "Şifre değiştirmek için yetkiniz yok."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "You do not have permission to view the details of this error."
 msgstr "Bu hatanın detaylarını görmeye yetkiniz yok."
@@ -8690,17 +7461,13 @@ msgstr ""
 msgid "You exceeded the allowed time."
 msgstr ""
 
-#
 #. ($numLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
-#, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
-msgstr "%1 %2 kaldı."
+msgstr ""
 
-#
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
-#, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "[negquant,_1,Sınırsız deneme hakkı,deneme hakkı,deneme hakkı] kaldı."
 
@@ -8711,14 +7478,11 @@ msgid ""
 "requested."
 msgstr ""
 
-#
 #. ($attempts)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
-#, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Logout.pm:158
 msgid "You have been logged out of WeBWorK."
 msgstr "WeBWorK sisteminden çıkış yaptınız."
@@ -8749,47 +7513,35 @@ msgid ""
 "number of tries to your original problem."
 msgstr ""
 
-#
 #. ($phrase_for_privileged_users)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:575
-#, fuzzy
 msgid ""
 "You may choose to show any of the following data. Correct answers, hints, "
 "and solutions are only available %1 after the answer date of the homework "
 "set."
 msgstr ""
-"Aşağıdaki bilgilerden herhangi bir tanesini görüntülemeyi seçebilirsiniz. "
-"Doğru cevaplar ve çözümler ödev setinin cevaplarının açıklanma tarihinden "
-"itibaren görülebilir."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
 msgid "You may not change your own password here!"
 msgstr "Şifrenizi buradan değiştiremezsiniz!"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
-#, fuzzy
 msgid "You may still check your answers."
-msgstr "Şifrenizi buradan değiştiremezsiniz!"
+msgstr ""
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:486
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before Show Me Another "
 "is available."
-msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
+msgstr ""
 
-#
 #. ($showMeAnother{TriesNeeded})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
-#, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
-msgstr "Bu soru için [quant,_1,deneme hakkı,deneme hakkı] kullandınız."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
 msgid "You must confirm the password for the initial instructor."
@@ -8806,101 +7558,74 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
-#, fuzzy
 msgid "You must select a course to rename."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:759
-#, fuzzy
 msgid "You must select at least one file for the archive"
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:663
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-#, fuzzy
 msgid "You must select one or more sets for scoring"
-msgstr "Notlamak için bir set seçili değil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
-#, fuzzy
 msgid "You must specify a course ID."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
-#, fuzzy
 msgid "You must specify a course name."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1240
-#, fuzzy
 msgid "You must specify a file name"
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
-#, fuzzy
 msgid "You must specify a first name for the initial instructor."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
-#, fuzzy
 msgid "You must specify a last name for the initial instructor."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
-#, fuzzy
 msgid "You must specify a new institution for the course."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
-#, fuzzy
 msgid "You must specify a new name for the course."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
-#, fuzzy
 msgid "You must specify a new title for the course."
-msgstr "Bir kullanıcı adı girmelisiniz."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
 msgid "You must specify a user ID."
 msgstr "Bir kullanıcı adı girmelisiniz."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
-#, fuzzy
 msgid "You must specify an email address for the initial instructor."
-msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
-#, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "Yeni dosya kaydetmek için dosya adı belirtmelisiniz."
 
@@ -8915,18 +7640,14 @@ msgstr ""
 msgid "You need to select a \"Target Set\" before you can edit it."
 msgstr ""
 
-#
 #. ($action)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:994
-#, fuzzy
 msgid "You need to select a file to %1."
-msgstr "Lütfen kaydedilecek dosyayın belirtin."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1425
-#, fuzzy
 msgid "You need to select a set definition file to view."
-msgstr "Set tanım dosyalarını değiştirme yetkiniz yok."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1388
 msgid "You need to select a set from this course to view."
@@ -8936,10 +7657,8 @@ msgstr ""
 msgid "You need to select a set to view."
 msgstr ""
 
-#
 #. (wwRound(0, $pg->{result}->{score} * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
-#, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "Bu soru için %1 puan aldınız."
 
@@ -9009,13 +7728,10 @@ msgstr ""
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
-#, fuzzy
 msgid "Your display options have been saved."
-msgstr "E-posta adresiniz değiştirildi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:173
 msgid "Your email address has been changed."
 msgstr "E-posta adresiniz değiştirildi."
@@ -9024,57 +7740,45 @@ msgstr "E-posta adresiniz değiştirildi."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
-#
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
-#, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Ortalama puanınız: %1.  %2"
 
-#
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
-#, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
-#
+# $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
-#, fuzzy
 msgid "Your score on this %1 WAS recorded."
-msgstr "Notunuz kaydedildi."
+msgstr ""
 
-#
+# $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
-#, fuzzy
 msgid "Your score on this %1 is %2/%3."
-msgstr "Ortalama puanınız: %1.  %2"
+msgstr ""
 
-#
+# $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
-#, fuzzy
 msgid "Your score on this %1 was NOT recorded."
-msgstr "Notunuz kaydedildi."
+msgstr ""
 
-#
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
-#, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr "Notunuz kaydedildi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
-#, fuzzy
 msgid "Your score on this problem was recorded."
-msgstr "Notunuz kaydedildi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
 msgid ""
@@ -9084,48 +7788,38 @@ msgstr ""
 "Notunuz kaydedilemedi, çünkü notun veritabanına kaydı sırasında bir hata "
 "oluştu."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Notunuz kaydedilemedi çünkü bu soru grubu kapalı."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
-#, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr ""
 
-#
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
-#, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
-msgstr "Notunuz kaydedilmedi çünkü bu soru size yöneltilmedi."
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
-#, fuzzy
 msgid "Your score was not recorded."
-msgstr "Notunuz kaydedildi."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
@@ -9133,7 +7827,6 @@ msgstr "Notunuz kaydedildi."
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
 msgid "Your score was recorded."
 msgstr "Notunuz kaydedildi."
@@ -9144,7 +7837,6 @@ msgstr "Notunuz kaydedildi."
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Oturumunuz zaman aşımına uğradı. Lütfen tekrar giriş yapınız."
@@ -9153,44 +7845,21 @@ msgstr "Oturumunuz zaman aşımına uğradı. Lütfen tekrar giriş yapınız."
 msgid "Your systems are up to date!"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
-#, fuzzy
 msgid "[Edit]"
-msgstr "~[düzenle~]"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:265
-#, fuzzy
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
 msgstr ""
-"Bu sayfa ödev setleri editörü. Burada bu derse ait ödev setlerini görebilir "
-"ve üzerlerinde değişiklikler yapabilirsiniz. Yukarıdaki formları kullanarak "
-"setleri istediğiniz kriterlere göre görüntüleyebilir, setleri "
-"düzenleyebilir, yeni setler yayımlayabilir, dışarıdan ödev setleri "
-"aktarabilir, ödevleri notlayabilir yahut var olan setleri silebilirsiniz.  "
-"Hangi işlemi yapmak istiyorsanız seçin ve gerekli bilgileri girin daha sonra "
-"\"İşlemi Gerçekleştir!\" tuşuna basın. Sayfanın aşağısında mevcut setler "
-"hakkında bir takım bilgiler var."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:419
-#, fuzzy
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
-"Bu sayfa ödev setleri editörü. Burada bu derse ait ödev setlerini görebilir "
-"ve üzerlerinde değişiklikler yapabilirsiniz. Yukarıdaki formları kullanarak "
-"setleri istediğiniz kriterlere göre görüntüleyebilir, setleri "
-"düzenleyebilir, yeni setler yayımlayabilir, dışarıdan ödev setleri "
-"aktarabilir, ödevleri notlayabilir yahut var olan setleri silebilirsiniz.  "
-"Hangi işlemi yapmak istiyorsanız seçin ve gerekli bilgileri girin daha sonra "
-"\"İşlemi Gerçekleştir!\" tuşuna basın. Sayfanın aşağısında mevcut setler "
-"hakkında bir takım bilgiler var."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
@@ -9204,7 +7873,6 @@ msgstr ""
 "bilgileri girin daha sonra \"İşlemi Gerçekleştir!\" tuşuna basın. Sayfanın "
 "altında öğrencilerin bilgilerini gösteren bir tablo var."
 
-#
 #. (CGI::strong($r->maketext($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:199
 msgid "_EXTERNAL_AUTH_MESSAGE"
@@ -9212,7 +7880,6 @@ msgstr ""
 "%1 harici bir kimlik doğrulama sistemi kullanıyor.  Bu sistemle kimliğinizi "
 "doğruladınız fakat bu derse giriş yapma izniniz yok."
 
-#
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:285
 msgid "_GUEST_LOGIN_MESSAGE"
@@ -9220,7 +7887,6 @@ msgstr ""
 "Bu derse misafir olarak girebilirsiniz. Misafir olarak girmek için %1 "
 "linkine basın. "
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:528
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
 msgstr ""
@@ -9233,7 +7899,6 @@ msgstr ""
 "\"İşlemi Gerçekleştir!\" tuşuna basın. Sayfanın aşağısında mevcut setler "
 "hakkında bir takım bilgiler var."
 
-#
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:207
 msgid "_LOGIN_MESSAGE"
@@ -9249,7 +7914,6 @@ msgstr ""
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
 msgid "_REQUEST_ERROR"
 msgstr ""
@@ -9263,39 +7927,35 @@ msgstr ""
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
 
-#
+# Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
 msgstr "İlk seçilen setin bir kopyası"
 
-#
+# Context is "Create set ______ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "Boş bir yeni set"
 
+# Context is "Save to a new file named:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
 msgid "a new file named:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1244
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1252
 msgid "a single set"
 msgstr "tek bir set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "active"
-msgstr "Aktif Değil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
-#, fuzzy
 msgid "add problems"
-msgstr "Soru ekle"
+msgstr ""
 
 #. ($setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
@@ -9306,6 +7966,7 @@ msgstr ""
 msgid "added missing permission level for user"
 msgstr ""
 
+# #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "admin"
 msgstr ""
@@ -9317,19 +7978,16 @@ msgstr ""
 msgid "all achievements"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
-#, fuzzy
 msgid "all current users"
-msgstr "bütün kullanıcılar"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:640
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1016
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1319
@@ -9345,13 +8003,10 @@ msgstr ""
 msgid "all sets"
 msgstr "bütün setler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
-#, fuzzy
 msgid "all students"
-msgstr "bütün setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
@@ -9373,42 +8028,37 @@ msgstr ""
 msgid "alphabetically"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:661
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:672
-#, fuzzy
 msgid "answer"
-msgstr "Cevap tarihi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
 msgid "any users"
 msgstr "her kullanıcı"
 
+# Context is "Create _____ as a new empty set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr ""
 
-#
+# Context is "Import achievements from ____ assigning the achievements to ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
 msgid "assigning the achievements to"
-msgstr "Bu set hangi kullanıcılara ödev verilecek?"
+msgstr ""
 
-#
+# Context is "Import set from ____ assigning this set to ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
-#, fuzzy
 msgid "assigning this set to"
-msgstr "Bu set hangi kullanıcılara ödev verilecek?"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:676
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:520
-#, fuzzy
 msgid "avg attempts"
-msgstr "deneme hakkı"
+msgstr ""
 
+# Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
 msgid "blank problem template(s) to end of homework set"
@@ -9420,33 +8070,27 @@ msgstr ""
 msgid "by last login date"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "değişiklikler kaydedilmedi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "değişiklikler kaydedildi"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "class list data"
-msgstr "Sınıf Listesi Düzenleyici"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
-#, fuzzy
 msgid "close"
-msgstr "Kapalı"
+msgstr ""
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:685
 msgid "column"
@@ -9456,143 +8100,109 @@ msgstr ""
 msgid "columns:"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
 msgid "correct"
 msgstr "doğru"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:413
-#, fuzzy
 msgid "course files"
-msgstr "Dersler"
+msgstr ""
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1084
-#, fuzzy
 msgid "deleted %1 sets"
 msgstr "%1 set silindi."
 
-#
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
-#, fuzzy
 msgid "deleted %1 users"
 msgstr "%1 kullanıcı silindi."
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:403
-#, fuzzy
 msgid "editing all achievements"
-msgstr "bütün setler düzenleniyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:868
 msgid "editing all sets"
 msgstr "bütün setler düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
 msgid "editing all users"
 msgstr "bütün kullancılar düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:405
-#, fuzzy
 msgid "editing selected achievements"
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:874
 msgid "editing selected sets"
 msgstr "seçili setler düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing selected users"
 msgstr "seçili kullanıcılar düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:871
 msgid "editing visible sets"
 msgstr "görünür setler düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing visible users"
 msgstr "görünür kullanıcılar düzenleniyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
-#, fuzzy
 msgid "email:"
-msgstr "E-posta"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
-#, fuzzy
 msgid "empty"
-msgstr "deneme hakkı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:687
 msgid "enter matching set IDs below"
 msgstr "eşleşen ödev setlerini aşağıya girin"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
-#, fuzzy
 msgid "entry rows."
-msgstr "Soruları Düzenle"
+msgstr ""
 
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "dışarı aktarım yapılmadı"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
-#, fuzzy
 msgid "exporting all achievements"
-msgstr "bürün setler dışarı aktarılıyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1381
 msgid "exporting all sets"
 msgstr "bürün setler dışarı aktarılıyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
-#, fuzzy
 msgid "exporting selected achievements"
-msgstr "Şeçili setleri dışarı aktar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1388
 msgid "exporting selected sets"
 msgstr "seçili setler dışarı aktarılıyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1385
 msgid "exporting visible sets"
 msgstr "görünür setler dışarı aktarılıyor"
 
-#
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#, fuzzy
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr "Set %1 başlığı '%2' olarak değiştirildi."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
@@ -9603,53 +8213,42 @@ msgstr ""
 msgid "for one <b>user</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:882
-#, fuzzy
 msgid "for students"
-msgstr "öğrenciler tarafından görülemez"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1249
 msgid "from"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
 msgid "giving new passwords to all users"
 msgstr "bütün kullanıcılara yeni şifre veriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to selected users"
 msgstr "seçili kullanıcılara yeni şifre veriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to visible users"
 msgstr "görünür kullanıcılara yeni şifre veriliyor"
 
-#
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:885
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:996
-#, fuzzy
 msgid "global %1 for set %2 not found."
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
-#
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:61
-#, fuzzy
 msgid "global set %1  not found."
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
-#
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:995
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1068
-#, fuzzy
 msgid "global set %1 not found."
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "grade_proctor"
@@ -9659,7 +8258,6 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
@@ -9667,22 +8265,20 @@ msgstr ""
 msgid "hidden"
 msgstr "gizli"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
 msgid "hidden from"
 msgstr "görüntülenmiyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "öğrenciler tarafından görülemez"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:686
 msgid "hidden sets"
 msgstr "gizli setler"
 
+# doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
 #: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
@@ -9696,17 +8292,15 @@ msgstr ""
 msgid "illegal character in input: '/'"
 msgstr ""
 
+# Context is " Show users who match _____ in their _____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
 msgid "in their"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
-#, fuzzy
 msgid "inactive"
-msgstr "Aktif Değil"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
 msgid "incorrect"
@@ -9725,80 +8319,61 @@ msgstr ""
 msgid "list of insertable macros"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
-#, fuzzy
 msgid "locations selected below"
-msgstr "seçili setler dışarı aktarılıyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:801
-#, fuzzy
 msgid "login"
-msgstr "Devam et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
-#, fuzzy
 msgid "login ID"
-msgstr "Devam et"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:78
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:89
-#, fuzzy
 msgid "login/studentID:"
-msgstr "Kullanıcı Adı"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "login_proctor"
 msgstr ""
 
-#
+# Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:934
-#, fuzzy
 msgid "made visible for"
-msgstr "görüntüleniyor"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:443
 msgid "max"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1245
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1253
 msgid "multiple sets"
 msgstr "birden fazla set"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
-#, fuzzy
 msgid "new set:"
-msgstr "Set yok"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
-#, fuzzy
 msgid "new users"
-msgstr "kullanıcı yok"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
-#, fuzzy
 msgid "no achievements"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
 msgid "no achievements."
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
-#, fuzzy
 msgid "no location"
-msgstr "Çözümleri göster"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1015
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1073
@@ -9810,13 +8385,10 @@ msgstr "Çözümleri göster"
 msgid "no sets"
 msgstr "Set yok"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
-#, fuzzy
 msgid "no students"
-msgstr "Set yok"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
@@ -9852,32 +8424,27 @@ msgstr ""
 msgid "one <b>user</b> (on one <b>set</b>)"
 msgstr ""
 
+# Context is Assign this set to which users?  "only ____"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1274
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1310
 msgid "only"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:783
-#, fuzzy
 msgid "only best scores"
-msgstr "Sınav Notu"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
-#, fuzzy
 msgid "or"
-msgstr "Sırala"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:754
-#, fuzzy
 msgid "or Problems from"
-msgstr "Sorular"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
@@ -9909,39 +8476,29 @@ msgstr ""
 msgid "pg warning"
 msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
-#, fuzzy
 msgid "point"
-msgstr "İpuçlarını göster"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
-#, fuzzy
 msgid "points"
-msgstr "İpuçlarını göster"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
 msgid "preserve existing data"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
-#, fuzzy
 msgid "preview answers"
-msgstr "Yanıtları görüntüle"
+msgstr ""
 
-#
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:667
-#, fuzzy
 msgid "problem"
-msgstr "Soru %1"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:792
-#, fuzzy
 msgid "problems"
-msgstr "Soru %1"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "professor"
@@ -9958,26 +8515,20 @@ msgstr ""
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
-#, fuzzy
 msgid "recitation #"
-msgstr "Problem cozum dersi"
+msgstr ""
 
-#
 #. ($studentName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:145
-#, fuzzy
 msgid "record for user %1 not found"
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
-#, fuzzy
 msgid "record for visible user %1 not found"
-msgstr "'%1' dosyası bulunamadı."
+msgstr ""
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
@@ -9989,45 +8540,34 @@ msgstr ""
 msgid "row"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:795
-#, fuzzy
 msgid "section #"
-msgstr "Bölüm"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:91
-#, fuzzy
 msgid "section:"
-msgstr "Bölüm"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#, fuzzy
 msgid "selected <b>sets</b>"
-msgstr "seçili setler"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
-#, fuzzy
 msgid "selected achievements"
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
-#, fuzzy
 msgid "selected achievements."
-msgstr "seçili setler"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1017
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1075
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1321
@@ -10043,7 +8583,6 @@ msgstr "seçili setler"
 msgid "selected sets"
 msgstr "seçili setler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
@@ -10058,138 +8597,101 @@ msgstr "seçili setler"
 msgid "selected users"
 msgstr "seçili kullanıcılar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:673
-#, fuzzy
 msgid "separate multiple IDs with commas"
 msgstr ""
-"Hangi özellikler eşleştirilecek? (birden fazla kullanıcı adını virgülle "
-"ayırın)"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:642
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:84
-#, fuzzy
 msgid "set"
-msgstr "Set"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#, fuzzy
 msgid "sets"
-msgstr "Set yok"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:659
 msgid "sets checked below"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:661
-#, fuzzy
 msgid "sets hidden from students"
-msgstr "öğrenciler tarafından görülemez"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:660
-#, fuzzy
 msgid "sets visible to students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:662
-#, fuzzy
 msgid "sets with matching set IDs:"
-msgstr "eşleşen ödev setlerini aşağıya girin"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:724
 msgid "showing all sets"
 msgstr "bütün setler gösteriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
 msgid "showing all users"
 msgstr "bütün kullanıcılar gösteriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:757
-#, fuzzy
 msgid "showing hidden sets"
-msgstr "hiçbir set gösterilmiyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:733
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:738
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:746
-#, fuzzy
 msgid "showing matching sets"
-msgstr "eşleşen kullanıcılar gösteriliyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing matching users"
 msgstr "eşleşen kullanıcılar gösteriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:727
 msgid "showing no sets"
 msgstr "hiçbir set gösterilmiyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing no users"
 msgstr "hiçbir kullanıcı gösterilmiyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:730
 msgid "showing selected sets"
 msgstr "seçili setler gösteriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing selected users"
 msgstr "seçili kullanıcılar gösteriliyor"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
-#, fuzzy
 msgid "showing visible sets"
-msgstr "görünür setler dışarı aktarılıyor"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
-#, fuzzy
 msgid "still open"
-msgstr "%1 tarihinde açılacak"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:82
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
-#, fuzzy
 msgid "student"
-msgstr "Kullanıcı Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:536
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:573
-#, fuzzy
 msgid "students"
-msgstr "Kullanıcı Adı"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "submission"
-msgstr "Yanıtları Gönder"
+msgstr ""
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "submission (test %1)"
-msgstr "Yanıtları Gönder"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
 msgid "summary"
@@ -10199,30 +8701,22 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
-#, fuzzy
 msgid "test"
-msgstr " %1 test"
+msgstr ""
 
-#
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
-#, fuzzy
 msgid "test (%1)"
-msgstr " %1 test"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:786
-#, fuzzy
 msgid "test date"
-msgstr "Sınav Tarihi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:789
-#, fuzzy
 msgid "test time"
-msgstr " %1 test"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
 msgid "the following file"
@@ -10232,26 +8726,22 @@ msgstr ""
 msgid "the following file(s)"
 msgstr ""
 
-#
 #. ($forcedSourceFile)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
-#, fuzzy
 msgid "the original path to the file is %1"
-msgstr "Dosyanın özgün yol belirteci: %1"
+msgstr ""
 
-#
+# Context is "Sort by ___ then by ___"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
-#, fuzzy
 msgid "then by"
-msgstr "sonra"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:387
 msgid "then delete them"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "time"
 msgstr "deneme hakkı"
@@ -10260,11 +8750,11 @@ msgstr "deneme hakkı"
 msgid "time limit exceeded"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
 msgid "times"
 msgstr "deneme hakkı"
 
+# Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
 msgid "to"
 msgstr ""
@@ -10277,40 +8767,33 @@ msgstr ""
 msgid "to one <b>set</b>"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
-#, fuzzy
 msgid "top score"
-msgstr "Sınav Notu"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
 msgid "total"
 msgstr ""
 
-#
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
-#, fuzzy
 msgid "unable to write to directory %1"
-msgstr "'%1' dosyasına kaydedildi"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
 msgid "unlimited"
 msgstr "sınırsız"
 
-#
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:564
-#, fuzzy
 msgid "userID: %1 --"
-msgstr "%1in yerine koy"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
 msgid ""
@@ -10318,24 +8801,18 @@ msgid ""
 "score,"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
-#, fuzzy
 msgid "users"
-msgstr "kullanıcı yok"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
 msgid "users who match on selected field"
 msgstr "seçili alanla eşleşen kullanıcılar"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
-#, fuzzy
 msgid "users who match:"
-msgstr "seçili alanla eşleşen kullanıcılar"
+msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
@@ -10343,7 +8820,6 @@ msgstr "seçili alanla eşleşen kullanıcılar"
 msgid "visible"
 msgstr "Görünür"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1320
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:826
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1363
@@ -10352,13 +8828,11 @@ msgstr "Görünür"
 msgid "visible sets"
 msgstr "görünür setler"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "öğrencilere görüntüleyebilir"
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
@@ -10379,460 +8853,434 @@ msgstr ""
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
 msgstr ""
 
-#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#, fuzzy
 msgid "your students"
-msgstr "öğrencilere görüntüleyebilir"
+msgstr ""
 
 #
+#, fuzzy
+msgid "Will open on %1"
+msgstr "%1 tarihinde açılacak"
+
+#
+#, fuzzy
+msgid "User ID:"
+msgstr "Kullanıcı Ekle"
+
+#
+msgid "Viewing temporary file"
+msgstr "Geçici dosya gösteriliyor"
+
+#
+#, fuzzy
+msgid "set %1."
+msgstr "%1'e geri dön"
+
+#
+#, fuzzy
+msgid "Bad Nonce for user "
+msgstr "Set %1 başlığı"
+
+#
+#, fuzzy
+msgid "Can't write to file: %1"
+msgstr "'%1' dosyasına kaydedildi"
+
+#
+#, fuzzy
+msgid "Change Display Options"
+msgstr "Görünüm Seçenekleri"
+
+#
+msgid "navNext"
+msgstr "&nbspSonraki"
+
+#
+msgid "navNextGrey"
+msgstr "&nbspSonraki"
+
+#
+msgid "navPrev"
+msgstr "&nbspÖnceki"
+
+#
+msgid "navPrevGrey"
+msgstr "&nbspÖnceki"
+
+#
+msgid "navProbListGrey"
+msgstr "&nbspSorular"
+
+#
+msgid "navUp"
+msgstr "&nbspYukarı"
+
+#
+#, fuzzy
+msgid "Show me another [_1]"
+msgstr "Yani pencerede göster"
+
+#
+msgid "Apply Options"
+msgstr "Seçenekleri Uygula"
+
+#
+msgid "Disable"
+msgstr "Devre dişi bırak"
+
+#
+msgid "Enable/Disable reduced scoring for selected sets"
+msgstr "Seçili setler için azaltılmış not seçenegini etkinleştir/kaldır"
+
+#
+msgid "Reduced Credit %1 for all sets"
+msgstr "Bütün setler için notlar %1 azaltıldı"
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_1"
+msgstr ""
+"Bu ödev seti için Azaltılmış Not süresi var. Bu süre %1 tarihinde başlıyor "
+"ve %2 tarihinde son buluyor. Bu süre içinde cevaplanan bütün sorular asıl "
+"değerlerinin yüzde %3 değerinde olacak."
+
+#
+msgid "_REDUCED_CREDIT_MESSAGE_2"
+msgstr ""
+"Bu ödev seti için Azaltılmış Not süresi vardı. Bu süre %1 tarihinde başladı "
+"ve %2 tarihinde bitti. Bu süre içinde cevaplanan bütün sorular asıl "
+"değerlerinin yüzde %3 değerinde notlandı."
+
+#
+msgid "completely"
+msgstr "tamamen"
+
+#
+msgid "Course Information for course [_1]"
+msgstr "%1 dersinin bilgileri"
+
+#
+msgid ""
+"Report bugs in a WeBWorK question/problem using this link. The very first "
+"time you do this you will need to register with an email address so that "
+"information on the bug fix can be reported back to you."
+msgstr ""
+"WebWork veya soruyla ilgili hata bildirmek için bu linki kullanın. Bunu ilk "
+"kez yaparken e-posta adresinizle kayıt olmanız gerekmektedir."
+
+#
+msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
+msgstr ""
+"%1 seti için yazdırılabilir dosya başlığı değiştirilemedi. Bilinmeyen hata."
+
+#
+msgid "Unable to make '[_1]' the set header for [_2]"
+msgstr "'%1' set %2 için dosya başlığı yapılamadı"
+
+#
+msgid "Can't determine user of temporary edit file [_1]."
+msgstr "Geçici dosya %1 için kullanıcı belirlenemedi."
+
+#
+msgid "Top level of author information on the wiki."
+msgstr "Wikide yazar bilgilerinin en üst seviyesi."
+
+#
+msgid "Reverting to original file '[_1]'"
+msgstr "Asıl dosyaya geri dönülüyor ('%1')"
+
+#
+msgid "Wiki summary page for MathObjects"
+msgstr "MathObjects için özet wiki sayfası"
+
+#
+msgid "Snippets of PG code illustrating specific techniques"
+msgstr "Özel teknikleri gösteren PG yazılımı"
+
+#
+msgid "Error copying [_1] to [_2]"
+msgstr "Dosya %1, %2ye kopyalanarken hata oluştu"
+
+#
+msgid "blank problem"
+msgstr "boş soru"
+
+#
+msgid ""
+"Note: this problem viewer is for viewing purposes only. As of right now, "
+"testing functionality is not possible."
+msgstr ""
+"Not: Bu soru görüntüleyici şu an sadece soruları görüntüleyebilir, soru "
+"çözme fonksiyonu şu an mevcut değil."
+
+#
+msgid "webwork"
+msgstr "webwork"
+
+#
+msgid "submit button clicked"
+msgstr "gönder düğmesine basıldı"
+
+#
+msgid ""
+"Test snippets of PG code in interactive lab.  Good way to learn PG language."
+msgstr ""
+"Interaktif labaratuarda PG test yazılımları. PG yazılım dilini öğrenmek içi "
+"iyi bir kaynak."
+
+#
+msgid "View Using Seed Number"
+msgstr "Tohum numarasını kullanarak göster"
+
+#
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"Şu anda sorunun orijinal hali gösteriliyor. Kaydedilmemiş değişiklikleri "
+"kurtarmak için internet tarayıcınızın \"Geri\" tuşunu kullanın."
+
+#
+msgid ""
+"Documentation from source code for PG modules and macro files. Often the "
+"most up-to-date information."
+msgstr ""
+"PG modülleri ve makro dosyaları hakkında bilgi dosyası. Genellikle en son "
+"bilgileri içerir."
+
+#
+msgid ""
+"PG mark down syntax used to format WeBWorK questions. This interactive lab "
+"can help you to learn the techniques."
+msgstr ""
+"WebWork sorularında kullanılan PG kodu sözdizimi. Bu interaktif labaratuar, "
+"teknikleri öğrenmek için kullanılabilir."
+
+#
+msgid ""
+"Error: This path is already in the temporary edit directory -- no new "
+"temporary file is created. path = [_1]"
+msgstr ""
+"Hata: Bu yol belirteci geçici düzenleme klasöründe mevcut -- yeni bir geçici "
+"dosya oluşturuldu. yol = %1"
+
+#
+msgid ""
+"Please use radio buttons to choose the method for saving this file. Can't "
+"recognize saveMode: |[_1]|."
+msgstr "Bu dosya için kaydetme modunu seçin. Kaydetme modu tanınmadı: |%1|."
+
+#
+msgid "Resources"
+msgstr "Kaynaklar"
+
+#
+msgid "Duplicate"
+msgstr "Çoğalt"
+
+#
+msgid "This path |[_1]| is not the path to a temporary edit file."
+msgstr "Bu yol belirteci |%1| geçici düzenleme dosyası yolu değil."
+
+#
+msgid ""
+"Unable to change the source file path for set [_1], problem [_2]. Unknown "
+"error."
+msgstr ""
+"Set %1, soru %2 için kaynak kodu yolu değiştirilemiyor. Bilinmeyen hata."
+
+#
+msgid "Save as new independent problem"
+msgstr "Yeni bir soru olarak kaydet"
+
+#
+msgid "Unknown file type"
+msgstr "Bilinmeyen dosya tipi"
+
 #, fuzzy
 #~ msgid "answer "
 #~ msgstr "Cevap tarihi"
 
-#
-#, fuzzy
-#~ msgid "Will open on %1"
-#~ msgstr "%1 tarihinde açılacak"
-
-#
-#, fuzzy
-#~ msgid "User ID:"
-#~ msgstr "Kullanıcı Ekle"
-
-#
-#~ msgid "Viewing temporary file"
-#~ msgstr "Geçici dosya gösteriliyor"
-
-#
 #, fuzzy
 #~ msgid "You are not authorized to access instructor tools"
 #~ msgstr "Eğitmen araçlarına erişim yetkiniz yok."
 
-#
 #, fuzzy
 #~ msgid "all current users."
 #~ msgstr "bütün kullanıcılar"
 
-#
 #, fuzzy
 #~ msgid "font-hidden"
 #~ msgstr "gizli"
 
-#
 #, fuzzy
 #~ msgid "font-visible"
 #~ msgstr "Görünür"
 
-#
 #, fuzzy
 #~ msgid "no users."
 #~ msgstr "kullanıcı yok"
 
-#
 #, fuzzy
-#~ msgid "set %1."
-#~ msgstr "%1'e geri dön"
-
-#
 #~ msgid "submitAnswers"
 #~ msgstr "Yanıtları Gönder"
 
-#
 #, fuzzy
 #~ msgid "All sets %1 all students"
-#~ msgstr "Bütün setler %1 all students"
+#~ msgstr "Bütün setleri seç"
 
-#
-#, fuzzy
-#~ msgid "Bad Nonce for user "
-#~ msgstr "Set %1 başlığı"
-
-#
-#, fuzzy
-#~ msgid "Can't write to file: %1"
-#~ msgstr "'%1' dosyasına kaydedildi"
-
-#
-#, fuzzy
-#~ msgid "Change Display Options"
-#~ msgstr "Görünüm Seçenekleri"
-
-#
 #, fuzzy
 #~ msgid "Changes saved."
 #~ msgstr "Değişiklikler kaydedildi"
 
-#
 #, fuzzy
 #~ msgid "Comment: "
 #~ msgstr "Yorum"
 
-#
 #, fuzzy
 #~ msgid "Hardcopy Theme:"
 #~ msgstr "Çıktı Dosyası Başlığı"
 
-#
+#, fuzzy
 #~ msgid "No sets selected for scoring."
-#~ msgstr "Notlama için bir set seçili değil."
+#~ msgstr "Notlamak için bir set seçili değil"
 
-#
 #, fuzzy
 #~ msgid "Note: "
 #~ msgstr "Not"
 
-#
 #, fuzzy
 #~ msgid "Recitation:"
 #~ msgstr "Problem cozum dersi"
 
-#
 #, fuzzy
 #~ msgid "Save as:"
 #~ msgstr "Farklı kaydet"
 
-#
 #, fuzzy
 #~ msgid "Log into"
 #~ msgstr "Çıkış Yap"
 
-#
 #, fuzzy
 #~ msgid "Sets assigned to $userID"
 #~ msgstr "Ödev verilmiş kullanıcıları düzenle"
 
-#
-#~ msgid "navNext"
-#~ msgstr "&nbspSonraki"
-
-#
-#~ msgid "navNextGrey"
-#~ msgstr "&nbspSonraki"
-
-#
-#~ msgid "navPrev"
-#~ msgstr "&nbspÖnceki"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "&nbspÖnceki"
-
-#
+#, fuzzy
 #~ msgid "navProbList"
-#~ msgstr "&nbspSorular"
+#~ msgstr "Soru Listesi"
 
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "&nbspSorular"
-
-#
-#~ msgid "navUp"
-#~ msgstr "&nbspYukarı"
-
-#
+#, fuzzy
 #~ msgid "Problem [_1]"
 #~ msgstr "Soru %1"
 
-#
 #, fuzzy
 #~ msgid "[_1]% correct"
 #~ msgstr "%1% doğru"
 
-#
 #, fuzzy
 #~ msgid "At least one of these answers is NOT completely correct."
-#~ msgstr "Yanıtların en az bir tanesi %1doğru değil."
+#~ msgstr "Yanıtların tümü doğru"
 
-#
 #, fuzzy
 #~ msgid "[_1]: Problem [_2]"
-#~ msgstr " set %1/soru %2"
+#~ msgstr "%1: Soru %2."
 
-#
-#, fuzzy
-#~ msgid "Show me another [_1]"
-#~ msgstr "Yani pencerede göster"
-
-#
 #, fuzzy
 #~ msgid "Edit "
 #~ msgstr "Düzenle"
 
-#
 #, fuzzy
 #~ msgid "Assign "
 #~ msgstr "Ödev verilmiş setler"
 
-#
 #, fuzzy
 #~ msgid "Delete "
 #~ msgstr "Sil"
 
-#
 #, fuzzy
 #~ msgid "Export "
 #~ msgstr "Dışa aktar"
 
-#
 #, fuzzy
 #~ msgid "Add "
 #~ msgstr "Kullanıcı Ekle"
 
-#
-#~ msgid "Apply Options"
-#~ msgstr "Seçenekleri Uygula"
-
-#
-#~ msgid "Disable"
-#~ msgstr "Devre dişi bırak"
-
-#
-#~ msgid "Enable/Disable reduced scoring for selected sets"
-#~ msgstr "Seçili setler için azaltılmış not seçenegini etkinleştir/kaldır"
-
-#
+#, fuzzy
 #~ msgid ""
 #~ "No students shown.  Choose one of the options above to \n"
 #~ "\t              list the students in the course."
 #~ msgstr ""
-#~ "Hiç öğrenci gösterilmiyor. Dersteki öğrencileri görmek için yukarıdaki "
-#~ "seçeneklerden birisini seçin."
+#~ "Hiç set gösterilmiyor. Dersteki setleri görmek için yukarıdaki "
+#~ "seçeneklerden birini işaretleyin."
 
-#
-#~ msgid "Reduced Credit %1 for all sets"
-#~ msgstr "Bütün setler için notlar %1 azaltıldı"
-
-#
+#, fuzzy
 #~ msgid "Reduced Credit %1 for selected sets"
-#~ msgstr "Seçili setler için notlar %1 azaltıldı"
+#~ msgstr "seçili setler düzenleniyor"
 
-#
+#, fuzzy
 #~ msgid "Reduced Credit %1 for visable sets"
-#~ msgstr "Görünür setler için notlar %1 azaltıldı"
+#~ msgstr "Tek set için notları kaydet"
 
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "Bu ödev seti için Azaltılmış Not süresi var. Bu süre %1 tarihinde "
-#~ "başlıyor ve %2 tarihinde son buluyor. Bu süre içinde cevaplanan bütün "
-#~ "sorular asıl değerlerinin yüzde %3 değerinde olacak."
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "Bu ödev seti için Azaltılmış Not süresi vardı. Bu süre %1 tarihinde "
-#~ "başladı ve %2 tarihinde bitti. Bu süre içinde cevaplanan bütün sorular "
-#~ "asıl değerlerinin yüzde %3 değerinde notlandı."
-
-#
-#~ msgid "completely"
-#~ msgstr "tamamen"
-
-#
-#~ msgid "Course Information for course [_1]"
-#~ msgstr "%1 dersinin bilgileri"
-
-#
+#, fuzzy
 #~ msgid "Cancel Password"
-#~ msgstr "Şifreyi iptal et"
+#~ msgstr "Şifre Değiştir"
 
-#
+#, fuzzy
 #~ msgid "Hardcopy Header for set [_1]"
-#~ msgstr "Set %1 için yazdırılabilir dosya başlığı"
+#~ msgstr "Çıktı Dosyası Başlığı"
 
-#
-#~ msgid ""
-#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
-#~ "time you do this you will need to register with an email address so that "
-#~ "information on the bug fix can be reported back to you."
-#~ msgstr ""
-#~ "WebWork veya soruyla ilgili hata bildirmek için bu linki kullanın. Bunu "
-#~ "ilk kez yaparken e-posta adresinizle kayıt olmanız gerekmektedir."
-
-#
+#, fuzzy
 #~ msgid "hardcopy header file"
-#~ msgstr "Yazdırılabilir ödev başlığı dosyası"
+#~ msgstr "Çıktı Dosyası Başlığı"
 
-#
+#, fuzzy
 #~ msgid "Unpublished"
-#~ msgstr "Yayınlanmadı"
+#~ msgstr "Yayımla"
 
-#
-#~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-#~ msgstr ""
-#~ "%1 seti için yazdırılabilir dosya başlığı değiştirilemedi. Bilinmeyen "
-#~ "hata."
-
-#
-#~ msgid "Unable to make '[_1]' the set header for [_2]"
-#~ msgstr "'%1' set %2 için dosya başlığı yapılamadı"
-
-#
-#~ msgid "Can't determine user of temporary edit file [_1]."
-#~ msgstr "Geçici dosya %1 için kullanıcı belirlenemedi."
-
-#
-#~ msgid "Top level of author information on the wiki."
-#~ msgstr "Wikide yazar bilgilerinin en üst seviyesi."
-
-#
+#, fuzzy
 #~ msgid "Save Password"
-#~ msgstr "Şifreyi kaydet"
+#~ msgstr "Yeni Şifre"
 
-#
-#~ msgid "Reverting to original file '[_1]'"
-#~ msgstr "Asıl dosyaya geri dönülüyor ('%1')"
-
-#
-#~ msgid "Wiki summary page for MathObjects"
-#~ msgstr "MathObjects için özet wiki sayfası"
-
-#
+#, fuzzy
 #~ msgid "Password/Email"
-#~ msgstr "Şifre/E-posta"
+#~ msgstr "Sifre"
 
-#
-#~ msgid "Snippets of PG code illustrating specific techniques"
-#~ msgstr "Özel teknikleri gösteren PG yazılımı"
-
-#
-#~ msgid "Error copying [_1] to [_2]"
-#~ msgstr "Dosya %1, %2ye kopyalanarken hata oluştu"
-
-#
+# Context is "This set is visible" or "This set is hidden"
+#, fuzzy
 #~ msgid "This set is [_1] students."
-#~ msgstr "Bu soru grubu öğrenciler tarafından %1."
+#~ msgstr "Bu set %1"
 
-#
-#~ msgid "blank problem"
-#~ msgstr "boş soru"
-
-#
-#~ msgid ""
-#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
-#~ "testing functionality is not possible."
-#~ msgstr ""
-#~ "Not: Bu soru görüntüleyici şu an sadece soruları görüntüleyebilir, soru "
-#~ "çözme fonksiyonu şu an mevcut değil."
-
-#
+#, fuzzy
 #~ msgid "Save Export"
-#~ msgstr "Dışa aktarımı kaydet"
+#~ msgstr "Dışa aktar"
 
-#
-#~ msgid "webwork"
-#~ msgstr "webwork"
-
-#
-#~ msgid "submit button clicked"
-#~ msgstr "gönder düğmesine basıldı"
-
-#
+#, fuzzy
 #~ msgid "Problem Source Code"
-#~ msgstr "Soru Kaynak Kodu"
+#~ msgstr "Soru Düzenleyici"
 
-#
-#~ msgid ""
-#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-#~ msgstr ""
-#~ "Interaktif labaratuarda PG test yazılımları. PG yazılım dilini öğrenmek "
-#~ "içi iyi bir kaynak."
-
-#
+#, fuzzy
 #~ msgid "Page generated at [_1] at [_2]"
-#~ msgstr "Sayfa %1 at %2"
+#~ msgstr "Sayfa %1de yaratıldı"
 
-#
-#~ msgid "View Using Seed Number"
-#~ msgstr "Tohum numarasını kullanarak göster"
-
-#
+#, fuzzy
 #~ msgid "Published"
-#~ msgstr "Yayınlandı"
+#~ msgstr "Yayımla"
 
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "Şu anda sorunun orijinal hali gösteriliyor. Kaydedilmemiş değişiklikleri "
-#~ "kurtarmak için internet tarayıcınızın \"Geri\" tuşunu kullanın."
-
-#
-#~ msgid ""
-#~ "Documentation from source code for PG modules and macro files. Often the "
-#~ "most up-to-date information."
-#~ msgstr ""
-#~ "PG modülleri ve makro dosyaları hakkında bilgi dosyası. Genellikle en son "
-#~ "bilgileri içerir."
-
-#
-#~ msgid ""
-#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
-#~ "lab can help you to learn the techniques."
-#~ msgstr ""
-#~ "WebWork sorularında kullanılan PG kodu sözdizimi. Bu interaktif "
-#~ "labaratuar, teknikleri öğrenmek için kullanılabilir."
-
-#
-#~ msgid ""
-#~ "Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = [_1]"
-#~ msgstr ""
-#~ "Hata: Bu yol belirteci geçici düzenleme klasöründe mevcut -- yeni bir "
-#~ "geçici dosya oluşturuldu. yol = %1"
-
-#
-#~ msgid ""
-#~ "Please use radio buttons to choose the method for saving this file. Can't "
-#~ "recognize saveMode: |[_1]|."
-#~ msgstr "Bu dosya için kaydetme modunu seçin. Kaydetme modu tanınmadı: |%1|."
-
-#
+#, fuzzy
 #~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-#~ msgstr "Seçilen problem (%1), %2 soru drubu için geçerli bir soru değil."
+#~ msgstr "Seçtiğiniz soru seti (%1) set %2 için geçerli değil"
 
-#
-#~ msgid "Resources"
-#~ msgstr "Kaynaklar"
-
-#
-#~ msgid "Duplicate"
-#~ msgstr "Çoğalt"
-
-#
-#~ msgid "This path |[_1]| is not the path to a temporary edit file."
-#~ msgstr "Bu yol belirteci |%1| geçici düzenleme dosyası yolu değil."
-
-#
-#~ msgid ""
-#~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
-#~ "error."
-#~ msgstr ""
-#~ "Set %1, soru %2 için kaynak kodu yolu değiştirilemiyor. Bilinmeyen hata."
-
-#
+#, fuzzy
 #~ msgid "Options Information"
-#~ msgstr "Seçenek Bilgileri"
+#~ msgstr "Web Alanı Bilgileri"
 
-#
-#~ msgid "Save as new independent problem"
-#~ msgstr "Yeni bir soru olarak kaydet"
-
-#
+#, fuzzy
 #~ msgid "Cancel Export"
-#~ msgstr "Dışa aktarımı iptal et"
+#~ msgstr "Dışa aktar"
 
-#
+#, fuzzy
 #~ msgid "options information"
-#~ msgstr "Seçenek bilgileri"
+#~ msgstr "Web Alanı Bilgileri"
 
-#
+#, fuzzy
 #~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-#~ msgstr "Seçili soru (%1) set %2 için geçerli değil."
-
-#
-#~ msgid "Unknown file type"
-#~ msgstr "Bilinmeyen dosya tipi"
+#~ msgstr "Seçtiğiniz soru seti (%1) set %2 için geçerli değil"

--- a/lib/WeBWorK/Localize/webwork2.pot
+++ b/lib/WeBWorK/Localize/webwork2.pot
@@ -14,11 +14,15 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+msgid "# of active students"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 msgid "#corr"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 msgid "#incorr"
 msgstr ""
 
@@ -31,13 +35,13 @@ msgid "% correct with review"
 msgstr ""
 
 # Percent students
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
 msgstr ""
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -73,17 +77,17 @@ msgid "%1 students out of %2"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 msgid "%1 users exported to file %2/%3"
 msgstr ""
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 msgid "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
 msgstr ""
 
@@ -104,7 +108,7 @@ msgstr ""
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 msgid "%1% correct"
 msgstr ""
 
@@ -139,7 +143,7 @@ msgid "%1's password has been changed."
 msgstr ""
 
 #. ($setID, $problemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr ""
 
@@ -149,12 +153,12 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 msgid "%1: The directory for the course not found."
 msgstr ""
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -169,44 +173,44 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr ""
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "%score"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267 /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343 /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid "(Instructor hint preview: show the student hint after the following number of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 msgid "(Your score on this %1 is not available.)"
 msgstr ""
 
@@ -247,13 +251,21 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 msgid "A course with ID %1 already exists."
 msgstr ""
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid "A directory already exists with the name %1. You must first delete this existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid "A file name cannot begin with a dot, it cannot be empty, it cannot contain a directory path component and only the characters -_.a-zA-Z0-9 and space  are allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid "A file name cannot begin with a dot, it cannot be empty, it cannot contain a directory path component and only the characters -_.a-zA-Z0-9 and space are allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1236
@@ -265,22 +277,22 @@ msgid "A hardcopy file was generated, but it may not be complete or correct. Ple
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid "A location with the name %1 already exists in the database.  Did you mean to edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 msgid "A new file has been created at '%1'"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 msgid "A new file has been created at '%1' with the contents below.  No changes have been made to set %2"
 msgstr ""
 
@@ -298,31 +310,31 @@ msgid "A table showing all the current users along with several fields of user i
 msgstr ""
 
 # Short for ADJUSTED STATUS
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 msgid "ANSWERS NOT RECORDED"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 msgid "ANSWERS NOT RECORDED --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr ""
 
@@ -331,12 +343,12 @@ msgid "Achievement"
 msgstr ""
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 msgid "Achievement %1 exists.  No achievement created"
 msgstr ""
 
@@ -353,11 +365,11 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -373,12 +385,16 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+msgid "Achievement has been assigned to selected users."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 msgid "Achievement scores saved to %1"
 msgstr ""
 
@@ -395,16 +411,16 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Acting as %1."
 msgstr ""
 
 #. ($actionID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 msgid "Action %1 not found"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr ""
 
@@ -416,7 +432,7 @@ msgstr ""
 msgid "Activiating this will enable achievement items. This features rewards students who earn achievements with items that allow them to affect their homework in a limited way."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr ""
 
@@ -424,7 +440,7 @@ msgstr ""
 msgid "Add All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 msgid "Add Course"
 msgstr ""
 
@@ -436,7 +452,7 @@ msgstr ""
 msgid "Add Users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -444,11 +460,11 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 msgid "Add as what filetype?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr ""
 
@@ -456,33 +472,33 @@ msgstr ""
 msgid "Add problems to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 msgid "Add to what set?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr ""
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 msgid "Added %1 to %2 as problem %3"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr ""
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 msgid "Added '%1' to %2 as new set header"
 msgstr ""
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -491,39 +507,39 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid "Address(es) %1 in the add list is(are) already in the location %2, and so were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid "Address(es) %1 in the delete list is(are) not in the location %2, and so were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid "Address(es) %1 is(are) not in a recognized form.  Please check your data entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid "Address(es) %1 is(are) not in a recognized form.  Please check your data entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid "Addresses for new location.  Enter one per line, as single IP addresses e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid "Addresses to add to the location.  Enter one per line, as single IP addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e.g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
@@ -535,7 +551,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -548,7 +564,7 @@ msgid "After set answer date"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
 
@@ -560,15 +576,15 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 msgid "All of the answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "All of the gradeable answers above are correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -588,7 +604,7 @@ msgstr ""
 msgid "All sets made visible for all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -650,23 +666,23 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
@@ -678,7 +694,7 @@ msgstr ""
 msgid "Answer Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr ""
 
@@ -691,12 +707,12 @@ msgid "Answer:"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
 # Leave out spaces
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -716,11 +732,15 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+msgid "Any changes made below will be reflected in the achievement for ALL students."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 msgid "Any changes made below will be reflected in the set for ONLY the student(s) listed above."
 msgstr ""
 
@@ -728,16 +748,16 @@ msgstr ""
 msgid "Any time problem numbers are intentionally changed, the problems will always be renumbered consecutively, starting from one.  When deleting problems, gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 msgid "Append to end of %1 set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 msgid "Archive"
 msgstr ""
 
@@ -751,23 +771,23 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 msgid "Archive Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 msgid "Archive next course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 msgid "Archive this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 msgid "Archived Courses"
 msgstr ""
 
@@ -777,17 +797,22 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid "Are you sure that you want to delete the course %1 after archiving? This cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid "Are you sure you want to delete the course %1? All course files and data will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "Assign"
+msgstr ""
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
@@ -810,15 +835,15 @@ msgstr ""
 msgid "Assigned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 msgid "Assigned achievements to users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 msgid "Assigned to"
 msgstr ""
 
@@ -826,7 +851,11 @@ msgstr ""
 msgid "Assignment type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+msgid "Assignments only"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 msgid "At least one of the answers above is NOT correct."
 msgstr ""
 
@@ -835,7 +864,7 @@ msgstr ""
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -843,7 +872,7 @@ msgstr ""
 msgid "Attempted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:533 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr ""
 
@@ -851,11 +880,11 @@ msgstr ""
 msgid "Audit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr ""
 
@@ -863,12 +892,12 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -900,16 +929,16 @@ msgstr ""
 msgid "By default, feeback is sent to all users above who have permission to receive feedback. Feedback is also sent to any addresses specified in this blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -939,7 +968,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -974,17 +1003,17 @@ msgid "Can't get password record for user '%1': %2"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 msgid "Can't open %1"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 msgid "Can't open file %1"
 msgstr ""
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 msgid "Can't read merge file %1. No message sent"
 msgstr ""
 
@@ -993,7 +1022,7 @@ msgstr ""
 msgid "Can't rename file: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1002,9 +1031,9 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#. ($!)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 msgid "Can't write to file %1"
 msgstr ""
 
@@ -1012,7 +1041,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 msgid "Cancel E-mail"
 msgstr ""
 
@@ -1025,7 +1054,7 @@ msgstr ""
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1041,11 +1070,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1057,7 +1086,7 @@ msgstr ""
 msgid "Change Email Address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1065,29 +1094,29 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 msgid "Change User Settings"
 msgstr ""
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr ""
 
@@ -1099,24 +1128,24 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 msgid "Check Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid "Check whether it exists and whether the directory %1 can be read by the webserver."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr ""
 
@@ -1129,7 +1158,7 @@ msgid "Choose the set which you would like to enable partial credit for."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104 /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126 /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216 /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:299
@@ -1164,7 +1193,7 @@ msgstr ""
 msgid "Click on a student's name to see the student's version of the homework set. Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid "Click on the login name to edit individual problem set data, (e.g. due dates) for these students."
 msgstr ""
 
@@ -1173,7 +1202,7 @@ msgstr ""
 msgid "Client ip address %1 is not allowed to work this assignment, because the assignment has ip address restrictions and there are no allowed locations associated with the restriction.  Contact your professor to have this problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 msgid "Close"
 msgstr ""
 
@@ -1203,7 +1232,7 @@ msgid "Closes"
 msgstr ""
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 msgid "Closes %1"
 msgstr ""
 
@@ -1211,24 +1240,24 @@ msgstr ""
 msgid "Closes:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr ""
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1236,7 +1265,7 @@ msgstr ""
 msgid "Completed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1245,7 +1274,7 @@ msgstr ""
 msgid "Confirm %1's New Password"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 msgid "Confirm Password:"
 msgstr ""
 
@@ -1258,7 +1287,7 @@ msgid "Continue"
 msgstr ""
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr ""
 
@@ -1270,7 +1299,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1278,7 +1307,7 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr ""
 
@@ -1286,7 +1315,7 @@ msgstr ""
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 msgid "Correct Answer"
 msgstr ""
 
@@ -1303,16 +1332,16 @@ msgid "Correct answers"
 msgstr ""
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 msgid "Correct: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 msgid "CorrectAnswers"
 msgstr ""
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
 
@@ -1327,45 +1356,45 @@ msgid "Couldn't change your email address: %1"
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 msgid "Couldn't save your display options: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
 msgstr ""
 
@@ -1373,11 +1402,11 @@ msgstr ""
 msgid "Course Configuration"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 msgid "Course ID:"
 msgstr ""
 
@@ -1385,11 +1414,11 @@ msgstr ""
 msgid "Course Info"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 msgid "Course Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 msgid "Course Title:"
 msgstr ""
 
@@ -1397,11 +1426,11 @@ msgstr ""
 msgid "Course archived."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid "Courses are listed either alphabetically or in order by the time of most recent login activity, oldest first. To change the listing order check the mode you want and click \"Refresh Listing\".  The listing format is: Course_Name (status :: date/time of most recent login) where status is \"hidden\" or \"visible\"."
 msgstr ""
 
@@ -1413,7 +1442,7 @@ msgstr ""
 msgid "Create CSV"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 msgid "Create Location:"
 msgstr ""
 
@@ -1421,7 +1450,7 @@ msgstr ""
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1429,11 +1458,11 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses directory. Before archiving, the course database is dumped into a subdirectory of the course's DATA directory. Currently the archive facility is only available for mysql databases. It depends on the mysqldump application."
 msgstr ""
 
@@ -1441,31 +1470,31 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 msgid "Database:"
 msgstr ""
 
@@ -1477,7 +1506,7 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
 msgstr ""
 
@@ -1497,63 +1526,63 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 msgid "Delete Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 msgid "Delete course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 msgid "Delete it?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 msgid "Delete location:"
 msgstr ""
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 msgid "Deleted %quant(%1,achievement)"
 msgstr ""
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 msgid "Deleting temp file at %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 msgid "Deletion deletes all location data and related addresses, and is not undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
 
@@ -1561,7 +1590,7 @@ msgstr ""
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 
@@ -1569,11 +1598,11 @@ msgstr ""
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 msgid "Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -1591,40 +1620,44 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 msgid "Directory structure"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid "Directory structure is missing directories or the webserver lacks sufficient privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 msgid "Display Mode:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:438
 msgid "Display Past Answers"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+msgid "Display of scores for this set is not allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -1647,28 +1680,28 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 msgid "Don't Unarchive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 msgid "Don't Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 msgid "Don't delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 msgid "Don't make changes"
 msgstr ""
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr ""
 
@@ -1677,15 +1710,15 @@ msgstr ""
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 msgid "Don't use in an achievement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -1707,7 +1740,7 @@ msgstr ""
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr ""
 
@@ -1728,6 +1761,16 @@ msgstr ""
 msgid "Drop"
 msgstr ""
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr ""
@@ -1740,7 +1783,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr ""
 
@@ -1756,7 +1799,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 msgid "E-mail:"
 msgstr ""
 
@@ -1764,12 +1807,12 @@ msgstr ""
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr ""
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 msgid "Edit %1 of set %2."
 msgstr ""
 
@@ -1781,19 +1824,19 @@ msgstr ""
 msgid "Edit Assigned Users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 msgid "Edit Header"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 msgid "Edit Location:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 msgid "Edit Problem"
 msgstr ""
 
@@ -1813,7 +1856,7 @@ msgstr ""
 msgid "Edit Target Set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr ""
 
@@ -1827,16 +1870,16 @@ msgid "Edit it"
 msgstr ""
 
 #. (CGI::strong($setID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid "Edit the current value of the location description, if desired, then add and select addresses to delete, and then click the \"Take Action\" button to make all of your changes.  Or, click \"Manage Locations\" above to make no changes and return to the Manage Locations page."
 msgstr ""
 
@@ -1845,22 +1888,22 @@ msgid "Edit which sets?"
 msgstr ""
 
 # Edit with a number 1 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 msgid "Edit1"
 msgstr ""
 
 # Edit with a number 2 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 msgid "Edit2"
 msgstr ""
 
 # Edit with a number 3 after with no space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 msgid "Edit3"
 msgstr ""
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 msgid "Editing %1 in file '%2'"
 msgstr ""
 
@@ -1870,32 +1913,32 @@ msgid "Editing achievement in file '%1'"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 msgid "Editor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 msgid "Editor rows:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 msgid "Email Body:"
 msgstr ""
 
@@ -1903,24 +1946,24 @@ msgstr ""
 msgid "Email Instructor On Failed Attempt"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 msgid "Email Link"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 msgid "Email address"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr ""
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid "Email is being sent to %quant(%1,recipient). You will be notified by email when the task is completed.  This may take several minutes if the class is large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -1956,7 +1999,7 @@ msgstr ""
 msgid "Enable reduced scoring for a homework set.  This will allow you to submit answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 msgid "Enabled"
 msgstr ""
 
@@ -1980,15 +2023,15 @@ msgstr ""
 msgid "Enrolled"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr ""
 
@@ -2000,7 +2043,7 @@ msgstr ""
 msgid "Enter information below for students you wish to add. Each student's password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr ""
 
@@ -2026,7 +2069,7 @@ msgstr ""
 msgid "Error message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 msgid "Error messages"
 msgstr ""
 
@@ -2046,7 +2089,7 @@ msgid "Error: Reduced scoring date must come between the open date and close dat
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 msgid "Error: The original file %1 cannot be read."
 msgstr ""
 
@@ -2060,6 +2103,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1524
 msgid "Error: open date cannot be more than 10 years from now in set %1"
@@ -2071,53 +2118,53 @@ msgid "Errors encountered while processing %1. This %2 has been omitted from the
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid "Errors occured while hiding the courses listed below when attempting to create the file hide_directory in the course's directory. Check the ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid "Errors occured while unhiding the courses listed below when attempting delete the file hide_directory in the course's directory. Check the ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid "Except for possible errors listed above, all selected courses are already hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid "Except for possible errors listed above, all selected courses are already unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid "Existing addresses for the location are given in the scrolling list below.  Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 msgid "Export selected achievements."
 msgstr ""
 
@@ -2125,7 +2172,7 @@ msgstr ""
 msgid "Export selected sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr ""
 
@@ -2133,12 +2180,12 @@ msgstr ""
 msgid "Export which sets?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr ""
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 msgid "Exported achievements to %1"
 msgstr ""
 
@@ -2150,16 +2197,16 @@ msgstr ""
 msgid "Extends the close date of a gateway test by 24 hours. Note: The test must still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 msgid "Failed to create new achievement: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr ""
 
@@ -2172,7 +2219,7 @@ msgstr ""
 msgid "Failed to create new set: no set name specified!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 msgid "Failed to duplicate achievement: no achievement selected for duplication!"
 msgstr ""
 
@@ -2201,7 +2248,7 @@ msgstr ""
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 msgid "Failed to open %1"
 msgstr ""
 
@@ -2210,11 +2257,11 @@ msgstr ""
 msgid "Failed to save: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "Feature exhausted for this problem"
 msgstr ""
 
@@ -2226,29 +2273,29 @@ msgstr ""
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 msgid "FeedbackMessage"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 msgid "File '%1' exists. File not saved. No changes have been made.  You can change the file path for this problem manually from the 'Hmwk Sets Editor' page"
 msgstr ""
 
@@ -2292,7 +2339,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr ""
 
@@ -2301,7 +2348,7 @@ msgstr ""
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr ""
 
@@ -2313,24 +2360,28 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 msgid "First name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid "For security reasons, you cannot specify a message file from a directory higher than the email directory (you can't use ../blah/blah for example). Please specify a different file or move the needed file to the email directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2303
 msgid "Force problems to be numbered consecutively from one (always done when reordering problems)"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+msgid "Format"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
@@ -2341,15 +2392,19 @@ msgstr ""
 msgid "Format:"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+msgid "Found no directories containing problems"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 msgid "From field must contain one valid email address."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr ""
 
@@ -2373,7 +2428,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 msgid "General Information"
 msgstr ""
 
@@ -2393,11 +2448,15 @@ msgstr ""
 msgid "Get Target Set Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185 /opt/webwork/pg/macros/problemRandomize.pl:186
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 msgid "Give new password to"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr ""
 
@@ -2422,7 +2481,7 @@ msgstr ""
 msgid "Global problem %1 for set %2 not found."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -2430,19 +2489,27 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291 /opt/webwork/pg/macros/compoundProblem.pl:480 /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 msgid "Grade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 msgid "Grade Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 msgid "Grade Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 msgid "Grader"
 msgstr ""
 
@@ -2470,7 +2537,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 msgid "HTTP Headers"
 msgstr ""
 
@@ -2490,11 +2557,15 @@ msgstr ""
 msgid "Hardcopy Theme"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 msgid "Headers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr ""
 
@@ -2506,11 +2577,11 @@ msgstr ""
 msgid "Hidden"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Hide Courses"
 msgstr ""
 
@@ -2522,7 +2593,7 @@ msgstr ""
 msgid "Hide Hints from Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 msgid "Hide Inactive Courses"
 msgstr ""
 
@@ -2534,7 +2605,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 msgid "Hint:"
 msgstr ""
 
@@ -2547,11 +2618,11 @@ msgstr ""
 msgid "Hmwk Sets Editor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 msgid "Homework Totals"
 msgstr ""
 
@@ -2559,15 +2630,15 @@ msgstr ""
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid "If a password field is left blank, the student's current password will be maintained."
 msgstr ""
 
@@ -2576,15 +2647,19 @@ msgid "If this flag is set then this problem will count towards the grade of its
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:326
-msgid "If this is enabled then instructors with the ability to receive feedback emails will be notified whenever a student runs out of attempts on a problem and its children without receiving an adjusted status of 100%"
+msgid "If this is enabled then instructors with the ability to receive feedback emails will be notified whenever a student runs out of attempts on a problem and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
-msgid "If this is enabled then students will be unable to attempt a problem until they have completed all of the previous problems, and their child problems if necessary"
+msgid "If this is enabled then students will be unable to attempt a problem until they have completed all of the previous problems, and their child problems if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
 msgid "If you check %1 your login information will be remembered by the browser you are using, allowing you to visit WeBWorK pages without typing your user name and password (until your session expires). This feature is not safe for public workstations, untrusted machines, and machines over which you do not have direct control."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
 msgstr ""
 
 #. ($file)
@@ -2592,7 +2667,7 @@ msgstr ""
 msgid "Illegal file '%1' specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -2600,8 +2675,9 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
-msgid "Import achievements from"
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
+msgid "Import achievements from %1 assigning the achievements to %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -2616,21 +2692,21 @@ msgstr ""
 msgid "Import sets with names"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr ""
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 msgid "Imported %quant(%1,achievement)"
 msgstr ""
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr ""
 
@@ -2638,16 +2714,16 @@ msgstr ""
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 msgid "Include Success Index"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 msgid "Incorrect"
 msgstr ""
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 msgid "Incorrect: %1/%2"
 msgstr ""
 
@@ -2656,7 +2732,7 @@ msgstr ""
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 msgid "Institution:"
 msgstr ""
 
@@ -2664,21 +2740,21 @@ msgstr ""
 msgid "Instructor Tools"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid "Invalid file name. The file name \"%1\" does not have a \".msg\" extension All email file names must end in the extension \".msg\" choose a file name with a \".msg\" extension. The message was not saved."
 msgstr ""
 
 #. ($headerType)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -2690,15 +2766,19 @@ msgstr ""
 msgid "It is before the open date.  You probably want to renumber the problems if you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 msgid "Jump to Page:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Jump to Problem:"
 msgstr ""
 
@@ -2710,7 +2790,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -2730,15 +2810,15 @@ msgstr ""
 msgid "Last Answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 msgid "Last name"
 msgstr ""
 
@@ -2762,15 +2842,15 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 msgid "Library Browser 3"
 msgstr ""
 
@@ -2798,29 +2878,29 @@ msgstr ""
 msgid "Local Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 msgid "Location"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid "Location %1 does not exist in the WeBWorK database.  Please check your input (perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 msgid "Location %1 has been created, with addresses %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 msgid "Location description:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 msgid "Location name:"
 msgstr ""
 
@@ -2828,7 +2908,7 @@ msgstr ""
 msgid "Log In Again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr ""
 
@@ -2836,16 +2916,16 @@ msgstr ""
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Logged in as %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Login"
 msgstr ""
 
@@ -2853,11 +2933,11 @@ msgstr ""
 msgid "Login Info"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr ""
 
@@ -2865,7 +2945,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr ""
 
@@ -2877,19 +2957,19 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 msgid "Make changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695 /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 msgid "Manual Grader"
 msgstr ""
 
@@ -2901,7 +2981,7 @@ msgstr ""
 msgid "Mark Correct"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 msgid "Mark Correct?"
 msgstr ""
 
@@ -2909,7 +2989,7 @@ msgstr ""
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr ""
 
@@ -2925,46 +3005,46 @@ msgstr ""
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 msgid "Merge file:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 msgid "Message file:"
 msgstr ""
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 msgid "Message:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid "Missing required input data. Please check that you have filled in all of the create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -2977,11 +3057,11 @@ msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
 # Short for Number of Fields
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
 msgstr ""
 
@@ -3013,11 +3093,11 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 msgid "New Name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr ""
 
@@ -3029,12 +3109,12 @@ msgstr ""
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr ""
 
 # No space
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3042,23 +3122,27 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:405 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:405 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 msgid "No Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+msgid "No achievements have been assigned yet"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3074,7 +3158,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid "No changes specified.  You must mark the checkbox of the item(s) to be changed and enter the change data."
 msgstr ""
 
@@ -3082,7 +3166,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 msgid "No course id defined"
 msgstr ""
 
@@ -3091,55 +3175,55 @@ msgstr ""
 msgid "No data exists for set %1 and problem %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 msgid "No merge data file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid "No new Achievement ID specified.  No new achievement created.  File not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid "No recipients selected. Please select one or more recipients from the list below."
 msgstr ""
 
 #. ($setID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 msgid "No record for global set %1."
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 msgid "No record for user %1."
 msgstr ""
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 msgid "No record found for problem %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -3151,19 +3235,19 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid "No sets shown.  Choose one of the options above to list the sets in the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 msgid "No students shown.  Choose one of the options above to list the students in the course."
 msgstr ""
 
@@ -3177,11 +3261,15 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -3190,23 +3278,27 @@ msgid "None Specified"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382 /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 msgid "Number"
 msgstr ""
 
@@ -3222,7 +3314,7 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -3251,7 +3343,7 @@ msgstr ""
 msgid "Only this permission level and higher get buttons for sending e-mail to the instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 msgid "Open"
 msgstr ""
 
@@ -3263,11 +3355,11 @@ msgstr ""
 msgid "Open Problem Library"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -3281,9 +3373,9 @@ msgstr ""
 msgid "Open, complete by %1."
 msgstr ""
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-msgid "Open, reduced scoring starts on %1."
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -3306,12 +3398,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 msgid "Orig. Lib. Browser"
 msgstr ""
 
 # Context is "7 Out Of 10" 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
 msgstr ""
 
@@ -3332,66 +3424,66 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
 # Doesn't need to be translated
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr ""
 
 # Problem Number
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
 # Problem Value
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr ""
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 msgid "Page generated at %1"
 msgstr ""
 
@@ -3403,7 +3495,7 @@ msgstr ""
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 msgid "Password:"
 msgstr ""
 
@@ -3412,7 +3504,7 @@ msgstr ""
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -3424,11 +3516,11 @@ msgstr ""
 msgid "Percentile cutoffs for number of attempts. <br/> The 50% column shows the median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid "Percentile cutoffs for number of attempts. The 50% column shows the median number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr ""
 
@@ -3436,7 +3528,7 @@ msgstr ""
 msgid "Permissions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid "Place a file named \"hide_directory\" in a course or other directory and it will not show up in the courses list on the WeBWorK home page. It will still appear in the Course Administration listing."
 msgstr ""
 
@@ -3460,7 +3552,7 @@ msgstr ""
 msgid "Please choose the set, the problem you would like to copy, and the problem you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -3473,7 +3565,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -3489,47 +3581,47 @@ msgstr ""
 msgid "Please select at least one user and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 msgid "Points"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview Message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 msgid "Preview My Answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 msgid "Preview Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 msgid "Preview message"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 msgid "Preview set to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 msgid "Previous page"
 msgstr ""
 
@@ -3537,12 +3629,12 @@ msgstr ""
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 # Short for Problem
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 msgid "Prob"
 msgstr ""
 
@@ -3559,12 +3651,12 @@ msgstr ""
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 msgid "Problem %1"
 msgstr ""
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 msgid "Problem %1."
 msgstr ""
 
@@ -3582,7 +3674,7 @@ msgstr ""
 msgid "Problem Editor3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr ""
 
@@ -3594,19 +3686,19 @@ msgstr ""
 msgid "Problem Number "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 msgid "Problem Viewer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr ""
 
@@ -3650,11 +3742,11 @@ msgstr ""
 msgid "Proctored tests require proctor authorization to start and to grade.  Provide a password to have a single password for all students to start a proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -3666,11 +3758,11 @@ msgstr ""
 msgid "Really delete the items listed above?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr ""
 
@@ -3682,22 +3774,12 @@ msgstr ""
 msgid "Reduced Scoring Date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Disabled"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 msgid "Reduced Scoring Enabled"
-msgstr ""
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-msgid "Reduced Scoring Starts %1"
-msgstr ""
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-msgid "Reduced scoring started on %1."
 msgstr ""
 
 # Short for "Reduced Scoring:"
@@ -3713,7 +3795,7 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 msgid "Refresh Listing"
 msgstr ""
 
@@ -3722,7 +3804,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 # Context is "Attempts Remaining"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr ""
 
@@ -3734,16 +3816,16 @@ msgstr ""
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:898 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:904
 msgid "Rename"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 msgid "Rename Course"
 msgstr ""
 
@@ -3751,19 +3833,19 @@ msgstr ""
 msgid "Rename file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 msgid "Renumber Problems"
 msgstr ""
 
@@ -3776,46 +3858,46 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr ""
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 msgid "Report for course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 msgid "Request information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 msgid "Request new version now."
 msgstr ""
 
@@ -3868,7 +3950,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -3876,11 +3958,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, the course database is restored from a subdirectory of the course's DATA directory. Currently the archive facility is only available for mysql databases. It depends on the mysqldump application."
 msgstr ""
 
@@ -3904,20 +3982,20 @@ msgstr ""
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 msgid "Result of last action performed"
 msgstr ""
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 msgid "Result of last action performed: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -3929,16 +4007,24 @@ msgstr ""
 msgid "Results of last action performed: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 msgid "Revert to %1"
 msgstr ""
 
@@ -3950,74 +4036,74 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:44 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr ""
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 msgid "Save %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 msgid "Save Changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 msgid "Save as"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 msgid "Save as Default"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 msgid "Save file to:"
 msgstr ""
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 msgid "Save to %1 and View"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 msgid "Saved to file '%1'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
 msgid "Score"
 msgstr ""
 
@@ -4029,11 +4115,11 @@ msgstr ""
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -4057,19 +4143,19 @@ msgstr ""
 msgid "Scoring Tools"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid "Screen and Hardcopy set header information can not be overridden for individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
 msgid "Secondary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr ""
 
@@ -4081,8 +4167,12 @@ msgstr ""
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+msgid "Select a Homework Set"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
@@ -4093,31 +4183,31 @@ msgstr ""
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 msgid "Select a course to delete."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid "Select a course to rename.  The courseID is used in the url and can only contain alphanumeric characters and underscores. The course title appears on the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 msgid "Select a course to unarchive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 msgid "Select a database layout below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 msgid "Select a listing format:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 msgid "Select above then:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 msgid "Select all eligible courses"
 msgstr ""
 
@@ -4125,23 +4215,23 @@ msgstr ""
 msgid "Select all sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 msgid "Select an action to perform:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 msgid "Select course(s) to hide or unhide."
 msgstr ""
 
@@ -4153,7 +4243,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid "Select the course(s) you want to hide (or unhide) and then click \"Hide Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden does no harm (the action is skipped). Likewise unhiding a course that is already visible does no harm (the action is skipped).  Hidden courses are still active but are not listed in the list of WeBWorK courses on the opening page.  To access the course, an instructor or student must know the full URL address for the course."
 msgstr ""
 
@@ -4165,23 +4255,23 @@ msgstr ""
 msgid "Select user(s) and/or set(s) below and click the action button of your choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "Selected students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 msgid "Send E-mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 msgid "Send Email"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr ""
 
@@ -4212,7 +4302,7 @@ msgstr ""
 msgid "Set Definition Files"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 msgid "Set Description"
 msgstr ""
 
@@ -4224,7 +4314,7 @@ msgstr ""
 msgid "Set Detail for set %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:470 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:782
 msgid "Set Header"
 msgstr ""
 
@@ -4232,11 +4322,11 @@ msgstr ""
 msgid "Set ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr ""
 
@@ -4248,8 +4338,12 @@ msgstr ""
 msgid "Set Name "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -4264,7 +4358,7 @@ msgstr ""
 msgid "Set to true to display the \"Entered\" column which automatically shows the evaluated student answer, e.g. 1 if student input is sin(pi/2). If this is set to false, e.g. to save space in the response area, the student can still see their evaluated answer by hovering the mouse pointer over the typeset version of their answer."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr ""
 
@@ -4276,7 +4370,7 @@ msgstr ""
 msgid "Sets assigned to %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Setting"
 msgstr ""
 
@@ -4284,11 +4378,11 @@ msgstr ""
 msgid "Shift dates so that the earliest is"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -4296,7 +4390,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr ""
 
@@ -4304,7 +4398,7 @@ msgstr ""
 msgid "Show Me Another"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr ""
 
@@ -4316,7 +4410,7 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr ""
 
@@ -4324,7 +4418,7 @@ msgstr ""
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr ""
 
@@ -4332,16 +4426,16 @@ msgstr ""
 msgid "Show all paths"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "Show me another"
 msgstr ""
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 msgid "Show me another %1"
 msgstr ""
 
@@ -4349,7 +4443,7 @@ msgstr ""
 msgid "Show path ..."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 msgid "Show saved answers?"
 msgstr ""
 
@@ -4357,15 +4451,15 @@ msgstr ""
 msgid "Show which sets?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "Showing"
 msgstr ""
 
@@ -4375,7 +4469,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr ""
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 msgid "Showing %1 out of %2 users"
 msgstr ""
 
@@ -4387,11 +4481,11 @@ msgstr ""
 msgid "Site Information"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534 /opt/webwork/pg/macros/PGbasicmacros.pl:1535 /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633 /opt/webwork/pg/macros/PGbasicmacros.pl:1634 /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 msgid "Solution:"
 msgstr ""
 
@@ -4399,12 +4493,16 @@ msgstr ""
 msgid "Solutions"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:733
 msgid "Some of these files are directories. Only delete directories if you really know what you are doing. You can seriously damage your course if you delete the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid "Some problems shown above represent multiple similar problems from the database.  If the (top) information line for a problem has a letter M for \"More\", hover your mouse over the M  to see how many similar problems are hidden, or click on the M to see the problems.  If you click to view these problems, the M becomes an L, which can be clicked on to hide the problems again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -4415,11 +4513,11 @@ msgstr ""
 msgid "Something was wrong with your LTI parameters.  If this recurs, please speak with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 msgid "Sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr ""
 
@@ -4440,7 +4538,7 @@ msgstr ""
 msgid "Source file paths cannot include .. or start with /: your source file path was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid "Specify an ID, title, and institution for the new course. The course ID may contain only letters, numbers, hyphens, and underscores."
 msgstr ""
 
@@ -4466,23 +4564,23 @@ msgstr ""
 msgid "Statistics for %1 student %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 msgid "Stop Archiving"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 msgid "Stop archiving courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr ""
 
@@ -4508,11 +4606,11 @@ msgstr ""
 msgid "Student answers"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -4524,30 +4622,34 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr ""
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 msgid "Submit Answers for %1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 msgid "Success Index"
 msgstr ""
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 msgid "Successfully created new achievement %1"
 msgstr ""
 
@@ -4557,35 +4659,35 @@ msgid "Successfully created new set %1"
 msgstr ""
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -4599,7 +4701,7 @@ msgstr ""
 msgid "Take %1 test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr ""
 
@@ -4651,11 +4753,11 @@ msgstr ""
 msgid "The Reduced Scoring Period is the default period before the due date during which all additional work done by the student counts at a reduced rate. When enabling reduced scoring for a set the reduced scoring date will be set to the due date minus this number. The reduced scoring date can then be changed. If the Reduced Scoring is enabled and if it is after the reduced scoring date, but before the due date, a message like \"This assignment has a Reduced Scoring Period that begins 11/08/2009 at 06:17pm EST and ends on the due date, 11/10/2009 at 06:17pm EST. During this period all additional work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid "The adjusted status of a problem is the larger of the problem's status and the weighted average of the status of those problems which count towards the parent grade."
 msgstr ""
 
@@ -4667,15 +4769,15 @@ msgstr ""
 msgid "The amount of time (in minutes) before the due date when the assignment is opened.  You can change this for individual homework, but WeBWorK will use this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 msgid "The answer above is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 msgid "The answer will be graded later."
 msgstr ""
 
@@ -4683,12 +4785,12 @@ msgstr ""
 msgid "The child problems for this problem will become visible to the student when they either have more incorrect attempts than is specified here, or when they run out of attempts, whichever comes first.  If \"max\" is specified here then child problems will only be available after a student runs out of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid "The configuration module did not find the data it needs to function.  Have your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid "The course '%1' has already been archived at '%2'. This earlier archive will be erased.  This cannot be undone."
 msgstr ""
 
@@ -4717,47 +4819,47 @@ msgid "The e-mail verbosity level controls how much information is automatically
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid "The file %1/%2 already exists and cannot be overwritten. The message was not saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 msgid "The file %1/%2 cannot be found."
 msgstr ""
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 msgid "The file '%1' cannot be found."
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 msgid "The file '%1' cannot be read!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "The file '%1' is a blank problem!"
 msgstr ""
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 msgid "The file '%1' is a directory!"
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 msgid "The file '%1' is protected!"
 msgstr ""
 
@@ -4770,55 +4872,55 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 msgid "The grade for this problem is the larger of the score for this problem, or the score of problem %1."
 msgstr ""
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid "The grade for this problem is the larger of the score for this problem, or the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid "The instructor account with user id %1 does not exist.  Please create the account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid "The library index is older than the library, you need to run OPL-update."
 msgstr ""
 
@@ -4832,11 +4934,11 @@ msgid "The name of course information file (located in the templates directory).
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid "The open date: %1, close date: %2, and answer date: %3 must be defined and in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -4850,7 +4952,7 @@ msgstr ""
 msgid "The passwords you entered in the %1 and %2 fields don't match. Please retype your new password and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr ""
 
@@ -4858,22 +4960,22 @@ msgstr ""
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid "The percentage of students receiving at least these scores. The median score is in the 50% column."
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 msgid "The recorded score for this test is  %1/%2."
 msgstr ""
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 msgid "The recorded score for this test is %1/%2."
 msgstr ""
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
 
@@ -4882,22 +4984,22 @@ msgid "The reduced scoring date should be between the open date and close date."
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 msgid "The score for this problem can count towards score of problem %1."
 msgstr ""
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr ""
 
 #. ($setID, $userCountMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 msgid "The set %1 is assigned to %2."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 msgid "The set header for set %1 has been renamed to '%2'."
 msgstr ""
 
@@ -4907,7 +5009,7 @@ msgid "The set name '%1' is already in use.  Pick a different name if you would 
 msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr ""
 
@@ -4916,13 +5018,17 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 msgid "The source file for 'set %1 / problem %2 has been changed from '%3' to '%4'"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid "The text box now contains the source of the original problem. You can recover lost edits by using the Back button on your browser."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
@@ -4934,51 +5040,52 @@ msgid "The time of the day that the assignment is due.  This can be changed on a
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 msgid "The title of the course %1 is now %2"
 msgstr ""
 
 #. ($editForUser[0], $setCountMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 msgid "The user %1 has been assigned %2."
 msgstr ""
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid "The value %1 for enableReducedScoring is not valid; it will be replaced with 'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid "The value %1 for the capTimeLimit option is not valid; it will be replaced with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid "The value %1 for the hideScore option is not valid; it will be replaced with 'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid "The value %1 for the hideWork option is not valid; it will be replaced with 'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid "The value %1 for the relaxRestrictIP option is not valid; it will be replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid "The value %1 for the restrictIP option is not valid; it will be replaced with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid "The webwork server must be able to write to these directories. Please correct the permssion errors."
 msgstr ""
 
@@ -4987,7 +5094,7 @@ msgid "Theme (refresh page after saving changes to reveal new theme.)"
 msgstr ""
 
 # Context is "Sort by ____ Then by _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr ""
 
@@ -5004,15 +5111,15 @@ msgstr ""
 msgid "There are currently two themes (or skins) to choose from: math3 and math4.  The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid "There are extra database fields  which are not defined in the schema for at least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid "There are extra database tables which are not defined in the schema.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid "There are extra database tables which are not defined in the schema.  They can only be removed manually from the database. They will not be renamed."
 msgstr ""
 
@@ -5020,26 +5127,27 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid "There are tables or fields missing from the database.  The database must be upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid "There are upgrades available for your current branch of PG from branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid "There are upgrades available for your current branch of WeBWorK from branch %1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
-msgid "There is NO undo for this function.  Do not use it unless you know what you are doing!  When you unassign a student using this button, or by unchecking their name, you destroy all of the data for achievement $achievementID for this student."
+msgid "There is NO undo for this function.  Do not use it unless you know what you are doing!  When you unassign a student using this button, or by unchecking their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -5054,11 +5162,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -5071,7 +5179,7 @@ msgstr ""
 msgid "There is no additional grade information.  A message about additional grades can go in in [TMPL]/email/%1. It is merged with the file [Scoring]/%2. These files can be edited using the \"Email\" link and the \"File Manager\" link in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid "There is no library tree file for the library, you will need to run OPL-update."
 msgstr ""
 
@@ -5087,15 +5195,15 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid "There may be something wrong with this question. Please inform your instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid "There was an error during the login process.  Please speak to your instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436 /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid "There was an error during the login process.  Please speak to your instructor or system administrator."
 msgstr ""
 
@@ -5111,15 +5219,15 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 msgid "This answer is NOT completely correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 msgid "This answer is NOT correct."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 msgid "This answer is correct."
 msgstr ""
 
@@ -5127,20 +5235,24 @@ msgstr ""
 msgid "This course supports guest logins. Click %1 to log into this course as a guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 msgid "This is a blank problem template file and can not be edited directly. Use the 'NewVersion' action below to create a local copy of the file and add it to the current problem set."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
@@ -5163,31 +5275,35 @@ msgstr ""
 msgid "This is the number of achievement points given to each user for completing a problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid "This problem has open subproblems.  You can visit them by using the links to the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#. ($shownYet{$problemFile})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr ""
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 msgid "This score for this problem does not count for the score of problem %1 or for the set."
 msgstr ""
 
@@ -5197,16 +5313,16 @@ msgid "This scoring message is generated from [TMPL]/email/%1. It is merged with
 msgstr ""
 
 #. (CGI::strong($setID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 msgid "This set %1 is assigned to %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 msgid "This set doesn't contain any problems yet."
 msgstr ""
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid "This set had a reduced scoring period that started on %1 and ended on %2.  During that period all work counted for %3% of its value."
 msgstr ""
 
@@ -5216,12 +5332,12 @@ msgstr ""
 
 # Context is "This set is visible" or "This set is hidden"
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 msgid "This set is %1"
 msgstr ""
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid "This set is in its reduced scoring period.  All work counts for %1% of its value."
 msgstr ""
 
@@ -5237,19 +5353,19 @@ msgstr ""
 msgid "This sets whether the Reduced Scoring system will be enabled.  If enabled you will need to set the default length of the reduced scoring period and the value of work done in the reduced scoring period below.  <p> To use this, you also have to enable Reduced Scoring for individual assignments and set their Reduced Scoring Dates by editing the set data.<p> This works with the avg_problem_grader (which is the the default grader) and the  std_problem_grader (the all or nothing grader).  It will work with custom graders if they are written appropriately."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 msgid "This source file is a directory!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -5261,11 +5377,11 @@ msgstr ""
 msgid "This table lists out the available homework sets for this class, along with its current status. Click on the link on the name of the homework sets to take you to the problems in that homework set.  Clicking on the links in the table headings will sort the table by the field it corresponds to.  You can also select sets for download to PDF or TeX format using the linkx next to the problem set names, and then clicking on the 'Download PDF or TeX Hardcopy for Selected Sets' button at the end of the table.  There is also a clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid "This table shows the problems that are in this problem set.  The columns from left to right are: name of the problem, current number of attempts made, number of attempts remaining, the point worth, and the completion status.  Click on the link on the name of the problem to take you to the problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 msgid "Time"
 msgstr ""
 
@@ -5274,7 +5390,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -5287,20 +5403,20 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid "To add an additional instructor to the new course, specify user information below. The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid "To add the WeBWorK administrators to the new course (as administrators) check the box below."
 msgstr ""
 
@@ -5308,19 +5424,19 @@ msgstr ""
 msgid "To change status (scores or grades) for this student for one set, click on the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid "To edit a specific student version of this set, edit (all of) her/his assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 msgid "To edit this text you must first make a copy of this file using the 'NewVersion' action below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 msgid "To edit this text you must use the 'NewVersion' action below to save it to another file."
 msgstr ""
 
@@ -5328,11 +5444,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -5348,7 +5464,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -5364,42 +5480,42 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 msgid "Unable to write to '%1': %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 msgid "Unarchive"
 msgstr ""
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 msgid "Unarchive %1 to course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 msgid "Unarchive Next Course"
 msgstr ""
 
@@ -5416,7 +5532,7 @@ msgid "Unassignments were not done.  You need to both click to \"Allow unassign\
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 msgid "Unattempted: %1/%2"
 msgstr ""
 
@@ -5424,11 +5540,11 @@ msgstr ""
 msgid "Unclassified Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 msgid "Unhide Courses"
 msgstr ""
 
@@ -5444,7 +5560,7 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 msgid "Unselect all courses"
 msgstr ""
 
@@ -5452,11 +5568,11 @@ msgstr ""
 msgid "Unselect all sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -5468,31 +5584,31 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 msgid "Upgrade"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 msgid "Upgrade Courses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -5504,11 +5620,11 @@ msgstr ""
 msgid "Use Date Picker"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -5516,20 +5632,20 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 msgid "Use in achievement %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 msgid "Use in new achievement:"
 msgstr ""
 
@@ -5545,16 +5661,16 @@ msgstr ""
 msgid "Use the interface below to quickly access commonly-used instructor tools, or select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid "Use this form to report to your professor a problem with the WeBWorK system or an error in a problem you are attempting. Along with your message, additional information about the state of the system will be included."
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid "User '%1' will not be copied from admin course as it is the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
 
@@ -5574,8 +5690,8 @@ msgstr ""
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid "UserProblem missing for user=%1 set=%2 problem=%3. This may indicate database corruption."
 msgstr ""
@@ -5589,7 +5705,7 @@ msgstr ""
 msgid "Username presented:  %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 msgid "Users"
 msgstr ""
 
@@ -5597,7 +5713,7 @@ msgstr ""
 msgid "Users Assigned to Set %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr ""
 
@@ -5610,7 +5726,7 @@ msgid "Users at this level and higher are allowed to change their password. Norm
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr ""
 
@@ -5622,15 +5738,16 @@ msgstr ""
 msgid "Users with this permssion level or greater will automatically be sent feedback from students (generated when they use the \"Contact instructor\" button on any problem page).  In addition the feedback message will be sent to addresses listed below.  To send ONLY to addresses listed below set permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 msgid "Using what display mode?: "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -5638,15 +5755,15 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr ""
 
@@ -5654,7 +5771,7 @@ msgstr ""
 msgid "View Problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr ""
 
@@ -5682,7 +5799,7 @@ msgstr ""
 msgid "View/Edit"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 msgid "Viewing temporary file:"
 msgstr ""
 
@@ -5698,15 +5815,15 @@ msgstr ""
 msgid "Visible to Students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 msgid "Warning"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 msgid "Warning messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 
@@ -5715,11 +5832,16 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 msgid "WeBWorK Error"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 msgid "WeBWorK Warnings"
 msgstr ""
 
@@ -5731,7 +5853,7 @@ msgstr ""
 msgid "WeBWorK has encountered a software error while attempting to process this problem. It is likely that there is an error in the problem itself. If you are a student, report this error message to your professor to have it corrected. If you are a professor, please consult the error output below for more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid "WeBWorK has encountered warnings while processing your request. If this occured when viewing a problem, it was likely caused by an error or ambiguity in that problem. Otherwise, it may indicate a problem with the WeBWorK system itself. If you are a student, report these warnings to your professor to have them corrected. If you are a professor, please consult the warning output below for more information."
 msgstr ""
 
@@ -5755,7 +5877,7 @@ msgstr ""
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr ""
 
@@ -5803,25 +5925,25 @@ msgstr ""
 msgid "Will open on %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 msgid "Write permissions have not been enabled for '%1'.  Changes must be saved to another file for viewing."
 msgstr ""
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 msgid "Write permissions have not been enabled in '%1'.  Changes must be saved to a different directory for viewing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid "Write permissions have not been enabled in the templates directory.  No changes can be made."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr ""
 
@@ -5842,11 +5964,11 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 msgid "You are not authorized to access the Instructor tools."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr ""
 
@@ -5854,7 +5976,7 @@ msgstr ""
 msgid "You are not authorized to modify homework sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr ""
 
@@ -5862,11 +5984,11 @@ msgstr ""
 msgid "You are not authorized to modify set definition files."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr ""
 
@@ -5883,7 +6005,7 @@ msgstr ""
 msgid "You are only allowed to click on Show Me Another %quant(%1,time,times) per problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -5893,6 +6015,10 @@ msgstr ""
 
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
@@ -5917,7 +6043,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid "You can use this feature %quant(%1,more time,more times,as many times as you want) on this problem"
 msgstr ""
 
@@ -5937,15 +6063,15 @@ msgstr ""
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 msgid "You cannot delete the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr ""
 
@@ -5957,7 +6083,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -5982,35 +6108,39 @@ msgstr ""
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr ""
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr ""
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid "You have %quant(%1,attempt,attempts) left before new version will be requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr ""
 
@@ -6018,7 +6148,7 @@ msgstr ""
 msgid "You have been logged out of WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -6047,11 +6177,15 @@ msgstr ""
 msgid "You may choose to show any of the following data. Correct answers, hints, and solutions are only available %1 after the answer date of the homework set."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 msgid "You may still check your answers."
 msgstr ""
 
@@ -6061,11 +6195,11 @@ msgid "You must attempt this problem %quant(%1,time,times) before Show Me Anothe
 msgstr ""
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 msgid "You must attempt this problem %quant(%1,time,times) before this feature is available"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -6077,7 +6211,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 msgid "You must select a course to rename."
 msgstr ""
 
@@ -6089,15 +6223,20 @@ msgstr ""
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
-msgid "You must select one or more sets for scoring"
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
+msgid "You must select one or more sets for scoring!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+msgid "You must specify a %1 name"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 msgid "You must specify a course ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 msgid "You must specify a course name."
 msgstr ""
 
@@ -6105,39 +6244,39 @@ msgstr ""
 msgid "You must specify a file name"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 msgid "You must specify a first name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 msgid "You must specify a last name for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 msgid "You must specify a new institution for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 msgid "You must specify a new name for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 msgid "You must specify a new title for the course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 msgid "You must specify an email address for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 msgid "You must specify an file name in order to save a new file."
 msgstr ""
 
@@ -6167,17 +6306,17 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 msgid "You received a score of %1 for this attempt."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid "You will not be able to proceed to problem %1 until you have completed, or run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid "You will not be able to proceed to problem %1 until you have completed, or run out of attempts, for this problem."
 msgstr ""
 
@@ -6208,26 +6347,26 @@ msgstr ""
 msgid "Your authentication failed.  Please try again. Please speak with your instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 msgid "Your display options have been saved."
 msgstr ""
 
@@ -6239,93 +6378,105 @@ msgstr ""
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 msgid "Your overall recorded score is %1.  %2"
 msgstr ""
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 msgid "Your recorded score on this test (number %1) is %2/%3."
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 msgid "Your score on this %1 WAS recorded."
 msgstr ""
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 msgid "Your score on this %1 is %2/%3."
 msgstr ""
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 msgid "Your score on this %1 was NOT recorded."
 msgstr ""
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 msgid "Your score on this problem was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid "Your score was not recorded because there was a failure in storing the problem record to the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid "Your score was not recorded because this problem has not been assigned to you."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 msgid "Your score was not recorded because this problem set version is not open."
 msgstr ""
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 msgid "Your score was not recorded because you have exceeded the time limit for this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 msgid "Your score was not recorded because you have no attempts remaining on this set version."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 msgid "Your score was not recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 msgid "[Edit]"
 msgstr ""
 
@@ -6337,7 +6488,7 @@ msgstr ""
 msgid "_ANSWER_LOG_DESCRIPTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 
@@ -6360,21 +6511,29 @@ msgstr ""
 msgid "_LOGIN_MESSAGE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+msgid "a duplicate of the first selected achievement."
 msgstr ""
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+msgid "a new empty achievement."
 msgstr ""
 
 # Context is "Create set ______ as a new empty set"
@@ -6383,7 +6542,7 @@ msgid "a new empty set"
 msgstr ""
 
 # Context is "Save to a new file named:"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -6391,7 +6550,7 @@ msgstr ""
 msgid "a single set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "active"
 msgstr ""
 
@@ -6400,11 +6559,11 @@ msgid "add problems"
 msgstr ""
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -6413,11 +6572,11 @@ msgstr ""
 msgid "admin"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 msgid "all current users"
 msgstr ""
 
@@ -6433,7 +6592,7 @@ msgstr ""
 msgid "all students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr ""
 
@@ -6441,26 +6600,31 @@ msgstr ""
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661 /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687 /opt/webwork/pg/macros/PGbasicmacros.pl:698
 msgid "answer"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr ""
 
 # Context is "Create _____ as a new empty set"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
-msgstr ""
-
-# Context is "Import achievements from ____ assigning the achievements to ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-msgid "assigning the achievements to"
 msgstr ""
 
 # Context is "Import set from ____ assigning this set to ____"
@@ -6473,19 +6637,19 @@ msgid "avg attempts"
 msgstr ""
 
 # Context is "Append ____ blank problem template(s) to end of homework set"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr ""
 
@@ -6501,15 +6665,15 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr ""
 
@@ -6523,7 +6687,7 @@ msgid "deleted %1 sets"
 msgstr ""
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 msgid "deleted %1 users"
 msgstr ""
 
@@ -6535,7 +6699,7 @@ msgstr ""
 msgid "editing all sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr ""
 
@@ -6547,7 +6711,7 @@ msgstr ""
 msgid "editing selected sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr ""
 
@@ -6555,7 +6719,7 @@ msgstr ""
 msgid "editing visible sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr ""
 
@@ -6563,7 +6727,7 @@ msgstr ""
 msgid "email:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 msgid "empty"
 msgstr ""
 
@@ -6576,15 +6740,15 @@ msgid "entry rows."
 msgstr ""
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 msgid "exporting all achievements"
 msgstr ""
 
@@ -6592,7 +6756,7 @@ msgstr ""
 msgid "exporting all sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 msgid "exporting selected achievements"
 msgstr ""
 
@@ -6625,15 +6789,15 @@ msgstr ""
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr ""
 
@@ -6660,7 +6824,7 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr ""
 
@@ -6668,7 +6832,7 @@ msgstr ""
 msgid "hidden from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr ""
 
@@ -6679,41 +6843,45 @@ msgstr ""
 # doe snot need to be translated
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34 /opt/webwork/pg/lib/Value/Vector.pm:280 /opt/webwork/pg/macros/contextLimitedVector.pl:94
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35 /opt/webwork/pg/lib/Value/Vector.pm:278 /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
 # Context is " Show users who match _____ in their _____"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 msgid "inactive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426 /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 msgid "locations selected below"
 msgstr ""
 
@@ -6721,7 +6889,7 @@ msgstr ""
 msgid "login"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "login ID"
 msgstr ""
 
@@ -6754,15 +6922,15 @@ msgstr ""
 msgid "new users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 msgid "no achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 msgid "no location"
 msgstr ""
 
@@ -6774,20 +6942,24 @@ msgstr ""
 msgid "no students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235 /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236 /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -6811,7 +6983,7 @@ msgstr ""
 msgid "only best scores"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
 msgid "or"
 msgstr ""
 
@@ -6819,52 +6991,56 @@ msgstr ""
 msgid "or Problems from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 msgid "point"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 msgid "points"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 msgid "preview answers"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 msgid "problem"
 msgstr ""
 
@@ -6881,7 +7057,7 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -6895,16 +7071,16 @@ msgid "record for user %1 not found"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 msgid "record for visible user %1 not found"
 msgstr ""
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -6924,11 +7100,11 @@ msgstr ""
 msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 msgid "selected achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 msgid "selected achievements."
 msgstr ""
 
@@ -6936,7 +7112,7 @@ msgstr ""
 msgid "selected sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr ""
 
@@ -6972,7 +7148,7 @@ msgstr ""
 msgid "showing all sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr ""
 
@@ -6984,7 +7160,7 @@ msgstr ""
 msgid "showing matching sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr ""
 
@@ -6992,7 +7168,7 @@ msgstr ""
 msgid "showing no sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr ""
 
@@ -7000,12 +7176,16 @@ msgstr ""
 msgid "showing selected sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:750
 msgid "showing visible sets"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -7020,16 +7200,16 @@ msgstr ""
 msgid "students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "submission"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "submission (test %1)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -7037,12 +7217,12 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "test"
 msgstr ""
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 msgid "test (%1)"
 msgstr ""
 
@@ -7054,7 +7234,7 @@ msgstr ""
 msgid "test time"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -7063,12 +7243,12 @@ msgid "the following file(s)"
 msgstr ""
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 msgid "the original path to the file is %1"
 msgstr ""
 
 # Context is "Sort by ___ then by ___"
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 msgid "then by"
 msgstr ""
 
@@ -7076,7 +7256,11 @@ msgstr ""
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr ""
 
@@ -7084,39 +7268,35 @@ msgstr ""
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr ""
 
 # Context is Assign ____ to _____
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 msgid "top score"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 msgid "unable to write to directory %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr ""
 
@@ -7125,23 +7305,23 @@ msgstr ""
 msgid "userID: %1 --"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid "username, last name, first name, section, achievement level, achievement score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "users"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 msgid "users who match:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr ""
 
@@ -7149,12 +7329,16 @@ msgstr ""
 msgid "visible sets"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470 /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
@@ -7162,8 +7346,12 @@ msgid "with set name(s):"
 msgstr ""
 
 #. ($dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411

--- a/lib/WeBWorK/Localize/zh_CN.po
+++ b/lib/WeBWorK/Localize/zh_CN.po
@@ -19,12 +19,17 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.6.10\n"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "选中的作业"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 #, fuzzy
 msgid "#corr"
 msgstr "正确"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 #, fuzzy
 msgid "#incorr"
 msgstr "错误"
@@ -38,16 +43,16 @@ msgstr "%1% 正确"
 msgid "% correct with review"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 #, fuzzy
 msgid "% students"
 msgstr "对学生是可见的"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -88,18 +93,18 @@ msgid "%1 students out of %2"
 msgstr "对学生是可见的"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 #, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "%1 个用户导出到文件 %2/%3"
 
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 #, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
@@ -130,8 +135,8 @@ msgstr "已完成。"
 
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 #, fuzzy
 msgid "%1% correct"
 msgstr "%1% 正确"
@@ -175,7 +180,7 @@ msgstr "%1的密码已修改。"
 
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 msgid "%1: Problem %2"
 msgstr "%1：第%2题"
 
@@ -186,13 +191,13 @@ msgid "%1: Problem %2 Show Me Another"
 msgstr "%1：第%2题"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 #, fuzzy
 msgid "%1: The directory for the course not found."
 msgstr "找不到这个文件 '[_1]'。"
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -207,50 +212,50 @@ msgid "%quant(%1,file) unpacked successfully"
 msgstr ""
 
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 #, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "%quant(%1,个问题,个问题) 未完成。"
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 #, fuzzy
 msgid "%score"
 msgstr "成绩"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(这道题将不会计入您的成绩.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 #, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "您总的纪录分数是%1. %2"
 
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 #, fuzzy
 msgid "(Your score on this %1 is not available.)"
 msgstr "您总的纪录分数是%1. %2"
@@ -326,17 +331,31 @@ msgstr ""
 
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 #, fuzzy
 msgid "A course with ID %1 already exists."
 msgstr "复制作业失败：作业 %1 已存在"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1212
@@ -353,27 +372,27 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 #, fuzzy
 msgid "A new file has been created at '%1'"
 msgstr "作业 %1 已存在。没有作业被创建"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 #, fuzzy
 msgid ""
@@ -412,40 +431,40 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 #, fuzzy
 msgid "ANSWERS NOT RECORDED"
 msgstr "只是预览 -- 答案未记录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 #, fuzzy
 msgid "ANSWERS NOT RECORDED --"
 msgstr "只是预览 -- 答案未记录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 #, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "答案仅检查 -- 答案没有被记录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "答案仅检查 -- 答案没有被记录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "放弃更改"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "放弃输出"
@@ -456,12 +475,12 @@ msgid "Achievement"
 msgstr "选中的作业"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 #, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "作业 %1 已存在。没有作业被创建"
@@ -479,13 +498,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -502,12 +521,17 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr "作业[_1]的文件名被改为'[_2]'。"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "作业[_1]的文件名被改为'[_2]'。"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 #, fuzzy
 msgid "Achievement scores saved to %1"
 msgstr "作业[_1]的文件名被改为'[_2]'。"
@@ -529,19 +553,19 @@ msgid "Act as:"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 #, fuzzy
 msgid "Acting as %1."
 msgstr "您现在的身份是 %1。"
 
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 #, fuzzy
 msgid "Action %1 not found"
 msgstr "找不到这个文件 '[_1]'。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "活跃的"
 
@@ -560,7 +584,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "添加"
@@ -569,9 +593,9 @@ msgstr "添加"
 msgid "Add All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 #, fuzzy
 msgid "Add Course"
 msgstr "课程"
@@ -586,7 +610,7 @@ msgstr "对学生是可见的"
 msgid "Add Users"
 msgstr "添加用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -594,13 +618,13 @@ msgstr ""
 msgid "Add a new test for which Gateway?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 #, fuzzy
 msgid "Add as what filetype?"
 msgstr "添加为哪种文件类型？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "增加多少学生?"
 
@@ -609,45 +633,45 @@ msgstr "增加多少学生?"
 msgid "Add problems to"
 msgstr "添加题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 #, fuzzy
 msgid "Add to what set?"
 msgstr "添加到哪个作业？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "增加哪种新用户?"
 
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 #, fuzzy
 msgid "Added %1 to %2 as problem %3"
 msgstr "添加[_1]到[_2]作为问题[_3]"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 #, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "添加 '[_1]' 到 [_2] 作为新的文件名"
 
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 #, fuzzy
 msgid "Added '%1' to %2 as new set header"
 msgstr "添加 '[_1]' 到 [_2] 作为新的文件名"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -656,53 +680,53 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Addresses"
 msgstr "电子邮件地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -717,7 +741,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -731,7 +755,7 @@ msgid "After set answer date"
 msgstr "答案日期"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -744,17 +768,17 @@ msgstr ""
 msgid "All assignments were made successfully."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 #, fuzzy
 msgid "All of the answers above are correct."
 msgstr "上面的所有答案都是正确的."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 #, fuzzy
 msgid "All of the gradeable answers above are correct."
 msgstr "上面的所有答案都是正确的."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -778,7 +802,7 @@ msgstr "对学生隐藏"
 msgid "All sets made visible for all students"
 msgstr "对学生是可见的"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -850,26 +874,26 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 #, fuzzy
 msgid "An error occured while archiving the course %1:"
 msgstr "成功创建新作业 %1"
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 #, fuzzy
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr "成功创建新作业 %1"
@@ -889,8 +913,8 @@ msgstr "答案日期"
 msgid "Answer Log"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "答案预览"
 
@@ -903,11 +927,11 @@ msgstr ""
 msgid "Answer:"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -931,15 +955,21 @@ msgstr ""
 msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr "以下所有修改会影响所有学生的这次作业。"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
 msgstr "以下所有修改会影响所有学生的这次作业。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 #, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
@@ -953,19 +983,19 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 #, fuzzy
 msgid "Append to end of %1 set"
 msgstr "添加到这个作业 [_1] 的最后面"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 #, fuzzy
 msgid "Archive"
 msgstr "课程"
@@ -980,29 +1010,29 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 #, fuzzy
 msgid "Archive Courses"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 #, fuzzy
 msgid "Archive next course"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 #, fuzzy
 msgid "Archive this Course"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 #, fuzzy
 msgid "Archived Courses"
 msgstr "课程"
@@ -1013,24 +1043,28 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 #, fuzzy
 msgid "Assign"
 msgstr "已布置的作业"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1056,18 +1090,18 @@ msgstr ""
 msgid "Assigned"
 msgstr "已布置的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 msgid "Assigned Sets"
 msgstr "已布置的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 #, fuzzy
 msgid "Assigned achievements to users"
 msgstr "这次作业留给哪些用户?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 #, fuzzy
 msgid "Assigned to"
 msgstr "已布置的作业"
@@ -1077,7 +1111,12 @@ msgstr "已布置的作业"
 msgid "Assignment type"
 msgstr "已布置的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "已布置的作业"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 #, fuzzy
 msgid "At least one of the answers above is NOT correct."
 msgstr "以上答案至少其中一个不是%1c正确。"
@@ -1086,7 +1125,7 @@ msgstr "以上答案至少其中一个不是%1c正确。"
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1099,7 +1138,7 @@ msgstr "尝试次数"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 msgid "Attempts"
 msgstr "尝试次数"
 
@@ -1107,13 +1146,14 @@ msgstr "尝试次数"
 msgid "Audit"
 msgstr "审核中"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "作者信息"
 
@@ -1121,12 +1161,12 @@ msgstr "作者信息"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1166,16 +1206,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:295
@@ -1210,7 +1250,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1251,19 +1291,19 @@ msgid "Can't get password record for user '%1': %2"
 msgstr "取不到用户'%1'的密码纪录：%2"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 #, fuzzy
 msgid "Can't open %1"
 msgstr "已保存到'[_1]'"
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 #, fuzzy
 msgid "Can't open file %1"
 msgstr "已保存到'[_1]'"
 
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 #, fuzzy
 msgid "Can't read merge file %1. No message sent"
 msgstr "已保存到'[_1]'"
@@ -1274,7 +1314,7 @@ msgstr "已保存到'[_1]'"
 msgid "Can't rename file: %1"
 msgstr "已保存到'[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1283,11 +1323,11 @@ msgstr ""
 msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 #, fuzzy
 msgid "Can't write to file %1"
 msgstr "已保存到'[_1]'"
@@ -1300,7 +1340,7 @@ msgstr "已保存到'[_1]'"
 msgid "Cancel"
 msgstr "取消编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 #, fuzzy
 msgid "Cancel E-mail"
 msgstr "取消电子邮件"
@@ -1315,8 +1355,8 @@ msgstr "已保存到'[_1]'"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1336,11 +1376,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1355,7 +1395,7 @@ msgstr "显示选项"
 msgid "Change Email Address"
 msgstr "修改电子邮箱地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1364,33 +1404,33 @@ msgstr ""
 msgid "Change Password"
 msgstr "更改密码"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 #, fuzzy
 msgid "Change User Settings"
 msgstr "修改用户选项"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 msgid "Changes abandoned"
 msgstr "放弃修改"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "对这个文件的修改还未永久保存。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 msgid "Changes saved"
 msgstr "保存修改"
 
@@ -1405,27 +1445,27 @@ msgstr ""
 msgid "Chapter:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 #, fuzzy
 msgid "Check Test"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 msgid "Checking additional error messages"
 msgstr "检查额外的错误信息"
 
@@ -1440,7 +1480,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1480,8 +1520,8 @@ msgid ""
 "Click heading to sort table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
@@ -1496,7 +1536,7 @@ msgid ""
 "problem resolved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 #, fuzzy
 msgid "Close"
 msgstr "已关闭"
@@ -1541,7 +1581,7 @@ msgid "Closes"
 msgstr "已关闭"
 
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 #, fuzzy
 msgid "Closes %1"
 msgstr "恢复到[_1]"
@@ -1552,39 +1592,39 @@ msgstr "恢复到[_1]"
 msgid "Closes:"
 msgstr "已关闭"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "评论"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1593,7 +1633,7 @@ msgstr ""
 msgid "Completed."
 msgstr "已完成。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1604,7 +1644,7 @@ msgstr ""
 msgid "Confirm %1's New Password"
 msgstr "确认%1的新密码"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 #, fuzzy
 msgid "Confirm Password:"
 msgstr "确认%1的新密码"
@@ -1619,8 +1659,8 @@ msgid "Continue"
 msgstr "继续"
 
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 #, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "已从 [_1] 复制新文件到新的位置 [_2]"
@@ -1635,7 +1675,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1644,8 +1684,8 @@ msgstr ""
 msgid "Copy this Problem"
 msgstr "编辑这道题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "正确"
@@ -1654,7 +1694,7 @@ msgstr "正确"
 msgid "Correct Adjusted Status"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 #, fuzzy
 msgid "Correct Answer"
 msgstr "正确答案"
@@ -1674,19 +1714,19 @@ msgid "Correct answers"
 msgstr "正确答案"
 
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 #, fuzzy
 msgid "Correct: %1/%2"
 msgstr "作业[_1]/第[_2]题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 #, fuzzy
 msgid "CorrectAnswers"
 msgstr "正确答案"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1705,49 +1745,50 @@ msgid "Couldn't change your email address: %1"
 msgstr "不能修改您的电子邮箱地址：%1"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 #, fuzzy
 msgid "Couldn't save your display options: %1"
 msgstr "不能修改您的电子邮箱地址：%1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1757,13 +1798,13 @@ msgstr "课程管理"
 msgid "Course Configuration"
 msgstr "课程配置"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 #, fuzzy
 msgid "Course ID:"
 msgstr "课程信息"
@@ -1773,14 +1814,14 @@ msgstr "课程信息"
 msgid "Course Info"
 msgstr "课程信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 #, fuzzy
 msgid "Course Name:"
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 #, fuzzy
 msgid "Course Title:"
 msgstr "课程"
@@ -1790,15 +1831,15 @@ msgstr "课程"
 msgid "Course archived."
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -1817,7 +1858,7 @@ msgstr "创建"
 msgid "Create CSV"
 msgstr "创建"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 #, fuzzy
 msgid "Create Location:"
 msgstr "习题课"
@@ -1826,7 +1867,7 @@ msgstr "习题课"
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -1834,12 +1875,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "创建为哪种类型的作业？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -1852,34 +1893,34 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 #, fuzzy
 msgid "Database:"
 msgstr "已放弃导出"
@@ -1893,7 +1934,7 @@ msgstr "开始日期"
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -1918,84 +1959,84 @@ msgstr ""
 msgid "Default Time that the Assignment is Due"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "删除"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 #, fuzzy
 msgid "Delete Course"
 msgstr "删除"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 #, fuzzy
 msgid "Delete course:"
 msgstr "删除"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "删除多少?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 #, fuzzy
 msgid "Delete it?"
 msgstr "删除"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 #, fuzzy
 msgid "Delete location:"
 msgstr "删除"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 #, fuzzy
 msgid "Deleted %quant(%1,achievement)"
 msgstr "选中的作业"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 #, fuzzy
 msgid "Deleting temp file at %1"
 msgstr "删除[_1]中临时文件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 #, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
 msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 #, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！"
@@ -2005,7 +2046,7 @@ msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！
 msgid "Deletion destroys all set-related data and is not undoable!"
 msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 #, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！"
@@ -2014,14 +2055,14 @@ msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！
 msgid "Deny From"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 #, fuzzy
 msgid "Description"
 msgstr "习题课"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -2040,48 +2081,48 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 #, fuzzy
 msgid "Directory structure"
 msgstr "监考员"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 #, fuzzy
 msgid "Display Mode:"
@@ -2091,6 +2132,11 @@ msgstr "显示模式"
 #, fuzzy
 msgid "Display Past Answers"
 msgstr "显示以往的回答"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+#, fuzzy
+msgid "Display of scores for this set is not allowed."
+msgstr "您总的纪录分数是%1. %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 #, fuzzy
@@ -2115,33 +2161,33 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 #, fuzzy
 msgid "Don't Unarchive"
 msgstr "保存修变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 #, fuzzy
 msgid "Don't Upgrade"
 msgstr "删除"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #, fuzzy
 msgid "Don't delete"
 msgstr "删除"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 #, fuzzy
 msgid "Don't make changes"
 msgstr "保存修变"
 
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 #, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "不能识别的保持模式|[_1]|。未知的错误。"
@@ -2151,18 +2197,18 @@ msgstr "不能识别的保持模式|[_1]|。未知的错误。"
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 #, fuzzy
 msgid "Don't use in an achievement"
 msgstr "保存修变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2195,8 +2241,8 @@ msgstr "打印副本"
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "下载选中的 %plural(%1,作业,作业)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "下载当前作业的PDF或者TeX文件"
 
@@ -2219,6 +2265,16 @@ msgstr "成绩下载"
 msgid "Drop"
 msgstr "退课"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
 msgstr "复制这次作业并重命名"
@@ -2239,7 +2295,7 @@ msgstr ""
 msgid "E-Mail"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 msgid "E-mail Instructor"
 msgstr "发电子邮件给老师"
 
@@ -2257,7 +2313,7 @@ msgstr ""
 msgid "E-mail verbosity level"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 #, fuzzy
 msgid "E-mail:"
 msgstr "电子邮件"
@@ -2266,25 +2322,25 @@ msgstr "电子邮件"
 msgid "Earned"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "编辑"
 
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 #, fuzzy
 msgid "Edit %1 of set %2."
 msgstr "编辑 [_1] 在文件 '[_2]' 中"
@@ -2298,21 +2354,21 @@ msgstr "编辑所有作业数据"
 msgid "Edit Assigned Users"
 msgstr "编辑选中的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 #, fuzzy
 msgid "Edit Header"
 msgstr "作业头"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 #, fuzzy
 msgid "Edit Location:"
 msgstr "习题课"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #, fuzzy
 msgid "Edit Problem"
 msgstr "编辑题目"
@@ -2337,7 +2393,7 @@ msgstr "编辑作业信息"
 msgid "Edit Target Set"
 msgstr "编辑作业信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "编辑哪些用户?"
 
@@ -2354,17 +2410,17 @@ msgstr "编辑"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2376,24 +2432,24 @@ msgstr ""
 msgid "Edit which sets?"
 msgstr "编辑哪些作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 #, fuzzy
 msgid "Edit1"
 msgstr "编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 #, fuzzy
 msgid "Edit2"
 msgstr "编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 #, fuzzy
 msgid "Edit3"
 msgstr "编辑"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 #, fuzzy
 msgid "Editing %1 in file '%2'"
 msgstr "编辑 [_1] 在文件 '[_2]' 中"
@@ -2405,46 +2461,46 @@ msgid "Editing achievement in file '%1'"
 msgstr "编辑 [_1] 在文件 '[_2]' 中"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 #, fuzzy
 msgid "Editor"
 msgstr "编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 #, fuzzy
 msgid "Editor rows:"
 msgstr "编辑题目"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "电子邮件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "电子邮件地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 #, fuzzy
 msgid "Email Body:"
 msgstr "电子邮件："
@@ -2454,31 +2510,31 @@ msgstr "电子邮件："
 msgid "Email Instructor On Failed Attempt"
 msgstr "发电子邮件给老师"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 #, fuzzy
 msgid "Email Link"
 msgstr "电子邮件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 #, fuzzy
 msgid "Email address"
 msgstr "电子邮件地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "发电子邮件给老师"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2522,8 +2578,8 @@ msgid ""
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 #, fuzzy
 msgid "Enabled"
 msgstr "启用"
@@ -2561,22 +2617,22 @@ msgstr ""
 msgid "Enrolled"
 msgstr "已注册"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "注册状态"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "输入文件名"
 
@@ -2590,8 +2646,8 @@ msgid ""
 "password will initially be set to their student ID."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "已输入"
 
@@ -2623,7 +2679,7 @@ msgstr ""
 msgid "Error message:"
 msgstr "消息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 #, fuzzy
 msgid "Error messages"
 msgstr "消息"
@@ -2646,7 +2702,7 @@ msgid ""
 msgstr ""
 
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 #, fuzzy
 msgid "Error: The original file %1 cannot be read."
@@ -2666,6 +2722,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2681,7 +2741,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2689,58 +2749,58 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "导出"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 #, fuzzy
 msgid "Export selected achievements."
 msgstr "导出已选定的作业"
@@ -2749,7 +2809,7 @@ msgstr "导出已选定的作业"
 msgid "Export selected sets"
 msgstr "导出已选定的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "导出为哪种文件类型？"
 
@@ -2757,12 +2817,12 @@ msgstr "导出为哪种文件类型？"
 msgid "Export which sets?"
 msgstr "导出哪些作业？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "导出哪些用户？"
 
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 #, fuzzy
 msgid "Exported achievements to %1"
 msgstr "导出已选定的作业"
@@ -2777,17 +2837,17 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 #, fuzzy
 msgid "Failed to create new achievement: %1"
 msgstr "创建新作业：%1失败"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 #, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "创建新作业失败：没有给定作业名！"
@@ -2802,7 +2862,7 @@ msgstr "创建新作业：%1失败"
 msgid "Failed to create new set: no set name specified!"
 msgstr "创建新作业失败：没有给定作业名！"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 #, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
@@ -2837,10 +2897,10 @@ msgstr "创建新作业：%1失败"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 #, fuzzy
 msgid "Failed to open %1"
 msgstr "已保存到'[_1]'"
@@ -2852,11 +2912,11 @@ msgid "Failed to save: %1"
 msgstr "已保存到'[_1]'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid "Feature exhausted for this problem"
 msgstr "报告这道题中的错误"
@@ -2870,36 +2930,36 @@ msgstr "反馈信息"
 msgid "Feedback by Section."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 #, fuzzy
 msgid "FeedbackMessage"
 msgstr "反馈信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 #, fuzzy
 msgid ""
@@ -2953,7 +3013,7 @@ msgstr ""
 msgid "File successfully renamed"
 msgstr "成功创建新作业 %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "文件名"
 
@@ -2962,7 +3022,7 @@ msgstr "文件名"
 msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "关键字"
 
@@ -2978,29 +3038,29 @@ msgstr "过滤"
 msgid "First"
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 #, fuzzy
 msgid "First name"
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3008,7 +3068,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -3017,6 +3077,11 @@ msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+#, fuzzy
+msgid "Format"
+msgstr "文件格式"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
@@ -3028,20 +3093,25 @@ msgstr ""
 msgid "Format:"
 msgstr "文件格式"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "这个作业没有包含任何题目。"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 #, fuzzy
 msgid "From field must contain one valid email address."
 msgstr "不能修改您的电子邮箱地址：%1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr "来自于："
 
@@ -3070,7 +3140,7 @@ msgid "General"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 #, fuzzy
 msgid "General Information"
 msgstr "站点信息"
@@ -3093,12 +3163,18 @@ msgstr "下一题"
 msgid "Get Target Set Problems"
 msgstr "编辑作业信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+#, fuzzy
+msgid "Get a new version of this problem"
+msgstr "报告这道题中的错误"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 #, fuzzy
 msgid "Give new password to"
 msgstr "为哪些用户设置新密码？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "为哪些用户设置新密码？"
 
@@ -3126,7 +3202,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "找不到这个文件 '[_1]'。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -3134,24 +3210,34 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 #, fuzzy
 msgid "Grade"
 msgstr "成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 #, fuzzy
 msgid "Grade Problem"
 msgstr "下一题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 #, fuzzy
 msgid "Grade Test"
 msgstr "成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 #, fuzzy
 msgid "Grader"
 msgstr "成绩"
@@ -3181,7 +3267,7 @@ msgstr ""
 msgid "Guest Login"
 msgstr "游客登录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 #, fuzzy
 msgid "HTTP Headers"
 msgstr "作业头"
@@ -3210,13 +3296,17 @@ msgstr "文件头"
 msgid "Hardcopy Theme"
 msgstr "文件头"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 #, fuzzy
 msgid "Headers"
 msgstr "作业头"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "帮助"
 
@@ -3228,12 +3318,12 @@ msgstr ""
 msgid "Hidden"
 msgstr "隐藏"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Hide Courses"
 msgstr "课程"
@@ -3248,8 +3338,8 @@ msgstr "提示"
 msgid "Hide Hints from Students"
 msgstr "对学生隐藏"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 #, fuzzy
 msgid "Hide Inactive Courses"
 msgstr "课程"
@@ -3263,7 +3353,7 @@ msgstr ""
 msgid "Hide path:"
 msgstr "提示"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 #, fuzzy
 msgid "Hint:"
 msgstr "提示"
@@ -3277,13 +3367,13 @@ msgstr "提示"
 msgid "Hmwk Sets Editor"
 msgstr "作业编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 #, fuzzy
 msgid "Homework Totals"
 msgstr "作业"
@@ -3292,15 +3382,15 @@ msgstr "作业"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3318,14 +3408,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3337,13 +3427,17 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
 #, fuzzy
 msgid "Illegal file '%1' specified"
 msgstr "这个文件 '[_1]' 是受保护的！"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3351,10 +3445,11 @@ msgstr ""
 msgid "Import"
 msgstr "导入"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
 #, fuzzy
-msgid "Import achievements from"
-msgstr "导出已选定的作业"
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "这次作业留给哪些用户?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
 msgid "Import from where?"
@@ -3368,22 +3463,22 @@ msgstr "导入多少次作业？"
 msgid "Import sets with names"
 msgstr "导入作业名为"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "从哪个文件导入用户？"
 
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 #, fuzzy
 msgid "Imported %quant(%1,achievement)"
 msgstr "导出已选定的作业"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "不活跃的"
 
@@ -3391,19 +3486,19 @@ msgstr "不活跃的"
 msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 #, fuzzy
 msgid "Include Success Index"
 msgstr "包括索引"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 #, fuzzy
 msgid "Incorrect"
 msgstr "错误"
 
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 #, fuzzy
 msgid "Incorrect: %1/%2"
 msgstr "错误"
@@ -3412,7 +3507,7 @@ msgstr "错误"
 msgid "Init"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 #, fuzzy
 msgid "Institution:"
 msgstr "习题课"
@@ -3421,16 +3516,16 @@ msgstr "习题课"
 msgid "Instructor Tools"
 msgstr "教师工具"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3439,7 +3534,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3454,17 +3549,21 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 #, fuzzy
 msgid "Jump to Page:"
 msgstr "下一题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 #, fuzzy
 msgid "Jump to Problem:"
 msgstr "下一题"
@@ -3477,7 +3576,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3500,28 +3599,28 @@ msgstr "姓"
 msgid "Last Answer"
 msgstr "显示以往的回答"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "姓"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 #, fuzzy
 msgid "Last name"
 msgstr "姓"
@@ -3550,18 +3649,18 @@ msgstr ""
 msgid "Level:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "浏览资料库"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 msgid "Library Browser 2"
 msgstr "浏览资料库2"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 #, fuzzy
 msgid "Library Browser 3"
@@ -3600,36 +3699,36 @@ msgstr ""
 msgid "Local Problems"
 msgstr "题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Location"
 msgstr "习题课"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
 msgstr ""
 
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 #, fuzzy
 msgid "Location %1 has been created, with addresses %2."
 msgstr "作业 %1 已存在。没有作业被创建"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 #, fuzzy
 msgid "Location description:"
 msgstr "显示/隐藏站点描述"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 #, fuzzy
 msgid "Location name:"
 msgstr "没有任何操作"
@@ -3638,8 +3737,8 @@ msgstr "没有任何操作"
 msgid "Log In Again"
 msgstr "重新登录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "登出"
 
@@ -3647,21 +3746,21 @@ msgstr "登出"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 #, fuzzy
 msgid "Logged in as %1."
 msgstr "登录为 %1 。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 #, fuzzy
 msgid "Login"
 msgstr "登入"
@@ -3674,23 +3773,23 @@ msgstr "登录信息"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "登录名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 msgid "Login Status"
 msgstr "登录状态"
 
@@ -3698,7 +3797,7 @@ msgstr "登录状态"
 msgid "Logout"
 msgstr "登出"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "主菜单"
 
@@ -3711,21 +3810,21 @@ msgstr ""
 msgid "Make Archive"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 #, fuzzy
 msgid "Make changes"
 msgstr "保存修变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 #, fuzzy
 msgid "Manual Grader"
@@ -3741,7 +3840,7 @@ msgid "Mark Correct"
 msgstr "正确"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 #, fuzzy
 msgid "Mark Correct?"
 msgstr "正确"
@@ -3750,8 +3849,9 @@ msgstr "正确"
 msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "关键字？ (用逗号分开多个用户名)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "数学函数对象"
 
@@ -3769,52 +3869,52 @@ msgstr "显示："
 msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 #, fuzzy
 msgid "Merge file:"
 msgstr "头文件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 #, fuzzy
 msgid "Message"
 msgstr "消息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 #, fuzzy
 msgid "Message file:"
 msgstr "头文件"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 #, fuzzy
 msgid "Message:"
 msgstr "消息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "消息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -3827,17 +3927,17 @@ msgstr "题目"
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -3881,13 +3981,13 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 #, fuzzy
 msgid "New Name:"
 msgstr "作业名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "新密码"
 
@@ -3900,12 +4000,12 @@ msgstr "文件名"
 msgid "New folder name:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "新密码已保存"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -3913,15 +4013,17 @@ msgstr ""
 msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "下一题"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -3929,21 +4031,27 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "否"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 #, fuzzy
 msgid "No Description"
 msgstr "显示/隐藏站点描述"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "作业[_1]的文件名被改为'[_2]'。"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -3963,7 +4071,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "没有修改任何作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -3975,7 +4083,7 @@ msgstr ""
 msgid "No changes were saved!"
 msgstr "已保存修改"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 #, fuzzy
 msgid "No course id defined"
 msgstr "课程"
@@ -3987,39 +4095,39 @@ msgstr "课程"
 msgid "No data exists for set %1 and problem %2"
 msgstr "作业[_1]/第[_2]题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 #, fuzzy
 msgid "No merge data file"
 msgstr "头文件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -4027,25 +4135,25 @@ msgstr ""
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 #, fuzzy
 msgid "No record for global set %1."
 msgstr "设置 [_1] 的作业名"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 #, fuzzy
 msgid "No record for user %1."
 msgstr "设置 [_1] 的作业名"
 
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 #, fuzzy
 msgid "No record found for problem %1."
 msgstr "设置 [_1] 的作业名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -4058,22 +4166,22 @@ msgstr ""
 msgid "No sets selected for scoring"
 msgstr "没有选中作业去计分"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr "没有显示作业。选择以上某个选项去列出这门课满足条件的作业。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 #, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
@@ -4092,15 +4200,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -4114,26 +4226,32 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "没有登录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "注意"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "注意"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 #, fuzzy
 msgid "Number"
 msgstr "题目预览"
@@ -4150,8 +4268,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -4184,7 +4302,7 @@ msgid ""
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 #, fuzzy
 msgid "Open"
 msgstr "开始日期"
@@ -4204,13 +4322,13 @@ msgstr "开始日期"
 msgid "Open Problem Library"
 msgstr "题目列表"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -4226,11 +4344,10 @@ msgstr "现在开放中, 截止于"
 msgid "Open, complete by %1."
 msgstr "进行中：已完成 %1"
 
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
-msgid "Open, reduced scoring starts on %1."
-msgstr "降低总分开始于：%1"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
 #, fuzzy
@@ -4255,12 +4372,12 @@ msgstr ""
 msgid "Order Problems Randomly"
 msgstr "题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 #, fuzzy
 msgid "Orig. Lib. Browser"
 msgstr "浏览资料库"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4284,64 +4401,67 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "只是预览 -- 答案未记录"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "填补栏"
 
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 #, fuzzy
 msgid "Page generated at %1"
 msgstr "页面生成于 %1"
@@ -4355,7 +4475,7 @@ msgstr "密码"
 msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 #, fuzzy
 msgid "Password:"
 msgstr "密码"
@@ -4366,7 +4486,7 @@ msgstr "密码"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "添加[_1]到[_2]作为问题[_3]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4380,24 +4500,24 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "权限等级"
 
@@ -4406,7 +4526,7 @@ msgstr "权限等级"
 msgid "Permissions"
 msgstr "权限等级"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4443,7 +4563,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4456,7 +4576,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "请在下面%1处输入你的用户名和密码 :"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4476,55 +4596,56 @@ msgstr "您必须指定文件名已保持一个新文件。"
 msgid "Please select at least one user and try again."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "请指定要保存到的文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #, fuzzy
 msgid "Points"
 msgstr "提示"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
 msgid "Preflight Log"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview Message"
 msgstr "答案预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 #, fuzzy
 msgid "Preview My Answers"
 msgstr "答案预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 #, fuzzy
 msgid "Preview Test"
 msgstr "答案预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview message"
 msgstr "答案预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 #, fuzzy
 msgid "Preview set to:"
 msgstr "答案预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "上一题"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 #, fuzzy
 msgid "Previous page"
@@ -4534,11 +4655,11 @@ msgstr "上一题"
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #, fuzzy
 msgid "Prob"
 msgstr "题目"
@@ -4558,21 +4679,21 @@ msgstr "第%1题"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 #, fuzzy
 msgid "Problem %1"
 msgstr "第%1题"
 
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 #, fuzzy
 msgid "Problem %1."
 msgstr "第%1题"
@@ -4591,8 +4712,8 @@ msgstr "题目编辑"
 msgid "Problem Editor3"
 msgstr "题目编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "题目列表"
 
@@ -4610,29 +4731,30 @@ msgstr "题目预览"
 msgid "Problem Number "
 msgstr "题目预览"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "问题方法"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 #, fuzzy
 msgid "Problem Viewer"
 msgstr "题目编辑"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "题目"
 
@@ -4682,11 +4804,11 @@ msgid ""
 "proctored test."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "发布"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -4700,28 +4822,28 @@ msgid "Really delete the items listed above?"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "习题课"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "记录单个作业的成绩"
 
@@ -4736,7 +4858,7 @@ msgid "Reduced Scoring Date"
 msgstr "减分模式已禁用"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Disabled"
 msgstr "减分模式已禁用"
@@ -4744,22 +4866,10 @@ msgstr "减分模式已禁用"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Enabled"
 msgstr "减分模式已启用"
-
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
-msgid "Reduced Scoring Starts %1"
-msgstr "降低总分开始于：%1"
-
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
-msgid "Reduced scoring started on %1."
-msgstr "降低总分开始于：%1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
@@ -4775,12 +4885,12 @@ msgstr ""
 msgid "Refresh Display"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Refresh Listing"
 msgstr "用户列表"
@@ -4789,7 +4899,7 @@ msgstr "用户列表"
 msgid "Relax IP restrictions when?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "剩余"
 
@@ -4801,7 +4911,7 @@ msgstr "自动登录"
 msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -4812,13 +4922,13 @@ msgid "Rename"
 msgstr "文件名"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 #, fuzzy
 msgid "Rename Course"
 msgstr "课程"
@@ -4828,20 +4938,20 @@ msgstr "课程"
 msgid "Rename file as:"
 msgstr "头文件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 #, fuzzy
 msgid "Render Problem"
 msgstr "下一题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 #, fuzzy
 msgid "Renumber Problems"
 msgstr "题目"
@@ -4858,55 +4968,56 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "替换哪些用户？"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "报告错误"
 
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 #, fuzzy
 msgid "Report for course %1:"
 msgstr "设置 [_1] 的作业名"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 #, fuzzy
 msgid "Request information"
 msgstr "站点信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 #, fuzzy
 msgid "Request new version now."
 msgstr "站点信息"
@@ -4975,8 +5086,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -4984,11 +5095,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -5019,24 +5126,24 @@ msgstr "习题课"
 msgid "Restrict release by set(s)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "结果"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 #, fuzzy
 msgid "Result of last action performed"
 msgstr "最后一次操作的结果"
 
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 #, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "最近一次操作的结果：%1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -5049,19 +5156,27 @@ msgstr "最后一次操作的结果"
 msgid "Results of last action performed: "
 msgstr "最后一次操作的结果"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "恢复"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 #, fuzzy
 msgid "Revert to %1"
@@ -5075,19 +5190,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -5096,93 +5211,93 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "保存"
 
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 #, fuzzy
 msgid "Save %1"
 msgstr "保存"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "另存为"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 #, fuzzy
 msgid "Save Changes"
 msgstr "保存修变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 #, fuzzy
 msgid "Save as"
 msgstr "另存为"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 #, fuzzy
 msgid "Save as Default"
 msgstr "使用系统默认配置"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "保存修变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 #, fuzzy
 msgid "Save file to:"
 msgstr "保存编辑"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 #, fuzzy
 msgid "Save to %1 and View"
 msgstr "保存 [_1] 并打开"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 #, fuzzy
 msgid "Saved to file '%1'"
 msgstr "已保存到'[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5198,11 +5313,11 @@ msgstr "成绩"
 msgid "Score required for release"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "对选中的作业进行计分并保存到："
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -5231,14 +5346,14 @@ msgid "Scoring Tools"
 msgstr "成绩编辑工具"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5248,24 +5363,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "班级"
@@ -5281,11 +5396,16 @@ msgstr "班级"
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "作业"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
 #, fuzzy
@@ -5296,41 +5416,41 @@ msgstr "选择以下操作"
 msgid "Select a Set from this Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 #, fuzzy
 msgid "Select a course to delete."
 msgstr "选择以下操作"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
 "the course home page and can be any string."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 #, fuzzy
 msgid "Select a course to unarchive."
 msgstr "选择以下操作"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 #, fuzzy
 msgid "Select a database layout below."
 msgstr "选择以下操作"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 #, fuzzy
 msgid "Select a listing format:"
 msgstr "选择一个操作去执行"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 #, fuzzy
 msgid "Select above then:"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 #, fuzzy
 msgid "Select all eligible courses"
 msgstr "选中所有用户"
@@ -5339,28 +5459,28 @@ msgstr "选中所有用户"
 msgid "Select all sets"
 msgstr "选中所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "选中所有用户"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "选择一个操作去执行"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 #, fuzzy
 msgid "Select an action to perform:"
 msgstr "选择一个操作去执行"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 #, fuzzy
 msgid "Select course(s) to hide or unhide."
 msgstr "选择以下操作"
@@ -5375,7 +5495,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5399,27 +5519,27 @@ msgid ""
 "choice."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 #, fuzzy
 msgid "Selected students"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 #, fuzzy
 msgid "Send E-mail"
 msgstr "发送电子邮件："
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 #, fuzzy
 msgid "Send Email"
 msgstr "发送电子邮件："
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 #, fuzzy
 msgid "Send to:"
 msgstr "发送电子邮件："
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "作业"
 
@@ -5458,7 +5578,7 @@ msgid "Set Definition Files"
 msgstr "定义作业的文件名"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 #, fuzzy
 msgid "Set Description"
 msgstr "显示/隐藏站点描述"
@@ -5472,7 +5592,7 @@ msgid "Set Detail for set %2"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -5487,12 +5607,12 @@ msgstr "作业头"
 msgid "Set ID"
 msgstr "学号"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "作业信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "作业清单"
 
@@ -5521,8 +5641,12 @@ msgid "Set Name "
 msgstr "作业名"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -5548,7 +5672,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "作业"
 
@@ -5562,7 +5686,7 @@ msgstr "编辑选中的用户"
 msgid "Sets assigned to %1"
 msgstr "编辑选中的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #, fuzzy
 msgid "Setting"
 msgstr "修改用户选项"
@@ -5572,12 +5696,12 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 #, fuzzy
 msgid "Show"
 msgstr "显示："
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -5585,7 +5709,7 @@ msgstr ""
 msgid "Show Date & Size"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "显示提示"
 
@@ -5594,8 +5718,8 @@ msgstr "显示提示"
 msgid "Show Me Another"
 msgstr "在新的窗口里显示"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "显示以往的回答"
 
@@ -5607,8 +5731,8 @@ msgstr ""
 msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "显示答案"
 
@@ -5616,7 +5740,7 @@ msgstr "显示答案"
 msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "显示哪些用户？"
 
@@ -5626,18 +5750,18 @@ msgstr "显示哪些用户？"
 msgid "Show all paths"
 msgstr "显示所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "显示正确答案"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 #, fuzzy
 msgid "Show me another"
 msgstr "在新的窗口里显示"
 
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 #, fuzzy
 msgid "Show me another %1"
 msgstr "在新的窗口里显示"
@@ -5648,7 +5772,7 @@ msgstr "在新的窗口里显示"
 msgid "Show path ..."
 msgstr "显示所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 #, fuzzy
 msgid "Show saved answers?"
 msgstr "显示以往的回答"
@@ -5660,17 +5784,17 @@ msgstr "显示哪些作业？"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "显示/隐藏站点描述"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr "显示："
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "Showing"
 msgstr "显示提示"
@@ -5682,7 +5806,7 @@ msgid "Showing %1 out of %2 sets."
 msgstr "显示 %2 次作业中的 %1 次。"
 
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 #, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "显示 %2 个用户中的 %1 个"
@@ -5699,13 +5823,13 @@ msgstr ""
 msgid "Site Information"
 msgstr "站点信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 #, fuzzy
 msgid "Solution:"
 msgstr "答案"
@@ -5715,7 +5839,7 @@ msgstr "答案"
 msgid "Solutions"
 msgstr "答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -5724,6 +5848,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -5742,15 +5876,15 @@ msgid ""
 "with your instructor"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 #, fuzzy
 msgid "Sort"
 msgstr "排序"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "排序方式为"
 
@@ -5781,7 +5915,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -5817,48 +5951,48 @@ msgstr "添加[_1]到[_2]作为问题[_3]"
 msgid "Statistics for %1 student %2"
 msgstr "查看学生统计数据"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "状态"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "停止担任"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 #, fuzzy
 msgid "Stop Archiving"
 msgstr "停止担任"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 #, fuzzy
 msgid "Stop archiving courses"
 msgstr "课程"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "学号"
 
@@ -5891,14 +6025,14 @@ msgstr "学生进度 [_1]"
 msgid "Student answers"
 msgstr "学生答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -5912,34 +6046,38 @@ msgstr "提交答案"
 msgid "Submit"
 msgstr "提交答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "提交答案"
 
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 #, fuzzy
 msgid "Submit Answers for %1"
 msgstr "替 %1 提交答案"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
 msgid "Success"
 msgstr "成功"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 #, fuzzy
 msgid "Success Index"
 msgstr "成功"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 #, fuzzy
 msgid "Successfully archived the course %1."
 msgstr "成功创建新作业 %1"
 
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 #, fuzzy
 msgid "Successfully created new achievement %1"
 msgstr "成功创建新作业 %1"
@@ -5951,46 +6089,46 @@ msgid "Successfully created new set %1"
 msgstr "成功创建新作业 %1"
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 #, fuzzy
 msgid "Successfully created the course %1"
 msgstr "成功创建新作业 %1"
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 #, fuzzy
 msgid "Successfully deleted the course %1."
 msgstr "成功创建新作业 %1"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 #, fuzzy
 msgid "Successfully renamed the course %1 to %2"
 msgstr "成功创建新作业 %1"
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 #, fuzzy
 msgid "Successfully unarchived %1 to the course %2"
 msgstr "成功创建新作业 %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -6010,16 +6148,16 @@ msgstr "参加 %1 测试"
 msgid "Take %1 test."
 msgstr "参加 %1 测试"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "确认操作！"
 
@@ -6087,11 +6225,11 @@ msgid ""
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "WeBWorK项目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6112,16 +6250,16 @@ msgid ""
 "this value when a set is created. "
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 #, fuzzy
 msgid "The answer above is NOT correct."
 msgstr "以上答案不是%1c正确。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "上面的答案是正确的."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 #, fuzzy
 msgid "The answer will be graded later."
 msgstr "上面的答案是正确的."
@@ -6135,14 +6273,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6183,60 +6321,60 @@ msgid ""
 msgstr ""
 
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 #, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "作业[_1]的副本文件名被改为'[_2]'。"
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
 msgstr ""
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 #, fuzzy
 msgid "The file %1/%2 cannot be found."
 msgstr "错误：原文件[_1]不能读。"
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 #, fuzzy
 msgid "The file '%1' cannot be found."
 msgstr "错误：原文件[_1]不能读。"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 #, fuzzy
 msgid "The file '%1' cannot be read!"
 msgstr "错误：原文件[_1]不能读。"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid "The file '%1' is a blank problem!"
 msgstr "这个文件 '[_1]' 不存在！"
 
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 #, fuzzy
 msgid "The file '%1' is a directory!"
 msgstr "这个文件'[_1]'是一个目录！"
 
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 #, fuzzy
 msgid "The file '%1' is protected!"
 msgstr "这个文件 '[_1]' 是受保护的！"
@@ -6250,28 +6388,28 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 #, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
@@ -6279,38 +6417,38 @@ msgid ""
 msgstr "这道题目不算成绩。"
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
 msgstr ""
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 #, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "作业[_1]的副本文件名被改为'[_2]'。"
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6329,13 +6467,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -6355,8 +6493,8 @@ msgid ""
 "your new password and try again."
 msgstr "你在%1和%2里输入的密码不匹配。请重新输入您的新密码再试一次。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "指向原文件的路径必须是完整的"
 
@@ -6365,7 +6503,7 @@ msgstr "指向原文件的路径必须是完整的"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -6373,19 +6511,19 @@ msgid ""
 msgstr ""
 
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 #, fuzzy
 msgid "The recorded score for this test is  %1/%2."
 msgstr "您总的纪录分数是%1. %2"
 
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #, fuzzy
 msgid "The recorded score for this test is %1/%2."
 msgstr "您总的纪录分数是%1. %2"
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -6397,26 +6535,26 @@ msgid ""
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 #, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "这道题目不算成绩。"
 
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 #, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "选中的作业(%1)对%2不是有效的"
 
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 #, fuzzy
 msgid "The set %1 is assigned to %2."
 msgstr "WeBWorK 作业 [_1] 截至于 : [_2]。"
 
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 #, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
@@ -6431,7 +6569,7 @@ msgstr ""
 
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 #, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "WeBWorK 作业 [_1] 截至于 : [_2]。"
@@ -6441,7 +6579,7 @@ msgid "The solution has been removed."
 msgstr ""
 
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 #, fuzzy
 msgid ""
@@ -6449,9 +6587,17 @@ msgid ""
 msgstr "'作业 [_1] / 题目 [_2]'的源文件已从[_3] 变为 '[_4]'。"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"这个文本框中包含原问题的来源。您可以通过点击您的浏览器上的后退按钮来恢复丢失"
+"的修改。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -6467,67 +6613,69 @@ msgid ""
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 #, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr "'作业 [_1] / 题目 [_2]'的源文件已从[_3] 变为 '[_4]'。"
 
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 #, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr "'作业 [_1] / 题目 [_2]'的源文件已从[_3] 变为 '[_4]'。"
 
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 #, fuzzy
 msgid "The user %1 has been assigned %2."
 msgstr "作业[_1]的文件名被改为'[_2]'。"
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -6538,8 +6686,8 @@ msgid "Theme (refresh page after saving changes to reveal new theme.)"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "然后按"
 
@@ -6561,24 +6709,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -6588,36 +6736,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -6638,11 +6786,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -6659,7 +6807,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -6679,25 +6827,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -6717,17 +6865,17 @@ msgstr ""
 msgid "This action will not overwrite existing users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 #, fuzzy
 msgid "This answer is NOT completely correct."
 msgstr "以上答案不是%1c正确。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 #, fuzzy
 msgid "This answer is NOT correct."
 msgstr "以上答案不是%1c正确。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 #, fuzzy
 msgid "This answer is correct."
 msgstr "上面的答案是正确的."
@@ -6738,20 +6886,20 @@ msgid ""
 "guest."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "这个作业没有包含任何题目。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "这个作业已关闭。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "这个作业还未开始。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 #, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
@@ -6760,6 +6908,10 @@ msgid ""
 msgstr ""
 "这是一个空的不能直接修改的题目模版文件。使用下面的'另存为'操作去创建该文件的"
 "一个副本并将它加入到当前的作业中。"
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -6817,35 +6969,39 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "这道题目不算成绩。"
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 #, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
@@ -6862,19 +7018,19 @@ msgstr ""
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 #, fuzzy
 msgid "This set %1 is assigned to %2."
 msgstr "作业[_1]的文件名被改为'[_2]'。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 #, fuzzy
 msgid "This set doesn't contain any problems yet."
 msgstr "这个作业没有包含任何题目。"
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -6887,14 +7043,14 @@ msgid ""
 msgstr ""
 
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 #, fuzzy
 msgid "This set is %1"
 msgstr "当前作业是 %1"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -6925,23 +7081,23 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 #, fuzzy
 msgid "This source file is a directory!"
 msgstr "这个文件'[_1]'是一个目录！"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -6965,7 +7121,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -6974,8 +7130,8 @@ msgid ""
 "problem page."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 #, fuzzy
 msgid "Time"
 msgstr "考试日期"
@@ -6985,7 +7141,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -6998,24 +7154,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7027,28 +7183,28 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 #, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
 "'NewVersion' action below."
 msgstr "要编辑这个文本您必须先用下面的'另存为'操作生成这个文件的一个副本。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
@@ -7060,11 +7216,11 @@ msgstr "要修改这个文本你必须使用下方的'另存为'操作将其保�
 msgid "To this Problem"
 msgstr "编辑这道题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -7081,7 +7237,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -7097,50 +7254,50 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 #, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "不能修改作业[_1]的文件名。未知的错误。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 #, fuzzy
 msgid "Unable to write to '%1': %2"
 msgstr "已保存到'[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 #, fuzzy
 msgid "Unarchive"
 msgstr "课程"
 
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 #, fuzzy
 msgid "Unarchive %1 to course:"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 #, fuzzy
 msgid "Unarchive Next Course"
 msgstr "课程"
@@ -7163,7 +7320,7 @@ msgid ""
 msgstr ""
 
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 #, fuzzy
 msgid "Unattempted: %1/%2"
 msgstr "不能写入'[_1]': [_2]"
@@ -7173,13 +7330,13 @@ msgstr "不能写入'[_1]': [_2]"
 msgid "Unclassified Problems"
 msgstr "编辑题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 #, fuzzy
 msgid "Unhide Courses"
 msgstr "课程"
@@ -7199,7 +7356,7 @@ msgstr ""
 msgid "Unpack archives automatically"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 #, fuzzy
 msgid "Unselect all courses"
 msgstr "取消选中所有用户"
@@ -7208,12 +7365,12 @@ msgstr "取消选中所有用户"
 msgid "Unselect all sets"
 msgstr "取消选中所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "取消选中所有用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -7225,39 +7382,39 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 #, fuzzy
 msgid "Upgrade"
 msgstr "成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 #, fuzzy
 msgid "Upgrade Courses"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -7271,11 +7428,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -7283,21 +7441,21 @@ msgstr ""
 msgid "Use Item"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "使用系统默认配置"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 #, fuzzy
 msgid "Use in achievement %1"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 #, fuzzy
 msgid "Use in new achievement:"
 msgstr "选中的作业"
@@ -7316,7 +7474,7 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -7326,13 +7484,13 @@ msgstr ""
 "同您的消息，关于系统状态的一些额外信息也会添加。"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -7357,8 +7515,8 @@ msgstr "文件名"
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -7377,7 +7535,7 @@ msgid "Username presented:  %1"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 #, fuzzy
@@ -7389,7 +7547,7 @@ msgstr "添加用户"
 msgid "Users Assigned to Set %2"
 msgstr "编辑选中的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "用户列表"
 
@@ -7407,7 +7565,7 @@ msgid ""
 msgstr ""
 
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 #, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "依据 %1 对用户进行排序，再依据 %2，接着依据 %3"
@@ -7427,18 +7585,19 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 #, fuzzy
 msgid "Using what display mode?: "
 msgstr "显示模式"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -7446,21 +7605,21 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "查看"
 
@@ -7474,7 +7633,7 @@ msgstr "查看"
 msgid "View Problems"
 msgstr "编辑题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr "公式显示为"
 
@@ -7507,8 +7666,8 @@ msgstr "查看学生进度"
 msgid "View/Edit"
 msgstr "编辑"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 #, fuzzy
 msgid "Viewing temporary file:"
@@ -7533,19 +7692,19 @@ msgstr "可见的"
 msgid "Visible to Students"
 msgstr "对学生是可见的"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 #, fuzzy
 msgid "Warning"
 msgstr "剩余"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 #, fuzzy
 msgid "Warning messages"
 msgstr "成绩编辑工具"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！"
 
@@ -7554,12 +7713,17 @@ msgstr "警告：删除会销毁所有与用户相关的资料且不可撤销！
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 #, fuzzy
 msgid "WeBWorK Error"
 msgstr "WeBWorK"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 #, fuzzy
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK"
@@ -7579,7 +7743,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -7613,7 +7777,7 @@ msgstr "欢迎来到WebWorK!"
 msgid "What could be inside?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "匹配用户哪项信息？"
 
@@ -7693,12 +7857,12 @@ msgstr ""
 msgid "Will open on %1."
 msgstr "开放于 %1"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "分数"
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
@@ -7706,31 +7870,33 @@ msgid ""
 msgstr "未在'[_1]'中启用写入权限。要查看所做的修改必须将其保持到另外一个文件。"
 
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
 "different directory for viewing."
 msgstr "未在'[_1]'中启用写入权限。要查看所做的修改必须将其保持到另外一个目录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
 msgstr "模版目录的写入权限未启用。不能做任何修改。"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "是"
 
@@ -7759,16 +7925,16 @@ msgstr ""
 msgid "You are not authorized to access the Instructor tools"
 msgstr "您没有被授权使用教师工具。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 #, fuzzy
 msgid "You are not authorized to access the Instructor tools."
 msgstr "您没有被授权使用教师工具。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "您没有被授权使用教师工具。"
 
@@ -7778,7 +7944,7 @@ msgid "You are not authorized to modify homework sets."
 msgstr "您没有被授权修改作业。"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "您没有被授权修改题目。"
 
@@ -7787,13 +7953,13 @@ msgstr "您没有被授权修改题目。"
 msgid "You are not authorized to modify set definition files."
 msgstr "您没有被授权修改作业定义文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 msgid "You are not authorized to modify student data"
 msgstr "您没有授权修改学生数据"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "您没有被授权执行此操作。"
 
@@ -7813,7 +7979,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -7824,6 +7990,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "这一题你可以得到部分成绩"
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
 #, fuzzy
@@ -7848,7 +8018,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -7871,16 +8041,16 @@ msgstr "这个文件'[_1]'是一个目录！"
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 #, fuzzy
 msgid "You cannot delete the course you are currently using."
 msgstr "你不能删除自己!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "你不能删除自己!"
 
@@ -7895,7 +8065,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "您必须指定用户名。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -7925,39 +8095,43 @@ msgstr "您没有权限去查看这个错误的详细信息。"
 msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "你没有权限改变你的密码。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "您没有权限去查看这个错误的详细信息。"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 #, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "您还剩下 %1 %2。"
 
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 #, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "您还剩下 %negquant(%1,无限次尝试,尝试,尝试)。"
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
 msgstr ""
 
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 #, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "您已经试过这个题目%quant(%1,次,次)。"
@@ -7966,7 +8140,7 @@ msgstr "您已经试过这个题目%quant(%1,次,次)。"
 msgid "You have been logged out of WeBWorK."
 msgstr "你已经登出WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -8003,11 +8177,16 @@ msgstr ""
 "您可以选择显示以下任何资料。正确的答案和解题方法只有在作业截至日期之后才可以"
 "看到。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "您不能在这里修改您自己的密码！"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "您不能在这里修改您自己的密码！"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 #, fuzzy
 msgid "You may still check your answers."
 msgstr "您不能在这里修改您自己的密码！"
@@ -8021,14 +8200,14 @@ msgid ""
 msgstr "您已经试过这个题目%quant(%1,次,次)。"
 
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "您已经试过这个题目%quant(%1,次,次)。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -8043,7 +8222,7 @@ msgstr ""
 msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 #, fuzzy
 msgid "You must select a course to rename."
 msgstr "您必须指定用户名。"
@@ -8057,22 +8236,28 @@ msgstr "您必须指定文件名已保持一个新文件。"
 msgid "You must select at least one file to delete"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
 #, fuzzy
-msgid "You must select one or more sets for scoring"
+msgid "You must select one or more sets for scoring!"
 msgstr "没有选中作业去计分"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "您必须指定用户名。"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 #, fuzzy
 msgid "You must specify a course ID."
 msgstr "您必须指定用户名。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 #, fuzzy
 msgid "You must specify a course name."
 msgstr "您必须指定用户名。"
@@ -8082,47 +8267,47 @@ msgstr "您必须指定用户名。"
 msgid "You must specify a file name"
 msgstr "您必须指定用户名。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 #, fuzzy
 msgid "You must specify a first name for the initial instructor."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 #, fuzzy
 msgid "You must specify a last name for the initial instructor."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 #, fuzzy
 msgid "You must specify a new institution for the course."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 #, fuzzy
 msgid "You must specify a new name for the course."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 #, fuzzy
 msgid "You must specify a new title for the course."
 msgstr "您必须指定用户名。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "您必须指定用户名。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 #, fuzzy
 msgid "You must specify an email address for the initial instructor."
 msgstr "您必须指定文件名已保持一个新文件。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 #, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "您必须指定文件名已保持一个新文件。"
@@ -8158,20 +8343,20 @@ msgid "You need to select a set to view."
 msgstr ""
 
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 #, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "这次您得到%1分。"
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8209,27 +8394,28 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 #, fuzzy
 msgid "Your display options have been saved."
 msgstr "你的电子邮件地址已经改变."
@@ -8242,120 +8428,133 @@ msgstr "你的电子邮件地址已经改变."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 #, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "您总的纪录分数是%1. %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 #, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "您总的纪录分数是%1. %2"
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 #, fuzzy
 msgid "Your score on this %1 WAS recorded."
 msgstr "您的成绩已记录。"
 
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 #, fuzzy
 msgid "Your score on this %1 is %2/%3."
 msgstr "您总的纪录分数是%1. %2"
 
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 #, fuzzy
 msgid "Your score on this %1 was NOT recorded."
 msgstr "您的成绩已记录。"
 
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 #, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "您的成绩已记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 #, fuzzy
 msgid "Your score on this problem was recorded."
 msgstr "您的成绩已记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
 msgstr "您的成绩没有被记录因为在将该问题的分数存入到数据库时出错。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "因为这个作业已经截止了，所以您的成绩没有记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "因为这个题目没有布置给您，所以您的成绩没有被记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 #, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
 msgstr "因为这个题目没有布置给您，所以您的成绩没有被记录。"
 
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr "因为这个题目没有布置给您，所以您的成绩没有被记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
 msgstr "因为这个题目没有布置给您，所以您的成绩没有被记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 #, fuzzy
 msgid "Your score was not recorded."
 msgstr "您的成绩已记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "您的成绩已记录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "您的会话已因闲置超时。请重新登录。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 #, fuzzy
 msgid "[Edit]"
@@ -8381,7 +8580,7 @@ msgstr ""
 "使用方法：首先选择您想执行的操作，接着在信息栏中输入相关信息，然后点击在表格"
 "底部的“确认执行！”。 该页的下方是一个显示作业以及它们相关信息的表格。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "这是班级名单修改页面，您可以在这里查看并修改这门课目前已注册的所有学生的记"
@@ -8418,34 +8617,44 @@ msgstr ""
 "WeBWorK页面时不需要在输入您的用户名和密码（直到您的会话到期）。此功能在公共服"
 "务器，不可信赖的机器和您不能直接控制的电脑上使用不安全。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 "在处理这道题时，WeBWorK碰到一个系统错误。很可能是问题本身有错误，如果您是学"
 "生，请将这个错误信息报告给您的老师。如果您是老师，您可以从下面的错误输出获得"
 "跟多信息。"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "第一个选中作业的副本"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1115
 msgid "a duplicate of the first selected set"
 msgstr "第一个选中作业的副本"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "一个新的空作业(没有题目)"
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "一个新的空作业(没有题目)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -8454,7 +8663,7 @@ msgstr ""
 msgid "a single set"
 msgstr "单个作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "active"
 msgstr "不活跃的"
@@ -8465,11 +8674,11 @@ msgid "add problems"
 msgstr "添加题目"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -8478,13 +8687,13 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 #, fuzzy
@@ -8515,14 +8724,14 @@ msgstr "所有作业"
 msgid "all students"
 msgstr "所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "所有用户"
 
@@ -8530,31 +8739,37 @@ msgstr "所有用户"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 #, fuzzy
 msgid "answer"
 msgstr "答案日期"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "任何用户"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
-msgid "assigning the achievements to"
-msgstr "这次作业留给哪些用户?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
 #, fuzzy
@@ -8568,22 +8783,22 @@ msgid "avg attempts"
 msgstr "尝试次数"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "已放弃修改"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "已保存修改"
@@ -8602,17 +8817,17 @@ msgstr ""
 msgid "close"
 msgstr "已关闭"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "正确"
 
@@ -8628,7 +8843,7 @@ msgid "deleted %1 sets"
 msgstr "删除 %1 次作业"
 
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 #, fuzzy
 msgid "deleted %1 users"
 msgstr "删除 %1 个用户"
@@ -8642,7 +8857,7 @@ msgstr "编辑所有作业"
 msgid "editing all sets"
 msgstr "编辑所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "编辑所有用户"
 
@@ -8655,7 +8870,7 @@ msgstr "选中的作业"
 msgid "editing selected sets"
 msgstr "编辑选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "编辑选中的用户"
 
@@ -8663,7 +8878,7 @@ msgstr "编辑选中的用户"
 msgid "editing visible sets"
 msgstr "编辑可见的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "编辑可见的用户"
 
@@ -8673,7 +8888,7 @@ msgstr "编辑可见的用户"
 msgid "email:"
 msgstr "电子邮件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 #, fuzzy
 msgid "empty"
 msgstr "尝试"
@@ -8688,16 +8903,16 @@ msgid "entry rows."
 msgstr "编辑题目"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "已放弃导出"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 #, fuzzy
 msgid "exporting all achievements"
 msgstr "导出所有作业"
@@ -8706,7 +8921,7 @@ msgstr "导出所有作业"
 msgid "exporting all sets"
 msgstr "导出所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 #, fuzzy
 msgid "exporting selected achievements"
 msgstr "导出已选定的作业"
@@ -8743,15 +8958,15 @@ msgstr "对学生隐藏"
 msgid "from"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "给所有用户设置新密码"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "给选中的用户设置新密码"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "给所有可见的用户设置新密码"
 
@@ -8783,9 +8998,9 @@ msgstr ""
 msgid "guest"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "hidden"
 msgstr "隐藏"
@@ -8794,7 +9009,7 @@ msgstr "隐藏"
 msgid "hidden from"
 msgstr "隐藏于"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "对学生隐藏"
@@ -8805,45 +9020,49 @@ msgstr "隐藏的作业"
 
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "inactive"
 msgstr "不活跃的"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "错误"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 #, fuzzy
 msgid "locations selected below"
 msgstr "导出选中的作业"
@@ -8853,7 +9072,7 @@ msgstr "导出选中的作业"
 msgid "login"
 msgstr "登入"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 #, fuzzy
 msgid "login ID"
 msgstr "登入"
@@ -8892,16 +9111,16 @@ msgstr "没有作业"
 msgid "new users"
 msgstr "没有用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 #, fuzzy
 msgid "no achievements"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 #, fuzzy
 msgid "no location"
 msgstr "答案"
@@ -8922,27 +9141,31 @@ msgstr "没有作业"
 msgid "no students"
 msgstr "没有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "没有用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -8967,7 +9190,7 @@ msgstr ""
 msgid "only best scores"
 msgstr "考试成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -8981,56 +9204,60 @@ msgstr "排序"
 msgid "or Problems from"
 msgstr "题目"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 #, fuzzy
 msgid "point"
 msgstr "提示"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 #, fuzzy
 msgid "points"
 msgstr "提示"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 #, fuzzy
 msgid "preview answers"
 msgstr "答案预览"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 #, fuzzy
 msgid "problem"
 msgstr "第%1题"
@@ -9050,8 +9277,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -9067,19 +9294,19 @@ msgid "record for user %1 not found"
 msgstr "找不到这个文件 '[_1]'。"
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 #, fuzzy
 msgid "record for visible user %1 not found"
 msgstr "找不到这个文件 '[_1]'。"
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -9104,14 +9331,14 @@ msgid "selected <b>users</b> to selected <b>sets</b>"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 #, fuzzy
 msgid "selected achievements"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 #, fuzzy
 msgid "selected achievements."
 msgstr "选中的作业"
@@ -9131,17 +9358,17 @@ msgstr "选中的作业"
 msgid "selected sets"
 msgstr "选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "选中的用户"
 
@@ -9185,7 +9412,7 @@ msgstr "在下面输入用于匹配的作业名"
 msgid "showing all sets"
 msgstr "显示所有作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "显示所有用户"
 
@@ -9202,7 +9429,7 @@ msgstr "没有显示任何作业"
 msgid "showing matching sets"
 msgstr "显示匹配的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "显示匹配的用户"
 
@@ -9210,7 +9437,7 @@ msgstr "显示匹配的用户"
 msgid "showing no sets"
 msgstr "没有显示任何作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "没有显示任何用户"
 
@@ -9218,7 +9445,7 @@ msgstr "没有显示任何用户"
 msgid "showing selected sets"
 msgstr "显示选中的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "显示选中的用户"
 
@@ -9226,6 +9453,10 @@ msgstr "显示选中的用户"
 #, fuzzy
 msgid "showing visible sets"
 msgstr "导出可见的作业"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 #, fuzzy
@@ -9244,18 +9475,18 @@ msgstr "学号"
 msgid "students"
 msgstr "学号"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "submission"
 msgstr "提交答案"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "submission (test %1)"
 msgstr "提交答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -9263,13 +9494,13 @@ msgstr ""
 msgid "ta"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "test"
 msgstr "%1 测试"
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "test (%1)"
 msgstr "%1 测试"
@@ -9284,7 +9515,7 @@ msgstr "考试日期"
 msgid "test time"
 msgstr "%1 测试"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -9293,14 +9524,14 @@ msgid "the following file(s)"
 msgstr ""
 
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 #, fuzzy
 msgid "the original path to the file is %1"
 msgstr "这个文件原来的路径是[_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 #, fuzzy
 msgid "then by"
 msgstr "然后按"
@@ -9309,7 +9540,11 @@ msgstr "然后按"
 msgid "then delete them"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "次"
 
@@ -9317,44 +9552,41 @@ msgstr "次"
 msgid "time limit exceeded"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "次"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 #, fuzzy
 msgid "top score"
 msgstr "考试成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 #, fuzzy
 msgid "unable to write to directory %1"
 msgstr "已保存到'[_1]'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "无限"
 
@@ -9364,29 +9596,29 @@ msgstr "无限"
 msgid "userID: %1 --"
 msgstr "替换 [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "users"
 msgstr "没有用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "匹配所选字段的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 #, fuzzy
 msgid "users who match:"
 msgstr "匹配所选字段的用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 msgid "visible"
 msgstr "可见的"
@@ -9399,20 +9631,25 @@ msgstr "可见的"
 msgid "visible sets"
 msgstr "可见的作业"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "visible to students"
 msgstr "对学生是可见的"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "可见的用户"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -9420,14 +9657,34 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 #, fuzzy
 msgid "your students"
 msgstr "对学生是可见的"
+
+#, fuzzy
+#~ msgid "Import achievements from"
+#~ msgstr "导出已选定的作业"
+
+#, fuzzy
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "降低总分开始于：%1"
+
+#, fuzzy
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "降低总分开始于：%1"
+
+#, fuzzy
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "降低总分开始于：%1"
 
 #, fuzzy
 #~ msgid "answer "
@@ -9501,10 +9758,6 @@ msgstr "对学生是可见的"
 
 #~ msgid "No sets selected for scoring."
 #~ msgstr "没有选中作业去计分。"
-
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "注意"
 
 #, fuzzy
 #~ msgid "Recitation:"
@@ -9707,13 +9960,6 @@ msgstr "对学生是可见的"
 
 #~ msgid "Published"
 #~ msgstr "已发布"
-
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "这个文本框中包含原问题的来源。您可以通过点击您的浏览器上的后退按钮来恢复丢"
-#~ "失的修改。"
 
 #~ msgid ""
 #~ "Documentation from source code for PG modules and macro files. Often the "

--- a/lib/WeBWorK/Localize/zh_hk.po
+++ b/lib/WeBWorK/Localize/zh_hk.po
@@ -17,13 +17,19 @@ msgstr ""
 "X-Generator: Poedit 1.6.10\n"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:477
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
+#, fuzzy
+msgid "# of active students"
+msgstr "tr: selected sets"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:489
 #, fuzzy
 msgid "#corr"
 msgstr "正确"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:491
 #, fuzzy
 msgid "#incorr"
 msgstr "错误"
@@ -39,16 +45,16 @@ msgid "% correct with review"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:716
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 #, fuzzy
 msgid "% students"
 msgstr "tr: visible sets"
 
 #. ($prettySetID)
 #. ($prettyProblemID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:823
 msgid "%1 (old editor)"
 msgstr ""
 
@@ -95,20 +101,20 @@ msgid "%1 students out of %2"
 msgstr "tr: visible sets"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1291
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1293
 msgid "%1 title and institution changed from %2 to %3 and from %4 to %5"
 msgstr ""
 
 #
 #. (scalar @userIDsToExport, $dir, $fileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1183
 #, fuzzy
 msgid "%1 users exported to file %2/%3"
 msgstr "tr: [_1] users exported to file [_2]/[_3]"
 
 #
 #. ($numReplaced, $numAdded, $numSkipped, join (", ", @$skipped)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1091
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1094
 #, fuzzy
 msgid ""
 "%1 users replaced, %2 users added, %3 users skipped. Skipped users: (%4)"
@@ -143,8 +149,8 @@ msgstr "tr: completely"
 #
 #. (wwRound(0, $answerScore*100)
 #. (int($answerScore*100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:422
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:429
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:278
 #, fuzzy
 msgid "%1% correct"
 msgstr "[_1]% 正确"
@@ -195,7 +201,7 @@ msgstr "[_1] 的密码已更改."
 #
 #. ($setID, $problemID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:58
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1129
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1139
 #, fuzzy
 msgid "%1: Problem %2"
 msgstr "[_1]: 题目 [_2]."
@@ -209,13 +215,13 @@ msgstr "[_1]: 题目 [_2]."
 
 #
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
 #, fuzzy
 msgid "%1: The directory for the course not found."
 msgstr "tr: The file '[_1]' cannot be found."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3214
 msgid "%quant(%1,course was, courses were) successfully unhidden."
 msgstr ""
 
@@ -231,54 +237,54 @@ msgstr ""
 
 #
 #. ($numBlanks)
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 #, fuzzy
 msgid "%quant(%1,of the questions remains,of the questions remain) unanswered."
 msgstr "Sorular谋n [_1] tanesi yan谋ts谋z b谋rak谋ld谋."
 
 #. ($succeeded_count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3138
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3144
 msgid "%quant_1( course was, courses were) successfully hidden."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 #, fuzzy
 msgid "%score"
 msgstr "成绩"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2554
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2580
 msgid "(Any unsaved changes will be lost.)"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1267
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1274
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1343
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1350
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1613
 msgid "(This problem will not count towards your grade.)"
 msgstr "(这道题将不会计算成绩.)"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1990
 msgid ""
 "(This test is overtime because it was not submitted in the allowed time.)"
 msgstr ""
 
 #
 #. ($testNoun, $self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1834
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1879
 #, fuzzy
 msgid "(Your score on this %1 is not available until %2.)"
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #
 #. ($testNoun)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1836
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1881
 #, fuzzy
 msgid "(Your score on this %1 is not available.)"
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
@@ -359,17 +365,31 @@ msgstr ""
 #
 #. ($add_courseID)
 #. ($rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1219
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:641
 #, fuzzy
 msgid "A course with ID %1 already exists."
 msgstr "tr: Failed to duplicate set: set [_1] already exists!"
 
 #. ($courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2145
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2151
 msgid ""
 "A directory already exists with the name %1. You must first delete this "
 "existing course before you can unarchive."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space  are "
+"allowed."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:45
+msgid ""
+"A file name cannot begin with a dot, it cannot be empty, it cannot contain a "
+"directory path component and only the characters -_.a-zA-Z0-9 and space are "
+"allowed."
 msgstr ""
 
 #
@@ -387,14 +407,14 @@ msgid ""
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2714
 msgid ""
 "A location with the name %1 already exists in the database.  Did you mean to "
 "edit that location instead?"
 msgstr ""
 
 #. ($subject, $number_of_recipients, $courseName, $failed_messages)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:897
 msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
@@ -402,14 +422,14 @@ msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:627
 #, fuzzy
 msgid "A new file has been created at '%1'"
 msgstr "tr: Set [_1] exists.  No set created"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1893
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1969
 #, fuzzy
 msgid ""
@@ -450,46 +470,46 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:471
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:483
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:671
 msgid "ADJ STATUS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2145
 #, fuzzy
 msgid "ANSWERS NOT RECORDED"
 msgstr "G脰STER陌M -- YANITLAR KAYDED陌LMED陌 "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2133
 #, fuzzy
 msgid "ANSWERS NOT RECORDED --"
 msgstr "G脰STER陌M -- YANITLAR KAYDED陌LMED陌 "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2144
 #, fuzzy
 msgid "ANSWERS ONLY CHECKED -- "
 msgstr "答案仅为检查 -- 答案没有被记录"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1882
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
 msgstr "答案仅为检查 -- 答案没有被记录"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1002
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:998
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1417
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1460
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1159
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1186
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1261
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1264
 msgid "Abandon changes"
 msgstr "放弃更改"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:925
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1399
 msgid "Abandon export"
 msgstr "放弃输出"
@@ -501,13 +521,13 @@ msgid "Achievement"
 msgstr "tr: selected sets"
 
 #. ($targetAchievementID, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:620
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:621
 msgid "Achievement %1 created with evaluator '%2'."
 msgstr ""
 
 #
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:729
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:726
 #, fuzzy
 msgid "Achievement %1 exists.  No achievement created"
 msgstr "tr: Set [_1] exists.  No set created"
@@ -525,13 +545,13 @@ msgstr ""
 msgid "Achievement Evaluator for achievement %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1332
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1336
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1351
 msgid "Achievement ID"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:587
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:588
 msgid "Achievement ID exists!  No new achievement created.  File not saved."
 msgstr ""
 
@@ -549,13 +569,19 @@ msgstr ""
 msgid "Achievement has been assigned to all users."
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:59
+#, fuzzy
+msgid "Achievement has been assigned to selected users."
+msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:56
 msgid "Achievement has been unassigned to all students."
 msgstr ""
 
 #
 #. (CGI::a({href=>$fileManagerURL},$scoreFileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:626
 #, fuzzy
 msgid "Achievement scores saved to %1"
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
@@ -579,7 +605,7 @@ msgstr ""
 
 #
 #. (HTML::Entities::encode_entities($eUserID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 #, fuzzy
 msgid "Acting as %1."
 msgstr "[_1] gibi davran谋l谋yor."
@@ -587,13 +613,13 @@ msgstr "[_1] gibi davran谋l谋yor."
 #
 #. ($actionID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:352
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:355
 #, fuzzy
 msgid "Action %1 not found"
 msgstr "tr: The file '[_1]' cannot be found."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Active"
 msgstr "活跃的"
 
@@ -613,7 +639,7 @@ msgstr ""
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2314
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2567
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1110
 msgid "Add"
 msgstr "添加"
@@ -623,9 +649,9 @@ msgid "Add All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:488
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:361
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:490
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:598
 #, fuzzy
 msgid "Add Course"
 msgstr "课程"
@@ -642,7 +668,7 @@ msgstr "tr: visible sets"
 msgid "Add Users"
 msgstr "添加用户"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:515
 msgid "Add WeBWorK administrators to new course"
 msgstr ""
 
@@ -651,14 +677,14 @@ msgid "Add a new test for which Gateway?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1412
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1466
 #, fuzzy
 msgid "Add as what filetype?"
 msgstr "tr: Add as what filetype?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:998
 msgid "Add how many students?"
 msgstr "增加多少学生?"
 
@@ -669,49 +695,49 @@ msgid "Add problems to"
 msgstr "tr: Add problem"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1465
 #, fuzzy
 msgid "Add to what set?"
 msgstr "tr: Add to which set?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1045
 msgid "Add which new users?"
 msgstr "增加哪种新用户?"
 
 #
+#. ($new_file_path, $setID, $targetProblemNumber)
 #. ($sourceFilePath, $targetSetName,($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
 #. ($new_file_name, $setName, ($set->assignment_type eq 'jitar' ? join('.',jitar_id_to_seq($targetProblemNumber)
-#. ($new_file_path, $setID, $targetProblemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1466
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1909
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1518
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1624
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1841
 #, fuzzy
 msgid "Added %1 to %2 as problem %3"
 msgstr "tr: Added [_1] to [_2] as problem [_3]"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1574
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1575
 #, fuzzy
 msgid "Added '%1' to %2 as new hardcopy header"
 msgstr "tr: Added '[_1]' to [_2] as new set header"
 
 #
 #. ($self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1476
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1549
 #, fuzzy
 msgid "Added '%1' to %2 as new set header"
 msgstr "tr: Added '[_1]' to [_2] as new set header"
 
 #. (join(', ', @toAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2955
 msgid "Added addresses %1 to location %2."
 msgstr ""
 
@@ -720,54 +746,54 @@ msgid "Additional addresses for receiving feedback e-mail."
 msgstr ""
 
 #. ($badLocAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2717
 msgid ""
 "Address(es) %1 already exist in the database.  THIS SHOULD NOT HAPPEN!  "
 "Please double check the integrity of the WeBWorK database before continuing."
 msgstr ""
 
 #. (join(', ', @noAdd)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2958
 msgid ""
 "Address(es) %1 in the add list is(are) already in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. (join(', ', @noDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2960
 msgid ""
 "Address(es) %1 in the delete list is(are) not in the location %2, and so "
 "were skipped."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2711
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and resubmit."
 msgstr ""
 
 #. ($badAddr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2953
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2959
 msgid ""
 "Address(es) %1 is(are) not in a recognized form.  Please check your data "
 "entry and try again."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Addresses"
 msgstr "Email地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid ""
 "Addresses for new location.  Enter one per line, as single IP addresses e."
 "g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges (e."
 "g., 192.168.1.101-192.168.1.150)):"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
 msgid ""
 "Addresses to add to the location.  Enter one per line, as single IP "
 "addresses (e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP "
@@ -782,7 +808,7 @@ msgstr ""
 msgid "Adds 48 hours to the close date of a homework."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:417
 msgid "Adjusted Status"
 msgstr ""
 
@@ -797,7 +823,7 @@ msgid "After set answer date"
 msgstr "答案日期"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:372
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
 msgstr ""
@@ -811,18 +837,18 @@ msgid "All assignments were made successfully."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:407
 #, fuzzy
 msgid "All of the answers above are correct."
 msgstr "上面的所有答案都是正确的."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 #, fuzzy
 msgid "All of the gradeable answers above are correct."
 msgstr "上面的所有答案都是正确的."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:229
 msgid "All of these files will also be made available for mail merge."
 msgstr ""
 
@@ -850,7 +876,7 @@ msgstr "tr: hidden from students"
 msgid "All sets made visible for all students"
 msgstr "tr: visible sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 msgid "All students in course"
 msgstr ""
 
@@ -930,25 +956,25 @@ msgstr ""
 
 #. ($archive_courseID)
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1985
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2223
 msgid "An error occured while archiving the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1279
 msgid "An error occured while changing the title of the course %1."
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2017
 msgid "An error occured while deleting the course %1:"
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1361
 msgid "An error occured while renaming the course %1 to %2:"
 msgstr ""
 
@@ -970,8 +996,8 @@ msgid "Answer Log"
 msgstr "检查答案"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:391
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
 msgid "Answer Preview"
 msgstr "答案预览"
 
@@ -985,11 +1011,11 @@ msgstr ""
 msgid "Answer:"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1349
 msgid "AnswerGroupInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1386
 msgid "AnswerHashInfo"
 msgstr ""
 
@@ -1016,8 +1042,16 @@ msgid "Answers cannot be made available until on or after the close date!"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:283
+#, fuzzy
+msgid ""
+"Any changes made below will be reflected in the achievement for ALL students."
+msgstr ""
+"tr: Any changes made below will be reflected in the set for ALL students."
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1944
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:561
 msgid "Any changes made below will be reflected in the set for ALL students."
@@ -1026,7 +1060,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1942
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2139
 #, fuzzy
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
@@ -1041,21 +1075,21 @@ msgid ""
 "gaps will be left in the numbering unless the box above is checked."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
 msgid "Append"
 msgstr ""
 
 #
 #. (CGI::strong("$fullSetID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1802
 #, fuzzy
 msgid "Append to end of %1 set"
 msgstr "tr: Append to end of set [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1918
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
 #, fuzzy
 msgid "Archive"
 msgstr "课程"
@@ -1070,33 +1104,33 @@ msgstr ""
 msgid "Archive '%1' deleted"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1665
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
 msgid "Archive Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1688
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1723
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1725
 #, fuzzy
 msgid "Archive Courses"
 msgstr "课程"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2054
 #, fuzzy
 msgid "Archive next course"
 msgstr "课程"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:928
 #, fuzzy
 msgid "Archive this Course"
 msgstr "课程"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:422
 #, fuzzy
 msgid "Archived Courses"
 msgstr "课程"
@@ -1107,25 +1141,29 @@ msgid "Archiving course as %1.tar.gz. Reload FileManager to see it."
 msgstr ""
 
 #. (CGI::b($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1877
 msgid ""
 "Are you sure that you want to delete the course %1 after archiving? This "
 "cannot be undone!"
 msgstr ""
 
 #. (CGI::b($delete_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1530
 msgid ""
 "Are you sure you want to delete the course %1? All course files and data "
 "will be destroyed. There is no undo available."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:418
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 #, fuzzy
 msgid "Assign"
 msgstr "tr: Edit Assigned Users"
+
+#. (CGI::popup_menu(			-name => "action.assign.scope",			-values => [qw(all selected)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:420
+msgid "Assign %1 to all users, create global data, and %2."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:265
 msgid "Assign All Sets to Current User"
@@ -1155,21 +1193,21 @@ msgid "Assigned"
 msgstr "tr: Edit Assigned Users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1850
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
 #, fuzzy
 msgid "Assigned Sets"
 msgstr "tr: Edit Assigned Users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:507
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:504
 #, fuzzy
 msgid "Assigned achievements to users"
 msgstr "这次作业留给哪些用户?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2042
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
 #, fuzzy
 msgid "Assigned to"
 msgstr "tr: Edit Assigned Users"
@@ -1181,7 +1219,13 @@ msgid "Assignment type"
 msgstr "tr: Edit Assigned Users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
+#, fuzzy
+msgid "Assignments only"
+msgstr "tr: Edit Assigned Users"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:412
 #, fuzzy
 msgid "At least one of the answers above is NOT correct."
 msgstr "Yan谋tlar谋n en az bir tanesi [_1]do臒ru de臒il."
@@ -1190,7 +1234,7 @@ msgstr "Yan谋tlar谋n en az bir tanesi [_1]do臒ru de臒il."
 msgid "Att. to Open Children"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1931
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1937
 msgid "Attempt to upgrade directories"
 msgstr ""
 
@@ -1205,7 +1249,7 @@ msgstr "Deneme say谋s谋"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:593
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1077
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1091
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
 #, fuzzy
 msgid "Attempts"
 msgstr "Deneme say谋s谋"
@@ -1215,14 +1259,15 @@ msgstr "Deneme say谋s谋"
 msgid "Audit"
 msgstr "tr: Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:266
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:272
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:281
 msgid "Authentication failed.  Please speak to your instructor."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:538
 msgid "Author Info"
 msgstr "tr: Author Info"
 
@@ -1230,12 +1275,12 @@ msgstr "tr: Author Info"
 msgid "Automatic"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
 msgid "Automatically render problems on page load"
 msgstr ""
 
 #. ($emailDirectory,$old_default_msg_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:404
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:412
 msgid "Backup file <code>%1/%2</code> created."
 msgstr ""
 
@@ -1275,16 +1320,16 @@ msgid ""
 "blank. Separate email address entries by commas."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:370
 msgid "CLOSE DATE"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:371
 msgid "CLOSE TIME"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:450
-msgid "Cake of Enlargment"
+msgid "Cake of Enlargement"
 msgstr ""
 
 #
@@ -1324,7 +1369,7 @@ msgid "Can't create archive '%1': command returned %2"
 msgstr ""
 
 #. ($courseID,  $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2300
 msgid "Can't create course environment for %1 because %2"
 msgstr ""
 
@@ -1372,21 +1417,21 @@ msgstr "Can't get password record for user '[_1]': [_2]"
 
 #
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:797
 #, fuzzy
 msgid "Can't open %1"
 msgstr "tr: Saved to file '[_1]'"
 
 #
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2238
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2247
 #, fuzzy
 msgid "Can't open file %1"
 msgstr "tr: Saved to file '[_1]'"
 
 #
 #. ($merge_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:457
 #, fuzzy
 msgid "Can't read merge file %1. No message sent"
 msgstr "tr: Saved to file '[_1]'"
@@ -1398,7 +1443,7 @@ msgstr "tr: Saved to file '[_1]'"
 msgid "Can't rename file: %1"
 msgstr "tr: Saved to file '[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1213
 msgid "Can't rename to the same name."
 msgstr ""
 
@@ -1408,11 +1453,11 @@ msgid "Can't unpack '%1': command returned %2"
 msgstr ""
 
 #
-#. ($!)
 #. ($fullPath)
+#. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1824
 #, fuzzy
 msgid "Can't write to file %1"
 msgstr "tr: Saved to file '[_1]'"
@@ -1427,7 +1472,7 @@ msgid "Cancel"
 msgstr "tr: Cancel Edit"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:383
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:394
 #, fuzzy
 msgid "Cancel E-mail"
 msgstr "取消电子邮件"
@@ -1443,8 +1488,8 @@ msgstr "tr: Saved to file '[_1]'"
 msgid "Cap Test Time at Set Close Date?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1338
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
 msgid "Category"
 msgstr ""
 
@@ -1464,11 +1509,11 @@ msgstr ""
 msgid "Causes a single homework problem to be worth twice as much."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:938
 msgid "Change Course Title to:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:925
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:927
 msgid "Change CourseID to:"
 msgstr ""
 
@@ -1486,7 +1531,7 @@ msgstr "显示选项"
 msgid "Change Email Address"
 msgstr "更改Email地址"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:949
 msgid "Change Institution to:"
 msgstr ""
 
@@ -1497,37 +1542,37 @@ msgid "Change Password"
 msgstr "更改密码"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:321
 #, fuzzy
 msgid "Change User Settings"
 msgstr "Kullan谋c谋 bilgilerini g眉ncelle"
 
 #. ($rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1000
 msgid "Change course institution from %1 to %2"
 msgstr ""
 
 #. ($rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:997
 msgid "Change title from %1 to %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1204
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1207
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1282
 #, fuzzy
 msgid "Changes abandoned"
 msgstr "tr: changes abandoned"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:385
 msgid "Changes in this file have not yet been permanently saved."
 msgstr "tr: Changes in this file have not yet been permanently saved."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:628
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1255
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:629
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1258
 #, fuzzy
 msgid "Changes saved"
 msgstr "更改已保存"
@@ -1544,29 +1589,29 @@ msgid "Chapter:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1493
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1503
 msgid "Check Answers"
 msgstr "检查答案"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2192
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2237
 #, fuzzy
 msgid "Check Test"
 msgstr "检查答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
 msgstr ""
 
 #. ($emailDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:226
 msgid ""
 "Check whether it exists and whether the directory %1 can be read by the "
 "webserver."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1731
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1741
 #, fuzzy
 msgid "Checking additional error messages"
 msgstr "tr: Checking additional error messages"
@@ -1582,7 +1627,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1104
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:126
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:903
-msgid "Choose the set which you would like to ressurect."
+msgid "Choose the set which you would like to resurrect."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:216
@@ -1630,8 +1675,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:575
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:552
 #, fuzzy
 msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
@@ -1650,7 +1695,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:786
 #, fuzzy
 msgid "Close"
 msgstr "已关闭"
@@ -1702,7 +1747,7 @@ msgstr "已关闭"
 
 #
 #. ($self->formatDateTime($set->due_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:142
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:144
 #, fuzzy
 msgid "Closes %1"
 msgstr "tr: Revert to [_1]"
@@ -1714,11 +1759,11 @@ msgstr "tr: Revert to [_1]"
 msgid "Closes:"
 msgstr "已关闭"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2476
 msgid "Collapse"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2349
 msgid "Collapse All"
 msgstr ""
 
@@ -1726,28 +1771,28 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:224
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:530
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:300
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1861
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:830
 msgid "Comment"
 msgstr "评论"
 
 #. ($self->formatDateTime($set->answer_date)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2029
 msgid "Completed results for this assignment are not available until %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2031
 msgid "Completed results for this assignment are not available."
 msgstr ""
 
@@ -1757,7 +1802,7 @@ msgstr ""
 msgid "Completed."
 msgstr "tr: completely"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2637
 msgid "Confirm"
 msgstr ""
 
@@ -1770,7 +1815,7 @@ msgid "Confirm %1's New Password"
 msgstr "确认[_1]的新密码 "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:529
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:531
 #, fuzzy
 msgid "Confirm Password:"
 msgstr "确认[_1]的新密码 "
@@ -1787,8 +1832,8 @@ msgstr "继续"
 
 #
 #. ($sourceDirectory, $outputDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1174
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1228
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1152
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1229
 #, fuzzy
 msgid "Copied auxiliary files from %1 to new location at %2"
 msgstr "tr: Copied auxiliary files from [_1] to  new location at [_2]"
@@ -1803,7 +1848,7 @@ msgstr ""
 msgid "Copy file as:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:559
 msgid "Copy templates from:"
 msgstr ""
 
@@ -1814,8 +1859,8 @@ msgid "Copy this Problem"
 msgstr "编辑这道题"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:385
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:415
 msgid "Correct"
 msgstr "正确"
@@ -1825,7 +1870,7 @@ msgid "Correct Adjusted Status"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
 #, fuzzy
 msgid "Correct Answer"
 msgstr "正确答案"
@@ -1849,20 +1894,20 @@ msgstr "正确答案"
 
 #
 #. ($total_correct,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:957
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
 #, fuzzy
 msgid "Correct: %1/%2"
 msgstr "tr: set [_1]/problem [_2]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1331
 #, fuzzy
 msgid "CorrectAnswers"
 msgstr "正确答案"
 
 #. ($newBlankProblems, $MAX_NEW_PROBLEMS)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1627
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1844
 msgid ""
 "Could not add %1 problems to this set.  The number must be between 1 and %2"
 msgstr ""
@@ -1883,51 +1928,52 @@ msgid "Couldn't change your email address: %1"
 msgstr "不能改变您的email地址: [_1]"
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3415
 msgid "Couldn't find OPL Branch %1 in remote %2"
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3380
 msgid "Couldn't find PG Branch %1 in remote %2"
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3318
 msgid "Couldn't find WeBWorK Branch %1 in remote %2"
 msgstr ""
 
 #
 #. ($@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:221
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:244
 #, fuzzy
 msgid "Couldn't save your display options: %1"
 msgstr "不能改变您的email地址: [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1342
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 msgid "Counter"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:418
 msgid "Counts for Parent"
 msgstr ""
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1121
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1876
 msgid "Course %1 database is in order"
 msgstr ""
 
 #. ($rename_oldCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1125
 msgid "Course %1 databases must be updated before renaming this course."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:735
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:737
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:169
 msgid "Course Administration"
@@ -1938,14 +1984,14 @@ msgstr "课程管理"
 msgid "Course Configuration"
 msgstr "课程结构"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1214
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:638
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:912
 #, fuzzy
 msgid "Course ID:"
 msgstr "课程信息"
@@ -1957,15 +2003,15 @@ msgid "Course Info"
 msgstr "课程信息"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2096
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2102
 #, fuzzy
 msgid "Course Name:"
 msgstr "名"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:504
 #, fuzzy
 msgid "Course Title:"
 msgstr "课程"
@@ -1977,15 +2023,15 @@ msgid "Course archived."
 msgstr "名"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:728
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:408
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:95
 msgid "Courses"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1444
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1669
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3018
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1446
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1671
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
 msgid ""
 "Courses are listed either alphabetically or in order by the time of most "
 "recent login activity, oldest first. To change the listing order check the "
@@ -2007,7 +2053,7 @@ msgid "Create CSV"
 msgstr "tr: Create"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2596
 #, fuzzy
 msgid "Create Location:"
 msgstr "tr: Recitation"
@@ -2016,7 +2062,7 @@ msgstr "tr: Recitation"
 msgid "Create a New Set in This Course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:693
 msgid "Create a new achievement with ID"
 msgstr ""
 
@@ -2026,12 +2072,12 @@ msgstr ""
 msgid "Create as what type of set?"
 msgstr "tr: Create as what type of set?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1766
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1743
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1815
 msgid "Create unattached problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1668
 msgid ""
 "Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses "
 "directory. Before archiving, the course database is dumped into a "
@@ -2044,35 +2090,35 @@ msgstr ""
 msgid "Cupcake of Enlargement"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 msgid "Current"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2565
 msgid "Currently defined locations are listed below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2028
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2153
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2209
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2235
 msgid "Data"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3650
 msgid "Database tables are ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables need updating."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2311
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2317
 msgid "Database tables ok"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2489
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2495
 #, fuzzy
 msgid "Database:"
 msgstr "tr: export abandoned"
@@ -2087,7 +2133,7 @@ msgstr "tr: Open Date"
 msgid "Debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:379
 msgid "Default"
@@ -2113,85 +2159,85 @@ msgid "Default Time that the Assignment is Due"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:639
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1540
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:161
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:353
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1067
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:943
 msgid "Delete"
 msgstr "tr: Delete"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1436
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1457
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1480
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1519
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1438
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1482
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:366
 #, fuzzy
 msgid "Delete Course"
 msgstr "tr: Delete"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2850
 msgid "Delete all existing addresses"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Delete course after archiving. Caution there is no undo!"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1712
 #, fuzzy
 msgid "Delete course:"
 msgstr "tr: Delete"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1037
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:936
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:939
 msgid "Delete how many?"
 msgstr "删除多少?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2268
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2489
 #, fuzzy
 msgid "Delete it?"
 msgstr "tr: Delete"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2619
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
 #, fuzzy
 msgid "Delete location:"
 msgstr "tr: Delete"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:684
 #, fuzzy
 msgid "Deleted %quant(%1,achievement)"
 msgstr "tr: selected sets"
 
 #. (join(', ', @delLocations)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2781
 msgid "Deleted Location(s): %1"
 msgstr ""
 
 #. (join(', ', @toDel)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2948
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2954
 msgid "Deleted addresses %1 from location."
 msgstr ""
 
 #
 #. ($self->shortPath($self->{tempFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1187
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1165
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1242
 #, fuzzy
 msgid "Deleting temp file at %1"
 msgstr "tr: Deleting temp file at [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2614
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2620
 #, fuzzy
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
@@ -2200,7 +2246,7 @@ msgstr ""
 "tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:647
 #, fuzzy
 msgid "Deletion destroys all achievement-related data and is not undoable!"
 msgstr ""
@@ -2214,7 +2260,7 @@ msgstr ""
 "tr: Warning: Deletion destroys all user-related data and is not undoable!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:952
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:955
 #, fuzzy
 msgid "Deletion destroys all user-related data and is not undoable!"
 msgstr ""
@@ -2225,14 +2271,14 @@ msgid "Deny From"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:108
 #, fuzzy
 msgid "Description"
 msgstr "tr: Recitation"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:486
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:494
 msgid "Didn't recognize action"
 msgstr ""
 
@@ -2252,50 +2298,50 @@ msgstr ""
 msgid "Directory '%1' removed (items deleted: %2)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:402
 msgid "Directory permission errors "
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1883
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2403
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2515
 #, fuzzy
 msgid "Directory structure"
 msgstr "tr: Proctor"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1135
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2405
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1137
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
 msgid ""
 "Directory structure is missing directories or the webserver lacks sufficient "
 "privileges."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1134
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1884
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2404
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2410
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2517
 msgid "Directory structure is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1929
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1935
 msgid "Directory structure needs to be repaired manually before archiving."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1182
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1184
 msgid "Directory structure needs to be repaired manually before renaming."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2316
 msgid "Directory structure or permissions need to be repaired. "
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2029
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2154
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2324
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2350
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:379
 #, fuzzy
 msgid "Display Mode:"
@@ -2306,6 +2352,12 @@ msgstr "显示模式"
 #, fuzzy
 msgid "Display Past Answers"
 msgstr "脰nceki Yan谋tlar谋 G枚ster"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
+#, fuzzy
+msgid "Display of scores for this set is not allowed."
+msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
@@ -2332,38 +2384,38 @@ msgstr ""
 msgid "Do not uncheck students, unless you know what you are doing."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1928
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1936
 msgid "Don't Archive"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2184
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2190
 #, fuzzy
 msgid "Don't Unarchive"
 msgstr "保存改变"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2432
 #, fuzzy
 msgid "Don't Upgrade"
 msgstr "tr: Delete"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1536
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1538
 #, fuzzy
 msgid "Don't delete"
 msgstr "tr: Delete"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
 #, fuzzy
 msgid "Don't make changes"
 msgstr "保存改变"
 
 #
 #. ($saveMode)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:628
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:629
 #, fuzzy
 msgid "Don't recognize saveMode: |%1|. Unknown error."
 msgstr "tr: Unrecognized saveMode: |[_1]|. Unknown error."
@@ -2373,19 +2425,19 @@ msgstr "tr: Unrecognized saveMode: |[_1]|. Unknown error."
 msgid "Don't recognize statistics display type: |%1|"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1169
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1175
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1183
 msgid "Don't rename"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:521
 #, fuzzy
 msgid "Don't use in an achievement"
 msgstr "保存改变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2538
 msgid "Done"
 msgstr ""
 
@@ -2422,8 +2474,8 @@ msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
 msgstr "Télécharger une copie de : [plural,_1,Set,Sets]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:452
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:454
 msgid "Download PDF or TeX Hardcopy for Current Set"
 msgstr "下载当前作业的PDF或者TeX文件"
 
@@ -2450,6 +2502,16 @@ msgstr "成绩下载"
 msgid "Drop"
 msgstr "tr: Drop"
 
+#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
+msgid "Due %1, after which reduced scoring is available until %2"
+msgstr ""
+
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:699
+msgid "Due date %1 has passed, reduced credit can still be earned until %2."
+msgstr ""
+
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1582
 msgid "Duplicate this set and name it"
@@ -2472,7 +2534,7 @@ msgid "E-Mail"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:358
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:369
 #, fuzzy
 msgid "E-mail Instructor"
 msgstr "发电子邮件给授课人"
@@ -2492,7 +2554,7 @@ msgid "E-mail verbosity level"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:378
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:389
 #, fuzzy
 msgid "E-mail:"
 msgstr "电子邮件"
@@ -2502,26 +2564,26 @@ msgid "Earned"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:157
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:349
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:409
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:819
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:222
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:857
 msgid "Edit"
 msgstr "编辑"
 
 #
 #. (CGI::a({href=>$editUsersAssignedToSetURL},$r->maketext('individual versions')
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1896
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2079
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2105
 #, fuzzy
 msgid "Edit %1 of set %2."
 msgstr "tr: Editing [_1] in file '[_2]'"
@@ -2537,24 +2599,24 @@ msgstr "编辑所有作业数据"
 msgid "Edit Assigned Users"
 msgstr "tr: Edit Assigned Users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1292
 msgid "Edit Evaluator"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
 #, fuzzy
 msgid "Edit Header"
 msgstr "tr: Set Header"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2582
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2588
 #, fuzzy
 msgid "Edit Location:"
 msgstr "tr: Recitation"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2486
 #, fuzzy
 msgid "Edit Problem"
 msgstr "编辑题目"
@@ -2584,7 +2646,7 @@ msgid "Edit Target Set"
 msgstr "tr: Edit Set Data"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:845
 msgid "Edit Which Users?"
 msgstr "编辑哪些用户?"
 
@@ -2602,17 +2664,17 @@ msgstr "编辑"
 
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1886
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2069
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
 msgstr ""
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1870
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2080
 msgid "Edit set %1 for this user."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2815
 msgid ""
 "Edit the current value of the location description, if desired, then add and "
 "select addresses to delete, and then click the \"Take Action\" button to "
@@ -2626,27 +2688,27 @@ msgid "Edit which sets?"
 msgstr "tr: Edit which sets?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1277
 #, fuzzy
 msgid "Edit1"
 msgstr "编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1283
 #, fuzzy
 msgid "Edit2"
 msgstr "编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
 #, fuzzy
 msgid "Edit3"
 msgstr "编辑"
 
 #
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:611
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:612
 #, fuzzy
 msgid "Editing %1 in file '%2'"
 msgstr "tr: Editing [_1] in file '[_2]'"
@@ -2659,51 +2721,51 @@ msgid "Editing achievement in file '%1'"
 msgstr "tr: Editing [_1] in file '[_2]'"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2813
 msgid "Editing location %1"
 msgstr ""
 
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1885
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2068
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:420
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:421
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:422
 #, fuzzy
 msgid "Editor"
 msgstr "编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:680
 #, fuzzy
 msgid "Editor rows:"
 msgstr "编辑题目"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1510
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1513
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:665
 msgid "Email"
 msgstr "电子邮件"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:547
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1779
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
 msgid "Email Address"
 msgstr "Email地址"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:740
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
 #, fuzzy
 msgid "Email Body:"
 msgstr "电子邮件"
@@ -2715,33 +2777,33 @@ msgid "Email Instructor On Failed Attempt"
 msgstr "发电子邮件给授课人"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
 #, fuzzy
 msgid "Email Link"
 msgstr "电子邮件"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:712
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:720
 #, fuzzy
 msgid "Email address"
 msgstr "Email地址"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1643
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1670
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1694
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1700
 msgid "Email instructor"
 msgstr "发电子邮件给授课人"
 
 #. (scalar(@{$self->{ra_send_to}})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:524
 msgid ""
 "Email is being sent to %quant(%1,recipient). You will be notified by email "
 "when the task is completed.  This may take several minutes if the class is "
 "large."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:574
 msgid "Emails to be sent to the following:"
 msgstr ""
 
@@ -2790,8 +2852,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1354
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1340
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
 #, fuzzy
 msgid "Enabled"
 msgstr "tr: Enable"
@@ -2830,24 +2892,24 @@ msgstr ""
 msgid "Enrolled"
 msgstr "tr: Enrolled"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:711
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:719
 msgid "Enrolled, Drop, etc."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:792
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:811
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:798
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:827
 msgid "Enrollment Status"
 msgstr "注册状态"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1126
 msgid "Enter filename below"
 msgstr "输入文件名"
 
@@ -2863,8 +2925,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:383
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:311
 msgid "Entered"
 msgstr "Yan谋t"
 
@@ -2899,7 +2961,7 @@ msgid "Error message:"
 msgstr "Mesajlar"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2090
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2096
 #, fuzzy
 msgid "Error messages"
 msgstr "Mesajlar"
@@ -2923,7 +2985,7 @@ msgstr ""
 
 #
 #. ($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1976
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1953
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2029
 #, fuzzy
 msgid "Error: The original file %1 cannot be read."
@@ -2943,6 +3005,10 @@ msgstr ""
 msgid "Error: close date cannot be more than 10 years from now in set %1"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:546
+msgid "Error: no file data was submitted!"
+msgstr ""
+
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1078
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1151
@@ -2958,7 +3024,7 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3130
 msgid ""
 "Errors occured while hiding the courses listed below when attempting to "
 "create the file hide_directory in the course's directory. Check the "
@@ -2966,60 +3032,60 @@ msgid ""
 msgstr ""
 
 #. ("$coursesDir/$failed_courses[0]/")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3218
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3224
 msgid ""
 "Errors occured while unhiding the courses listed below when attempting "
 "delete the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
 msgid "Evaluator"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1344
 msgid "Evaluator File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3137
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "hidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3201
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3207
 msgid ""
 "Except for possible errors listed above, all selected courses are already "
 "unhidden."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
 msgid ""
 "Existing addresses for the location are given in the scrolling list below.  "
 "Select addresses from the list to delete them:"
 msgstr ""
 
 #. ($filePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2283
 msgid "Existing file %1 could not be backed up and was lost."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2475
 msgid "Expand"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2321
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2347
 msgid "Expand All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:891
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:887
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1092
 msgid "Export"
 msgstr "tr: Export"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:940
 #, fuzzy
 msgid "Export selected achievements."
 msgstr "输出已选定的集合"
@@ -3030,7 +3096,7 @@ msgid "Export selected sets"
 msgstr "输出已选定的集合"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1122
 msgid "Export to what kind of file?"
 msgstr "输出哪种文件"
 
@@ -3040,13 +3106,13 @@ msgid "Export which sets?"
 msgstr "tr: Export which sets?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1105
 msgid "Export which users?"
 msgstr "tr: Export which users?"
 
 #
 #. ($FileName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:991
 #, fuzzy
 msgid "Exported achievements to %1"
 msgstr "输出已选定的集合"
@@ -3061,19 +3127,19 @@ msgid ""
 "still be open for this to work."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "FIRST NAME"
 msgstr ""
 
 #
 #. ($@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:759
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:756
 #, fuzzy
 msgid "Failed to create new achievement: %1"
 msgstr "tr: Failed to duplicate set: [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:725
 #, fuzzy
 msgid "Failed to create new achievement: no achievement ID specified!"
 msgstr "tr: Failed to create new set: no set name specified!"
@@ -3091,7 +3157,7 @@ msgid "Failed to create new set: no set name specified!"
 msgstr "tr: Failed to create new set: no set name specified!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:740
 #, fuzzy
 msgid ""
 "Failed to duplicate achievement: no achievement selected for duplication!"
@@ -3132,10 +3198,10 @@ msgstr "tr: Failed to duplicate set: [_1]"
 #. ($filePath)
 #. ($scoreFilePath)
 #. ($FilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:970
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:966
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2412
 #, fuzzy
 msgid "Failed to open %1"
 msgstr "tr: Saved to file '[_1]'"
@@ -3148,12 +3214,12 @@ msgid "Failed to save: %1"
 msgstr "tr: Saved to file '[_1]'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:201
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:218
 msgid "False"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid "Feature exhausted for this problem"
 msgstr "tr: report bugs in this problem"
@@ -3169,37 +3235,37 @@ msgid "Feedback by Section."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:260
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:261
 #, fuzzy
 msgid "FeedbackMessage"
 msgstr "反馈信息"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1066
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3601
 msgid "Field is ok"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1811
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3593
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1817
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3599
 msgid "Field missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1063
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1818
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3600
 msgid "Field missing in schema"
 msgstr ""
 
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:581
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:582
 msgid "File '%1' exists.  File not saved.  No changes have been made."
 msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1835
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1812
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1885
 #, fuzzy
 msgid ""
@@ -3256,7 +3322,7 @@ msgid "File successfully renamed"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1136
 msgid "Filename"
 msgstr "文件名"
 
@@ -3266,7 +3332,7 @@ msgid "Files with extension '.%1' usually belong in '%2'"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:662
 msgid "Filter by what text?"
 msgstr "tr: Filter by what text?"
 
@@ -3285,30 +3351,30 @@ msgid "First"
 msgstr "名"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:539
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1777
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:290
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:766
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:804
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:835
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:271
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:746
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:792
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:821
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:795
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:824
 msgid "First Name"
 msgstr "名"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:707
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
 #, fuzzy
 msgid "First name"
 msgstr "名"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:256
 msgid ""
 "For security reasons, you cannot specify a message file from a directory "
 "higher than the email directory (you can't use ../blah/blah for example). "
@@ -3316,7 +3382,7 @@ msgid ""
 "directory"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2559
 msgid "Force problems to be numbered consecutively from one"
 msgstr ""
 
@@ -3325,6 +3391,12 @@ msgid ""
 "Force problems to be numbered consecutively from one (always done when "
 "reordering problems)"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
+#, fuzzy
+msgid "Format"
+msgstr "tr: Hardcopy Header"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:383
 msgid "Format for the subject line in feedback e-mails"
@@ -3337,22 +3409,28 @@ msgstr ""
 msgid "Format:"
 msgstr "tr: Hardcopy Header"
 
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:410
+#, fuzzy
+msgid "Found no directories containing problems"
+msgstr "Bu soru grubunda soru bulunmamaktad谋r."
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:888
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm:797
 msgid "From This Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
 #, fuzzy
 msgid "From field must contain one valid email address."
 msgstr "不能改变您的email地址: [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:370
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:384
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:667
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:392
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
 msgid "From:"
 msgstr ""
 
@@ -3383,7 +3461,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1962
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2135
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2161
 #, fuzzy
 msgid "General Information"
 msgstr "tr: Options Information"
@@ -3410,13 +3488,20 @@ msgid "Get Target Set Problems"
 msgstr "tr: Edit Set Data"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:897
+#: /opt/webwork/pg/macros/problemRandomize.pl:185
+#: /opt/webwork/pg/macros/problemRandomize.pl:186
+#, fuzzy
+msgid "Get a new version of this problem"
+msgstr "tr: report bugs in this problem"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:900
 #, fuzzy
 msgid "Give new password to"
 msgstr "tr: Give new password to which users?"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:889
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:892
 msgid "Give new password to which users?"
 msgstr "tr: Give new password to which users?"
 
@@ -3445,7 +3530,7 @@ msgid "Global problem %1 for set %2 not found."
 msgstr "tr: The file '[_1]' cannot be found."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2006
 msgid "Global set data will be shown instead of user specific data"
 msgstr ""
 
@@ -3453,28 +3538,38 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:291
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+#: /opt/webwork/pg/macros/compoundProblem.pl:491
+msgid "Go on to next part"
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
 #, fuzzy
 msgid "Grade"
 msgstr "成绩"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2434
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:694
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:534
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:536
 #, fuzzy
 msgid "Grade Problem"
 msgstr "下一题"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2234
 #, fuzzy
 msgid "Grade Test"
 msgstr "成绩"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:420
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:422
 #, fuzzy
 msgid "Grader"
 msgstr "成绩"
@@ -3507,7 +3602,7 @@ msgid "Guest Login"
 msgstr "游客登录"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2112
 #, fuzzy
 msgid "HTTP Headers"
 msgstr "tr: Set Header"
@@ -3542,15 +3637,19 @@ msgstr "tr: Hardcopy Header"
 msgid "Hardcopy Theme"
 msgstr "tr: Hardcopy Header"
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:409
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2027
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2234
 #, fuzzy
 msgid "Headers"
 msgstr "tr: Set Header"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:923
 msgid "Help"
 msgstr "帮助"
 
@@ -3563,13 +3662,13 @@ msgstr ""
 msgid "Hidden"
 msgstr "隐藏的"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2319
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2345
 msgid "Hide All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Hide Courses"
 msgstr "课程"
@@ -3587,8 +3686,8 @@ msgid "Hide Hints from Students"
 msgstr "tr: hidden from students"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3013
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:376
 #, fuzzy
 msgid "Hide Inactive Courses"
 msgstr "课程"
@@ -3604,7 +3703,7 @@ msgid "Hide path:"
 msgstr "提示"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1538
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1638
 #, fuzzy
 msgid "Hint:"
 msgstr "提示"
@@ -3621,14 +3720,14 @@ msgid "Hmwk Sets Editor"
 msgstr "作业编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:736
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:117
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:258
 msgid "Homework Sets"
 msgstr "Soru Gruplar谋"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:485
 #, fuzzy
 msgid "Homework Totals"
 msgstr "Soru Gruplar谋"
@@ -3637,16 +3736,16 @@ msgstr "Soru Gruplar谋"
 msgid "I couldn't find the file [ACHEVDIR]/surprise_message.txt!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1335
 msgid "Icon"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1349
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
 msgid "Icon File"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:545
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:548
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
@@ -3666,14 +3765,14 @@ msgstr ""
 msgid ""
 "If this is enabled then instructors with the ability to receive feedback "
 "emails will be notified whenever a student runs out of attempts on a problem "
-"and its children without receiving an adjusted status of 100%"
+"and its children without receiving an adjusted status of 100%."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:316
 msgid ""
 "If this is enabled then students will be unable to attempt a problem until "
 "they have completed all of the previous problems, and their child problems "
-"if necessary"
+"if necessary."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:88
@@ -3685,6 +3784,10 @@ msgid ""
 "have direct control."
 msgstr ""
 
+#: /opt/webwork/pg/macros/problemRandomize.pl:408
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
 #
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:684
@@ -3692,7 +3795,7 @@ msgstr ""
 msgid "Illegal file '%1' specified"
 msgstr "tr: The file '[_1]' is protected!"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2268
 msgid "Illegal filename contains '..'"
 msgstr ""
 
@@ -3702,10 +3805,11 @@ msgid "Import"
 msgstr "tr: Import"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
+#. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:773
 #, fuzzy
-msgid "Import achievements from"
-msgstr "输出已选定的集合"
+msgid "Import achievements from %1 assigning the achievements to %2."
+msgstr "这次作业留给哪些用户?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1262
@@ -3723,24 +3827,24 @@ msgid "Import sets with names"
 msgstr "tr: Import sets with names"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1012
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1015
 msgid "Import users from what file?"
 msgstr "tr: Import users from what file?"
 
 #
 #. ($count)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:883
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:879
 #, fuzzy
 msgid "Imported %quant(%1,achievement)"
 msgstr "输出已选定的集合"
 
 #. ($total_inprogress, $num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:967
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:977
 msgid "In progress: %1/%2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1706
 msgid "Inactive"
 msgstr "tr: Inactive"
 
@@ -3749,13 +3853,13 @@ msgid "Inactivity time before a user is required to login again"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:167
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:179
 #, fuzzy
 msgid "Include Success Index"
 msgstr "Inclure l'index"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1962
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:421
 #, fuzzy
 msgid "Incorrect"
@@ -3763,7 +3867,7 @@ msgstr "错误"
 
 #
 #. ($total_incorrect,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:985
 #, fuzzy
 msgid "Incorrect: %1/%2"
 msgstr "错误"
@@ -3773,7 +3877,7 @@ msgid "Init"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:506
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:508
 #, fuzzy
 msgid "Institution:"
 msgstr "tr: Recitation"
@@ -3783,16 +3887,16 @@ msgstr "tr: Recitation"
 msgid "Instructor Tools"
 msgstr "授课人工具"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1296
 msgid "Instructor solution preview: show the student solution after due date."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:431
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
 msgid "Invalid Reply-to address."
 msgstr ""
 
 #. ($output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:259
 msgid ""
 "Invalid file name. The file name \"%1\" does not have a \".msg\" extension "
 "All email file names must end in the extension \".msg\" choose a file name "
@@ -3801,7 +3905,7 @@ msgstr ""
 
 #. ($headerType)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1708
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1899
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1925
 msgid "Invalid headerType %1"
 msgstr ""
 
@@ -3817,19 +3921,23 @@ msgid ""
 "you are deleting some from the middle."
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
+msgid "Item Used Successfully!"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:226
 msgid "Items"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2079
 #, fuzzy
 msgid "Jump to Page:"
 msgstr "下一题"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2061
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2063
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2106
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 #, fuzzy
 msgid "Jump to Problem:"
 msgstr "下一题"
@@ -3842,7 +3950,7 @@ msgstr ""
 msgid "Keywords:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "LAST NAME"
 msgstr ""
 
@@ -3868,29 +3976,29 @@ msgid "Last Answer"
 msgstr "脰nceki Yan谋tlar谋 G枚ster"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:541
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:543
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:291
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:767
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:805
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:836
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:272
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:747
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:770
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:808
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
 msgid "Last Name"
 msgstr "姓"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:715
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:723
 msgid "Last column of merge file"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:708
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:716
 #, fuzzy
 msgid "Last name"
 msgstr "姓"
@@ -3921,21 +4029,21 @@ msgid "Level:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:847
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1610
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:503
 msgid "Library Browser"
 msgstr "K眉t眉phane Taray谋c谋"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:521
 #, fuzzy
 msgid "Library Browser 2"
 msgstr "K眉t眉phane Taray谋c谋"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:530
 #, fuzzy
 msgid "Library Browser 3"
@@ -3979,14 +4087,14 @@ msgid "Local Problems"
 msgstr "题目"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #, fuzzy
 msgid "Location"
 msgstr "tr: Recitation"
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2853
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2878
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2884
 msgid ""
 "Location %1 does not exist in the WeBWorK database.  Please check your input "
 "(perhaps you need to reload the location management page?)."
@@ -3994,24 +4102,24 @@ msgstr ""
 
 #
 #. ($locationID, join(', ', @addresses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2736
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2742
 #, fuzzy
 msgid "Location %1 has been created, with addresses %2."
 msgstr "tr: Set [_1] exists.  No set created"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2775
 msgid "Location deletion requires confirmation."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2603
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2829
 #, fuzzy
 msgid "Location description:"
 msgstr "tr: Show/Hide Site Description"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2592
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2598
 #, fuzzy
 msgid "Location name:"
 msgstr "tr: no action"
@@ -4022,8 +4130,8 @@ msgid "Log In Again"
 msgstr "再次登录"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 msgid "Log Out"
 msgstr "登出"
 
@@ -4031,23 +4139,23 @@ msgstr "登出"
 #. ($rename_oldCourseID)
 #. ($rename_newCourseID)
 #. ($new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1297
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1378
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2235
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1380
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2241
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:857
 msgid "Log into %1"
 msgstr ""
 
 #
 #. (HTML::Entities::encode_entities($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:977
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
 #, fuzzy
 msgid "Logged in as %1."
 msgstr "[_1] olarak giri艧 yapt谋n谋z."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 #, fuzzy
 msgid "Login"
 msgstr "登入"
@@ -4063,24 +4171,24 @@ msgstr "登录信息"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:877
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:289
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:765
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:784
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:803
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:834
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:745
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:768
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:837
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Login Name"
 msgstr "登录名"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1852
 #, fuzzy
 msgid "Login Status"
 msgstr "登录状态"
@@ -4091,7 +4199,7 @@ msgid "Logout"
 msgstr "登出"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:727
 msgid "Main Menu"
 msgstr "Ana Menü"
 
@@ -4105,22 +4213,22 @@ msgid "Make Archive"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1028
 #, fuzzy
 msgid "Make changes"
 msgstr "保存改变"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1021
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1023
 msgid "Make these changes in  course:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2563
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:374
 msgid "Manage Locations"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:695
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:453
 #, fuzzy
 msgid "Manual Grader"
@@ -4138,7 +4246,7 @@ msgstr "正确"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2270
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2490
 #, fuzzy
 msgid "Mark Correct?"
 msgstr "正确"
@@ -4149,8 +4257,9 @@ msgid "Match on what? (separate multiple IDs with commas)"
 msgstr "tr: Match on what? (separate multiple IDs with commas)"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:517
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:518
 msgid "Math Objects"
 msgstr "tr: Math Objects"
 
@@ -4169,56 +4278,56 @@ msgid "Maximum times Show me Another can be used per problem (-1 => unlimited)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:666
 #, fuzzy
 msgid "Merge file:"
 msgstr "tr: header file"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:314
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 #, fuzzy
 msgid "Message"
 msgstr "Mesajlar"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:657
 #, fuzzy
 msgid "Message file:"
 msgstr "tr: header file"
 
 #. ($emailDirectory, $output_file)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:419
 msgid "Message saved to file <code>%1/%2</code>."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:395
 #, fuzzy
 msgid "Message:"
 msgstr "Mesajlar"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:394
 msgid "Messages"
 msgstr "Mesajlar"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2104
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2186
 msgid "Method"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2701
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2707
 msgid ""
 "Missing required input data. Please check that you have filled in all of the "
 "create location fields and resubmit."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2455
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2481
 msgid "Move"
 msgstr ""
 
 #. ($recipient, $ur->email_address)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:877
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:888
 msgid "Msg sent to %1 at %2."
 msgstr ""
 
@@ -4232,18 +4341,18 @@ msgstr "题目"
 msgid "Mysterious Package (with Ribbons)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:355
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:367
 msgid "NO OF FIELDS"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1333
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1337
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1352
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:834
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:863
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:243
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:244
 msgid "Name"
@@ -4292,14 +4401,14 @@ msgid "New Folder"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2110
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2116
 #, fuzzy
 msgid "New Name:"
 msgstr "tr: Set Name"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1713
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1866
 msgid "New Password"
 msgstr "新密码"
 
@@ -4314,12 +4423,12 @@ msgid "New folder name:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1322
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1325
 msgid "New passwords saved"
 msgstr "新密码已保存"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
 msgid "NewVersion"
 msgstr ""
 
@@ -4328,16 +4437,18 @@ msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1076
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1088
 msgid "Next Problem"
 msgstr "下一题"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1728
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:924
 msgid "Next page"
 msgstr ""
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:150
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:207
@@ -4345,22 +4456,29 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:433
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "No"
 msgstr "tr: No"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2187
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2213
 #, fuzzy
 msgid "No Description"
 msgstr "tr: Show/Hide Site Description"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1392
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:325
+#, fuzzy
+msgid "No achievements have been assigned yet"
+msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1388
 msgid "No achievements shown.  Create an achievement!"
 msgstr ""
 
@@ -4382,7 +4500,7 @@ msgstr ""
 msgid "No change made to any set"
 msgstr "tr: No change made to any set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1228
 msgid ""
 "No changes specified.  You must mark the checkbox of the item(s) to be "
 "changed and enter the change data."
@@ -4396,7 +4514,7 @@ msgid "No changes were saved!"
 msgstr "tr: changes saved"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2417
 #, fuzzy
 msgid "No course id defined"
 msgstr "课程"
@@ -4409,40 +4527,40 @@ msgstr "课程"
 msgid "No data exists for set %1 and problem %2"
 msgstr "tr: set [_1]/problem [_2]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:245
 msgid "No filename was specified for saving!  The message was not saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:341
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:347
 msgid "No guest logins are available. Please try again in a few minutes."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2879
 msgid "No location specified to edit?! Please check your input data."
 msgstr ""
 
 #. ($badID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2771
 msgid "No location with name %1 exists in the database"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:448
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:456
 #, fuzzy
 msgid "No merge data file"
 msgstr "tr: header file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:584
 msgid ""
 "No new Achievement ID specified.  No new achievement created.  File not "
 "saved."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:566
 msgid "No problems matched the given parameters."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:439
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:447
 msgid ""
 "No recipients selected. Please select one or more recipients from the list "
 "below."
@@ -4451,7 +4569,7 @@ msgstr ""
 #
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1756
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1947
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1973
 #, fuzzy
 msgid "No record for global set %1."
 msgstr "tr: Set Header for set [_1]"
@@ -4459,19 +4577,19 @@ msgstr "tr: Set Header for set [_1]"
 #
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1758
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1975
 #, fuzzy
 msgid "No record for user %1."
 msgstr "tr: Set Header for set [_1]"
 
 #
 #. ($prob)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2310
 #, fuzzy
 msgid "No record found for problem %1."
 msgstr "tr: Set Header for set [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2266
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2275
 msgid "No record found."
 msgstr ""
 
@@ -4486,7 +4604,7 @@ msgid "No sets selected for scoring"
 msgstr "tr: No sets selected for scoring"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2788
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
@@ -4495,16 +4613,16 @@ msgstr ""
 "course."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1699
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1890
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1916
 msgid "No source filePath specified"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2133
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2141
 msgid "No source_file for problem in .def file"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1899
 #, fuzzy
 msgid ""
 "No students shown.  Choose one of the options above to list the students in "
@@ -4526,15 +4644,19 @@ msgid "No user specific data exists for user %1"
 msgstr ""
 
 #. ($locationID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2963
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2969
 msgid "No valid changes submitted for location %1."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:304
+msgid "No versions of this assignment have been taken."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1920
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1922
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2092
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2093
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2118
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2119
 msgid "None"
 msgstr ""
 
@@ -4548,29 +4670,36 @@ msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1979
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2005
 msgid "None of the selected users are assigned to this set: %1"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:984
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:986
 msgid "Not logged in."
 msgstr "Giri艧 yapmad谋n谋z."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1229
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2168
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1239
 msgid "Note"
 msgstr "tr: Note"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2195
+#
+#: /opt/webwork/pg/macros/problemRandomize.pl:382
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+#, fuzzy
+msgid "Note:"
+msgstr "tr: Note"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2240
 msgid ""
 "Note: grading the test grades all problems, not just those on this page."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1343
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1339
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1353
 #, fuzzy
 msgid "Number"
 msgstr "tr: Problem Viewer"
@@ -4587,8 +4716,8 @@ msgstr ""
 msgid "Number of Tests per Time Interval (0=infty)"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2056
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2062
 msgid "OK"
 msgstr ""
 
@@ -4624,7 +4753,7 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:658
 #, fuzzy
 msgid "Open"
 msgstr "tr: Open Date"
@@ -4646,13 +4775,13 @@ msgstr "tr: Open Date"
 msgid "Open Problem Library"
 msgstr "题目列表"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "Open in New Window"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:727
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:767
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:768
 msgid "Open in new window"
 msgstr ""
 
@@ -4670,12 +4799,10 @@ msgstr "现在开放, 截止 "
 msgid "Open, complete by %1."
 msgstr "a莽谋k: [_1] tarihine kadar tamamlay谋n"
 
-#
-#. ($beginReducedScoringPeriod)
+#. ($beginReducedScoringPeriod, $self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:689
-#, fuzzy
-msgid "Open, reduced scoring starts on %1."
-msgstr "tr: Reduced Credit Starts: [_1]"
+msgid "Open, due %1, afterward reduced credit can be earned until %2."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -4704,12 +4831,12 @@ msgid "Order Problems Randomly"
 msgstr "题目"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:855
 #, fuzzy
 msgid "Orig. Lib. Browser"
 msgstr "K眉t眉phane Taray谋c谋"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:460
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:464
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:838
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:866
 msgid "Out Of"
@@ -4734,67 +4861,70 @@ msgstr ""
 msgid "PG - Problem Display/Answer Checking"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:798
 msgid "PG debug messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:800
 msgid "PG internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
 msgid "PG question failed to render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:797
 msgid "PG question processing error messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:789
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:799
 msgid "PG warning messages"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1405
 msgid "PGInfo"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:527
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:509
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:528
 msgid "PGLab"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:532
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:532
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:533
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:533
 msgid "PGML"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:522
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:523
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:523
 msgid "POD"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1886
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2155
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1896
 msgid "PREVIEW ONLY -- ANSWERS NOT RECORDED"
 msgstr "G脰STER陌M -- YANITLAR KAYDED陌LMED陌 "
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:369
 msgid "PROB NUMBER"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:360
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:372
 msgid "PROB VALUE"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:197
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:209
 msgid "Pad Fields"
 msgstr "Remplir les champs"
 
 #
 #. (timestamp($self)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1103
 #, fuzzy
 msgid "Page generated at %1"
 msgstr "tr: Page generated at [_1]"
@@ -4811,7 +4941,7 @@ msgid "Password (Leave blank for regular proctoring)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:527
 #, fuzzy
 msgid "Password:"
 msgstr "tr: New Password"
@@ -4823,7 +4953,7 @@ msgstr "tr: New Password"
 msgid "Past Answers for %1, set %2, problem %3"
 msgstr "tr: Added [_1] to [_2] as problem [_3]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:462
 msgid "Percent"
 msgstr ""
 
@@ -4837,25 +4967,25 @@ msgid ""
 "median number of attempts"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:796
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:846
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:756
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:779
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:802
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
 msgid "Permission Level"
 msgstr "tr: Permission Level"
 
@@ -4865,7 +4995,7 @@ msgstr "tr: Permission Level"
 msgid "Permissions"
 msgstr "tr: Permission Level"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3097
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3103
 msgid ""
 "Place a file named \"hide_directory\" in a course or other directory and it "
 "will not show up in the courses list on the WeBWorK home page. It will still "
@@ -4902,7 +5032,7 @@ msgid ""
 "you would like to copy it to."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:387
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:389
 msgid "Please correct the following errors and try again:"
 msgstr ""
 
@@ -4916,7 +5046,7 @@ msgstr ""
 msgid "Please enter your username and password for %1 below:"
 msgstr "请在下面[_1]处输入你的用户名和密码 :"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2767
 msgid "Please provide a location name to delete."
 msgstr ""
 
@@ -4940,20 +5070,20 @@ msgid "Please select at least one user and try again."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:556
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1806
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:557
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1856
 msgid "Please specify a file to save to."
 msgstr "tr: Please specify a file to save to."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1345
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1341
 #, fuzzy
 msgid "Points"
 msgstr "提示"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:537
-msgid "Potion of Forgetfullness"
+msgid "Potion of Forgetfulness"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:674
@@ -4961,42 +5091,43 @@ msgid "Preflight Log"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview Message"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1491
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1501
 #, fuzzy
 msgid "Preview My Answers"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2231
 #, fuzzy
 msgid "Preview Test"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:691
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:699
 #, fuzzy
 msgid "Preview message"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:698
 #, fuzzy
 msgid "Preview set to:"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1062
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1074
 msgid "Previous Problem"
 msgstr "上一题"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1724
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:919
 #, fuzzy
 msgid "Previous page"
@@ -5006,12 +5137,12 @@ msgstr "上一题"
 msgid "Primary sort"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1961
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2006
 msgid "Print Test"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #, fuzzy
 msgid "Prob"
 msgstr "题目"
@@ -5034,22 +5165,22 @@ msgstr "tr: Problem"
 #. ($problemID)
 #. ($problemNumber)
 #. ($prettyProblemIDs{$probID})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:761
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:450
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:764
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:928
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:930
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:934
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:496
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:763
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:451
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:940
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:500
 #, fuzzy
 msgid "Problem %1"
 msgstr "tr: Problem"
 
 #
 #. ($problemNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2119
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2164
 #, fuzzy
 msgid "Problem %1."
 msgstr "tr: Problem"
@@ -5072,8 +5203,8 @@ msgid "Problem Editor3"
 msgstr "题目编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1068
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1070
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1080
 msgid "Problem List"
 msgstr "题目列表"
 
@@ -5094,31 +5225,32 @@ msgid "Problem Number "
 msgstr "tr: Problem Viewer"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:512
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:513
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:513
 msgid "Problem Techniques"
 msgstr "tr: Problem Techniques"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:778
 #, fuzzy
 msgid "Problem Viewer"
 msgstr "题目编辑"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1700
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1917
 msgid "Problem source is drawn from a grouping set"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2152
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:430
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:840
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:871
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:881
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid "Problems"
 msgstr "题目"
 
@@ -5171,11 +5303,11 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2829
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2840
 msgid "Publish"
 msgstr "tr: Publish"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
 msgstr ""
 
@@ -5190,29 +5322,29 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:710
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:153
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:155
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:842
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:875
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1786
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:299
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:775
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:794
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:844
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1860
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:280
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:754
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:777
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:800
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:829
 msgid "Recitation"
 msgstr "tr: Recitation"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:189
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:201
 msgid "Record Scores for Single Sets"
 msgstr "Ajouter les résultats de chaque devoir"
 
@@ -5229,7 +5361,7 @@ msgstr "tr: Reduced Credit Disabled"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Disabled"
 msgstr "tr: Reduced Credit Disabled"
@@ -5238,24 +5370,10 @@ msgstr "tr: Reduced Credit Disabled"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2223
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2559
 #, fuzzy
 msgid "Reduced Scoring Enabled"
 msgstr "tr: Reduced Credit Enabled"
-
-#
-#. ($self->formatDateTime($set->reduced_scoring_date,undef,				       $r->ce->{studentDateDisplayFormat})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:138
-#, fuzzy
-msgid "Reduced Scoring Starts %1"
-msgstr "tr: Reduced Credit Starts: [_1]"
-
-#
-#. ($beginReducedScoringPeriod)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:700
-#, fuzzy
-msgid "Reduced scoring started on %1."
-msgstr "tr: Reduced Credit Starts: [_1]"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:36
 msgid "Reduced:"
@@ -5272,12 +5390,12 @@ msgid "Refresh Display"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1456
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1479
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1687
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1722
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3038
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1458
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1481
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1689
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1724
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3066
 #, fuzzy
 msgid "Refresh Listing"
 msgstr "用户列表"
@@ -5287,7 +5405,7 @@ msgid "Relax IP restrictions when?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
 msgid "Remaining"
 msgstr "Kalan hak"
 
@@ -5301,7 +5419,7 @@ msgid "Remember to return to your original problem when you're finished here!"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1171
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1173
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:160
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:351
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:650
@@ -5312,14 +5430,14 @@ msgid "Rename"
 msgstr "文件名"
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1168
 msgid "Rename %1 to %2"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:362
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:899
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:901
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:961
 #, fuzzy
 msgid "Rename Course"
 msgstr "课程"
@@ -5330,22 +5448,22 @@ msgstr "课程"
 msgid "Rename file as:"
 msgstr "tr: header file"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 msgid "Render"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2317
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2343
 msgid "Render All"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2459
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2485
 #, fuzzy
 msgid "Render Problem"
 msgstr "下一题"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2341
 #, fuzzy
 msgid "Renumber Problems"
 msgstr "题目"
@@ -5362,60 +5480,61 @@ msgid "Reorder problems only"
 msgstr ""
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1745
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1722
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1794
 msgid "Replace current problem: %1"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1027
 msgid "Replace which users?"
 msgstr "tr: Replace which users?"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:557
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:668
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:676
 msgid "Reply-To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:542
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:542
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:543
 msgid "Report Bugs in this Problem"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:935
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:937
 msgid "Report bugs"
 msgstr "Hataları bildir"
 
 #
 #. ($upgrade_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2383
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2518
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2524
 #, fuzzy
 msgid "Report for course %1:"
 msgstr "tr: Set Header for set [_1]"
 
 #. ($rename_oldCourseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1070
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1819
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1072
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1825
 msgid "Report on database structure for course %1:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1487
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1497
 msgid "Request New Version"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2101
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2107
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2183
 #, fuzzy
 msgid "Request information"
 msgstr "tr: Options Information"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1572
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1582
 #, fuzzy
 msgid "Request new version now."
 msgstr "tr: Options Information"
@@ -5489,8 +5608,8 @@ msgid "Reset"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1951
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2124
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2150
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2579
 msgid "Reset Form"
 msgstr ""
 
@@ -5498,11 +5617,7 @@ msgstr ""
 msgid "Resets the number of incorrect attempts on a single homework problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
-msgid "Ressurect which Gateway?"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2085
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2091
 msgid ""
 "Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, "
 "the course database is restored from a subdirectory of the course's DATA "
@@ -5536,26 +5651,26 @@ msgid "Restrict release by set(s)"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:312
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:313
 msgid "Result"
 msgstr "结果"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:384
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:387
 #, fuzzy
 msgid "Result of last action performed"
 msgstr "tr: Results of last action performed"
 
 #
 #. (CGI::i($self->$actionHandler(\%genericParams, \%actionParams, \%tableParams)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:364
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:367
 #, fuzzy
 msgid "Result of last action performed: %1"
 msgstr "tr: Result of last action performed: [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:324
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:325
 msgid "Results for this submission"
 msgstr ""
 
@@ -5570,21 +5685,29 @@ msgstr "tr: Results of last action performed"
 msgid "Results of last action performed: "
 msgstr "tr: Results of last action performed"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1288
+#: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1586
+msgid "Resurrect which Gateway?"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1290
 msgid "Retitled"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:324
+msgid "Return to your work"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:167
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:586
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:133
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:134
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:135
 msgid "Revert"
 msgstr "tr: Revert"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1955
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:2031
 #, fuzzy
 msgid "Revert to %1"
@@ -5598,19 +5721,19 @@ msgstr ""
 msgid "Robe of Longevity"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "SECTION"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:356
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:368
 msgid "SET NAME"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:467
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:479
 msgid "STATUS"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
 msgstr ""
 
@@ -5620,103 +5743,103 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:169
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:587
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:749
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:209
 msgid "Save"
 msgstr "保存"
 
 #
 #. (CGI::b($self->shortPath($self->{sourceFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:454
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:455
 #, fuzzy
 msgid "Save %1"
 msgstr "保存"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:45
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:588
 msgid "Save As"
 msgstr "另存为"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:715
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1950
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2325
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2123
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2552
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2149
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2578
 #, fuzzy
 msgid "Save Changes"
 msgstr "保存改变"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:750
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:758
 #, fuzzy
 msgid "Save as"
 msgstr "另存为"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:761
 #, fuzzy
 msgid "Save as Default"
 msgstr "tr: Use System Default"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1017
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1013
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1441
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1484
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:363
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1182
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1255
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1210
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1285
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1185
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1258
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1213
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1288
 msgid "Save changes"
 msgstr "保存改变"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1770
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1819
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:664
 #, fuzzy
 msgid "Save file to:"
 msgstr "tr: Save Edit"
 
 #
 #. (CGI::b($self->shortPath($self->{editFilePath})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1559
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1610
 #, fuzzy
 msgid "Save to %1 and View"
 msgstr "tr: Save [_1] and View"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:411
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1194
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1248
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1172
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1249
 #, fuzzy
 msgid "Saved to file '%1'"
 msgstr "tr: Saved to file '[_1]'"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1065
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1067
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1820
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3602
 msgid "Schema and database field definitions do not agree"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3591
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1815
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3597
 msgid "Schema and database table definitions do not agree"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:459
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:516
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:513
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:732
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:837
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:865
@@ -5734,11 +5857,11 @@ msgid "Score required for release"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:217
 msgid "Score selected set(s) and save to:"
 msgstr "Sauvegarder les résultats sélectionnés sous"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1957
 msgid "Score summary for last submit:"
 msgstr ""
 
@@ -5772,14 +5895,14 @@ msgid "Scoring Tools"
 msgstr "成绩编辑工具"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2113
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2274
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2300
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
-msgid "Scroll of Ressurection"
+msgid "Scroll of Resurrection"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:771
@@ -5790,24 +5913,24 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm:217
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:709
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:717
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:152
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:154
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:873
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1782
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:295
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:790
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:809
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:840
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1856
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:276
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:773
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:825
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:298
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:843
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:279
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:753
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:776
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:828
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Section"
 msgstr "tr: Section"
@@ -5824,11 +5947,17 @@ msgstr "tr: Section"
 msgid "Seed"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2643
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2649
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:442
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1773
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1776
 msgid "Select"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:444
+#, fuzzy
+msgid "Select a Homework Set"
+msgstr "Soru Gruplar谋"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:50
@@ -5841,12 +5970,12 @@ msgid "Select a Set from this Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1462
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1464
 #, fuzzy
 msgid "Select a course to delete."
 msgstr "tr: Select action below"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:905
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:907
 msgid ""
 "Select a course to rename.  The courseID is used in the url and can only "
 "contain alphanumeric characters and underscores. The course title appears on "
@@ -5854,33 +5983,33 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2092
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2098
 #, fuzzy
 msgid "Select a course to unarchive."
 msgstr "tr: Select action below"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:577
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:579
 #, fuzzy
 msgid "Select a database layout below."
 msgstr "tr: Select action below"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1448
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1679
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1450
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1681
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3036
 #, fuzzy
 msgid "Select a listing format:"
 msgstr "tr: Select an action to perform"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:287
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
 #, fuzzy
 msgid "Select above then:"
 msgstr "tr: selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2259
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
 #, fuzzy
 msgid "Select all eligible courses"
 msgstr "选择所有用户"
@@ -5891,31 +6020,31 @@ msgid "Select all sets"
 msgstr "tr: Select all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:546
 msgid "Select all users"
 msgstr "选择所有用户"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:285
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:564
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:503
 msgid "Select an action to perform"
 msgstr "tr: Select an action to perform"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2578
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2584
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:534
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:517
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:520
 #, fuzzy
 msgid "Select an action to perform:"
 msgstr "tr: Select an action to perform"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1692
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1694
 msgid "Select course(s) to archive."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3043
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3049
 #, fuzzy
 msgid "Select course(s) to hide or unhide."
 msgstr "tr: Select action below"
@@ -5930,7 +6059,7 @@ msgstr ""
 msgid "Select sets below to assign them to the newly-created users."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3015
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3021
 msgid ""
 "Select the course(s) you want to hide (or unhide) and then click \"Hide "
 "Courses\" (or \"Unhide Courses\"). Hiding a course that is already hidden "
@@ -5955,29 +6084,29 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:695
 #, fuzzy
 msgid "Selected students"
 msgstr "tr: selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:381
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:392
 #, fuzzy
 msgid "Send E-mail"
 msgstr "电子邮件"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:748
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:756
 #, fuzzy
 msgid "Send Email"
 msgstr "电子邮件"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:684
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:692
 msgid "Send to:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:457
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:461
 msgid "Set"
 msgstr "Soru Grubu"
 
@@ -6020,7 +6149,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2007
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2180
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2206
 #, fuzzy
 msgid "Set Description"
 msgstr "tr: Show/Hide Site Description"
@@ -6035,7 +6164,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2084
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2276
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:92
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:447
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:762
@@ -6052,13 +6181,13 @@ msgid "Set ID"
 msgstr "学生ID"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:312
 msgid "Set Info"
 msgstr "Informations"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2755
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2766
 msgid "Set List"
 msgstr "tr: Set List"
 
@@ -6089,8 +6218,12 @@ msgid "Set Name "
 msgstr "tr: Set Name"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2085
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2251
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2277
 msgid "Set headers are not used in display of gateway tests."
+msgstr ""
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:187
+msgid "Set random seed to:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:365
@@ -6117,7 +6250,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:496
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:368
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:429
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:193
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:195
 msgid "Sets"
 msgstr "Devoirs"
 
@@ -6134,7 +6267,7 @@ msgid "Sets assigned to %1"
 msgstr "tr: Edit Assigned Users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:703
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:704
 #, fuzzy
 msgid "Setting"
 msgstr "Kullan谋c谋 bilgilerini g眉ncelle"
@@ -6144,11 +6277,11 @@ msgid "Shift dates so that the earliest is"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:649
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:652
 msgid "Show"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1357
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1367
 msgid "Show Auxiliary Resources"
 msgstr ""
 
@@ -6157,7 +6290,7 @@ msgid "Show Date & Size"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1417
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1427
 msgid "Show Hints"
 msgstr "展示提示"
 
@@ -6168,8 +6301,8 @@ msgid "Show Me Another"
 msgstr "在新的窗口里显示"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2228
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2273
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2068
 msgid "Show Past Answers"
 msgstr "脰nceki Yan谋tlar谋 G枚ster"
 
@@ -6182,8 +6315,8 @@ msgid "Show Scores on Finished Assignments?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1441
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1451
 msgid "Show Solutions"
 msgstr "展示答案"
 
@@ -6192,7 +6325,7 @@ msgid "Show Total Homework Grade on Grades Page"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:629
 msgid "Show Which Users?"
 msgstr "tr: Show Which Users?"
 
@@ -6204,20 +6337,20 @@ msgid "Show all paths"
 msgstr "tr: showing all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2220
 msgid "Show correct answers"
 msgstr "Do臒ru yan谋tlar谋 g枚ster"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:361
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 #, fuzzy
 msgid "Show me another"
 msgstr "在新的窗口里显示"
 
 #
 #. ($exhausted)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1525
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1535
 #, fuzzy
 msgid "Show me another %1"
 msgstr "在新的窗口里显示"
@@ -6230,7 +6363,7 @@ msgid "Show path ..."
 msgstr "tr: showing all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:253
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:276
 #, fuzzy
 msgid "Show saved answers?"
 msgstr "脰nceki Yan谋tlar谋 G枚ster"
@@ -6244,19 +6377,19 @@ msgstr "tr: Show which sets?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:264
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:418
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:463
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:466
 msgid "Show/Hide Site Description"
 msgstr "tr: Show/Hide Site Description"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:577
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1315
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1325
 msgid "Show:"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "Showing"
 msgstr "展示提示"
@@ -6270,7 +6403,7 @@ msgstr "tr: Showing [_1] out of [_2] sets."
 
 #
 #. (scalar @Users, scalar @allUserIDs)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:543
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:546
 #, fuzzy
 msgid "Showing %1 out of %2 users"
 msgstr "tr: Showing [_1] out of [_2] users"
@@ -6289,14 +6422,14 @@ msgstr ""
 msgid "Site Information"
 msgstr "tr: Options Information"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1923
 msgid "Skip archiving this course"
 msgstr ""
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1534
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1535
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:1536
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1633
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1634
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:1635
 #, fuzzy
 msgid "Solution:"
 msgstr "答案"
@@ -6307,7 +6440,7 @@ msgstr "答案"
 msgid "Solutions"
 msgstr "答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:398
 msgid "Some answers will be graded later."
 msgstr ""
 
@@ -6316,6 +6449,16 @@ msgid ""
 "Some of these files are directories. Only delete directories if you really "
 "know what you are doing. You can seriously damage your course if you delete "
 "the wrong thing."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1734
+msgid ""
+"Some problems shown above represent multiple similar problems from the "
+"database.  If the (top) information line for a problem has a letter M for "
+"\"More\", hover your mouse over the M  to see how many similar problems are "
+"hidden, or click on the M to see the problems.  If you click to view these "
+"problems, the M becomes an L, which can be clicked on to hide the problems "
+"again."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:147
@@ -6335,16 +6478,16 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2828
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1921
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2839
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1924
 #, fuzzy
 msgid "Sort"
 msgstr "tr: Sort"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:775
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:759
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:739
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:762
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:742
 msgid "Sort by"
 msgstr "tr: Sort by"
 
@@ -6377,7 +6520,7 @@ msgid ""
 "was modified."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:494
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:496
 msgid ""
 "Specify an ID, title, and institution for the new course. The course ID may "
 "contain only letters, numbers, hyphens, and underscores."
@@ -6418,52 +6561,52 @@ msgid "Statistics for %1 student %2"
 msgstr "tr: View statistics by student"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1959
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:392
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1093
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1781
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:294
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1855
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1858
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:278
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:246
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:247
 msgid "Status"
 msgstr "Durumu"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:981
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:983
 msgid "Stop Acting"
 msgstr "Rol Yapmay谋 b谋rak"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1915
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1921
 #, fuzzy
 msgid "Stop Archiving"
 msgstr "Rol Yapmay谋 b谋rak"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2047
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2053
 #, fuzzy
 msgid "Stop archiving courses"
 msgstr "课程"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1780
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:293
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:769
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:788
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1854
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:748
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:771
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:794
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:823
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1783
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:772
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:791
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:810
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:751
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:774
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:826
 msgid "Student ID"
 msgstr "学生ID"
 
@@ -6502,14 +6645,14 @@ msgstr "Progrès des étudiants"
 msgid "Student answers"
 msgstr "提交答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:558
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:566
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:717
 msgid "Subject:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:677
 msgid "Subject: "
 msgstr ""
 
@@ -6526,16 +6669,20 @@ msgid "Submit"
 msgstr "提交答案"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1502
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
 msgid "Submit Answers"
 msgstr "提交答案"
 
 #
 #. ($effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1499
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1509
 #, fuzzy
 msgid "Submit Answers for %1"
 msgstr "[_1] i莽in Yan谋tlar谋 G枚nder"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:502
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1620
@@ -6543,20 +6690,20 @@ msgid "Success"
 msgstr "tr: Success"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:553
 #, fuzzy
 msgid "Success Index"
 msgstr "tr: Success"
 
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1990
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1996
 msgid "Successfully archived the course %1."
 msgstr ""
 
 #
 #. ($newAchievementID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:758
 #, fuzzy
 msgid "Successfully created new achievement %1"
 msgstr "tr: selected sets"
@@ -6567,42 +6714,42 @@ msgid "Successfully created new set %1"
 msgstr ""
 
 #. ($add_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:849
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:851
 msgid "Successfully created the course %1"
 msgstr ""
 
 #. ($delete_courseID)
 #. ($archive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1597
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1599
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2039
 msgid "Successfully deleted the course %1."
 msgstr ""
 
 #. ($rename_oldCourseID, $rename_newCourseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1366
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1368
 msgid "Successfully renamed the course %1 to %2"
 msgstr ""
 
 #. ($unarchive_courseID, $new_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2222
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2228
 msgid "Successfully unarchived %1 to the course %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1058
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1807
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3589
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1060
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1813
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3595
 msgid "Table defined in database but missing in schema"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1057
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1812
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3594
 msgid "Table defined in schema but missing in database"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1059
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1808
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3590
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1814
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3596
 msgid "Table is ok"
 msgstr ""
 
@@ -6625,16 +6772,16 @@ msgid "Take %1 test."
 msgstr "tr: Take [_1] test"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2635
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2641
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2855
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:289
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:729
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:769
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:730
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:770
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:582
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:607
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:562
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:540
 msgid "Take Action!"
 msgstr "tr: Take Action!"
 
@@ -6708,11 +6855,11 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1102
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1107
 msgid "The WeBWorK Project"
 msgstr "tr: The WeBWorK Project"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:409
 msgid ""
 "The adjusted status of a problem is the larger of the problem's status and "
 "the weighted average of the status of those problems which count towards the "
@@ -6734,18 +6881,18 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:400
 #, fuzzy
 msgid "The answer above is NOT correct."
 msgstr "Yukar谋daki yan谋t [_1]do臒ru de臒il."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:396
 msgid "The answer above is correct."
 msgstr "上面的答案是正确的."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:445
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:452
 #, fuzzy
 msgid "The answer will be graded later."
 msgstr "上面的答案是正确的."
@@ -6759,14 +6906,14 @@ msgid ""
 "attempts."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:684
 msgid ""
 "The configuration module did not find the data it needs to function.  Have "
 "your site administrator check that Constants.pm is up to date."
 msgstr ""
 
 #. ($archive_courseID, $archive_path)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1917
 msgid ""
 "The course '%1' has already been archived at '%2'. This earlier archive will "
 "be erased.  This cannot be undone."
@@ -6809,13 +6956,13 @@ msgstr ""
 
 #
 #. ($achievementName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:608
 #, fuzzy
 msgid "The evaluator for %1 has been renamed to '%2'."
 msgstr "tr: The hardcopy header for set [_1] has been renamed to '[_2]'."
 
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:401
 msgid ""
 "The file %1/%2 already exists and cannot be overwritten. The message was not "
 "saved"
@@ -6823,52 +6970,52 @@ msgstr ""
 
 #
 #. ($emailDirectory, $openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:217
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:225
 #, fuzzy
 msgid "The file %1/%2 cannot be found."
 msgstr "tr: Error: The original file [_1] cannot be read."
 
 #. ($emailDirectory,$openfilename)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:210
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:218
 msgid "The file %1/%2 is not readable by the webserver."
 msgstr ""
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:385
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:386
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:387
 #, fuzzy
 msgid "The file '%1' cannot be found."
 msgstr "tr: Error: The original file [_1] cannot be read."
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1026
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1082
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1083
 #, fuzzy
 msgid "The file '%1' cannot be read!"
 msgstr "tr: Error: The original file [_1] cannot be read."
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid "The file '%1' is a blank problem!"
 msgstr "tr: The file '[_1]' is a blank problem!"
 
 #
 #. ($self->shortPath($editFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1020
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1076
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:998
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1077
 #, fuzzy
 msgid "The file '%1' is a directory!"
 msgstr "tr: The file '[_1]' is a directory!"
 
 #
 #. ($self->shortPath($inputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:388
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
 #, fuzzy
 msgid "The file '%1' is protected!"
 msgstr "tr: The file '[_1]' is protected!"
@@ -6882,29 +7029,29 @@ msgid "The file you are trying to download doesn't exist"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3136
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3142
 msgid "The following courses were successfully hidden: %1"
 msgstr ""
 
 #. (@succeeded_courses)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3212
 msgid "The following courses were successfully unhidden: %1"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3440
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3446
 msgid "The following upgrades are available for your WeBWorK system:"
 msgstr ""
 
 #. (CGI::b(join(", ", @unassignedUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1786
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2003
 msgid ""
 "The following users are NOT assigned to this set and will be ignored: %1"
 msgstr ""
 
 #
 #. (join('.', @{$problemSeqs[$children_counts_indexs[0]]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1662
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1672
 #, fuzzy
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
@@ -6912,7 +7059,7 @@ msgid ""
 msgstr "这道题目不算成绩"
 
 #. (join(', ', map({join('.', @{$problemSeqs[$_]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1664
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1674
 msgid ""
 "The grade for this problem is the larger of the score for this problem, or "
 "the weighted average of the problems: %1."
@@ -6920,31 +7067,31 @@ msgstr ""
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1841
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1913
 #, fuzzy
 msgid "The hardcopy header for set %1 has been renamed to '%2'."
 msgstr "tr: The hardcopy header for set [_1] has been renamed to '[_2]'."
 
 #. ($rename_oldCourseID, $rename_oldCourseInstitution, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1286
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
 msgstr ""
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1337
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1339
 msgid "The institution associated with the course %1 is now %2"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:498
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:515
 msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3432
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3438
 msgid ""
 "The library index is older than the library, you need to run OPL-update."
 msgstr ""
@@ -6963,13 +7110,13 @@ msgid ""
 msgstr ""
 
 #. ($openDate, $dueDate, $answerDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1978
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1981
 msgid ""
 "The open date: %1, close date: %2, and answer date: %3 must be defined and "
 "in chronological order."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:650
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:652
 msgid "The password and password confirmation for the instructor must match."
 msgstr ""
 
@@ -6996,8 +7143,8 @@ msgstr ""
 "girerek tekrar deneyiniz."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:806
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:862
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:863
 msgid "The path to the original file should be absolute"
 msgstr "tr: The path to the original file should be absolute"
 
@@ -7006,7 +7153,7 @@ msgstr "tr: The path to the original file should be absolute"
 msgid "The percentage of active students with correct answers for each problem"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:713
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:720
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:533
 msgid ""
 "The percentage of students receiving at least these scores. The median score "
@@ -7015,20 +7162,20 @@ msgstr ""
 
 #
 #. ($recScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1859
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1904
 #, fuzzy
 msgid "The recorded score for this test is  %1/%2."
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #
 #. ($recScore, $totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1914
 #, fuzzy
 msgid "The recorded score for this test is %1/%2."
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #. ($openDate, $dueDate)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1985
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1988
 msgid ""
 "The reduced credit date should be between the open date %1 and close date %2"
 msgstr ""
@@ -7041,14 +7188,14 @@ msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1695
 #, fuzzy
 msgid "The score for this problem can count towards score of problem %1."
 msgstr "这道题目不算成绩"
 
 #
 #. ($setName,$effectiveUser)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:346
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:348
 #, fuzzy
 msgid "The selected problem set (%1) is not a valid set for %2"
 msgstr "tr: The selected problem set ([_1]) is not a valid set for [_2]"
@@ -7056,14 +7203,14 @@ msgstr "tr: The selected problem set ([_1]) is not a valid set for [_2]"
 #
 #. ($setID, $userCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1837
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2027
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2053
 #, fuzzy
 msgid "The set %1 is assigned to %2."
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
 
 #
 #. ($setName, $self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1856
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1905
 #, fuzzy
 msgid "The set header for set %1 has been renamed to '%2'."
@@ -7079,7 +7226,7 @@ msgstr ""
 #
 #. ($setID, $editingSetVersion, $editForUser[0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1800
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1991
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2017
 #, fuzzy
 msgid "The set-version (%1, version %2) is not assigned to user %3."
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
@@ -7090,7 +7237,7 @@ msgstr ""
 
 #
 #. ($fullSetName, $prettyProblemNumber, $self->shortPath($sourceFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1884
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1861
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1935
 #, fuzzy
 msgid ""
@@ -7100,9 +7247,18 @@ msgstr ""
 "to '[_4]'."
 
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1950
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1995
 msgid "The test (which is number %1) may  no longer be submitted for a grade."
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1808
+msgid ""
+"The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
+msgstr ""
+"tr: The text box now contains the source of the original problem. You can "
+"recover lost edits by using the Back button on your browser."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm:224
 msgid ""
@@ -7119,7 +7275,7 @@ msgstr ""
 
 #
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1282
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1284
 #, fuzzy
 msgid "The title of the course %1 has been changed from %2 to %3"
 msgstr ""
@@ -7128,7 +7284,7 @@ msgstr ""
 
 #
 #. ($rename_newCourseID, $rename_newCourseTitle)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1330
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1332
 #, fuzzy
 msgid "The title of the course %1 is now %2"
 msgstr ""
@@ -7138,54 +7294,56 @@ msgstr ""
 #
 #. ($editForUser[0], $setCountMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1838
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2028
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2054
 #, fuzzy
 msgid "The user %1 has been assigned %2."
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
 
 #. ($enableReducedScoring)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1995
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1998
 msgid ""
 "The value %1 for enableReducedScoring is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($timeCap)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2026
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2034
 msgid ""
 "The value %1 for the capTimeLimit option is not valid; it will be replaced "
 "with '0'."
 msgstr ""
 
 #. ($hideScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2017
+#. ($hideScoreByProblem)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2020
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2025
 msgid ""
 "The value %1 for the hideScore option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($hideWork)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2022
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2030
 msgid ""
 "The value %1 for the hideWork option is not valid; it will be replaced with "
 "'N'."
 msgstr ""
 
 #. ($relaxRestrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2047
 msgid ""
 "The value %1 for the relaxRestrictIP option is not valid; it will be "
 "replaced with 'No'."
 msgstr ""
 
 #. ($restrictIP)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2031
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2039
 msgid ""
 "The value %1 for the restrictIP option is not valid; it will be replaced "
 "with 'No'."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:403
 msgid ""
 "The webwork server must be able to write to these directories. Please "
 "correct the permssion errors."
@@ -7197,8 +7355,8 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:796
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:762
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:785
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:765
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:788
 msgid "Then by"
 msgstr "tr: Then by"
 
@@ -7220,24 +7378,24 @@ msgid ""
 "The theme specifies a unified look and feel for the WeBWorK course web pages."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1118
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1867
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2394
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1120
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2400
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2506
 msgid ""
 "There are extra database fields  which are not defined in the schema for at "
 "least one table.  They can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1864
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2391
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2497
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2503
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1117
 msgid ""
 "There are extra database tables which are not defined in the schema.  They "
 "can only be removed manually from the database. They will not be renamed."
@@ -7247,36 +7405,36 @@ msgstr ""
 msgid "There are no matching WeBWorK problems"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1879
 msgid ""
 "There are tables or fields missing from the database.  The database must be "
 "upgraded before archiving this course."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3406
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3412
 msgid "There are upgrades available for the Open Problem Library."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
 msgid ""
 "There are upgrades available for your current branch of PG from branch %1 in "
 "remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
 msgid ""
 "There are upgrades available for your current branch of WeBWorK from branch "
 "%1 in remote %2."
 msgstr ""
 
+#. ($achievementID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:224
 msgid ""
 "There is NO undo for this function.  Do not use it unless you know what you "
 "are doing!  When you unassign a student using this button, or by unchecking "
-"their name, you destroy all of the data for achievement $achievementID for "
-"this student."
+"their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
@@ -7297,11 +7455,11 @@ msgstr ""
 msgid "There is NO undo for unassigning students."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3367
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3373
 msgid "There is a new version of PG available."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3311
 msgid "There is a new version of WeBWorK available."
 msgstr ""
 
@@ -7318,7 +7476,7 @@ msgid ""
 "in the left margin."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3422
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3428
 msgid ""
 "There is no library tree file for the library, you will need to run OPL-"
 "update."
@@ -7338,25 +7496,25 @@ msgstr ""
 msgid "There is no written solution available for this problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2125
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2131
 msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:356
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:243
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:259
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:391
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:398
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:410
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:440
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:252
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:268
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:408
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:415
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:427
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:457
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
@@ -7377,19 +7535,19 @@ msgid "This action will not overwrite existing users."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:454
 #, fuzzy
 msgid "This answer is NOT completely correct."
 msgstr "Yukar谋daki yan谋t [_1]do臒ru de臒il."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:449
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:456
 #, fuzzy
 msgid "This answer is NOT correct."
 msgstr "Yukar谋daki yan谋t [_1]do臒ru de臒il."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:450
 #, fuzzy
 msgid "This answer is correct."
 msgstr "上面的答案是正确的."
@@ -7401,23 +7559,23 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:437
 msgid "This homework set contains no problems."
 msgstr "Bu soru grubunda soru bulunmamaktad谋r."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1588
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1598
 msgid "This homework set is closed."
 msgstr "Bu soru grubu kapal谋."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1586
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1596
 msgid "This homework set is not yet open."
 msgstr "Bu soru grubu hen眉z a莽谋k de臒il."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1004
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:926
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1005
 #, fuzzy
 msgid ""
 "This is a blank problem template file and can not be edited directly. Use "
@@ -7427,6 +7585,10 @@ msgstr ""
 "tr: This is a blank problem template file and can not be edited directly. "
 "Use the 'Save as' action below to create a local copy of the file and add it "
 "to the current problem set."
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:407
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:99
 msgid ""
@@ -7484,37 +7646,41 @@ msgid ""
 "problem."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2805
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3031
 msgid "This problem contains a video which must be viewed online."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1659
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1923
+#: /opt/webwork/pg/macros/compoundProblem.pl:602
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1669
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1933
 msgid ""
 "This problem has open subproblems.  You can visit them by using the links to "
 "the left or visiting the set page."
 msgstr ""
 
-#. ($shownYet{$problemFile})
 #. ($prettyID)
+#. ($shownYet{$problemFile})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2218
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2396
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2422
 msgid "This problem uses the same source file as number %1."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:533
 msgid "This problem will not count towards your grade."
 msgstr "这道题目不算成绩"
 
 #. ($EMAIL)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1019
 msgid "This sample mail would be sent to %1"
 msgstr ""
 
 #
 #. (join('.',@seq)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1698
 #, fuzzy
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
@@ -7532,20 +7698,20 @@ msgstr ""
 #
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1895
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2078
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2104
 #, fuzzy
 msgid "This set %1 is assigned to %2."
 msgstr "tr: The set header for set [_1] has been renamed to '[_2]'."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2310
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2537
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2563
 #, fuzzy
 msgid "This set doesn't contain any problems yet."
 msgstr "Bu soru grubunda soru bulunmamaktad谋r."
 
 #. ($beginReducedScoringPeriod,$dueDate,$reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:377
 msgid ""
 "This set had a reduced scoring period that started on %1 and ended on %2.  "
 "During that period all work counted for %3% of its value."
@@ -7559,14 +7725,14 @@ msgstr ""
 
 #
 #. (CGI::span({class=>$visiblityStateClass}, $visiblityStateText)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:527
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:90
 #, fuzzy
 msgid "This set is %1"
 msgstr "tr: This set is [_1]"
 
 #. ($reducedScoringPerCent)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:373
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:375
 msgid ""
 "This set is in its reduced scoring period.  All work counts for %1% of its "
 "value."
@@ -7597,24 +7763,24 @@ msgid ""
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1719
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1910
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1936
 msgid "This source file does not exist!"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1718
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1909
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1935
 #, fuzzy
 msgid "This source file is a directory!"
 msgstr "tr: The file '[_1]' is a directory!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1720
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1911
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1937
 msgid "This source file is not a plain file!"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1717
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1934
 msgid "This source file is not readable!"
 msgstr ""
 
@@ -7638,7 +7804,7 @@ msgid ""
 "clear button and an Email instructor button at the end of the table."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:405
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:407
 msgid ""
 "This table shows the problems that are in this problem set.  The columns "
 "from left to right are: name of the problem, current number of attempts "
@@ -7648,8 +7814,8 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2103
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2109
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2185
 #, fuzzy
 msgid "Time"
 msgstr "tr: Test Date"
@@ -7659,7 +7825,7 @@ msgid "Time Interval for New Test Versions (min; 0=infty)"
 msgstr ""
 
 #. ($elapsedTime,$allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1986
 msgid "Time taken on test: %1 min (%2 min allowed)."
 msgstr ""
 
@@ -7672,24 +7838,24 @@ msgid "Timezone for the course"
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:716
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:715
 msgid "To access this set you must score at least %1% on set %2."
 msgstr ""
 
 #. (sprintf("%.0f",$restriction)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:717
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:514
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
 msgid ""
 "To add an additional instructor to the new course, specify user information "
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:511
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:513
 msgid ""
 "To add the WeBWorK administrators to the new course (as administrators) "
 "check the box below."
@@ -7701,21 +7867,21 @@ msgid ""
 "the individual set link."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:553
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:555
 msgid ""
 "To copy problem templates from an existing course, select the course below."
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1878
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2062
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2088
 msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:389
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:390
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:391
 #, fuzzy
 msgid ""
 "To edit this text you must first make a copy of this file using the "
@@ -7725,8 +7891,8 @@ msgstr ""
 "'Save as' action below."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:393
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:394
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:395
 #, fuzzy
 msgid ""
 "To edit this text you must use the 'NewVersion' action below to save it to "
@@ -7741,11 +7907,11 @@ msgstr ""
 msgid "To this Problem"
 msgstr "编辑这道题"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:555
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:563
 msgid "To:"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:239
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:251
 msgid "Totals"
 msgstr ""
 
@@ -7762,7 +7928,8 @@ msgid "Transfer"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:200
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:216
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:211
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:217
 msgid "True"
 msgstr ""
 
@@ -7778,55 +7945,55 @@ msgstr ""
 msgid "Two Columns"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1350
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1346
 msgid "Type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2105
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2187
 msgid "URI"
 msgstr ""
 
 #
 #. ($achievementName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:610
 #, fuzzy
 msgid "Unable to change the evaluator for set %1. Unknown error."
 msgstr "tr: Unable to change the set header for set [_1]. Unknown error."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:780
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:790
 msgid "Unable to obtain error messages from within the PG question."
 msgstr ""
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:400
 #, fuzzy
 msgid "Unable to write to '%1': %2"
 msgstr "tr: Saved to file '[_1]'"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2186
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2192
 #, fuzzy
 msgid "Unarchive"
 msgstr "课程"
 
 #
 #. ($unarchive_courseID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2181
 #, fuzzy
 msgid "Unarchive %1 to course:"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2083
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2115
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2160
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2089
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2166
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
 msgid "Unarchive Course"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2242
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2248
 #, fuzzy
 msgid "Unarchive Next Course"
 msgstr "课程"
@@ -7852,7 +8019,7 @@ msgstr ""
 
 #
 #. ($unattempted,$num_of_problems)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:983
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:993
 #, fuzzy
 msgid "Unattempted: %1/%2"
 msgstr "tr: Unable to write to '[_1]': [_2]"
@@ -7863,14 +8030,14 @@ msgstr "tr: Unable to write to '[_1]': [_2]"
 msgid "Unclassified Problems"
 msgstr "编辑题目"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:416
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:270
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:271
 msgid "Ungraded"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3039
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3045
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3067
 #, fuzzy
 msgid "Unhide Courses"
 msgstr "课程"
@@ -7891,7 +8058,7 @@ msgid "Unpack archives automatically"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2271
 #, fuzzy
 msgid "Unselect all courses"
 msgstr "tr: Unselect all users"
@@ -7902,12 +8069,12 @@ msgid "Unselect all sets"
 msgstr "tr: Unselect all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:549
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:552
 msgid "Unselect all users"
 msgstr "tr: Unselect all users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:131
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:132
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:133
 msgid "Update"
 msgstr ""
 
@@ -7919,41 +8086,41 @@ msgstr ""
 msgid "Update Menus"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:609
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:617
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:683
 msgid "Update settings and refresh page"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2277
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2283
 msgid "Update the checked directories?"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2901
 msgid "Updated location description."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2302
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2382
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2427
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2388
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2433
 #, fuzzy
 msgid "Upgrade"
 msgstr "成绩"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1177
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1924
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1179
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1930
 msgid "Upgrade Course Tables"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2275
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2319
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:370
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2325
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:372
 #, fuzzy
 msgid "Upgrade Courses"
 msgstr "课程"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2528
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2534
 msgid "Upgrade process completed"
 msgstr ""
 
@@ -7967,11 +8134,12 @@ msgid "Use Date Picker"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2102
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2267
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2293
 msgid "Use Default Header File"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:269
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:292
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:308
 msgid "Use Equation Editor?"
 msgstr ""
 
@@ -7980,23 +8148,23 @@ msgid "Use Item"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2743
 msgid "Use System Default"
 msgstr "tr: Use System Default"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:565
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:573
 msgid "Use browser back button to return from preview mode"
 msgstr ""
 
 #
 #. (CGI::b("$achievementID")
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:501
 #, fuzzy
 msgid "Use in achievement %1"
 msgstr "tr: selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:508
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:509
 #, fuzzy
 msgid "Use in new achievement:"
 msgstr "tr: selected sets"
@@ -8015,7 +8183,7 @@ msgid ""
 "select a tool from the list to the left."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:375
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:386
 msgid ""
 "Use this form to report to your professor a problem with the WeBWorK system "
 "or an error in a problem you are attempting. Along with your message, "
@@ -8023,13 +8191,13 @@ msgid ""
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:728
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:730
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:523
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
 msgid "User ID"
 msgstr ""
@@ -8057,8 +8225,8 @@ msgstr "文件名"
 msgid "User's username is:"
 msgstr ""
 
-#. ($user, $setID, $sortme[$j][0])
 #. ($user, $setID, $j)
+#. ($user, $setID, $sortme[$j][0])
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:944
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:999
 msgid ""
@@ -8079,7 +8247,7 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:495
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1359
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1355
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:367
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:428
 #, fuzzy
@@ -8093,7 +8261,7 @@ msgid "Users Assigned to Set %2"
 msgstr "tr: Edit Assigned Users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1876
 msgid "Users List"
 msgstr "用户列表"
 
@@ -8112,7 +8280,7 @@ msgstr ""
 
 #
 #. ($names{$primary}, $names{$secondary}, $names{$ternary})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:834
 #, fuzzy
 msgid "Users sorted by %1, then by %2, then by %3"
 msgstr "tr: Users sorted by [_1], then by [_2], then by [_3]"
@@ -8132,19 +8300,20 @@ msgid ""
 "permission level to \"nobody\"."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
-msgid "Using contents of the default message $default_msg_file instead."
+#. ($default_msg_file)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:227
+msgid "Using contents of the default message %1 instead."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1252
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1305
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1230
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1306
 #, fuzzy
 msgid "Using what display mode?: "
 msgstr "显示模式"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1248
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1301
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1302
 msgid "Using what seed?: "
 msgstr ""
 
@@ -8152,22 +8321,22 @@ msgstr ""
 msgid "Value of work done in Reduced Scoring Period"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:666
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:667
 msgid "Variable Documentation:"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1768
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1959
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1985
 msgid "Versions of a set can only be edited for one user at a time."
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:348
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:129
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:130
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2461
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:131
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2487
 msgid "View"
 msgstr "tr: View"
 
@@ -8183,7 +8352,7 @@ msgid "View Problems"
 msgstr "编辑题目"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:240
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:263
 msgid "View equations as"
 msgstr ""
 
@@ -8224,8 +8393,8 @@ msgid "View/Edit"
 msgstr "编辑"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2009
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:265
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2019
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:267
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:91
 #, fuzzy
 msgid "Viewing temporary file:"
@@ -8254,21 +8423,21 @@ msgid "Visible to Students"
 msgstr "tr: visible sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2124
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2130
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:730
 #, fuzzy
 msgid "Warning"
 msgstr "Kalan hak"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2175
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2181
 #, fuzzy
 msgid "Warning messages"
 msgstr "成绩编辑工具"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:932
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:935
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
 msgstr ""
 "tr: Warning: Deletion destroys all user-related data and is not undoable!"
@@ -8278,14 +8447,19 @@ msgstr ""
 msgid "Warnings encountered while processing %1. Error text: %2"
 msgstr ""
 
+#. ($copyright_years,$theme, $ww_version, $pg_version)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1105
+msgid "WeBWorK &#169; %1| theme: %2 | ww_version: %3 | pg_version %4|"
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2087
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2093
 #, fuzzy
 msgid "WeBWorK Error"
 msgstr "WeBWorK"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2173
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2179
 #, fuzzy
 msgid "WeBWorK Warnings"
 msgstr "WeBWorK"
@@ -8305,7 +8479,7 @@ msgid ""
 "more information."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2174
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2180
 msgid ""
 "WeBWorK has encountered warnings while processing your request. If this "
 "occured when viewing a problem, it was likely caused by an error or "
@@ -8341,7 +8515,7 @@ msgid "What could be inside?"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:649
 msgid "What field should filtered users match on?"
 msgstr "tr: What field should filtered users match on?"
 
@@ -8423,13 +8597,13 @@ msgid "Will open on %1."
 msgstr "将在%1时开放 "
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:412
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Worth"
 msgstr "De臒eri"
 
 #
 #. ($self->shortPath($outputFilePath)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:397
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:398
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled for '%1'.  Changes must be saved to "
@@ -8440,7 +8614,7 @@ msgstr ""
 
 #
 #. ($self->shortPath($currentDirectory)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:395
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:396
 #, fuzzy
 msgid ""
 "Write permissions have not been enabled in '%1'.  Changes must be saved to a "
@@ -8450,7 +8624,7 @@ msgstr ""
 "saved to a different directory for viewing."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:393
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
@@ -8459,18 +8633,20 @@ msgstr ""
 "changes can be made."
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:149
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:159
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:404
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:432
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2317
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2318
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2661
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2662
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2663
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:258
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:274
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:527
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2672
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2674
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:281
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:297
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:313
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:529
 msgid "Yes"
 msgstr "tr: Yes"
 
@@ -8501,9 +8677,9 @@ msgid "You are not authorized to access the Instructor tools"
 msgstr "tr: You are not authorized to access the instructor tools."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:654
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1760
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1977
 #, fuzzy
 msgid "You are not authorized to access the Instructor tools."
 msgstr "tr: You are not authorized to access the instructor tools."
@@ -8511,7 +8687,7 @@ msgstr "tr: You are not authorized to access the instructor tools."
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:321
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:435
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:253
 msgid "You are not authorized to access the instructor tools."
 msgstr "tr: You are not authorized to access the instructor tools."
 
@@ -8523,7 +8699,7 @@ msgstr "tr: You are not authorized to modify homework sets."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1763
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1954
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:1980
 msgid "You are not authorized to modify problems."
 msgstr "tr: You are not authorized to modify problems."
 
@@ -8534,15 +8710,15 @@ msgid "You are not authorized to modify set definition files."
 msgstr "tr: You are not authorized to modify set definition files."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:317
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:323
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:320
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:326
 #, fuzzy
 msgid "You are not authorized to modify student data"
 msgstr "tr: You are not authorized to modify student data."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:406
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:368
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:371
 msgid "You are not authorized to perform this action."
 msgstr "tr: You are not authorized to perform this action."
 
@@ -8562,7 +8738,7 @@ msgid ""
 "problem. %2 Close this tab, and return to the original problem."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1945
 msgid "You are out of time.  Press grade now!"
 msgstr ""
 
@@ -8574,6 +8750,10 @@ msgstr ""
 #: /opt/webwork/pg/macros/PGanswermacros.pl:1693
 msgid "You can earn partial credit on this problem."
 msgstr "这一题你可以得到部分成绩"
+
+#: /opt/webwork/pg/macros/problemRandomize.pl:383
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1238
@@ -8599,7 +8779,7 @@ msgid "You can only unpack files ending in '.tgz', '.tar' or '.tar.gz'"
 msgstr ""
 
 #. (($showMeAnother{MaxReps}>=$showMeAnother{Count})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1512
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1522
 msgid ""
 "You can use this feature %quant(%1,more time,more times,as many times as you "
 "want) on this problem"
@@ -8623,18 +8803,18 @@ msgstr "tr: The file '[_1]' is a directory!"
 msgid "You can't view files of that type"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1745
 msgid "You cannot archive the course you are currently using."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1502
 #, fuzzy
 msgid "You cannot delete the course you are currently using."
 msgstr "你不能删除自己!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:975
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:978
 msgid "You cannot delete yourself!"
 msgstr "你不能删除自己!"
 
@@ -8650,7 +8830,7 @@ msgstr ""
 msgid "You did not specify a new set name."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:284
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:292
 msgid "You didn't enter any message."
 msgstr ""
 
@@ -8686,34 +8866,38 @@ msgid "You do not have permission to generate hardcopy in %1 format."
 msgstr "你没有权限改变你的密码."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1289
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1299
 msgid "You do not have permission to view the details of this error."
 msgstr "Bu hatan谋n detaylar谋n谋 g枚rmeye yetkiniz yok."
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
+msgid "You don't have any Achievement data associated to you!"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:263
 msgid "You don't have any items!"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1930
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1975
 msgid "You exceeded the allowed time."
 msgstr ""
 
 #
 #. ($numLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1952
 #, fuzzy
 msgid "You have %1 attempt(s) remaining on this test."
 msgstr "[_1] [_2] kald谋."
 
 #
 #. ($attemptsLeft)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1612
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1622
 #, fuzzy
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
 msgstr "你还有[negquant,_1,无限次尝试,尝试,尝试] 机会."
 
 #. ($attempts_before_rr)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1579
 msgid ""
 "You have %quant(%1,attempt,attempts) left before new version will be "
 "requested."
@@ -8721,7 +8905,7 @@ msgstr ""
 
 #
 #. ($attempts)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1606
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1616
 #, fuzzy
 msgid "You have attempted this problem %quant(%1,time,times)."
 msgstr "Bu soru i莽in [quant,_1,deneme hakk谋,deneme hakk谋] kulland谋n谋z."
@@ -8731,7 +8915,7 @@ msgstr "Bu soru i莽in [quant,_1,deneme hakk谋,deneme hakk谋] kulland谋n谋z.
 msgid "You have been logged out of WeBWorK."
 msgstr "你已经登出WeBWorK."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1941
 msgid "You have less than 1 minute to complete this test."
 msgstr ""
 
@@ -8766,12 +8950,18 @@ msgid ""
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1709
+#: /opt/webwork/pg/macros/compoundProblem.pl:610
+#, fuzzy
+msgid "You may not change your answers when going on to the next part!"
+msgstr "tr: You may not change your own password here!"
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1712
 msgid "You may not change your own password here!"
 msgstr "tr: You may not change your own password here!"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1996
 #, fuzzy
 msgid "You may still check your answers."
 msgstr "tr: You may not change your own password here!"
@@ -8787,14 +8977,14 @@ msgstr "Bu soru i莽in [quant,_1,deneme hakk谋,deneme hakk谋] kulland谋n谋z.
 
 #
 #. ($showMeAnother{TriesNeeded})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1524
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1534
 #, fuzzy
 msgid ""
 "You must attempt this problem %quant(%1,time,times) before this feature is "
 "available"
 msgstr "Bu soru i莽in [quant,_1,deneme hakk谋,deneme hakk谋] kulland谋n谋z."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:647
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:649
 msgid "You must confirm the password for the initial instructor."
 msgstr ""
 
@@ -8810,7 +9000,7 @@ msgid "You must provide a student ID, a set ID, and a problem number."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1205
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1207
 #, fuzzy
 msgid "You must select a course to rename."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
@@ -8826,24 +9016,31 @@ msgid "You must select at least one file to delete"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:115
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:120
 #, fuzzy
-msgid "You must select one or more sets for scoring"
+msgid "You must select one or more sets for scoring!"
 msgstr "tr: No sets selected for scoring"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:633
+#. ($object)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1216
+#, fuzzy
+msgid "You must specify a %1 name"
+msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:635
 #, fuzzy
 msgid "You must specify a course ID."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1498
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1741
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2142
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2338
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3080
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3162
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1500
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1743
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2148
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2344
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3168
 #, fuzzy
 msgid "You must specify a course name."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
@@ -8855,54 +9052,54 @@ msgid "You must specify a file name"
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:655
 #, fuzzy
 msgid "You must specify a first name for the initial instructor."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:656
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:658
 #, fuzzy
 msgid "You must specify a last name for the initial instructor."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1223
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1225
 #, fuzzy
 msgid "You must specify a new institution for the course."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1208
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1210
 #, fuzzy
 msgid "You must specify a new name for the course."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1220
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1222
 #, fuzzy
 msgid "You must specify a new title for the course."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:644
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:646
 msgid "You must specify a password for the initial instructor."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:438
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:453
 msgid "You must specify a user ID."
 msgstr "Bir kullan谋c谋 ad谋 girmelisiniz."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:661
 #, fuzzy
 msgid "You must specify an email address for the initial instructor."
 msgstr "tr: You must specify an file name in order to save a new file."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:346
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1074
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1130
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:347
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1131
 #, fuzzy
 msgid "You must specify an file name in order to save a new file."
 msgstr "tr: You must specify an file name in order to save a new file."
@@ -8941,20 +9138,20 @@ msgstr ""
 
 #
 #. (wwRound(0, $pg->{result}->{score} * 100)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1607
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1617
 #, fuzzy
 msgid "You received a score of %1 for this attempt."
 msgstr "Bu soru i莽in [_1] puan ald谋n谋z."
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem and its graded subproblems."
 msgstr ""
 
 #. (join('.',@{$problemSeqs[$next_id]})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1678
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid ""
 "You will not be able to proceed to problem %1 until you have completed, or "
 "run out of attempts, for this problem."
@@ -8992,28 +9189,29 @@ msgid ""
 "instructor if you need help."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2800
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:3026
 msgid "Your browser does not support the video tag."
 msgstr ""
 
 #. ($PGBranch, $PGRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3376
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3382
 msgid "Your current branch of PG is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($WeBWorKBranch, $WeBWorKRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3314
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3320
 msgid ""
 "Your current branch of WeBWorK is up to date with branch %1 in remote %2."
 msgstr ""
 
 #. ($LibraryBranch, $LibraryRemote)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3411
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3417
 msgid "Your current branch of the Open Problem Library is up to date."
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:248
 #, fuzzy
 msgid "Your display options have been saved."
 msgstr "你的电子邮件地址已经改变."
@@ -9027,59 +9225,72 @@ msgstr "你的电子邮件地址已经改变."
 msgid "Your file name contains illegal characters"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:123
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+msgid "Your file name is not valid! "
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:323
+msgid "Your message was sent successfully."
+msgstr ""
+
 #
 #. ($lastScore,$notCountedMessage)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1610
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1620
 #, fuzzy
 msgid "Your overall recorded score is %1.  %2"
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #
 #. ($versionNumber, wwRound(2,$recordedScore)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1927
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1972
 #, fuzzy
 msgid "Your recorded score on this test (number %1) is %2/%3."
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
+#: /opt/webwork/pg/macros/compoundProblem.pl:603
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1826
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1871
 #, fuzzy
 msgid "Your score on this %1 WAS recorded."
 msgstr "Notunuz kaydedildi."
 
 #
 #. ($testNoun,$attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1831
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1876
 #, fuzzy
 msgid "Your score on this %1 is %2/%3."
 msgstr "Ortalama puan谋n谋z: [_1].  [_2]"
 
 #
 #. ($testNounNum)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1822
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1867
 #, fuzzy
 msgid "Your score on this %1 was NOT recorded."
 msgstr "Notunuz kaydedildi."
 
 #
 #. ($attemptScore,$totPossible)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1911
 #, fuzzy
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
 msgstr "Notunuz kaydedildi."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1535
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2086
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1568
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1857
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2131
 #, fuzzy
 msgid "Your score on this problem was recorded."
 msgstr "Notunuz kaydedildi."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1537
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:204
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1570
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
@@ -9088,19 +9299,19 @@ msgstr ""
 "hata olu艧tu."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:244
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:303
 msgid "Your score was not recorded because this homework set is closed."
 msgstr "Notunuz kaydedilemedi 莽眉nk眉 bu soru grubu kapal谋."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:250
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:309
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
 msgstr "Notunuz kaydedilmedi 莽眉nk眉 bu soru size y枚neltilmedi."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1593
 #, fuzzy
 msgid ""
 "Your score was not recorded because this problem set version is not open."
@@ -9108,7 +9319,7 @@ msgstr "Notunuz kaydedilmedi 莽眉nk眉 bu soru size y枚neltilmedi."
 
 #
 #. ($elapsed, $allowed)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1576
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1609
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
@@ -9116,7 +9327,7 @@ msgid ""
 msgstr "Notunuz kaydedilmedi 莽眉nk眉 bu soru size y枚neltilmedi."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1564
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1597
 #, fuzzy
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
@@ -9124,42 +9335,42 @@ msgid ""
 msgstr "Notunuz kaydedilmedi 莽眉nk眉 bu soru size y枚neltilmedi."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1578
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:246
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1611
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:305
 #, fuzzy
 msgid "Your score was not recorded."
 msgstr "Notunuz kaydedildi."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1847
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:231
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:237
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:290
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:296
 msgid "Your score was not successfully sent to the LMS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:202
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:261
 msgid "Your score was recorded."
 msgstr "Notunuz kaydedildi."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1891
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:288
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:294
 msgid "Your score was successfully sent to the LMS"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:538
+#: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:553
 msgid "Your session has timed out due to inactivity. Please log in again."
 msgstr "Oturumunuz zaman a艧谋m谋na u臒rad谋. L眉tfen tekrar giri艧 yap谋n谋z."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3444
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3450
 msgid "Your systems are up to date!"
 msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1229
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:308
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:310
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:99
 #, fuzzy
 msgid "[Edit]"
@@ -9198,7 +9409,7 @@ msgstr ""
 "information."
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:464
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:467
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
 msgstr ""
 "tr: This is the classlist editor page, where you can view and edit the "
@@ -9253,13 +9464,13 @@ msgstr ""
 "public workstations, untrusted machines, and machines over which you do not "
 "have direct control."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2750
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2752
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2761
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2763
 msgid "_PROBLEM_SET_SUMMARY"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2088
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2094
 msgid "_REQUEST_ERROR"
 msgstr ""
 "WeBWorK has encountered a software error while attempting to process this "
@@ -9268,10 +9479,16 @@ msgstr ""
 "corrected. If you are a professor, please consult the error output below for "
 "more information."
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1868
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1870
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1871
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1873
 msgid "_USER_TABLE_SUMMARY"
 msgstr ""
+
+#
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:707
+#, fuzzy
+msgid "a duplicate of the first selected achievement."
+msgstr "tr: a duplicate of the first selected set"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1139
@@ -9280,12 +9497,18 @@ msgid "a duplicate of the first selected set"
 msgstr "tr: a duplicate of the first selected set"
 
 #
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:706
+#, fuzzy
+msgid "a new empty achievement."
+msgstr "tr: a new empty set"
+
+#
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1138
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1114
 msgid "a new empty set"
 msgstr "tr: a new empty set"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1105
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1108
 msgid "a new file named:"
 msgstr ""
 
@@ -9296,7 +9519,7 @@ msgid "a single set"
 msgstr "tr: a single set"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "active"
 msgstr "tr: Inactive"
@@ -9308,11 +9531,11 @@ msgid "add problems"
 msgstr "tr: Add problem"
 
 #. ($setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1771
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1772
 msgid "addGlobalSet %1 in ProblemSetList:  %2"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:447
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:450
 msgid "added missing permission level for user"
 msgstr ""
 
@@ -9321,14 +9544,14 @@ msgid "admin"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:386
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:523
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:897
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:423
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:893
 msgid "all achievements"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:788
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:783
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1273
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1309
 #, fuzzy
@@ -9362,14 +9585,14 @@ msgid "all students"
 msgstr "tr: all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1095
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:655
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:860
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:903
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1108
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:632
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:848
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:895
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1098
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:863
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:906
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1111
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:851
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:898
 msgid "all users"
 msgstr "tr: all users"
 
@@ -9377,34 +9600,39 @@ msgstr "tr: all users"
 msgid "all users for one <b>set</b>"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1440
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1673
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3024
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1442
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1675
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3030
 msgid "alphabetically"
 msgstr ""
 
+#. ($count,$numSets)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
+msgid "an impossible number of sets: %1 out of %2"
+msgstr ""
+
+#. ($count,$numUsers)
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
+msgid "an impossible number of users: %1 out of %2"
+msgstr ""
+
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:661
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:672
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:687
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:698
 #, fuzzy
 msgid "answer"
 msgstr "答案日期"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1030
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1048
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1051
 msgid "any users"
 msgstr "tr: any users"
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:700
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "as"
 msgstr ""
-
-#
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:782
-#, fuzzy
-msgid "assigning the achievements to"
-msgstr "这次作业留给哪些用户?"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1267
@@ -9420,24 +9648,24 @@ msgid "avg attempts"
 msgstr "尝试"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2321
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2548
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:2574
 msgid "blank problem template(s) to end of homework set"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1441
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1674
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3025
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1443
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3031
 msgid "by last login date"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1011
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1478
 msgid "changes abandoned"
 msgstr "tr: changes abandoned"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1061
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1057
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1567
 msgid "changes saved"
 msgstr "tr: changes saved"
@@ -9458,18 +9686,18 @@ msgstr ""
 msgid "close"
 msgstr "已关闭"
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:685
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:711
 msgid "column"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:673
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:681
 msgid "columns:"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:413
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:420
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:513
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:266
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:267
 msgid "correct"
 msgstr "正确"
 
@@ -9488,7 +9716,7 @@ msgstr "tr: deleted [_1] sets"
 
 #
 #. ($num)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:989
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:992
 #, fuzzy
 msgid "deleted %1 users"
 msgstr "tr: deleted [_1] users"
@@ -9505,7 +9733,7 @@ msgid "editing all sets"
 msgstr "tr: editing all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:866
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
 msgid "editing all users"
 msgstr "编辑所有用户"
 
@@ -9521,7 +9749,7 @@ msgid "editing selected sets"
 msgstr "tr: editing selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:875
 msgid "editing selected users"
 msgstr "tr: editing selected users"
 
@@ -9531,7 +9759,7 @@ msgid "editing visible sets"
 msgstr "tr: editing visible sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:869
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:872
 msgid "editing visible users"
 msgstr "tr: editing visible users"
 
@@ -9543,7 +9771,7 @@ msgid "email:"
 msgstr "电子邮件"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:505
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:516
 #, fuzzy
 msgid "empty"
 msgstr "尝试"
@@ -9560,18 +9788,18 @@ msgid "entry rows."
 msgstr "编辑题目"
 
 #. ($restrictLoc, $setName, $@)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1782
 msgid "error adding set location %1 for set %2: %3"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:938
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1417
 msgid "export abandoned"
 msgstr "tr: export abandoned"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:914
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:910
 #, fuzzy
 msgid "exporting all achievements"
 msgstr "tr: exporting all sets"
@@ -9582,7 +9810,7 @@ msgid "exporting all sets"
 msgstr "tr: exporting all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:917
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:913
 #, fuzzy
 msgid "exporting selected achievements"
 msgstr "输出已选定的集合"
@@ -9624,17 +9852,17 @@ msgid "from"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:913
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
 msgid "giving new passwords to all users"
 msgstr "tr: giving new passwords to all users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:922
 msgid "giving new passwords to selected users"
 msgstr "tr: giving new passwords to selected users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:916
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:919
 msgid "giving new passwords to visible users"
 msgstr "tr: giving new passwords to visible users"
 
@@ -9670,9 +9898,9 @@ msgid "guest"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1422
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1649
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2999
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3005
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 #, fuzzy
 msgid "hidden"
@@ -9684,7 +9912,7 @@ msgid "hidden from"
 msgstr "g枚r眉nt眉lenmiyor"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 msgid "hidden from students"
 msgstr "tr: hidden from students"
@@ -9696,48 +9924,52 @@ msgstr "tr: hidden sets"
 
 #. ('j','k','_0')
 #. ('j','k')
-#: /opt/webwork/pg/lib/Parser/List/Vector.pm:34
-#: /opt/webwork/pg/lib/Value/Vector.pm:280
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:35
+#: /opt/webwork/pg/lib/Value/Vector.pm:278
 #: /opt/webwork/pg/macros/contextLimitedVector.pl:94
 msgid "i"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1371
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1465
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:774
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1374
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1468
 msgid "illegal character in input: '/'"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:693
 msgid "in their"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1639
 #, fuzzy
 msgid "inactive"
 msgstr "tr: Inactive"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:419
-#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:275
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:426
+#: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:276
 msgid "incorrect"
 msgstr "错误"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:583
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:595
 msgid "index"
 msgstr ""
 
 #. ($restrictLoc, $setName)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1785
 msgid "input set location %1 already exists for set %2."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:705
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:713
 msgid "list of insertable macros"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2625
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2631
 #, fuzzy
 msgid "locations selected below"
 msgstr "tr: exporting selected sets"
@@ -9749,7 +9981,7 @@ msgid "login"
 msgstr "登入"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:33
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 #, fuzzy
 msgid "login ID"
 msgstr "登入"
@@ -9794,17 +10026,17 @@ msgid "new users"
 msgstr "tr: no users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:522
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:519
 #, fuzzy
 msgid "no achievements"
 msgstr "tr: selected sets"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:645
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:642
 msgid "no achievements."
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2626
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2632
 #, fuzzy
 msgid "no location"
 msgstr "答案"
@@ -9828,27 +10060,31 @@ msgid "no students"
 msgstr "tr: no sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:789
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:656
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:946
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1033
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1049
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:633
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:942
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:784
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1036
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1052
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:636
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:945
 msgid "no users"
 msgstr "tr: no users"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:235
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:236
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:107
 msgid "nobody"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:714
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "nth colum of merge file"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:203
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:206
 msgid "number of students not defined"
+msgstr ""
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1731
+msgid "of"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
@@ -9875,7 +10111,7 @@ msgid "only best scores"
 msgstr "tr: Test Score"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2841
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2847
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -9890,60 +10126,64 @@ msgstr "tr: Sort"
 msgid "or Problems from"
 msgstr "题目"
 
+#: /opt/webwork/pg/macros/contextPiecewiseFunction.pl:777
+msgid "otherwise"
+msgstr ""
+
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:593
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 msgid "out of"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:435
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:433
 msgid "overwrite all data"
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:678
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:704
 msgid "part"
 msgstr ""
 
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1225
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1228
 msgid "permissions for %1 not defined"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1732
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1742
 msgid "pg debug"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1734
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1744
 msgid "pg internal errors"
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1733
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1743
 msgid "pg warning"
 msgstr ""
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2180
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2368
 #, fuzzy
 msgid "point"
 msgstr "提示"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:2177
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:2365
 #, fuzzy
 msgid "points"
 msgstr "提示"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:436
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:434
 msgid "preserve existing data"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2127
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2172
 #, fuzzy
 msgid "preview answers"
 msgstr "答案预览"
 
 #
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:667
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:693
 #, fuzzy
 msgid "problem"
 msgstr "tr: Problem"
@@ -9964,8 +10204,8 @@ msgid "progress"
 msgstr ""
 
 #. ($line)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1968
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2206
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1971
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:2214
 msgid "readSetDef error, can't read the line: ||%1||"
 msgstr ""
 
@@ -9984,19 +10224,19 @@ msgstr "tr: The file '[_1]' cannot be found."
 
 #
 #. ($userID)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1223
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1296
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1226
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1299
 #, fuzzy
 msgid "record for visible user %1 not found"
 msgstr "tr: The file '[_1]' cannot be found."
 
 #. ($restrictLoc)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1787
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1788
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
 msgstr ""
 
-#: /opt/webwork/pg/macros/PGbasicmacros.pl:684
+#: /opt/webwork/pg/macros/PGbasicmacros.pl:710
 msgid "row"
 msgstr ""
 
@@ -10025,15 +10265,15 @@ msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:387
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:425
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:524
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:898
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:424
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:521
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:894
 #, fuzzy
 msgid "selected achievements"
 msgstr "tr: selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:646
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:643
 #, fuzzy
 msgid "selected achievements."
 msgstr "tr: selected sets"
@@ -10055,17 +10295,17 @@ msgid "selected sets"
 msgstr "tr: selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1097
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:862
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:905
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:948
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1032
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1110
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:634
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:850
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:897
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:944
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1100
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:865
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:908
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:951
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1035
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1113
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:637
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:853
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:900
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:947
 msgid "selected users"
 msgstr "tr: selected users"
 
@@ -10117,7 +10357,7 @@ msgid "showing all sets"
 msgstr "tr: showing all sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:687
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
 msgid "showing all users"
 msgstr "tr: showing all users"
 
@@ -10137,7 +10377,7 @@ msgid "showing matching sets"
 msgstr "tr: showing matching users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:699
 msgid "showing matching users"
 msgstr "tr: showing matching users"
 
@@ -10147,7 +10387,7 @@ msgid "showing no sets"
 msgstr "tr: showing no sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:690
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
 msgid "showing no users"
 msgstr "tr: showing no users"
 
@@ -10157,7 +10397,7 @@ msgid "showing selected sets"
 msgstr "tr: showing selected sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:693
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:696
 msgid "showing selected users"
 msgstr "tr: showing selected users"
 
@@ -10166,6 +10406,10 @@ msgstr "tr: showing selected users"
 #, fuzzy
 msgid "showing visible sets"
 msgstr "tr: exporting visible sets"
+
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1732
+msgid "shown"
+msgstr ""
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
@@ -10188,19 +10432,19 @@ msgid "students"
 msgstr "学生ID"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "submission"
 msgstr "提交答案"
 
 #
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "submission (test %1)"
 msgstr "提交答案"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:630
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:642
 msgid "summary"
 msgstr ""
 
@@ -10209,14 +10453,14 @@ msgid "ta"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1799
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 #, fuzzy
 msgid "test"
 msgstr "tr: [_1] test"
 
 #
 #. ($versionNumber)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1801
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1846
 #, fuzzy
 msgid "test (%1)"
 msgstr "tr: [_1] test"
@@ -10233,7 +10477,7 @@ msgstr "tr: Test Date"
 msgid "test time"
 msgstr "tr: [_1] test"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:778
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:774
 msgid "the following file"
 msgstr ""
 
@@ -10243,15 +10487,15 @@ msgstr ""
 
 #
 #. ($forcedSourceFile)
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:1008
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1064
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm:986
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm:1065
 #, fuzzy
 msgid "the original path to the file is %1"
 msgstr "tr: the original path to the file is [_1]"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:778
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:797
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:781
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:800
 #, fuzzy
 msgid "then by"
 msgstr "tr: Then by"
@@ -10260,8 +10504,12 @@ msgstr "tr: Then by"
 msgid "then delete them"
 msgstr ""
 
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:810
+msgid "there are no set definition files in this course to look at."
+msgstr ""
+
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "time"
 msgstr "次"
 
@@ -10270,16 +10518,13 @@ msgid "time limit exceeded"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1560
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1570
 msgid "times"
 msgstr "次"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1101
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:757
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1104
 msgid "to"
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:429
-msgid "to all users, create global data, and"
 msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
@@ -10287,13 +10532,13 @@ msgid "to one <b>set</b>"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:718
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:725
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm:538
 #, fuzzy
 msgid "top score"
 msgstr "tr: Test Score"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:575
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:587
 msgid "total"
 msgstr ""
 
@@ -10301,16 +10546,16 @@ msgstr ""
 #. ($ce->{webworkDirs}{logs})
 #. ($ce->{webworkDirs}{tmp})
 #. ($ce->{webworkDirs}{DATA})
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:396
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:397
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:400
 #, fuzzy
 msgid "unable to write to directory %1"
 msgstr "tr: Saved to file '[_1]'"
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm:357
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:504
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:506
 msgid "unlimited"
 msgstr "无限"
 
@@ -10321,33 +10566,33 @@ msgstr "无限"
 msgid "userID: %1 --"
 msgstr "tr: Replace [_1]"
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:571
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:568
 msgid ""
 "username, last name, first name, section, achievement level, achievement "
 "score,"
 msgstr ""
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:569
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:572
 #, fuzzy
 msgid "users"
 msgstr "tr: no users"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:635
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:638
 msgid "users who match on selected field"
 msgstr "tr: users who match on selected field"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:659
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:662
 #, fuzzy
 msgid "users who match:"
 msgstr "tr: users who match on selected field"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1424
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1651
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3001
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1426
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1653
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:878
 #, fuzzy
 msgid "visible"
@@ -10363,22 +10608,27 @@ msgid "visible sets"
 msgstr "tr: visible sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:519
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:526
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:88
 #, fuzzy
 msgid "visible to students"
 msgstr "tr: visible sets"
 
 #
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1096
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:904
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1031
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1109
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:849
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:896
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1099
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:864
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:907
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1034
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1112
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:852
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:899
 msgid "visible users"
 msgstr "tr: visible users"
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:470
+#: /opt/webwork/pg/macros/compoundProblem.pl:480
+msgid "when you submit your answers"
+msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1258
 msgid "with set name(s):"
@@ -10386,8 +10636,12 @@ msgstr ""
 
 #. ($dir, $fileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm:1696
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1372
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm:1375
 msgid "won't be able to read from file %1/%2: does it exist? is it readable?"
+msgstr ""
+
+#: /opt/webwork/pg/macros/compoundProblem.pl:604
+msgid "your overall score is for all the parts combined."
 msgstr ""
 
 #
@@ -10395,6 +10649,26 @@ msgstr ""
 #, fuzzy
 msgid "your students"
 msgstr "tr: visible sets"
+
+#
+#, fuzzy
+#~ msgid "Import achievements from"
+#~ msgstr "输出已选定的集合"
+
+#
+#, fuzzy
+#~ msgid "Open, reduced scoring starts on %1."
+#~ msgstr "tr: Reduced Credit Starts: [_1]"
+
+#
+#, fuzzy
+#~ msgid "Reduced Scoring Starts %1"
+#~ msgstr "tr: Reduced Credit Starts: [_1]"
+
+#
+#, fuzzy
+#~ msgid "Reduced scoring started on %1."
+#~ msgstr "tr: Reduced Credit Starts: [_1]"
 
 #
 #, fuzzy
@@ -10489,11 +10763,6 @@ msgstr "tr: visible sets"
 #, fuzzy
 #~ msgid "No sets selected for scoring."
 #~ msgstr "tr: No sets selected for scoring"
-
-#
-#, fuzzy
-#~ msgid "Note: "
-#~ msgstr "tr: Note"
 
 #
 #, fuzzy
@@ -10770,14 +11039,6 @@ msgstr "tr: visible sets"
 #
 #~ msgid "Published"
 #~ msgstr "Yay谋nland谋"
-
-#
-#~ msgid ""
-#~ "The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
-#~ msgstr ""
-#~ "tr: The text box now contains the source of the original problem. You can "
-#~ "recover lost edits by using the Back button on your browser."
 
 #
 #~ msgid ""


### PR DESCRIPTION
This is an attempt to update the translation files for release 2.14.

I tried to update the translation files for release 2.14 using both the  data from Transifex and an updated webwork2.pot file.

I did not attempt to handle the French translation from Transifex (there are multiple files versions in Transifex) or Chinese (also). Someone else can try those. I did take the risk of pulling in the translations for Spanish, Turkish, and Hungarian from the files downloaded from Transifex.

The process I used is summarized below. I hope I logged all the steps.

I did not yet try to upload the new POT file to Transifex.

---

1. Set up a branch based on origin/rel-ww2.14 in my local Git repository:

`git checkout -b tani-rel-2.14-translation-file-updates origin/rel-ww2.14`

2. Copy the current files from
        `lib/WeBWorK/Localize`
of the new branch into a temporary working directory (to allow easy comparisons if needed).

Change into the temporary working directory.

3. I noticed there were both en.po and en_us.po files, and that they slightly differ.

I fixed three messages in en.po where the msgstr was empty or "fake":

```
        msgid "%1: Problem %2"
        msgid "Problem %1"
        msgid "Problem %1."
```

(copy file back to local git repo and commit to git)

4. I merged differences from en.po into en_us.po (using vimdiff).

(copy file back to local git repo and commit to git)

5. I downloaded a ZIP of all the current translation files from Transifex.

Unzip the ZIP file into a TRFX/ subdirectory of the working directory.

6. Merge the files from Transifex into the ones from Git.

```
mkdir TRFX-DONE
mkdir TRFX-IGNORE
mkdir BAK
mkdir DONE
```

---

Turkish - "tr" is listed by Transifex as 20.01% translated, but tr_TR as 0% translated.

```
mv TRFX/webwork2pot_tr_TR.po TRFX-IGNORE
```

---

Korean - "ko" is listed by Transifex as 0% translated

```
mv TRFX/webwork2pot_ko.po TRFX-IGNORE
mv ko.po DONE
```

NOTE: There seem to be translated strings in the file, it should probably be uploaded to Transifex, but since I have no idea what is in the file, nor in Transifex - I did not do this now.

---

Swedish - "sv" is listed by Transifex as 0.06% translated

```
mv TRFX/webwork2pot_sv.po TRFX-IGNORE
```

---

Russian (ru_RU) was missing in Transifex, but there is a PO file.
I added the language to Transifex, and uploaded the PO file.

```
mv ru_RU.po DONE/
```

---

```
cp heb.po BAK/
msgmerge -o heb.po TRFX/webwork2pot_he.po BAK/heb.po
vim heb.po
        # Fix some "1%" which should be "%1"
vimdiff TRFX/webwork2pot_he.po heb.po
        # Very quick review
mv TRFX/webwork2pot_he.po TRFX-DONE
# Copy file back to local git repo, then commit
mv heb.po DONE
```

In local repo: `git commit -m "Merged in translations from Transifex" heb.po`

---

```
cp en.po BAK/
msgmerge -o en.po TRFX/webwork2pot_en_US.po BAK/en.po
vimdiff TRFX/webwork2pot_en_US.po en.po
        # Very quick review
mv TRFX/webwork2pot_en_US.po TRFX-DONE
cp en.po en_us.po
# Copy file back to local git repo, will commit later
mv en.po DONE
mv en_us.po DONE
```

In local repo: `git commit -m "Merged in translations from Transifex" en.po en_us.po`

---

```
cp es.po BAK/
msgmerge -o es.po TRFX/webwork2pot_es.po BAK/es.po
vimdiff TRFX/webwork2pot_es.po es.po
        # Very quick review
mv TRFX/webwork2pot_es.po TRFX-DONE
# Copy file back to local git repo, then commit
mv es.po DONE
```

In local repo: `git commit -m "Merged in translations from Transifex" es.po`

---

```
cp tr.po BAK/
msgmerge -o tr.po TRFX/webwork2pot_tr.po BAK/tr.po
vimdiff TRFX/webwork2pot_tr.po tr.po
        # Very quick review
mv TRFX/webwork2pot_tr.po TRFX-DONE
# Copy file back to local git repo, then commit
mv tr.po DONE
mv tr.bak DONE
```

In local repo: `git commit -m "Merged in translations from Transifex" tr.po`

---

Hungarian - hu is listed by Transifex as 34.44% translated. It is a *new* language

```
cp -a TRFX/webwork2pot_hu.po hu.po
mv TRFX/webwork2pot_hu.po TRFX-DONE
# Copy file back to local git repo, then commit
mv hu.po DONE
```

In local repo:
```
git add hu.po
git commit -m "New Hungarian translations from Transifex" hu.po
```

---

7. Not yet attempted - as there is material both in the current files and in Transifex, and I cannot tell what to do.


    From Git:
        fr.po

    From Transifex:
        webwork2pot_fr_CA.po
        webwork2pot_fr_FR.po
        webwork2pot_fr.po


    From Git:
        zh_CN.po
        zh_hk.po

    From Transifex:
        webwork2pot_zh_CN.po
        webwork2pot_zh_HK.po



8. Make update webwork2.pot using Docker

In 2.14 repo with the changes above:
```
cd /data2/webwork_docker_2.14rc/webwork2/
docker-compose up
docker container exec -it webwork2_app_1 bash
```

Inside container:
```
cd /opt/webwork/webwork2/lib/WeBWorK/Localize
xgettext.pl -o webwork2.pot -D $WEBWORK_ROOT/lib -D $PG_ROOT/lib -D $PG_ROOT/macros
exit
```

Outside the container:
```
cd /data2/webwork_docker_2.14rc/webwork2/lib/WeBWorK/Localize
find . -name '*.po' -exec bash -c "echo \"Updating {}\"; msgmerge -qU {} webwork2.pot" \;
```

---

Cleanup work:

```
vim en.ps
# Search for "fuzzy" and fix what I can
cp en.ps en_us.po
git commit -m "Merged in from new webwork2.pot and then cleaned up fuzzy entries." en.po en_us.po
```

---

```
vim heb.po
# Search for "fuzzy" and fix what I can
# Also fixed some Hebrew translation issues I noticed.
git commit heb.po
```

---

Commit all the other languages without doing any additional cleanup.

```
git commit -m "Merged in from new webwork2.pot, but fuzzy entries for these languages have NOT been examined at all. Some issues with the fuzzy entries are expected to exist and need to be fixed by people with knowledge of the relevant languages." es.po fr.po hu.po ko.po ru_RU.po tr.po zh_CN.po zh_hk.po
```
