### PR TITLE
Give PreTeXt access to answer hash

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -113,6 +113,7 @@ my @modulesList = qw(
 	UUID::Tiny
 	XML::Parser
 	XML::Parser::EasyTree
+	XML::Simple
 	XML::Writer
 	XMLRPC::Lite
 	YAML

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -120,6 +120,7 @@ use HTML::Entities;
 use WeBWorK::PG::ImageGenerator;
 use IO::Socket::SSL;
 use Digest::SHA qw(sha1_base64);
+use XML::Simple qw(XMLout);
 
 use constant  TRANSPORT_METHOD => 'XMLRPC::Lite';
 use constant  REQUEST_CLASS    => 'WebworkXMLRPC';  # WebworkXMLRPC is used for soap also!!
@@ -621,6 +622,7 @@ sub formatRenderedProblem {
 	my $encoded_source     = $self->encoded_source//'';
 	my $sourceFilePath    = $self->{sourceFilePath}//'';
 	my $warnings          = '';
+        my $answerhashXML     = XMLout($rh_answers, RootName => 'answerhashes');
 	
 	#################################################
 	# regular Perl warning messages generated with warn

--- a/lib/WebworkClient/ptx_format.pl
+++ b/lib/WebworkClient/ptx_format.pl
@@ -3,6 +3,7 @@ $ptx_static_format = <<'ENDPROBLEMTEMPLATE';
 <!--BEGIN PROBLEM-->
 <webwork>
 $problemText
+$answerhashXML
 </webwork>
 <!--END PROBLEM-->
 ENDPROBLEMTEMPLATE


### PR DESCRIPTION
This makes it so that when PreTeXt calls for a problem rendered in PTX, the answer hash(es) is/are included. So for example when writing a book and you include some WeBWorK problem with some specific seed, PTX can print the question and perhaps also print the answer in the back of the book.