### PR TITLE
2 related fixes to Authen.pm: a. Deny authentication in checkPassword() of lib/WeBWorK/Authen.pm when the submitted password is an empty string or an all white-space string. b. Fix the new trim() function and override an override so session timeouts will behave again. 

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -647,7 +647,16 @@ sub checkPassword {
 		# succeed in matching an entered password
 		# Use case: Moodle wwassignment stores null passwords and forces the creation 
 		# of a key -- Moodle wwassignment does not use  passwords for authentication, only keys.
-		if (($dbPassword =~/\S/) && $possibleCryptPassword eq $Password->password) {
+		# The following line was modified to also reject cases when the database has a crypted password
+		# which matches a submitted all white-space or null password by requiring that the
+		# $possibleClearPassword contain some non-space character. This is intended to address
+		# the issue raised in http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4529 .
+		# Since several authentication modules fall back to calling this function without
+		# trimming the possibleClearPassword as done during get_credentials() here in
+		# lib/WeBWorK/Authen.pm we do not assume that an all-white space password would have
+		# already been converted to an empty string and instead explicitly test it for a non-space
+		# character.
+		if (($possibleClearPassword =~/\S/) && ($dbPassword =~/\S/) && $possibleCryptPassword eq $Password->password) {
 			$self->write_log_entry("AUTH WWDB: password accepted");
 			return 1;
 		} else {


### PR DESCRIPTION
**Revised and ready to test. See also the following comments**

Modify the main checkPassword() in lib/WeBWorK/Authen.pm to forbid accepting empty or all white-space password even if they happen to match the crypted password in the database. (In certain settings such as LTI authentication and LDAP authentication, and when wwassignment is being used, some users may have such a null password.)

Since the function is called as a fallback by some of the other authentication modules which do not "trim" the possibleClearPassword being sent for testing (unlike what is done in get_credentials() in lib/WeBWorK/Authen.pm), we explicitly test for a non-space character and don't only reject the possibleClearPassword when it is an empty string.

This is intended to address the issue reported in the forums http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4529 .