### PR TITLE
Timezone issue fix for creating assignment

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
@@ -593,8 +593,7 @@ sub pre_header_initialize {
 			debug("new value of local_sets is ", $r->param('local_sets'));
 			my $newSetRecord	 = $db->getGlobalSet($newSetName);
 			if (defined($newSetRecord)) {
-	            $self->addbadmessage("The set name $newSetName is already in use.  
-	            Pick a different name if you would like to start a new set.");
+		            $self->addbadmessage($r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetName));
 			} else {			# Do it!
 				# DBFIXME use $db->newGlobalSet
 				$newSetRecord = $db->{set}->{record}->new();
@@ -605,7 +604,7 @@ sub pre_header_initialize {
 				
 				my $dueDate = time+2*60*60*24*7;
 				my $display_tz = $ce->{siteDefaults}{timezone};
-				my $fDueDate = $self->formatDateTime($dueDate, $display_tz);
+				my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P");
 				my $dueTime = $ce->{pg}{timeAssignDue};
 				
 				# We replace the due time by the one from the config variable

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1130,7 +1130,11 @@ sub create_handler {
 
 	my $newSetID = $actionParams->{"action.create.name"}->[0];
 	return CGI::div({class => "ResultsWithError"}, $r->maketext("Failed to create new set: no set name specified!")) unless $newSetID =~ /\S/;
-	return CGI::div({class => "ResultsWithError"}, $r->maketext("Set [_1] exists.  No set created", $newSetID)) if $db->existsGlobalSet($newSetID);
+	return CGI::div({class => "ResultsWithError"},
+			$r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetID)
+			. " " . $r->maketext("No set created.")
+                       ) if $db->existsGlobalSet($newSetID);
+
 	my $newSetRecord = $db->newGlobalSet;
 	my $oldSetID = $self->{selectedSetIDs}->[0];
 
@@ -1140,7 +1144,7 @@ sub create_handler {
 
 	my $dueDate = time+2*ONE_WEEK();
 	my $display_tz = $ce->{siteDefaults}{timezone};
-	my $fDueDate = $self->formatDateTime($dueDate, $display_tz);
+	my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P");
 	my $dueTime = $ce->{pg}{timeAssignDue};
 
 	# We replace the due time by the one from the config variable

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1464,7 +1464,7 @@ sub pre_header_initialize {
 				
 				my $dueDate = time+2*60*60*24*7;
 				my $display_tz = $ce->{siteDefaults}{timezone};
-				my $fDueDate = $self->formatDateTime($dueDate, $display_tz);
+				my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P");
 				my $dueTime = $ce->{pg}{timeAssignDue};
 				
 				# We replace the due time by the one from the config variable

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
@@ -1167,8 +1167,7 @@ sub pre_header_initialize {
 			debug("new value of local_sets is ", $r->param('local_sets'));
 			my $newSetRecord	 = $db->getGlobalSet($newSetName);
 			if (defined($newSetRecord)) {
-	            $self->addbadmessage("The set name $newSetName is already in use.  
-	            Pick a different name if you would like to start a new set.");
+		            $self->addbadmessage($r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetName));
 			} else {			# Do it!
 				# DBFIXME use $db->newGlobalSet
 				$newSetRecord = $db->{set}->{record}->new();
@@ -1180,7 +1179,7 @@ sub pre_header_initialize {
 				
 				my $dueDate = time+2*60*60*24*7;
 				my $display_tz = $ce->{siteDefaults}{timezone};
-				my $fDueDate = $self->formatDateTime($dueDate, $display_tz);
+				my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P");
 				my $dueTime = $ce->{pg}{timeAssignDue};
 				
 				# We replace the due time by the one from the config variable


### PR DESCRIPTION
## Explanation of changes

1. Add a "safe" time format `"%m/%d/%Y at %I:%M%P"`  to the `my $fDueDate = $self->formatDateTime(...)` call to avoid issues with the short time-zone alias used by `%Z` in the default time format which causes the following `$dueDate = $self->parseDateTime()` call to fail in many time-zones. 
   * Ex: Asia/Jerusalem Africa/Johannesburg America/Santiago Asia/Bangkok Australia/Perth

2. In all 4 files use the same error message: 
   * `The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.`
  *using* `$r->maketext` when the requested set name is already in use.
   * `lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm` 
     * had this maketext string which was copied to the other files.
   * `lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm` and
   * `lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm` 
     * had no maketext but had essentially the same text.  
     * added $r->maketext()
   * `lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm`
     * had slightly different text in maketext.
     * changed to the "standardized" message.

## Explanation of why the changes are needed
 * **Before the change**, setting the course timezone to `Asia/Jerusalem` or many other timezones **would trigger an error whenever the user tried to create a new homework set** using:
    * the "Create a New Set in This Course" button in the library browser (Calls `SetMaker.pm`)
    * the "Create" new set button from "Instructor Tools".  (This method also calls `SetMaker.pm`)
    * the "Create" part of "Hmwk Sets Editor" (This method calls `lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm`)
 * **After this patch, the error no longer occurs.**
 * The cause of the error is the fact that the default time format (`"%m/%d/%Y at %I:%M%P %Z"`)
 used by `lib/WeBWorK/Utils.pm` includes `%Z` which generates a "short" time-zone string, which may not be able to be read back in during the parsing stage as representing a unique time-zone.
 * The error messages like

```
WeBWorK error
An error occured while processing your request. For help, please send mail
to this site's webmaster (techdesk@mathnet.technion.ac.il), including all of
the following information as well as what what you were doing when the error
occured.

DATE

Warning messages

Error messages
        Time zone 'IST' not recognized.

Call stack

The information below can help locate the source of the problem.

in WeBWorK::Utils::parseDateTime called at line 2255 of         /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::parseDateTime called at line 1490 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
in WeBWorK::ContentGenerator::Instructor::SetMaker::pre_header_initialize called at line 214 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::go called at line 384 of /opt/webwork/webwork2/lib/WeBWorK.pm
```

```
WeBWorK error
An error occured while processing your request. For help, please send mail
to this site's webmaster (techdesk@mathnet.technion.ac.il), including all of
the following information as well as what what you were doing when the error
occured.

DATE

Warning messages

Error messages
    Time zone 'IST' not recognized.

Call stack

The information below can help locate the source of the problem.

in WeBWorK::Utils::parseDateTime called at line 2255 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::parseDateTime called at line 1150 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
in WeBWorK::ContentGenerator::Instructor::ProblemSetList2::create_handler
called at line 404 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
in WeBWorK::ContentGenerator::Instructor::ProblemSetList2::initialize called at line 231 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::go called at line 384 of /opt/webwork/webwork2/lib/WeBWorK.pm
```
## Additional information
 * It does not seem necessary to include **any** timezone in this process, as the parse phase will be done for the course time-zone regardless of what had been included in the originally generated due date string.
 * The Perl documentation at https://metacpan.org/pod/DateTime about `$dt->time_zone_short_name()` states:
   * This method returns the time zone abbreviation for the current time zone, such as "PST" or "GMT". These names are not definitive, and should **not** be used in any application intended for general use by users around the world.
 * http://webwork.maa.org/wiki/Dates,_Times,_and_Time_Zones#Detailed_Information  suggests not listing an abbreviated time zone when entering dates, but in this setting WW was adding it automatically.



