### PR TITLE
Relocate the courses "data" for Docker to be outside the webwork2/ tree.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ services:
       - r
     volumes:
       - ".:/opt/webwork/webwork2"
-      - "./.data/courses:/opt/webwork/courses"
+      # OLD approach put the courses tree under webwork2/.data/courses
+      #- "./.data/courses:/opt/webwork/courses"
+      # NEW appoach puts the courses tree in a separate tree outside of webwork2/
+      - "../ww-docker-data/courses:/opt/webwork/courses"
       # Uncomment the line below to use local OPL for development
       #- "../opl:/opt/webwork/libraries/webwork-open-problem-library"
       # Uncomment the line below to use local PG for development


### PR DESCRIPTION
This change effects only Docker user of WeBWorK.

The PR moves the persistent storage for the courses in a Docker installation out of the `webwork2` directory into a parallel location. This keeps the `webwork2` "code" tree separate from the (persistent) "data" about the courses stored in the (persistent) "course" directory tree. Using a different storage location should also make it possible for power users to use a single persistent courses directory with different development trees run under Docker (when used one at a time).

The following commands should be run (once) from inside the `webwork2` folder used for Docker to create the necessary folders:
```
mkdir ../ww-docker-data
mkdir ../ww-docker-data/courses
```

If your current Docker configuration had the `courses` data stored under `webwork2/.data/courses` also run the following commands (from inside the the `webwork2` folder) when the webwork Docker container is **not** running:
```
mv .data/courses/*   ../ww-docker-data/courses
rmdir .data/courses/
```

You may also have a `.data/db` directory in which the WeBWorK SQL databases used to be stored, before their storage was moved to a "named volume" (which works properly on all known systems using Docker, while the `.data/db` storage option does **not** work on Dockers CE on Windows). In that case, you probably can and should delete the contents of the `.data/db` directory, possibly after manually transferring any data you want to save into the new "named volume" persistent storage.