### PR TITLE
Remove contents of webwork2/htdocs/tmp when restarting webwork inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,10 +103,8 @@ RUN curl -fSL https://github.com/openwebwork/pg/archive/${PG_BRANCH}.tar.gz -o /
 RUN curl -fSL https://github.com/mathjax/MathJax/archive/master.tar.gz -o /tmp/mathjax.tar.gz \
     && tar xzf /tmp/mathjax.tar.gz \
     && mv MathJax-master $APP_ROOT/MathJax \
-
     && rm /tmp/mathjax.tar.gz
     #&& rm /tmp/VERSION
-
     #curl -fSL https://github.com/openwebwork/webwork2/archive/WeBWorK-${WEBWORK_VERSION}.tar.gz -o /tmp/WeBWorK-${WEBWORK_VERSION}.tar.gz \
     #&& tar xzf /tmp/WeBWorK-${WEBWORK_VERSION}.tar.gz \
     #&& mv webwork2-WeBWorK-${WEBWORK_VERSION} $APP_ROOT/webwork2 \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -73,11 +73,14 @@ if [ "$1" = 'apache2' ]; then
     # Fix possible permission issues
     echo "Fixing ownership and permissions (just in case it is needed)"
     cd $APP_ROOT/webwork2
-    chown -R www-data logs tmp DATA htdocs/tmp
-    chmod -R u+w logs tmp DATA htdocs/tmp ../courses
+    rm -rf htdocs/tmp/*    # pointers which which have no target shut down the rebuild process.
+                           # the tmp directory is rebuilt automatically at the cost of some speed.
+    chown -R www-data logs tmp DATA 
+    chmod -R u+w logs tmp DATA  ../courses
     cd $APP_ROOT
     find courses -type f -exec chown www-data:root {} \;
     find courses -type d -exec chown www-data:root {} \;
+    echo "end fixing ownership and permissions"
     # OLD: chown www-data -R $APP_ROOT/courses
     #    but that sometimes caused errors in Docker on Mac OS X when there was a broken symbolic link somewhere in the directory tree being processed
 


### PR DESCRIPTION
webwork2/htdocs/tmp contains pointers to library problems which may have existed only in memory.  Trying to reset ownership of these links causes errors -- it seems more reliable just to remove them.  An accidental side-effect is that the README file is also removed. It doesn't seem that important.

I believe that all links to images in webwork2/htdocs/tmp are automatically recreated if they are missing.  There might be issues with references to images of tex equations -- that was not tested thoroughly since MathJax is now more widely used. 