### PR TITLE
Leaderboard for comparing achievement points

### DIFF
--- a/htdocs/js/apps/Leaderboard/leaderboard.css
+++ b/htdocs/js/apps/Leaderboard/leaderboard.css
@@ -1,0 +1,67 @@
+  .filler {
+    background: #1DA598;
+    vertical-align: middle;
+    border-radius: 50px;
+    transition: width .2s ease-in;
+  }
+  .ion-android-arrow-dropup{
+    font-size: 20px;
+    margin-left: 4px;
+  }
+  .ion-android-arrow-dropdown{
+    font-size: 20px;
+    margin-left: 4px;
+  }
+  .tableStyleLB {
+    width: 100%;
+    table-layout: fixed;
+    border-spacing: 0px;
+    border: 1px solid #e6e6e6;
+    box-shadow: 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2);
+  }
+  .pStyleLB {
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-weight: 300;
+    font-size: 13px;
+    text-align: center;
+    padding-right: 10%;
+  }
+  .buttonStyleLB {
+    background: none";
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+  }
+  .divStyleLB {
+    overflow-y: auto;
+    height: 80%;
+    width: 70%;
+    min-width: 550px;
+  }
+  .thStyleLB {
+    background-color: #003388;
+    color: white;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    padding: 15px;
+    cursor: pointer;
+  }
+  .tdStyleLB {
+    text-align: center;
+    vertical-align: middle;
+    padding: 15px;
+  }
+  .trStyleLB {
+    height: 2%;
+  }
+  .LeaderItemTr {
+    background-color: #f6f6f6;
+    color: black;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-weight: 300;
+    padding: 15px;
+    border-spacing: 2px;
+  }
+

--- a/htdocs/js/apps/Leaderboard/leaderboard.css
+++ b/htdocs/js/apps/Leaderboard/leaderboard.css
@@ -1,8 +1,139 @@
-  .filler {
-    background: #1DA598;
+  .lbContainer {
+    overflow-y: auto;
+    /* height: 80%; */
+    width: 90%;
+    min-width: 600px;
+  }
+  .lbTable {
+    width: 100%;
+    table-layout: fixed;
+    border-spacing: 0px;
+    border: 1px solid #003388;
+    box-shadow: 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2);
+  }
+  #username {
+    width: 35%;
+  }
+  #Earned {
+    width: 25%;
+  }
+  #Points {
+    width: 15%;
+  }
+  #progress {
+    /* width: 45%; */
+  }
+  table.lbTable tr {
+    /* height: 2%; */
+  }
+  table.lbTable tr th:nth-child(3) {
+    display: none;
+  }
+  table.lbTable tr td:nth-child(3) {
+    display: none;
+  }
+  table.lbTable thead th {
+    background-color: #003388;
+    color: white;
+    font-size: 12pt;
+    font-family: 'Aldrich';
+    padding: 5px;
+    cursor: pointer;
+  }
+  table.lbTable tbody tr {
+    height: 32px;
+    background-color: #f6f6f6;
+    color: white;
+    font-size: 16pt;
+    font-family: 'Luckiest Guy';
+    padding: 15px;
+    text-shadow:   0px -1px 0 #212121,  
+                   0px  1px 0 #212121,
+                  -1px  0px 0 #212121,  
+                   1px  0px 0 #212121,
+                  -1px  0px 0 #212121,
+                   1px  0px 0 #212121,
+                  -1px -1px 0 #212121,  
+                   1px -1px 0 #212121,
+                  -1px  1px 0 #212121,
+                   1px  1px 0 #212121;
+  }
+  table.lbTable tbody tr:nth-child(1) {
+    background: gold;
+  }
+  table.lbTable tbody tr:nth-child(2) {
+    background: #c0c0c0;
+  }
+  table.lbTable tbody tr:nth-child(3) {
+    background: #cd7f32;
+  }
+  table.lbTable tbody tr.myRow {
+  font-size: 22pt;
+  font-family: 'Luckiest Guy';
+  color: #fff;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-shadow:   0px -2px 0 #212121,  
+                 0px  2px 0 #212121,
+                -2px  0px 0 #212121,  
+                 2px  0px 0 #212121,
+                -2px  0px 0 #212121,
+                 2px  0px 0 #212121,
+                -2px -2px 0 #212121,  
+                 2px -2px 0 #212121,
+                -2px  2px 0 #212121,
+                 2px  2px 0 #212121,
+                -2px  6px 0 #212121,
+                 0px  6px 0 #212121,
+                 2px  6px 0 #212121,
+                 0 6px 1px rgba(0,0,0,.1),
+                 0 0 2px rgba(0,0,0,.1),
+                 0 2px 1px rgba(0,0,0,.3),
+                 0 4px 2px rgba(0,0,0,.2),
+                 0 6px 6px rgba(0,0,0,.25),
+                 0 8px 8px rgba(0,0,0,.2),
+                 0 12px 12px rgba(0,0,0,.15);
+  }
+  table.lbTable tr.myRow td {
+    padding-top: 5px;
+  }
+  table.lbTable tbody td {
+    height: 100%;
+    width: 100%;
+    text-align: center;
     vertical-align: middle;
-    border-radius: 50px;
+    padding: 5px 15px;
+    padding-top: 12px;
+  }
+  .fillerContainer {
+    height: 20px;
+    /* width: 80%; */
+    margin-right: 65px;
+    text-align: left;
+    position: relative;
+    /* display: table; */
+    /* overflow: hidden; */
+  }
+  .fillerBar {
+    /* background: #1DA598; */
+    vertical-align: middle;
+    border-radius: 10px;
     transition: width .2s ease-in;
+    border: 1px solid black;
+    height: 16px;
+    display: inline-block;
+    position: absolute;
+    top: -3px;
+  }
+  tr.myRow .fillerBar {
+    top: 1px;
+  }
+  .fillerLabel {
+    /* width: 50px; */
+    /* display: table-cell; */
+    text-align: left;
+    margin-left: 10px;
+    position:absolute;
   }
   .ion-android-arrow-dropup{
     font-size: 20px;
@@ -12,18 +143,12 @@
     font-size: 20px;
     margin-left: 4px;
   }
-  .tableStyleLB {
-    width: 100%;
-    table-layout: fixed;
-    border-spacing: 0px;
-    border: 1px solid #e6e6e6;
-    box-shadow: 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2);
-  }
-  .pStyleLB {
+  table.lbTable caption {
+    caption-side: bottom;
     font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
     font-weight: 300;
     font-size: 13px;
-    text-align: center;
+    text-align: right;
     padding-right: 10%;
   }
   .buttonStyleLB {
@@ -35,33 +160,3 @@
     cursor: pointer;
     outline: inherit;
   }
-  .divStyleLB {
-    overflow-y: auto;
-    height: 80%;
-    width: 70%;
-    min-width: 550px;
-  }
-  .thStyleLB {
-    background-color: #003388;
-    color: white;
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
-    padding: 15px;
-    cursor: pointer;
-  }
-  .tdStyleLB {
-    text-align: center;
-    vertical-align: middle;
-    padding: 15px;
-  }
-  .trStyleLB {
-    height: 2%;
-  }
-  .LeaderItemTr {
-    background-color: #f6f6f6;
-    color: black;
-    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
-    font-weight: 300;
-    padding: 15px;
-    border-spacing: 2px;
-  }
-

--- a/htdocs/js/apps/Leaderboard/leaderboard.js
+++ b/htdocs/js/apps/Leaderboard/leaderboard.js
@@ -12,85 +12,22 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var user = null;
 var key = null;
 
-// uncomment the following two lines,
-// replace courseinfo.name with courseName
-// replace hard-coded leaderboard URL, 
-// and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
-// along with "compiled" version of this app.js
+// get static values from webwork
+var courseName = document.getElementById("courseName").value;
+var leaderboardURL = document.getElementById("site_url").value + "/js/apps/Leaderboard/leaderboard.php";
+var pointsPerProblem = document.getElementById('achievementPPP').value;
+var maxScore = 0;
 
-// const courseName = document.getElementByID('courseName').value;
-// const leaderboardURL = document.getElementByID('site_url').value + 'js/apps/Leaderboard/leaderboard.php'/;
-
-// to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
-// then uncomment this bad boy
-// const maxExperience = document.getElementByID('maxExperience').value;
-
+// we must pull the user + key to authenticate for php
+// php script is set to require a valid user/key pair
 function checkCookies() {
-  var value = getCookie("WeBWorKCourseAuthen." + courseinfo.name); // getCookie defined at the bottom
+  var value = getCookie("WeBWorKCourseAuthen." + courseName); // getCookie defined at the bottom
   user = value.split("\t")[0];
   key = value.split("\t")[1];
 }
 if (!user & !key) {
   checkCookies();
 }
-
-// is it possible to move this css to a leaderboard.css file?
-// along with the css styles from the Leaderboards.tmpl file?
-// place combined leaderboard.css file in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard
-
-var styles = {
-  tableStyle: {
-    width: "100%",
-    tableLayout: "fixed",
-    borderSpacing: "0px",
-    border: "1px solid #e6e6e6",
-    boxShadow: "0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2)"
-  },
-  pStyle: {
-    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
-    fontWeight: "300",
-    fontSize: "13px",
-    textAlign: "center",
-    paddingRight: "10%"
-  },
-  buttonStyle: {
-    background: "none",
-    color: "inherit",
-    border: "none",
-    padding: 0,
-    font: "inherit",
-    cursor: "pointer",
-    outline: "inherit"
-  },
-  divStyle: {
-    overflowY: "auto",
-    height: "80%",
-    width: "70%",
-    minWidth: "550px"
-  },
-  thStyle: {
-    backgroundColor: "#003388",
-    color: "white",
-    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
-    padding: "15px",
-    cursor: "pointer"
-  },
-  tdStyle: {
-    textAlign: "center",
-    padding: "15px"
-  },
-  trStyle: {
-    height: "2%"
-  },
-  LeaderItemTrStyle: {
-    backgroundColor: "#f6f6f6",
-    color: "black",
-    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
-    fontWeight: "300",
-    padding: "15px",
-    borderSpacing: "2px"
-  }
-};
 
 var LeaderTable = function (_React$Component) {
   _inherits(LeaderTable, _React$Component);
@@ -112,45 +49,25 @@ var LeaderTable = function (_React$Component) {
   }
 
   _createClass(LeaderTable, [{
-    key: "componentWillMount",
-    value: function componentWillMount() {
+    key: "componentDidMount",
+    value: function componentDidMount() {
       var _this2 = this;
 
       var requestObject = {
         user: user,
         key: key,
-        courseName: courseinfo.name // replace this with courseName
+        courseName: courseName
       };
-      // The url  needs to be taken from a global environment variable
-      // This would idealy be a variable in the leaderboards.tmpl file
-      // leaderboard.php should be placed in /var/www/html/
-      // fetch("http://mathww.citytech.cuny.edu/leaderboard.php", {
-      //   method: "POST",
-      //   headers: { "Content-type": "application/x-www-form-urlencoded" },
-      //   body: formEncode(requestObject) // formEncode defined at the bottom
-      // })
-      //   .then(response => {
-      //     if (!response.ok) {
-      //       throw Error(response.statusText);
-      //     }
-      //     return response.json();
-      //   })
-      //   .then(data => {
-      //     data.forEach(item => {
-      //       if (item.achievementPoints == null) item.achievementPoints = 0;
-      //     });
-      //     this.setState({ data });
-      //   })
-      //   .catch(err => {
-      //     console.log("An error has occurred: " + err);
-      //   });
 
-      $.post("http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
-      requestObject, function (data) {
+      $.post(leaderboardURL, requestObject, function (data) {
         data.forEach(function (item) {
           if (item.achievementPoints == null) item.achievementPoints = 0;
         });
-        _this2.setState({ data: data });
+        maxScore = parseInt(data[0].numOfProblems) * parseInt(pointsPerProblem) + parseInt(data[0].achievementPtsSum);
+        data.sort(function (a, b) {
+          return b.achievementPoints - a.achievementPoints;
+        });
+        _this2.setState({ data: data, current: "progress" });
       }, "json");
     }
   }, {
@@ -163,7 +80,7 @@ var LeaderTable = function (_React$Component) {
           return parseFloat(a.achievementsEarned) - parseFloat(b.achievementsEarned);
         });
         if (this.state.current == "Point") this.setState({ clicks: 0 });
-      } else if (option.target.id == "Point") {
+      } else if (option.target.id == "Point" || option.target.id == "progress") {
         newData.sort(function (a, b) {
           return parseFloat(a.achievementPoints) - parseFloat(b.achievementPoints);
         });
@@ -186,34 +103,34 @@ var LeaderTable = function (_React$Component) {
   }, {
     key: "renderTable",
     value: function renderTable() {
-      var tdStyle = styles.tdStyle;
-
       var tableInfo = [];
       if (this.state.data.length > 0) {
-        for (var i = 0; i < 21; i++) {
+        for (var i = 0; i < this.state.data.length; i++) {
           var current = this.state.data[i];
           tableInfo.push(React.createElement(
             LeaderTableItem,
-            null,
+            { rID: current.id },
             React.createElement(
               "td",
-              { style: tdStyle },
-              current.username ? current.username : current.id
+              { className: "tdStyleLB" },
+              current.username ? current.username : "Anonymous"
             ),
             React.createElement(
               "td",
-              { style: tdStyle },
+              { className: "tdStyleLB" },
               current.achievementsEarned
             ),
             React.createElement(
               "td",
-              { style: tdStyle },
+              { className: "tdStyleLB" },
               current.achievementPoints ? current.achievementPoints : 0
             ),
             React.createElement(
               "td",
-              { style: tdStyle },
-              React.createElement(Filler, { percentage: current.achievementPoints / 2000 * 100 })
+              { className: "tdStyleLB" },
+              React.createElement(Filler, {
+                percentage: Math.floor(current.achievementPoints / maxScore * 1000) / 10
+              })
             )
           ));
         }
@@ -224,55 +141,61 @@ var LeaderTable = function (_React$Component) {
   }, {
     key: "render",
     value: function render() {
-      var tableStyle = styles.tableStyle,
-          thStyle = styles.thStyle,
-          tdStyle = styles.tdStyle,
-          trStyle = styles.trStyle,
-          divStyle = styles.divStyle,
-          pStyle = styles.pStyle;
 
       var tableInfo = this.renderTable();
 
       return React.createElement(
         "div",
-        { style: divStyle },
+        { className: "lbContainer" },
         React.createElement(
           "table",
-          { style: tableStyle },
+          { className: "lbTable" },
           React.createElement(
-            "tr",
-            { style: trStyle },
+            "caption",
+            null,
+            "Sponsored by Santander Bank"
+          ),
+          React.createElement(
+            "thead",
+            null,
             React.createElement(
-              "th",
-              { id: "username", style: thStyle },
-              "Username"
-            ),
-            React.createElement(
-              "th",
-              {
-                className: "sortButtons",
-                style: thStyle,
-                id: "Earned",
-                onClick: this.checkOption
-              },
-              "Achievements Earned",
-              this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
-            ),
-            React.createElement(
-              "th",
-              {
-                className: "sortButtons",
-                style: thStyle,
-                id: "Point",
-                onClick: this.checkOption
-              },
-              "Achievement Points",
-              this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
-            ),
-            React.createElement(
-              "th",
-              { style: thStyle },
-              "Progress"
+              "tr",
+              null,
+              React.createElement(
+                "th",
+                { id: "username" },
+                "Username"
+              ),
+              React.createElement(
+                "th",
+                {
+                  className: "sortButtons",
+                  id: "Earned",
+                  onClick: this.checkOption
+                },
+                "Achievements Earned",
+                this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
+              ),
+              React.createElement(
+                "th",
+                {
+                  className: "sortButtons",
+                  id: "Point",
+                  onClick: this.checkOption
+                },
+                "Achievement Points",
+                this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
+              ),
+              React.createElement(
+                "th",
+                {
+                  className: "sortButtons",
+                  id: "progress",
+                  onClick: this.checkOption
+                },
+                "Achievement Points Collected",
+                this.state.current == "progress" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
+              )
             )
           ),
           React.createElement(
@@ -300,11 +223,16 @@ var LeaderTableItem = function (_React$Component2) {
   _createClass(LeaderTableItem, [{
     key: "render",
     value: function render() {
-      var LeaderItemTrStyle = styles.LeaderItemTrStyle;
-
+      if (this.props.rID == user) {
+        return React.createElement(
+          "tr",
+          { className: "myRow" },
+          this.props.children
+        );
+      }
       return React.createElement(
         "tr",
-        { style: LeaderItemTrStyle },
+        { className: "LeaderItemTr" },
         this.props.children
       );
     }
@@ -325,27 +253,11 @@ var Leaderboard = function (_React$Component3) {
   _createClass(Leaderboard, [{
     key: "render",
     value: function render() {
-      var tableStyle = styles.tableStyle,
-          thStyle = styles.thStyle,
-          tdStyle = styles.tdStyle,
-          trStyle = styles.trStyle,
-          divStyle = styles.divStyle,
-          pStyle = styles.pStyle,
-          LeaderItemTrStyle = styles.LeaderItemTrStyle;
 
       return React.createElement(
         "div",
         null,
-        React.createElement(LeaderTable, null),
-        React.createElement(
-          "p",
-          { style: pStyle },
-          React.createElement(
-            "i",
-            null,
-            "Sponsored by Santander Bank"
-          )
-        )
+        React.createElement(LeaderTable, null)
       );
     }
   }]);
@@ -369,38 +281,40 @@ var Filler = function (_React$Component4) {
   _createClass(Filler, [{
     key: "changeColor",
     value: function changeColor() {
-      var percentage = parseInt(this.props.percentage);
-      var colorValue = "";
-
-      switch (true) {
-        case percentage <= 20:
-          colorValue = "#ff6961";
-          break;
-        case percentage >= 60 && percentage <= 80:
-          colorValue = "#4dff88";
-          break;
-        case percentage >= 20 && percentage < 60:
-          colorValue = "#FF7F50";
-          break;
+      var perc = parseInt(this.props.percentage);
+      var r,
+          g,
+          b = 0;
+      if (perc < 50) {
+        r = 255;
+        g = Math.round(5.1 * perc);
+      } else {
+        g = 255;
+        r = Math.round(510 - 5.10 * perc);
       }
-      return colorValue;
+      var h = r * 0x10000 + g * 0x100 + b * 0x1;
+      return '#' + ('000000' + h.toString(16)).slice(-6);
     }
   }, {
     key: "render",
     value: function render() {
       return React.createElement(
         "div",
-        {
-          className: "filler",
+        { className: "fillerContainer" },
+        React.createElement("span", { className: "fillerBar",
           style: {
             width: this.props.percentage + "%",
             background: this.changeColor()
           }
-        },
+        }),
         React.createElement(
-          "p",
-          { style: { fontWeight: "100" } },
-          this.props.percentage
+          "div",
+          { className: "fillerLabel",
+            style: {
+              left: this.props.percentage + "%"
+            } },
+          this.props.percentage,
+          "%"
         )
       );
     }

--- a/htdocs/js/apps/Leaderboard/leaderboard.js
+++ b/htdocs/js/apps/Leaderboard/leaderboard.js
@@ -1,0 +1,438 @@
+"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+// Development file only.
+var user = null;
+var key = null;
+
+// uncomment the following two lines,
+// replace courseinfo.name with courseName
+// replace hard-coded leaderboard URL, 
+// and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
+// along with "compiled" version of this app.js
+
+// const courseName = document.getElementByID('courseName').value;
+// const leaderboardURL = document.getElementByID('site_url').value + 'js/apps/Leaderboard/leaderboard.php'/;
+
+// to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
+// then uncomment this bad boy
+// const maxExperience = document.getElementByID('maxExperience').value;
+
+function checkCookies() {
+  var value = getCookie("WeBWorKCourseAuthen." + courseinfo.name); // getCookie defined at the bottom
+  user = value.split("\t")[0];
+  key = value.split("\t")[1];
+}
+if (!user & !key) {
+  checkCookies();
+}
+
+// is it possible to move this css to a leaderboard.css file?
+// along with the css styles from the Leaderboards.tmpl file?
+// place combined leaderboard.css file in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard
+
+var styles = {
+  tableStyle: {
+    width: "100%",
+    tableLayout: "fixed",
+    borderSpacing: "0px",
+    border: "1px solid #e6e6e6",
+    boxShadow: "0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2)"
+  },
+  pStyle: {
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    fontSize: "13px",
+    textAlign: "center",
+    paddingRight: "10%"
+  },
+  buttonStyle: {
+    background: "none",
+    color: "inherit",
+    border: "none",
+    padding: 0,
+    font: "inherit",
+    cursor: "pointer",
+    outline: "inherit"
+  },
+  divStyle: {
+    overflowY: "auto",
+    height: "80%",
+    width: "70%",
+    minWidth: "550px"
+  },
+  thStyle: {
+    backgroundColor: "#003388",
+    color: "white",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    padding: "15px",
+    cursor: "pointer"
+  },
+  tdStyle: {
+    textAlign: "center",
+    padding: "15px"
+  },
+  trStyle: {
+    height: "2%"
+  },
+  LeaderItemTrStyle: {
+    backgroundColor: "#f6f6f6",
+    color: "black",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    padding: "15px",
+    borderSpacing: "2px"
+  }
+};
+
+var LeaderTable = function (_React$Component) {
+  _inherits(LeaderTable, _React$Component);
+
+  function LeaderTable() {
+    _classCallCheck(this, LeaderTable);
+
+    var _this = _possibleConstructorReturn(this, (LeaderTable.__proto__ || Object.getPrototypeOf(LeaderTable)).call(this));
+
+    _this.state = {
+      data: [],
+      option: null,
+      clicks: 0,
+      current: null,
+      currentSort: null
+    };
+    _this.checkOption = _this.checkOption.bind(_this);
+    return _this;
+  }
+
+  _createClass(LeaderTable, [{
+    key: "componentWillMount",
+    value: function componentWillMount() {
+      var _this2 = this;
+
+      var requestObject = {
+        user: user,
+        key: key,
+        courseName: courseinfo.name // replace this with courseName
+      };
+      // The url  needs to be taken from a global environment variable
+      // This would idealy be a variable in the leaderboards.tmpl file
+      // leaderboard.php should be placed in /var/www/html/
+      // fetch("http://mathww.citytech.cuny.edu/leaderboard.php", {
+      //   method: "POST",
+      //   headers: { "Content-type": "application/x-www-form-urlencoded" },
+      //   body: formEncode(requestObject) // formEncode defined at the bottom
+      // })
+      //   .then(response => {
+      //     if (!response.ok) {
+      //       throw Error(response.statusText);
+      //     }
+      //     return response.json();
+      //   })
+      //   .then(data => {
+      //     data.forEach(item => {
+      //       if (item.achievementPoints == null) item.achievementPoints = 0;
+      //     });
+      //     this.setState({ data });
+      //   })
+      //   .catch(err => {
+      //     console.log("An error has occurred: " + err);
+      //   });
+
+      $.post("http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
+      requestObject, function (data) {
+        data.forEach(function (item) {
+          if (item.achievementPoints == null) item.achievementPoints = 0;
+        });
+        _this2.setState({ data: data });
+      }, "json");
+    }
+  }, {
+    key: "checkOption",
+    value: function checkOption(option) {
+      this.setState({ clicks: this.state.clicks + 1 });
+      var newData = this.state.data;
+      if (option.target.id == "Earned") {
+        newData.sort(function (a, b) {
+          return parseFloat(a.achievementsEarned) - parseFloat(b.achievementsEarned);
+        });
+        if (this.state.current == "Point") this.setState({ clicks: 0 });
+      } else if (option.target.id == "Point") {
+        newData.sort(function (a, b) {
+          return parseFloat(a.achievementPoints) - parseFloat(b.achievementPoints);
+        });
+        if (this.state.current == "Earned") this.setState({ clicks: 0 });
+      }
+      if (this.state.clicks % 2 == 0) {
+        this.setState({
+          data: newData.reverse(),
+          current: option.target.id,
+          currentSort: "Desc"
+        });
+      } else {
+        this.setState({
+          data: newData,
+          current: option.target.id,
+          currentSort: "Asc"
+        });
+      }
+    }
+  }, {
+    key: "renderTable",
+    value: function renderTable() {
+      var tdStyle = styles.tdStyle;
+
+      var tableInfo = [];
+      if (this.state.data.length > 0) {
+        for (var i = 0; i < 21; i++) {
+          var current = this.state.data[i];
+          tableInfo.push(React.createElement(
+            LeaderTableItem,
+            null,
+            React.createElement(
+              "td",
+              { style: tdStyle },
+              current.username ? current.username : current.id
+            ),
+            React.createElement(
+              "td",
+              { style: tdStyle },
+              current.achievementsEarned
+            ),
+            React.createElement(
+              "td",
+              { style: tdStyle },
+              current.achievementPoints ? current.achievementPoints : 0
+            ),
+            React.createElement(
+              "td",
+              { style: tdStyle },
+              React.createElement(Filler, { percentage: current.achievementPoints / 2000 * 100 })
+            )
+          ));
+        }
+      }
+
+      return tableInfo;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var tableStyle = styles.tableStyle,
+          thStyle = styles.thStyle,
+          tdStyle = styles.tdStyle,
+          trStyle = styles.trStyle,
+          divStyle = styles.divStyle,
+          pStyle = styles.pStyle;
+
+      var tableInfo = this.renderTable();
+
+      return React.createElement(
+        "div",
+        { style: divStyle },
+        React.createElement(
+          "table",
+          { style: tableStyle },
+          React.createElement(
+            "tr",
+            { style: trStyle },
+            React.createElement(
+              "th",
+              { id: "username", style: thStyle },
+              "Username"
+            ),
+            React.createElement(
+              "th",
+              {
+                className: "sortButtons",
+                style: thStyle,
+                id: "Earned",
+                onClick: this.checkOption
+              },
+              "Achievements Earned",
+              this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
+            ),
+            React.createElement(
+              "th",
+              {
+                className: "sortButtons",
+                style: thStyle,
+                id: "Point",
+                onClick: this.checkOption
+              },
+              "Achievement Points",
+              this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
+            ),
+            React.createElement(
+              "th",
+              { style: thStyle },
+              "Progress"
+            )
+          ),
+          React.createElement(
+            "tbody",
+            null,
+            tableInfo
+          )
+        )
+      );
+    }
+  }]);
+
+  return LeaderTable;
+}(React.Component);
+
+var LeaderTableItem = function (_React$Component2) {
+  _inherits(LeaderTableItem, _React$Component2);
+
+  function LeaderTableItem() {
+    _classCallCheck(this, LeaderTableItem);
+
+    return _possibleConstructorReturn(this, (LeaderTableItem.__proto__ || Object.getPrototypeOf(LeaderTableItem)).apply(this, arguments));
+  }
+
+  _createClass(LeaderTableItem, [{
+    key: "render",
+    value: function render() {
+      var LeaderItemTrStyle = styles.LeaderItemTrStyle;
+
+      return React.createElement(
+        "tr",
+        { style: LeaderItemTrStyle },
+        this.props.children
+      );
+    }
+  }]);
+
+  return LeaderTableItem;
+}(React.Component);
+
+var Leaderboard = function (_React$Component3) {
+  _inherits(Leaderboard, _React$Component3);
+
+  function Leaderboard() {
+    _classCallCheck(this, Leaderboard);
+
+    return _possibleConstructorReturn(this, (Leaderboard.__proto__ || Object.getPrototypeOf(Leaderboard)).apply(this, arguments));
+  }
+
+  _createClass(Leaderboard, [{
+    key: "render",
+    value: function render() {
+      var tableStyle = styles.tableStyle,
+          thStyle = styles.thStyle,
+          tdStyle = styles.tdStyle,
+          trStyle = styles.trStyle,
+          divStyle = styles.divStyle,
+          pStyle = styles.pStyle,
+          LeaderItemTrStyle = styles.LeaderItemTrStyle;
+
+      return React.createElement(
+        "div",
+        null,
+        React.createElement(LeaderTable, null),
+        React.createElement(
+          "p",
+          { style: pStyle },
+          React.createElement(
+            "i",
+            null,
+            "Sponsored by Santander Bank"
+          )
+        )
+      );
+    }
+  }]);
+
+  return Leaderboard;
+}(React.Component);
+
+var Filler = function (_React$Component4) {
+  _inherits(Filler, _React$Component4);
+
+  function Filler() {
+    _classCallCheck(this, Filler);
+
+    var _this5 = _possibleConstructorReturn(this, (Filler.__proto__ || Object.getPrototypeOf(Filler)).call(this));
+
+    _this5.state = { color: null };
+    _this5.changeColor = _this5.changeColor.bind(_this5);
+    return _this5;
+  }
+
+  _createClass(Filler, [{
+    key: "changeColor",
+    value: function changeColor() {
+      var percentage = parseInt(this.props.percentage);
+      var colorValue = "";
+
+      switch (true) {
+        case percentage <= 20:
+          colorValue = "#ff6961";
+          break;
+        case percentage >= 60 && percentage <= 80:
+          colorValue = "#4dff88";
+          break;
+        case percentage >= 20 && percentage < 60:
+          colorValue = "#FF7F50";
+          break;
+      }
+      return colorValue;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      return React.createElement(
+        "div",
+        {
+          className: "filler",
+          style: {
+            width: this.props.percentage + "%",
+            background: this.changeColor()
+          }
+        },
+        React.createElement(
+          "p",
+          { style: { fontWeight: "100" } },
+          this.props.percentage
+        )
+      );
+    }
+  }]);
+
+  return Filler;
+}(React.Component);
+
+//Utility functions
+
+
+function formEncode(obj) {
+  var str = [];
+  for (var p in obj) {
+    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+  }return str.join("&");
+}
+
+function getCookie(cname) {
+  var name = cname + "=";
+  var decodedCookie = decodeURIComponent(document.cookie);
+  var ca = decodedCookie.split(";");
+  for (var i = 0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0) == " ") {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return "";
+}
+
+ReactDOM.render(React.createElement(Leaderboard, null), document.getElementById("LeaderboardPage"));

--- a/htdocs/js/apps/Leaderboard/leaderboard.php
+++ b/htdocs/js/apps/Leaderboard/leaderboard.php
@@ -1,0 +1,95 @@
+<?php
+  define('DB_HOST', 'localhost');
+  define('DB_NAME', 'webwork');
+  define('DB_USER', 'webworkWrite');
+  define('DB_PASS', 'passwordRW');
+
+  global $conn;
+
+  $conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+
+    if($conn->errno){
+        echo "Failed to connect to MySQL database ".$conn->error;
+    }
+
+  $user = mysqli_real_escape_string($conn, $_POST['user']);  
+  $key = mysqli_real_escape_string($conn, $_POST['key']);
+  $courseName = mysqli_real_escape_string($conn, $_POST['courseName']);
+
+  //  MAT1275EN-S18-Parker_achievement_user        
+  //  MAT1275EN-S18-Parker_global_user_achievement 
+  //  MAT1275EN-S18-Parker_user
+
+  if(validateUser($conn, $user, $key, $courseName) != False){
+    http_response_code(200);
+    echo leaderboard($conn, $courseName);
+  }else{
+    http_response_code(401);
+  }
+  
+  
+  function validateUser($conn, $user, $key, $courseName){
+      $query = "SELECT user_id from `".$courseName."_key` WHERE user_id = '".$user."' AND key_not_a_keyword = '".$key."';";
+      $result = $conn->query($query);
+  
+      if(mysqli_num_rows($result) == 0) return null;
+  
+      return $result;
+  }
+  
+  
+  
+  function leaderboard($conn, $courseName){
+  
+    $query = "SELECT user_id, comment from `".$courseName."_user` WHERE user_id NOT IN (SELECT user_id from `".$courseName."_permission` WHERE permission > 0);";
+  
+    // 2D array with only one collumn
+    $users = extractRows($conn->query($query), 0);
+  
+    $achievementsEarned = [];
+    $achievementPoints = [];
+    $data = [];
+  
+    foreach($users as $user){
+      $getEarned = "SELECT COUNT(*) FROM `".$courseName."_achievement_user` WHERE user_id = '$user[0]' AND earned > 0;";
+      $getPoints = "SELECT achievement_points FROM `".$courseName."_global_user_achievement` WHERE user_id = '$user[0]';";
+  
+      array_push($achievementsEarned, extractRows($conn->query($getEarned), 0)[0][0]);
+      array_push($achievementPoints, extractRows($conn->query($getPoints), 0)[0][0]);
+  
+    }
+  
+
+  
+    for($i=0; $i < sizeof($achievementPoints); $i++){
+      $data[$i] = ["id" => $users[$i][0], "username" => $users[$i][1], "achievementsEarned" => $achievementsEarned[$i], "achievementPoints" => $achievementPoints[$i]];
+    }
+  
+  
+  
+    return json_encode($data);
+  }
+
+
+
+
+
+
+  function extractRows($results, $num_or_assoc){
+      $rows = array();
+      if($num_or_assoc == 0){
+          while($row = $results->fetch_array(MYSQLI_NUM) ){
+              array_push($rows, $row);
+          }
+
+      }else{
+          while($row = $results->fetch_array(MYSQLI_ASSOC) ){
+              array_push($rows, $row);
+          }
+      }
+
+      return $rows;
+
+    }
+
+    $conn->close();

--- a/htdocs/js/apps/Leaderboard/leaderboard.php
+++ b/htdocs/js/apps/Leaderboard/leaderboard.php
@@ -45,6 +45,14 @@
   
     // 2D array with only one collumn
     $users = extractRows($conn->query($query), 0);
+
+    $query = "select count(*) from `".$courseName."_problem`;";
+
+    $numOfProblems = extractRows($conn->query($query), 0);
+
+    $query = "select SUM(points) from `".$courseName."_achievement`;";
+
+    $achievementPtsSum = extractRows($conn->query($query), 0);
   
     $achievementsEarned = [];
     $achievementPoints = [];
@@ -58,11 +66,12 @@
       array_push($achievementPoints, extractRows($conn->query($getPoints), 0)[0][0]);
   
     }
-  
+    
+    
 
   
     for($i=0; $i < sizeof($achievementPoints); $i++){
-      $data[$i] = ["id" => $users[$i][0], "username" => $users[$i][1], "achievementsEarned" => $achievementsEarned[$i], "achievementPoints" => $achievementPoints[$i]];
+      $data[$i] = ["id" => $users[$i][0], "username" => $users[$i][1], "achievementsEarned" => $achievementsEarned[$i], "achievementPoints" => $achievementPoints[$i], "achievementPtsSum" => $achievementPtsSum[0][0], "numOfProblems" => $numOfProblems[0][0]];
     }
   
   

--- a/htdocs/js/apps/Leaderboard/leaderboard.rel.js
+++ b/htdocs/js/apps/Leaderboard/leaderboard.rel.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -14,12 +14,12 @@ var key = null;
 
 // uncomment the following two lines,
 // replace courseinfo.name with courseName
-// replace hard-coded leaderboard URL, 
+// replace hard-coded leaderboard URL,
 // and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
 // along with "compiled" version of this app.js
 
-var courseNameStr = document.getElementById('courseName').value;
-var leaderboardURL = getRootUrl(document.location) + document.getElementById('site_url').value + '/js/apps/Leaderboard/leaderboard.php';
+var courseNameStr = document.getElementById("courseName").value;
+var leaderboardURL = getRootUrl(document.location) + document.getElementById("site_url").value + "/js/apps/Leaderboard/leaderboard.php";
 
 // to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
 // then uncomment this bad boy
@@ -29,7 +29,7 @@ var leaderboardURL = getRootUrl(document.location) + document.getElementById('si
 var maxScore = 0;
 
 function checkCookies() {
-  var value = getCookie('WeBWorKCourseAuthen.' + courseNameStr); // getCookie defined at the bottom
+  var value = getCookie("WeBWorKCourseAuthen." + courseNameStr); // getCookie defined at the bottom
   user = value.split("\t")[0];
   key = value.split("\t")[1];
 }
@@ -115,7 +115,7 @@ var LeaderTable = function (_React$Component) {
   }
 
   _createClass(LeaderTable, [{
-    key: 'componentWillMount',
+    key: "componentWillMount",
     value: function componentWillMount() {
       var _this2 = this;
 
@@ -153,13 +153,15 @@ var LeaderTable = function (_React$Component) {
       requestObject, function (data) {
         data.forEach(function (item) {
           if (item.achievementPoints == null) item.achievementPoints = 0;
-          if (item.achievementPoints > maxScore) maxScore = item.achievementPoints;
+
+          if (parseInt(item.achievementPoints) > maxScore) maxScore = item.achievementPoints;
         });
+        console.log(data);
         _this2.setState({ data: data });
       }, "json");
     }
   }, {
-    key: 'checkOption',
+    key: "checkOption",
     value: function checkOption(option) {
       this.setState({ clicks: this.state.clicks + 1 });
       var newData = this.state.data;
@@ -189,7 +191,7 @@ var LeaderTable = function (_React$Component) {
       }
     }
   }, {
-    key: 'renderTable',
+    key: "renderTable",
     value: function renderTable() {
       var tdStyle = styles.tdStyle;
 
@@ -201,24 +203,27 @@ var LeaderTable = function (_React$Component) {
             LeaderTableItem,
             null,
             React.createElement(
-              'td',
-              { className: 'tdStyleLB' },
+              "td",
+              { className: "tdStyleLB" },
               current.username ? current.username : current.id
             ),
             React.createElement(
-              'td',
-              { className: 'tdStyleLB' },
+              "td",
+              { className: "tdStyleLB" },
               current.achievementsEarned
             ),
             React.createElement(
-              'td',
-              { className: 'tdStyleLB' },
+              "td",
+              { className: "tdStyleLB" },
               current.achievementPoints ? current.achievementPoints : 0
             ),
             React.createElement(
-              'td',
-              { className: 'tdStyleLB' },
-              React.createElement(Filler, { percentage: Math.floor(current.achievementPoints / maxScore * 1000) / 10, score: current.achievementPoints })
+              "td",
+              { className: "tdStyleLB" },
+              React.createElement(Filler, {
+                percentage: Math.floor(current.achievementPoints / maxScore * 1000) / 10,
+                score: current.achievementPoints
+              })
             )
           ));
         }
@@ -227,7 +232,7 @@ var LeaderTable = function (_React$Component) {
       return tableInfo;
     }
   }, {
-    key: 'render',
+    key: "render",
     value: function render() {
       var tableStyle = styles.tableStyle,
           thStyle = styles.thStyle,
@@ -239,53 +244,53 @@ var LeaderTable = function (_React$Component) {
       var tableInfo = this.renderTable();
 
       return React.createElement(
-        'div',
-        { className: 'divStyleLB' },
+        "div",
+        { className: "divStyleLB" },
         React.createElement(
-          'table',
-          { className: 'tableStyleLB' },
+          "table",
+          { className: "tableStyleLB" },
           React.createElement(
-            'tbody',
+            "tbody",
             null,
             React.createElement(
-              'tr',
-              { className: 'trStyleLB' },
+              "tr",
+              { className: "trStyleLB" },
               React.createElement(
-                'th',
-                { id: 'username', className: 'thStyleLB' },
-                'Username'
+                "th",
+                { id: "username", className: "thStyleLB" },
+                "Username"
               ),
               React.createElement(
-                'th',
+                "th",
                 {
-                  className: 'sortButtons thStyleLB',
+                  className: "sortButtons thStyleLB",
                   style: thStyle,
-                  id: 'Earned',
+                  id: "Earned",
                   onClick: this.checkOption
                 },
-                'Achievements Earned',
-                this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement('i', { className: 'ion-android-arrow-dropup' }) : React.createElement('i', { className: 'ion-android-arrow-dropdown' }) : null
+                "Achievements Earned",
+                this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
               ),
               React.createElement(
-                'th',
+                "th",
                 {
-                  className: 'sortButtons thStyleLB',
+                  className: "sortButtons thStyleLB",
                   style: thStyle,
-                  id: 'Point',
+                  id: "Point",
                   onClick: this.checkOption
                 },
-                'Achievement Points',
-                this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement('i', { className: 'ion-android-arrow-dropup' }) : React.createElement('i', { className: 'ion-android-arrow-dropdown' }) : null
+                "Achievement Points",
+                this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement("i", { className: "ion-android-arrow-dropup" }) : React.createElement("i", { className: "ion-android-arrow-dropdown" }) : null
               ),
               React.createElement(
-                'th',
-                { className: 'thStyleLB' },
-                'Progress'
+                "th",
+                { className: "thStyleLB" },
+                "Progress"
               )
             )
           ),
           React.createElement(
-            'tbody',
+            "tbody",
             null,
             tableInfo
           )
@@ -307,13 +312,13 @@ var LeaderTableItem = function (_React$Component2) {
   }
 
   _createClass(LeaderTableItem, [{
-    key: 'render',
+    key: "render",
     value: function render() {
       var LeaderItemTrStyle = styles.LeaderItemTrStyle;
 
       return React.createElement(
-        'tr',
-        { className: 'LeaderItemTr' },
+        "tr",
+        { className: "LeaderItemTr" },
         this.props.children
       );
     }
@@ -332,7 +337,7 @@ var Leaderboard = function (_React$Component3) {
   }
 
   _createClass(Leaderboard, [{
-    key: 'render',
+    key: "render",
     value: function render() {
       var tableStyle = styles.tableStyle,
           thStyle = styles.thStyle,
@@ -343,16 +348,16 @@ var Leaderboard = function (_React$Component3) {
           LeaderItemTrStyle = styles.LeaderItemTrStyle;
 
       return React.createElement(
-        'div',
+        "div",
         null,
         React.createElement(LeaderTable, null),
         React.createElement(
-          'p',
-          { className: 'pStyleLB' },
+          "p",
+          { className: "pStyleLB" },
           React.createElement(
-            'i',
+            "i",
             null,
-            'Sponsored by Santander Bank'
+            "Sponsored by Santander Bank"
           )
         )
       );
@@ -376,7 +381,7 @@ var Filler = function (_React$Component4) {
   }
 
   _createClass(Filler, [{
-    key: 'changeColor',
+    key: "changeColor",
     value: function changeColor() {
       var percentage = parseInt(this.props.percentage);
       var colorValue = "";
@@ -401,19 +406,19 @@ var Filler = function (_React$Component4) {
       return colorValue;
     }
   }, {
-    key: 'render',
+    key: "render",
     value: function render() {
       return React.createElement(
-        'div',
+        "div",
         {
-          className: 'filler',
+          className: "filler",
           style: {
-            width: this.props.percentage + '%',
+            width: this.props.percentage + "%",
             background: this.changeColor()
           }
         },
         React.createElement(
-          'p',
+          "p",
           { style: { fontWeight: "100" } },
           this.props.score
         )

--- a/htdocs/js/apps/Leaderboard/leaderboard.rel.js
+++ b/htdocs/js/apps/Leaderboard/leaderboard.rel.js
@@ -1,0 +1,457 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+// Development file only.
+var user = null;
+var key = null;
+
+// uncomment the following two lines,
+// replace courseinfo.name with courseName
+// replace hard-coded leaderboard URL, 
+// and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
+// along with "compiled" version of this app.js
+
+var courseNameStr = document.getElementById('courseName').value;
+var leaderboardURL = getRootUrl(document.location) + document.getElementById('site_url').value + '/js/apps/Leaderboard/leaderboard.php';
+
+// to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
+// then uncomment this bad boy
+// const maxExperience = document.getElementByID('maxExperience').value;
+
+// instead: keep track of highest experience for the class
+var maxScore = 0;
+
+function checkCookies() {
+  var value = getCookie('WeBWorKCourseAuthen.' + courseNameStr); // getCookie defined at the bottom
+  user = value.split("\t")[0];
+  key = value.split("\t")[1];
+}
+if (!user & !key) {
+  checkCookies();
+}
+
+// is it possible to move this css to a leaderboard.css file?
+// along with the css styles from the Leaderboards.tmpl file?
+// place combined leaderboard.css file in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard
+
+var styles = {
+  tableStyle: {
+    width: "100%",
+    tableLayout: "fixed",
+    borderSpacing: "0px",
+    border: "1px solid #e6e6e6",
+    boxShadow: "0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2)"
+  },
+  pStyle: {
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    fontSize: "13px",
+    textAlign: "center",
+    paddingRight: "10%"
+  },
+  buttonStyle: {
+    background: "none",
+    color: "inherit",
+    border: "none",
+    padding: 0,
+    font: "inherit",
+    cursor: "pointer",
+    outline: "inherit"
+  },
+  divStyle: {
+    overflowY: "auto",
+    height: "80%",
+    width: "70%",
+    minWidth: "550px"
+  },
+  thStyle: {
+    backgroundColor: "#003388",
+    color: "white",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    padding: "15px",
+    cursor: "pointer"
+  },
+  tdStyle: {
+    textAlign: "center",
+    padding: "15px"
+  },
+  trStyle: {
+    height: "2%"
+  },
+  LeaderItemTrStyle: {
+    backgroundColor: "#f6f6f6",
+    color: "black",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    padding: "15px",
+    borderSpacing: "2px"
+  }
+};
+
+var LeaderTable = function (_React$Component) {
+  _inherits(LeaderTable, _React$Component);
+
+  function LeaderTable() {
+    _classCallCheck(this, LeaderTable);
+
+    var _this = _possibleConstructorReturn(this, (LeaderTable.__proto__ || Object.getPrototypeOf(LeaderTable)).call(this));
+
+    _this.state = {
+      data: [],
+      option: null,
+      clicks: 0,
+      current: null,
+      currentSort: null
+    };
+    _this.checkOption = _this.checkOption.bind(_this);
+    return _this;
+  }
+
+  _createClass(LeaderTable, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      var _this2 = this;
+
+      var requestObject = {
+        user: user,
+        key: key,
+        courseName: courseNameStr // replace this with courseName
+      };
+      // The url  needs to be taken from a global environment variable
+      // This would idealy be a variable in the leaderboards.tmpl file
+      // leaderboard.php should be placed in /var/www/html/
+      // fetch("http://mathww.citytech.cuny.edu/leaderboard.php", {
+      //   method: "POST",
+      //   headers: { "Content-type": "application/x-www-form-urlencoded" },
+      //   body: formEncode(requestObject) // formEncode defined at the bottom
+      // })
+      //   .then(response => {
+      //     if (!response.ok) {
+      //       throw Error(response.statusText);
+      //     }
+      //     return response.json();
+      //   })
+      //   .then(data => {
+      //     data.forEach(item => {
+      //       if (item.achievementPoints == null) item.achievementPoints = 0;
+      //     });
+      //     this.setState({ data });
+      //   })
+      //   .catch(err => {
+      //     console.log("An error has occurred: " + err);
+      //   });
+
+      $.post(leaderboardURL,
+      //      "http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
+      requestObject, function (data) {
+        data.forEach(function (item) {
+          if (item.achievementPoints == null) item.achievementPoints = 0;
+          if (item.achievementPoints > maxScore) maxScore = item.achievementPoints;
+        });
+        _this2.setState({ data: data });
+      }, "json");
+    }
+  }, {
+    key: 'checkOption',
+    value: function checkOption(option) {
+      this.setState({ clicks: this.state.clicks + 1 });
+      var newData = this.state.data;
+      if (option.target.id == "Earned") {
+        newData.sort(function (a, b) {
+          return parseFloat(a.achievementsEarned) - parseFloat(b.achievementsEarned);
+        });
+        if (this.state.current == "Point") this.setState({ clicks: 0 });
+      } else if (option.target.id == "Point") {
+        newData.sort(function (a, b) {
+          return parseFloat(a.achievementPoints) - parseFloat(b.achievementPoints);
+        });
+        if (this.state.current == "Earned") this.setState({ clicks: 0 });
+      }
+      if (this.state.clicks % 2 == 0) {
+        this.setState({
+          data: newData.reverse(),
+          current: option.target.id,
+          currentSort: "Desc"
+        });
+      } else {
+        this.setState({
+          data: newData,
+          current: option.target.id,
+          currentSort: "Asc"
+        });
+      }
+    }
+  }, {
+    key: 'renderTable',
+    value: function renderTable() {
+      var tdStyle = styles.tdStyle;
+
+      var tableInfo = [];
+      if (this.state.data.length > 0) {
+        for (var i = 0; i < this.state.data.length; i++) {
+          var current = this.state.data[i];
+          tableInfo.push(React.createElement(
+            LeaderTableItem,
+            null,
+            React.createElement(
+              'td',
+              { className: 'tdStyleLB' },
+              current.username ? current.username : current.id
+            ),
+            React.createElement(
+              'td',
+              { className: 'tdStyleLB' },
+              current.achievementsEarned
+            ),
+            React.createElement(
+              'td',
+              { className: 'tdStyleLB' },
+              current.achievementPoints ? current.achievementPoints : 0
+            ),
+            React.createElement(
+              'td',
+              { className: 'tdStyleLB' },
+              React.createElement(Filler, { percentage: Math.floor(current.achievementPoints / maxScore * 1000) / 10, score: current.achievementPoints })
+            )
+          ));
+        }
+      }
+
+      return tableInfo;
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var tableStyle = styles.tableStyle,
+          thStyle = styles.thStyle,
+          tdStyle = styles.tdStyle,
+          trStyle = styles.trStyle,
+          divStyle = styles.divStyle,
+          pStyle = styles.pStyle;
+
+      var tableInfo = this.renderTable();
+
+      return React.createElement(
+        'div',
+        { className: 'divStyleLB' },
+        React.createElement(
+          'table',
+          { className: 'tableStyleLB' },
+          React.createElement(
+            'tbody',
+            null,
+            React.createElement(
+              'tr',
+              { className: 'trStyleLB' },
+              React.createElement(
+                'th',
+                { id: 'username', className: 'thStyleLB' },
+                'Username'
+              ),
+              React.createElement(
+                'th',
+                {
+                  className: 'sortButtons thStyleLB',
+                  style: thStyle,
+                  id: 'Earned',
+                  onClick: this.checkOption
+                },
+                'Achievements Earned',
+                this.state.current == "Earned" ? this.state.currentSort == "Asc" ? React.createElement('i', { className: 'ion-android-arrow-dropup' }) : React.createElement('i', { className: 'ion-android-arrow-dropdown' }) : null
+              ),
+              React.createElement(
+                'th',
+                {
+                  className: 'sortButtons thStyleLB',
+                  style: thStyle,
+                  id: 'Point',
+                  onClick: this.checkOption
+                },
+                'Achievement Points',
+                this.state.current == "Point" ? this.state.currentSort == "Asc" ? React.createElement('i', { className: 'ion-android-arrow-dropup' }) : React.createElement('i', { className: 'ion-android-arrow-dropdown' }) : null
+              ),
+              React.createElement(
+                'th',
+                { className: 'thStyleLB' },
+                'Progress'
+              )
+            )
+          ),
+          React.createElement(
+            'tbody',
+            null,
+            tableInfo
+          )
+        )
+      );
+    }
+  }]);
+
+  return LeaderTable;
+}(React.Component);
+
+var LeaderTableItem = function (_React$Component2) {
+  _inherits(LeaderTableItem, _React$Component2);
+
+  function LeaderTableItem() {
+    _classCallCheck(this, LeaderTableItem);
+
+    return _possibleConstructorReturn(this, (LeaderTableItem.__proto__ || Object.getPrototypeOf(LeaderTableItem)).apply(this, arguments));
+  }
+
+  _createClass(LeaderTableItem, [{
+    key: 'render',
+    value: function render() {
+      var LeaderItemTrStyle = styles.LeaderItemTrStyle;
+
+      return React.createElement(
+        'tr',
+        { className: 'LeaderItemTr' },
+        this.props.children
+      );
+    }
+  }]);
+
+  return LeaderTableItem;
+}(React.Component);
+
+var Leaderboard = function (_React$Component3) {
+  _inherits(Leaderboard, _React$Component3);
+
+  function Leaderboard() {
+    _classCallCheck(this, Leaderboard);
+
+    return _possibleConstructorReturn(this, (Leaderboard.__proto__ || Object.getPrototypeOf(Leaderboard)).apply(this, arguments));
+  }
+
+  _createClass(Leaderboard, [{
+    key: 'render',
+    value: function render() {
+      var tableStyle = styles.tableStyle,
+          thStyle = styles.thStyle,
+          tdStyle = styles.tdStyle,
+          trStyle = styles.trStyle,
+          divStyle = styles.divStyle,
+          pStyle = styles.pStyle,
+          LeaderItemTrStyle = styles.LeaderItemTrStyle;
+
+      return React.createElement(
+        'div',
+        null,
+        React.createElement(LeaderTable, null),
+        React.createElement(
+          'p',
+          { className: 'pStyleLB' },
+          React.createElement(
+            'i',
+            null,
+            'Sponsored by Santander Bank'
+          )
+        )
+      );
+    }
+  }]);
+
+  return Leaderboard;
+}(React.Component);
+
+var Filler = function (_React$Component4) {
+  _inherits(Filler, _React$Component4);
+
+  function Filler() {
+    _classCallCheck(this, Filler);
+
+    var _this5 = _possibleConstructorReturn(this, (Filler.__proto__ || Object.getPrototypeOf(Filler)).call(this));
+
+    _this5.state = { color: null };
+    _this5.changeColor = _this5.changeColor.bind(_this5);
+    return _this5;
+  }
+
+  _createClass(Filler, [{
+    key: 'changeColor',
+    value: function changeColor() {
+      var percentage = parseInt(this.props.percentage);
+      var colorValue = "";
+
+      switch (true) {
+        case percentage < 20:
+          colorValue = "#ff6961";
+          break;
+        case percentage >= 20 && percentage < 40:
+          colorValue = "#FF7F50";
+          break;
+        case percentage >= 40 && percentage < 60:
+          colorValue = "#fada5e";
+          break;
+        case percentage >= 60 && percentage < 80:
+          colorValue = "#aedb30";
+          break;
+        case percentage >= 80:
+          colorValue = "#4dff88";
+          break;
+      }
+      return colorValue;
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return React.createElement(
+        'div',
+        {
+          className: 'filler',
+          style: {
+            width: this.props.percentage + '%',
+            background: this.changeColor()
+          }
+        },
+        React.createElement(
+          'p',
+          { style: { fontWeight: "100" } },
+          this.props.score
+        )
+      );
+    }
+  }]);
+
+  return Filler;
+}(React.Component);
+
+//Utility functions
+
+
+function formEncode(obj) {
+  var str = [];
+  for (var p in obj) {
+    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+  }return str.join("&");
+}
+
+function getCookie(cname) {
+  var name = cname + "=";
+  var decodedCookie = decodeURIComponent(document.cookie);
+  var ca = decodedCookie.split(";");
+  for (var i = 0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0) == " ") {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return "";
+}
+
+function getRootUrl(url) {
+  return url.toString().replace(/^(.*\/\/[^\/?#]*).*$/, "$1");
+}
+
+ReactDOM.render(React.createElement(Leaderboard, null), document.getElementById("LeaderboardPage"));

--- a/htdocs/js/apps/Leaderboard/package.json
+++ b/htdocs/js/apps/Leaderboard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ww-leaderboards",
+  "version": "1.0.0",
+  "description": "",
+  "main": "leaderboard.js",
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "build-babel": "babel src/app.js --out-file=leaderboard.js --presets=env,react --watch",
+    "build-babel-rel": "babel src/app.relative.js --out-file=leaderboard.rel.js --presets=env,react --watch"
+  },
+  "dependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-preset-env": "^1.5.2",
+    "babel-preset-react": "^6.24.1"
+  }
+}

--- a/htdocs/js/apps/Leaderboard/src/app.js
+++ b/htdocs/js/apps/Leaderboard/src/app.js
@@ -1,0 +1,338 @@
+// Development file only.
+let user = null;
+let key = null;
+
+// uncomment the following two lines,
+// replace courseinfo.name with courseName
+// replace hard-coded leaderboard URL, 
+// and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
+// along with "compiled" version of this app.js
+
+// const courseName = document.getElementByID('courseName').value;
+// const leaderboardURL = document.getElementByID('site_url').value + 'js/apps/Leaderboard/leaderboard.php'/;
+
+// to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
+// then uncomment this bad boy
+// const maxExperience = document.getElementByID('maxExperience').value;
+
+function checkCookies() {
+  const value = getCookie(`WeBWorKCourseAuthen.${courseinfo.name}`); // getCookie defined at the bottom
+  user = value.split("\t")[0];
+  key = value.split("\t")[1];
+}
+if (!user & !key) {
+  checkCookies();
+}
+
+// is it possible to move this css to a leaderboard.css file?
+// along with the css styles from the Leaderboards.tmpl file?
+// place combined leaderboard.css file in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard
+
+const styles = {
+  tableStyle: {
+    width: "100%",
+    tableLayout: "fixed",
+    borderSpacing: "0px",
+    border: "1px solid #e6e6e6",
+    boxShadow:
+      "0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2)"
+  },
+  pStyle: {
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    fontSize: "13px",
+    textAlign: "center",
+    paddingRight: "10%"
+  },
+  buttonStyle: {
+    background: "none",
+    color: "inherit",
+    border: "none",
+    padding: 0,
+    font: "inherit",
+    cursor: "pointer",
+    outline: "inherit"
+  },
+  divStyle: {
+    overflowY: "auto",
+    height: "80%",
+    width: "70%",
+    minWidth: "550px"
+  },
+  thStyle: {
+    backgroundColor: "#003388",
+    color: "white",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    padding: "15px",
+    cursor: "pointer"
+  },
+  tdStyle: {
+    textAlign: "center",
+    padding: "15px"
+  },
+  trStyle: {
+    height: "2%"
+  },
+  LeaderItemTrStyle: {
+    backgroundColor: "#f6f6f6",
+    color: "black",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    padding: "15px",
+    borderSpacing: "2px"
+  }
+};
+class LeaderTable extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      data: [],
+      option: null,
+      clicks: 0,
+      current: null,
+      currentSort: null
+    };
+    this.checkOption = this.checkOption.bind(this);
+  }
+
+  componentWillMount() {
+    const requestObject = {
+      user,
+      key,
+      courseName: courseinfo.name // replace this with courseName
+    };
+    // The url  needs to be taken from a global environment variable
+    // This would idealy be a variable in the leaderboards.tmpl file
+    // leaderboard.php should be placed in /var/www/html/
+    // fetch("http://mathww.citytech.cuny.edu/leaderboard.php", {
+    //   method: "POST",
+    //   headers: { "Content-type": "application/x-www-form-urlencoded" },
+    //   body: formEncode(requestObject) // formEncode defined at the bottom
+    // })
+    //   .then(response => {
+    //     if (!response.ok) {
+    //       throw Error(response.statusText);
+    //     }
+    //     return response.json();
+    //   })
+    //   .then(data => {
+    //     data.forEach(item => {
+    //       if (item.achievementPoints == null) item.achievementPoints = 0;
+    //     });
+    //     this.setState({ data });
+    //   })
+    //   .catch(err => {
+    //     console.log("An error has occurred: " + err);
+    //   });
+
+    $.post(
+      "http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
+      requestObject,
+      data => {
+        data.forEach(item => {
+          if (item.achievementPoints == null) item.achievementPoints = 0;
+        });
+        this.setState({ data: data });
+      },
+      "json"
+    );
+  }
+  checkOption(option) {
+    this.setState({ clicks: this.state.clicks + 1 });
+    let newData = this.state.data;
+    if (option.target.id == "Earned") {
+      newData.sort(function(a, b) {
+        return (
+          parseFloat(a.achievementsEarned) - parseFloat(b.achievementsEarned)
+        );
+      });
+      if (this.state.current == "Point") this.setState({ clicks: 0 });
+    } else if (option.target.id == "Point") {
+      newData.sort(function(a, b) {
+        return (
+          parseFloat(a.achievementPoints) - parseFloat(b.achievementPoints)
+        );
+      });
+      if (this.state.current == "Earned") this.setState({ clicks: 0 });
+    }
+    if (this.state.clicks % 2 == 0) {
+      this.setState({
+        data: newData.reverse(),
+        current: option.target.id,
+        currentSort: "Desc"
+      });
+    } else {
+      this.setState({
+        data: newData,
+        current: option.target.id,
+        currentSort: "Asc"
+      });
+    }
+  }
+  renderTable() {
+    let { tdStyle } = styles;
+    let tableInfo = [];
+    if (this.state.data.length > 0) {
+      for (var i = 0; i < 21; i++) {
+        var current = this.state.data[i];
+        tableInfo.push(
+          <LeaderTableItem>
+            <td style={tdStyle}>
+              {current.username ? current.username : current.id}
+            </td>
+            <td style={tdStyle}>{current.achievementsEarned}</td>
+            <td style={tdStyle}>
+              {current.achievementPoints ? current.achievementPoints : 0}
+            </td>
+            <td style={tdStyle}>
+              <Filler percentage={(current.achievementPoints / 2000) * 100} />
+            </td>
+          </LeaderTableItem>
+        );
+      }
+    }
+
+    return tableInfo;
+  }
+  render() {
+    let { tableStyle, thStyle, tdStyle, trStyle, divStyle, pStyle } = styles;
+    let tableInfo = this.renderTable();
+
+    return (
+      <div style={divStyle}>
+        <table style={tableStyle}>
+          <tr style={trStyle}>
+            <th id="username" style={thStyle}>
+              Username
+            </th>
+            <th
+              className="sortButtons"
+              style={thStyle}
+              id="Earned"
+              onClick={this.checkOption}
+            >
+              Achievements Earned
+              {this.state.current == "Earned" ? (
+                this.state.currentSort == "Asc" ? (
+                  <i className="ion-android-arrow-dropup" />
+                ) : (
+                  <i className="ion-android-arrow-dropdown" />
+                )
+              ) : null}
+            </th>
+            <th
+              className="sortButtons"
+              style={thStyle}
+              id="Point"
+              onClick={this.checkOption}
+            >
+              Achievement Points
+              {this.state.current == "Point" ? (
+                this.state.currentSort == "Asc" ? (
+                  <i className="ion-android-arrow-dropup" />
+                ) : (
+                  <i className="ion-android-arrow-dropdown" />
+                )
+              ) : null}
+            </th>
+            <th style={thStyle}>Progress</th>
+          </tr>
+          <tbody>{tableInfo}</tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+class LeaderTableItem extends React.Component {
+  render() {
+    let { LeaderItemTrStyle } = styles;
+    return <tr style={LeaderItemTrStyle}>{this.props.children}</tr>;
+  }
+}
+class Leaderboard extends React.Component {
+  render() {
+    let {
+      tableStyle,
+      thStyle,
+      tdStyle,
+      trStyle,
+      divStyle,
+      pStyle,
+      LeaderItemTrStyle
+    } = styles;
+    return (
+      <div>
+        <LeaderTable />
+        <p style={pStyle}>
+          <i>Sponsored by Santander Bank</i>
+        </p>
+      </div>
+    );
+  }
+}
+
+class Filler extends React.Component {
+  constructor() {
+    super();
+    this.state = { color: null };
+    this.changeColor = this.changeColor.bind(this);
+  }
+  changeColor() {
+    const percentage = parseInt(this.props.percentage);
+    let colorValue = "";
+
+    switch (true) {
+      case percentage <= 20:
+        colorValue = "#ff6961";
+        break;
+      case percentage >= 60 && percentage <= 80:
+        colorValue = "#4dff88";
+        break;
+      case percentage >= 20 && percentage < 60:
+        colorValue = "#FF7F50";
+        break;
+    }
+    return colorValue;
+  }
+
+  render() {
+    return (
+      <div
+        className="filler"
+        style={{
+          width: `${this.props.percentage}%`,
+          background: this.changeColor()
+        }}
+      >
+        <p style={{ fontWeight: "100" }}>{this.props.percentage}</p>
+      </div>
+    );
+  }
+}
+
+//Utility functions
+function formEncode(obj) {
+  var str = [];
+  for (var p in obj)
+    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+  return str.join("&");
+}
+
+function getCookie(cname) {
+  const name = cname + "=";
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == " ") {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return "";
+}
+
+ReactDOM.render(<Leaderboard />, document.getElementById("LeaderboardPage"));

--- a/htdocs/js/apps/Leaderboard/src/app.relative.js
+++ b/htdocs/js/apps/Leaderboard/src/app.relative.js
@@ -1,0 +1,353 @@
+// Development file only.
+let user = null;
+let key = null;
+
+// uncomment the following two lines,
+// replace courseinfo.name with courseName
+// replace hard-coded leaderboard URL, 
+// and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
+// along with "compiled" version of this app.js
+
+const courseNameStr = document.getElementById('courseName').value;
+const leaderboardURL = getRootUrl(document.location) + document.getElementById('site_url').value + '/js/apps/Leaderboard/leaderboard.php';
+
+// to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
+// then uncomment this bad boy
+// const maxExperience = document.getElementByID('maxExperience').value;
+
+// instead: keep track of highest experience for the class
+var maxScore = 0;
+
+function checkCookies() {
+  const value = getCookie(`WeBWorKCourseAuthen.${courseNameStr}`); // getCookie defined at the bottom
+  user = value.split("\t")[0];
+  key = value.split("\t")[1];
+}
+if (!user & !key) {
+  checkCookies();
+}
+
+// is it possible to move this css to a leaderboard.css file?
+// along with the css styles from the Leaderboards.tmpl file?
+// place combined leaderboard.css file in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard
+
+const styles = {
+  tableStyle: {
+    width: "100%",
+    tableLayout: "fixed",
+    borderSpacing: "0px",
+    border: "1px solid #e6e6e6",
+    boxShadow:
+      "0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .2)"
+  },
+  pStyle: {
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    fontSize: "13px",
+    textAlign: "center",
+    paddingRight: "10%"
+  },
+  buttonStyle: {
+    background: "none",
+    color: "inherit",
+    border: "none",
+    padding: 0,
+    font: "inherit",
+    cursor: "pointer",
+    outline: "inherit"
+  },
+  divStyle: {
+    overflowY: "auto",
+    height: "80%",
+    width: "70%",
+    minWidth: "550px"
+  },
+  thStyle: {
+    backgroundColor: "#003388",
+    color: "white",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    padding: "15px",
+    cursor: "pointer"
+  },
+  tdStyle: {
+    textAlign: "center",
+    padding: "15px"
+  },
+  trStyle: {
+    height: "2%"
+  },
+  LeaderItemTrStyle: {
+    backgroundColor: "#f6f6f6",
+    color: "black",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontWeight: "300",
+    padding: "15px",
+    borderSpacing: "2px"
+  }
+};
+class LeaderTable extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      data: [],
+      option: null,
+      clicks: 0,
+      current: null,
+      currentSort: null
+    };
+    this.checkOption = this.checkOption.bind(this);
+  }
+
+  componentWillMount() {
+    const requestObject = {
+      user,
+      key,
+      courseName: courseNameStr // replace this with courseName
+    };
+    // The url  needs to be taken from a global environment variable
+    // This would idealy be a variable in the leaderboards.tmpl file
+    // leaderboard.php should be placed in /var/www/html/
+    // fetch("http://mathww.citytech.cuny.edu/leaderboard.php", {
+    //   method: "POST",
+    //   headers: { "Content-type": "application/x-www-form-urlencoded" },
+    //   body: formEncode(requestObject) // formEncode defined at the bottom
+    // })
+    //   .then(response => {
+    //     if (!response.ok) {
+    //       throw Error(response.statusText);
+    //     }
+    //     return response.json();
+    //   })
+    //   .then(data => {
+    //     data.forEach(item => {
+    //       if (item.achievementPoints == null) item.achievementPoints = 0;
+    //     });
+    //     this.setState({ data });
+    //   })
+    //   .catch(err => {
+    //     console.log("An error has occurred: " + err);
+    //   });
+
+    $.post(
+      leaderboardURL,
+//      "http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
+      requestObject,
+      data => {
+        data.forEach(item => {
+          if (item.achievementPoints == null) item.achievementPoints = 0;
+	  if (item.achievementPoints > maxScore) maxScore = item.achievementPoints;
+        });
+        this.setState({ data: data });
+      },
+      "json"
+    );
+  }
+  checkOption(option) {
+    this.setState({ clicks: this.state.clicks + 1 });
+    let newData = this.state.data;
+    if (option.target.id == "Earned") {
+      newData.sort(function(a, b) {
+        return (
+          parseFloat(a.achievementsEarned) - parseFloat(b.achievementsEarned)
+        );
+      });
+      if (this.state.current == "Point") this.setState({ clicks: 0 });
+    } else if (option.target.id == "Point") {
+      newData.sort(function(a, b) {
+        return (
+          parseFloat(a.achievementPoints) - parseFloat(b.achievementPoints)
+        );
+      });
+      if (this.state.current == "Earned") this.setState({ clicks: 0 });
+    }
+    if (this.state.clicks % 2 == 0) {
+      this.setState({
+        data: newData.reverse(),
+        current: option.target.id,
+        currentSort: "Desc"
+      });
+    } else {
+      this.setState({
+        data: newData,
+        current: option.target.id,
+        currentSort: "Asc"
+      });
+    }
+  }
+  renderTable() {
+    let { tdStyle } = styles;
+    let tableInfo = [];
+    if (this.state.data.length > 0) {
+      for (var i = 0; i < this.state.data.length; i++) {
+        var current = this.state.data[i];
+        tableInfo.push(
+          <LeaderTableItem>
+            <td className="tdStyleLB">
+              {current.username ? current.username : current.id}
+            </td>
+            <td className="tdStyleLB">{current.achievementsEarned}</td>
+            <td className="tdStyleLB">
+              {current.achievementPoints ? current.achievementPoints : 0}
+            </td>
+            <td className="tdStyleLB">
+              <Filler percentage={Math.floor((current.achievementPoints / maxScore) * 1000)/10} score={current.achievementPoints} />
+            </td>
+          </LeaderTableItem>
+        );
+      }
+    }
+
+    return tableInfo;
+  }
+  render() {
+    let { tableStyle, thStyle, tdStyle, trStyle, divStyle, pStyle } = styles;
+    let tableInfo = this.renderTable();
+
+    return (
+      <div className="divStyleLB">
+        <table className="tableStyleLB">
+          <tbody><tr className="trStyleLB">
+            <th id="username" className="thStyleLB">
+              Username
+            </th>
+            <th
+              className="sortButtons thStyleLB"
+              style={thStyle}
+              id="Earned"
+              onClick={this.checkOption}
+            >
+              Achievements Earned
+              {this.state.current == "Earned" ? (
+                this.state.currentSort == "Asc" ? (
+                  <i className="ion-android-arrow-dropup" />
+                ) : (
+                  <i className="ion-android-arrow-dropdown" />
+                )
+              ) : null}
+            </th>
+            <th
+              className="sortButtons thStyleLB"
+              style={thStyle}
+              id="Point"
+              onClick={this.checkOption}
+            >
+              Achievement Points
+              {this.state.current == "Point" ? (
+                this.state.currentSort == "Asc" ? (
+                  <i className="ion-android-arrow-dropup" />
+                ) : (
+                  <i className="ion-android-arrow-dropdown" />
+                )
+              ) : null}
+            </th>
+            <th className="thStyleLB">Progress</th>
+          </tr></tbody>
+          <tbody>{tableInfo}</tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+class LeaderTableItem extends React.Component {
+  render() {
+    let { LeaderItemTrStyle } = styles;
+    return <tr className="LeaderItemTr">{this.props.children}</tr>;
+  }
+}
+class Leaderboard extends React.Component {
+  render() {
+    let {
+      tableStyle,
+      thStyle,
+      tdStyle,
+      trStyle,
+      divStyle,
+      pStyle,
+      LeaderItemTrStyle
+    } = styles;
+    return (
+      <div>
+        <LeaderTable />
+        <p className="pStyleLB">
+          <i>Sponsored by Santander Bank</i>
+        </p>
+      </div>
+    );
+  }
+}
+
+class Filler extends React.Component {
+  constructor() {
+    super();
+    this.state = { color: null };
+    this.changeColor = this.changeColor.bind(this);
+  }
+  changeColor() {
+    const percentage = parseInt(this.props.percentage);
+    let colorValue = "";
+
+    switch (true) {
+      case percentage < 20:
+        colorValue = "#ff6961";
+        break;
+      case percentage >= 20 && percentage < 40:
+        colorValue = "#FF7F50";
+        break;
+      case percentage >= 40 && percentage < 60:
+        colorValue = "#fada5e";
+        break;
+      case percentage >= 60 && percentage < 80:
+        colorValue = "#aedb30";
+        break;
+      case percentage >= 80:
+        colorValue = "#4dff88";
+        break;
+    }
+    return colorValue;
+  }
+
+  render() {
+    return (
+      <div
+        className="filler"
+        style={{
+          width: `${this.props.percentage}%`,
+          background: this.changeColor()
+        }}
+      >
+        <p style={{ fontWeight: "100" }}>{this.props.score}</p>
+      </div>
+    );
+  }
+}
+
+//Utility functions
+function formEncode(obj) {
+  var str = [];
+  for (var p in obj)
+    str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+  return str.join("&");
+}
+
+function getCookie(cname) {
+  const name = cname + "=";
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(";");
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == " ") {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return "";
+}
+
+function getRootUrl(url) {
+  return url.toString().replace(/^(.*\/\/[^\/?#]*).*$/,"$1");
+}
+
+ReactDOM.render(<Leaderboard />, document.getElementById("LeaderboardPage"));

--- a/htdocs/js/apps/Leaderboard/src/app.relative.js
+++ b/htdocs/js/apps/Leaderboard/src/app.relative.js
@@ -4,12 +4,15 @@ let key = null;
 
 // uncomment the following two lines,
 // replace courseinfo.name with courseName
-// replace hard-coded leaderboard URL, 
+// replace hard-coded leaderboard URL,
 // and place leaderboard.php in /opt/webwork/webwork2/htdocs/js/apps/Leaderboard/
 // along with "compiled" version of this app.js
 
-const courseNameStr = document.getElementById('courseName').value;
-const leaderboardURL = getRootUrl(document.location) + document.getElementById('site_url').value + '/js/apps/Leaderboard/leaderboard.php';
+const courseNameStr = document.getElementById("courseName").value;
+const leaderboardURL =
+  getRootUrl(document.location) +
+  document.getElementById("site_url").value +
+  "/js/apps/Leaderboard/leaderboard.php";
 
 // to do: construct maxExperience in Leaderboards.pm and stash it in id='maxExperience'
 // then uncomment this bad boy
@@ -130,12 +133,14 @@ class LeaderTable extends React.Component {
 
     $.post(
       leaderboardURL,
-//      "http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
+      //      "http://mathww.citytech.cuny.edu/leaderboard.php", // replace this with leaderboardURL
       requestObject,
       data => {
         data.forEach(item => {
           if (item.achievementPoints == null) item.achievementPoints = 0;
-	  if (item.achievementPoints > maxScore) maxScore = item.achievementPoints;
+
+          if (parseInt(item.achievementPoints) > maxScore)
+            maxScore = item.achievementPoints;
         });
         this.setState({ data: data });
       },
@@ -190,7 +195,12 @@ class LeaderTable extends React.Component {
               {current.achievementPoints ? current.achievementPoints : 0}
             </td>
             <td className="tdStyleLB">
-              <Filler percentage={Math.floor((current.achievementPoints / maxScore) * 1000)/10} score={current.achievementPoints} />
+              <Filler
+                percentage={
+                  Math.floor((current.achievementPoints / maxScore) * 1000) / 10
+                }
+                score={current.achievementPoints}
+              />
             </td>
           </LeaderTableItem>
         );
@@ -206,42 +216,44 @@ class LeaderTable extends React.Component {
     return (
       <div className="divStyleLB">
         <table className="tableStyleLB">
-          <tbody><tr className="trStyleLB">
-            <th id="username" className="thStyleLB">
-              Username
-            </th>
-            <th
-              className="sortButtons thStyleLB"
-              style={thStyle}
-              id="Earned"
-              onClick={this.checkOption}
-            >
-              Achievements Earned
-              {this.state.current == "Earned" ? (
-                this.state.currentSort == "Asc" ? (
-                  <i className="ion-android-arrow-dropup" />
-                ) : (
-                  <i className="ion-android-arrow-dropdown" />
-                )
-              ) : null}
-            </th>
-            <th
-              className="sortButtons thStyleLB"
-              style={thStyle}
-              id="Point"
-              onClick={this.checkOption}
-            >
-              Achievement Points
-              {this.state.current == "Point" ? (
-                this.state.currentSort == "Asc" ? (
-                  <i className="ion-android-arrow-dropup" />
-                ) : (
-                  <i className="ion-android-arrow-dropdown" />
-                )
-              ) : null}
-            </th>
-            <th className="thStyleLB">Progress</th>
-          </tr></tbody>
+          <tbody>
+            <tr className="trStyleLB">
+              <th id="username" className="thStyleLB">
+                Username
+              </th>
+              <th
+                className="sortButtons thStyleLB"
+                style={thStyle}
+                id="Earned"
+                onClick={this.checkOption}
+              >
+                Achievements Earned
+                {this.state.current == "Earned" ? (
+                  this.state.currentSort == "Asc" ? (
+                    <i className="ion-android-arrow-dropup" />
+                  ) : (
+                    <i className="ion-android-arrow-dropdown" />
+                  )
+                ) : null}
+              </th>
+              <th
+                className="sortButtons thStyleLB"
+                style={thStyle}
+                id="Point"
+                onClick={this.checkOption}
+              >
+                Achievement Points
+                {this.state.current == "Point" ? (
+                  this.state.currentSort == "Asc" ? (
+                    <i className="ion-android-arrow-dropup" />
+                  ) : (
+                    <i className="ion-android-arrow-dropdown" />
+                  )
+                ) : null}
+              </th>
+              <th className="thStyleLB">Progress</th>
+            </tr>
+          </tbody>
           <tbody>{tableInfo}</tbody>
         </table>
       </div>
@@ -347,7 +359,7 @@ function getCookie(cname) {
 }
 
 function getRootUrl(url) {
-  return url.toString().replace(/^(.*\/\/[^\/?#]*).*$/,"$1");
+  return url.toString().replace(/^(.*\/\/[^\/?#]*).*$/, "$1");
 }
 
 ReactDOM.render(<Leaderboard />, document.getElementById("LeaderboardPage"));

--- a/htdocs/js/apps/Problem/problem.js
+++ b/htdocs/js/apps/Problem/problem.js
@@ -1,7 +1,7 @@
 $(function() {    
-    // Cause achievement popups to appear and then go away 
+    // Cause achievement popups to appear and then go away
     $(window).load(function() { $('#achievementModal').modal('show');
-				setTimeout(function(){$('#achievementModal').modal('hide');},5000);
+				setTimeout(function(){$('#achievementModal').modal('hide');},120000);
 			      });
     
     // Prevent problems which are disabled from acting as links

--- a/htdocs/themes/math4/achievements.css
+++ b/htdocs/themes/math4/achievements.css
@@ -12,19 +12,20 @@
 }
 
 .levelbox {
-    height:100px;
+    height:200px;
     margin-bottom:30px;
 }
 
 .levelbox img {
     float:left;
-    height:100px;
-    width:100px;
+    height:200px;
+    width:200px;
 }
 
 .leveldatabox {
     margin-left:20px;
     float:left;
+    margin-top:30px;
 }
 
 .leveldatabox h1 {
@@ -105,6 +106,18 @@
     width:50%;
 }
 
+.cheevopopupinner {
+    width:100%;
+    height:75px;
+    margin-bottom:5px;
+}
+
+.cheevopopupinner img {
+    float:left;
+    height:75px;
+    width:75px;
+}
+
 .cheevopopupouter {
     margin-bottom:10px;
     margin-right:15px;
@@ -122,7 +135,7 @@
 }
 
 .cheevopopuptext h1 {
-    margin-top:0px;
+    margin-top:5px;
     margin-bottom:5px;
     font-size:20px;
     font-weight:bold;

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -257,24 +257,37 @@ sub checkForAchievements {
 			$imgSrc .= $ce->{webworkURLs}->{htdocs}."/images/defaulticon.png";
 	    }
 
-	    $cheevoMessage .=  CGI::start_div({id=>"test", class=>'cheevopopupouter modal-body'});
+#	    $cheevoMessage .=  CGI::start_div({class=>'modal-header'});
+#	    $cheevoMessage .=  CGI::h5({class=>'modal-title',id=>'modalLabel'},"You Earned an Achievement!");
+#	    $cheevoMessage .=  '<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+#          <span aria-hidden="true">&times;</span>
+#        </button>';
+	    if (!$cheevoMessage){
+	            $cheevoMessage .=  CGI::start_div({class=>'modal-header'});
+        	    $cheevoMessage .=  CGI::a({href=>"#",class=>"close","data-dismiss"=>"modal", "aria-hidden"=>"true"},CGI::span({class=>"icon icon-remove"}),CGI::div({class=>"sr-only"},$r->maketext("Close")));
+	            $cheevoMessage .=  CGI::h3({id=>"modalLabel"},"You Earned an Achievement!");
+		    $cheevoMessage .=  CGI::end_div();
+		    $cheevoMessage .=  CGI::start_div({class=>'modal-body cheevopopupouter'});
+	    } # initialize cheevo-modal with a header - start body for multiple cheevos
+	    $cheevoMessage .=  CGI::start_div({class=>'cheevopopupinner'});
 	    $cheevoMessage .=  CGI::img({src=>$imgSrc, alt=>'Achievement Icon'});
-	    $cheevoMessage .= CGI::start_div({class=>'cheevopopuptext'});  
+	    $cheevoMessage .=  CGI::start_div({class=>'cheevopopuptext'});  
 	    if ($achievement->category eq 'level') {
 		
-			$cheevoMessage = $cheevoMessage . CGI::h2("$achievement->{name}");
+			$cheevoMessage = $cheevoMessage . CGI::h1("$achievement->{name}");
 			#print out description as part of message if we are using items
 			
 			$cheevoMessage .= CGI::div($ce->{achievementItemsEnabled} ?  $achievement->{description} : $r->maketext("Congratulations, you earned a new level!"));
-			$cheevoMessage .= CGI::end_div();
 
 	    } else {
 		
-			$cheevoMessage .=  CGI::h2("$achievement->{name}");
+			$cheevoMessage .=  CGI::h1("$achievement->{name}");
 			$cheevoMessage .=  CGI::div("<i>$achievement->{points} Points</i>: $achievement->{description}");
-			$cheevoMessage .= CGI::end_div();
 	    }
-	    
+
+	    $cheevoMessage .= CGI::end_div(); # end cheevopopuptext
+	    $cheevoMessage .= CGI::end_div(); # end cheevopopupinner
+
 	    # this feature doesn't really work anymore because
 	    # of a change in facebooks api
 	    #if facebook integration is enables then create a facebook popup
@@ -296,9 +309,7 @@ sub checkForAchievements {
 			$cheevoMessage .= CGI::end_script();
 
 	    }
-	        
-	    $cheevoMessage .= CGI::end_div();
-	    
+
 	        
 	    my $points = $achievement->points;
 	    #just in case points is an ininitialzied variable
@@ -321,8 +332,13 @@ sub checkForAchievements {
     $globalUserAchievement->frozen_hash(nfreeze($globalData));
     $db->putGlobalUserAchievement($globalUserAchievement);
 
+    # if a message has been created, end the body and add footer
     if ($cheevoMessage) {
-	$cheevoMessage = CGI::div({id=>"achievementModal", class=>"modal hide fade"},$cheevoMessage);
+	$cheevoMessage .= CGI::end_div(); # end modal-body cheevopopupouter
+	$cheevoMessage .= CGI::div({class=>"modal-footer"},'<button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>');
+#	$cheevoMessage = CGI::div({class=>"modal-content"},$cheevoMessage);
+#	$cheevoMessage = CGI::div({class=>"modal-dialog", role=>"document"},$cheevoMessage);
+	$cheevoMessage = CGI::div({id=>"achievementModal", class=>"modal hide fade in", tabindex=>"-1", role=>"dialog", 'aria-labeledby'=>"modalLabel", 'aria-hidden'=>"true"},$cheevoMessage);
     }
 
     return $cheevoMessage;
@@ -330,3 +346,5 @@ sub checkForAchievements {
 
 #Perl magic
 1;
+
+

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -776,6 +776,7 @@ sub links {
 			
 			if ($ce->{achievementsEnabled}) {
 			    print CGI::li(&$makelink("${pfx}Achievements", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args)); 
+				print CGI::li(&$makelink("${pfx}Leaderboards", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args)); 
 
 			}
 

--- a/lib/WeBWorK/ContentGenerator/Leaderboards.pm
+++ b/lib/WeBWorK/ContentGenerator/Leaderboards.pm
@@ -109,6 +109,8 @@ sub head {
 
 	print "<link crossorigin=\"anonymous\" media=\"all\" href=\"https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css\" rel=\"stylesheet\" />";
 
+	print "<link href=\"https://fonts.googleapis.com/css?family=Luckiest+Guy|Aldrich|Rubik:mediumitalic,bolditalic\" rel=\"stylesheet\" />";
+
 	return "";
 }
 
@@ -188,10 +190,12 @@ sub body {
 
 	my $courseName = $ce->{courseName};
 	my $site_url = $ce->{webworkURLs}->{htdocs};
+	my $achievementPPP = $ce->{achievementPointsPerProblem};
 
 	# stash the courseName for use in js later...
 	print "<input type=\"hidden\" id=\"courseName\" value=\"$courseName\">";
 	print "<input type=\"hidden\" id=\"site_url\" value=\"$site_url\">";
+	print "<input type=\"hidden\" id=\"achievementPPP\" value=\"$achievementPPP\">";
 
 	# this is a place where the maximum achievement points may be calculated
 	# then stash the max value in a hidden input field for js to access...
@@ -199,7 +203,7 @@ sub body {
 	# print the leaderboard div and call the js to fill it in
 	print CGI::div({id=>'LeaderboardPage'});
 
-	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Leaderboard/leaderboard.rel.js"}), CGI::end_script();
+	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Leaderboard/leaderboard.js"}), CGI::end_script();
 
   return "";
 

--- a/lib/WeBWorK/ContentGenerator/Leaderboards.pm
+++ b/lib/WeBWorK/ContentGenerator/Leaderboards.pm
@@ -1,0 +1,207 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Skeleton.pm,v 1.5 2006/07/08 14:07:34 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+# SKEL: Welcome to the ContentGenerator skeleton!
+# 
+# This module is designed to help you in creating subclasses of
+# WeBWorK::ContentGenerator. Follow the instructions marked "SKEL" below to
+# create your very own module.
+# 
+# When you've finished, I recommend you do some cleanup. These modules are much
+# easier to maintain if they doesn't contain "vestigal" garbage code. Remove the
+# "SKEL" comments and anything else that that you're not using in your module.
+
+# SKEL: Declare the name and superclass of your module here:
+package WeBWorK::ContentGenerator::Leaderboards;
+use base qw(WeBWorK::ContentGenerator);
+
+# SKEL: change the name of the module below and provide a short description. Add
+# additional POD documentation as you see fit.
+
+=head1 Leaderboards
+
+WeBWorK::ContentGenerator::Skeleton - Template for creating subclasses of
+WeBWorK::ContentGenerator.
+
+=cut
+
+use strict;
+use warnings;
+use WeBWorK::CGI;
+use HTML::Template;
+use JSON qw(encode_json);
+
+# SKEL: Add "use" lines for libraries you will be using here. Note that you only
+# need to add a "use" line here if you will be instantiating now objects or
+# calling free functions. If you have an existing instance (like $self->r) you
+# can use it without a corresponding "use" line. Sample lines are given below:
+# 
+# You'll probably want to generate HTML code:
+#use CGI qw(-nosticky );
+# 
+# You might need some utility functions:
+#use WeBWorK::Utils qw(function1 function2);
+
+# SKEL: If you need to do any processing before the HTTP header is sent, do it
+# in this method:
+# 
+sub pre_header_initialize {
+	my ($self) = @_;
+	my $r              = $self->r;
+	my $ce             = $r->ce;
+	
+	# Do your processing here! Don't print or return anything -- store data in
+	# the self hash for later retrieveal.
+}
+
+# SKEL: To emit your own HTTP header, uncomment this:
+# 
+#sub header {
+#	my ($self) = @_;
+#	
+#	# Generate your HTTP header here.
+#	
+#	# If you return something, it will be used as the HTTP status code for this
+#	# request. The Apache::Constants module might be useful for gerating status
+#	# codes. If you don't return anything, the status code "OK" will be used.
+#	return "";
+#}
+
+# SKEL: If you need to do any processing after the HTTP header is sent, but before
+# any template processing occurs, or you need to calculate values that will be
+# used in multiple methods, do it in this method:
+# 
+#sub initialize {
+#	my ($self) = @_;
+#	
+#	# Do your processing here! Don't print or return anything -- store data in
+#	# the self hash for later retrieveal.
+#}
+
+# SKEL: If you need to add tags to the document <HEAD>, uncomment this method:
+# 
+sub head {
+	my ($self) = @_;
+	my $r              = $self->r;
+	my $ce             = $r->ce;
+	my $site_url = $ce->{webworkURLs}->{htdocs};
+
+	print CGI::start_script({type=>"text/javascript", src=>"https://fb.me/react-15.0.0.js"}), CGI::end_script();
+
+	print CGI::start_script({type=>"text/javascript", src=>"https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.34/browser.min.js"}), CGI::end_script();
+
+	print CGI::start_script({type=>"text/javascript", src=>"https://fb.me/react-dom-15.0.0.js"}), CGI::end_script();
+
+	print "<link href=\"$site_url/js/apps/Leaderboard/leaderboard.css\" rel=\"stylesheet\" />";
+
+	print "<link crossorigin=\"anonymous\" media=\"all\" href=\"https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css\" rel=\"stylesheet\" />";
+
+	return "";
+}
+
+# SKEL: To fill in the "info" box (to the right of the main body), use this
+# method:
+# 
+#sub info {
+#	my ($self) = @_;
+#	
+#	# Print HTML here.
+#	
+#	return "";
+#}
+
+# SKEL: To provide navigation links, use this method:
+# 
+#sub nav {
+#	my ($self, $args) = @_;
+#	
+#	# See the documentation of path() and pathMacro() in
+#	# WeBWorK::ContentGenerator for more information.
+#	
+#	return "";
+#}
+
+# SKEL: For a little box for display options, etc., use this method:
+# 
+#sub options {
+#	my ($self) = @_;
+#	
+#	# Print HTML here.
+#	
+#	return "";
+#}
+
+# SKEL: For a list of sibling objects, use this method:
+# 
+#sub siblings {
+#	my ($self, $args) = @_;
+#	
+#	# See the documentation of siblings() and siblingsMacro() in
+#	# WeBWorK::ContentGenerator for more information.
+#	# 
+#	# Refer to implementations in ProblemSet and Problem.
+#	
+#	return "";
+#}
+
+# SKEL: Okay, here's the body. Most of your stuff will go here:
+# 
+sub body {
+	my ($self) = @_;
+	
+	# SKEL: Useful things from the superclass:
+	# 
+	# The WeBWorK::Request object. Good for accessing request params and so on.
+	my $r = $self->r;
+	# 
+	# Do you need data from the course environment?
+	my $ce = $r->ce;
+	# 
+	# Will you be accessing the database?
+	my $db = $r->db;
+	# 
+	# Query authorization:
+	#my $authz = $r->authz;
+	# 
+	# The WeBWorK::URLPath object. Necessary for getting/generating URL data:
+	#my $urlpath = $r->urlpath;
+	
+	# FIXME: Add more examples of common idioms, mention WeBWorK::HTML::*
+	# classes, refer to superclass methods.
+	
+	# SKEL: Print your content here!
+	
+	#return "<a href='http://localhost/webwork2/MAT1275EN-S18-Parker/Leaderboards.html'>Leaderboards</a>";
+
+	my $courseName = $ce->{courseName};
+	my $site_url = $ce->{webworkURLs}->{htdocs};
+
+	# stash the courseName for use in js later...
+	print "<input type=\"hidden\" id=\"courseName\" value=\"$courseName\">";
+	print "<input type=\"hidden\" id=\"site_url\" value=\"$site_url\">";
+
+	# this is a place where the maximum achievement points may be calculated
+	# then stash the max value in a hidden input field for js to access...
+
+	# print the leaderboard div and call the js to fill it in
+	print CGI::div({id=>'LeaderboardPage'});
+
+	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/Leaderboard/leaderboard.rel.js"}), CGI::end_script();
+
+  return "";
+
+}
+1;

--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright ï¿½ 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Options.pm,v 1.24 2006/07/24 23:28:41 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -55,6 +55,7 @@ sub body {
 	my $newP = $r->param("newPassword");
 	my $confirmP = $r->param("confirmPassword");
 	my $newA = $r->param("newAddress");
+	my $newName = $r->param("newName");
 		
 	print CGI::start_form(-method=>"POST", -action=>$r->uri);
 	print $self->hidden_authen_fields;
@@ -197,7 +198,52 @@ sub body {
 		print CGI::p($r->maketext("You do not have permission to change email addresses."))
 			unless $changeOptions and $newA; # avoid double message
 	}
+
+
+	print CGI::h2($r->maketext("Change Display Name"));
 	
+		# changing display name
+	if ($changeOptions and $newName) {
+		if ($authz->hasPermissions($userID, "change_email_address")) {
+			
+			my $oldName = $EUser->comment;
+			$EUser->comment($newName);
+			eval { $db->putUser($EUser) };
+			if ($@) {
+				$EUser->comment($oldName);
+				print CGI::div({class=>"ResultsWithError",tabindex=>'-1'},
+					CGI::p($r->maketext("Couldn't change your display name: [_1]",$@)),
+				);
+			} else {
+				print CGI::div({class=>"ResultsWithoutError"},
+					CGI::p($r->maketext("Your display name has been changed.")),
+				);
+			}
+			
+		} else {
+			print CGI::div({class=>"ResultsWithError",tabindex=>'-1'},
+				CGI::p($r->maketext("You do not have permission to change your display name.")),
+			);
+		}
+	}
+
+# Creating form to change display name
+	if ($authz->hasPermissions($userID, "change_email_address")) {
+		print CGI::table({class=>"FormLayout"},
+			CGI::Tr({},
+				CGI::td(CGI::label({'for' => 'currName'},$r->maketext("[_1]'s Current Display Name",$e_user_name))),
+				CGI::td(CGI::input({ type=>"text", readonly=>"true", id=>"currName", name=>"currName", value=>$EUser->comment})),
+			),
+			CGI::Tr({},
+				CGI::td(CGI::label({'for'=>'newName'},$r->maketext("[_1]'s New Name",$e_user_name))),
+#				CGI::td(CGI::textfield(-name=>"newAddress", -text=>$newA)),
+				CGI::td(CGI::textfield(-name=>"newName",-id,=>"newName")),
+			),
+		);
+	} else {
+		print CGI::p($r->maketext("You do not have permission to change display name."))
+			unless $changeOptions and $newName; # avoid double message
+	}
 
 	
 	print CGI::h2($r->maketext("Change Display Settings"));

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The openWeBWorK Project, http://github.com/openwebwork
+# Copyright ï¿½ 2000-2012 The openWeBWorK Project, http://github.com/openwebwork
 # $CVSHeader: webwork2/lib/WeBWorK/URLPath.pm,v 1.36 2008/04/29 19:27:34 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -206,7 +206,7 @@ our %pathTypes = (
 	set_list => {
 		name    => '[_4]',
 		parent  => 'root',
-		kids    => [ qw/equation_display feedback gateway_quiz proctored_gateway_quiz answer_log grades hardcopy achievements
+		kids    => [ qw/equation_display feedback gateway_quiz proctored_gateway_quiz answer_log grades hardcopy achievements leaderboards
 			logout options instructor_tools problem_list
 		/ ],
 		match   => qr|^([^/]+)/|,
@@ -291,6 +291,17 @@ our %pathTypes = (
                 produce => 'achievements/',
                 display => 'WeBWorK::ContentGenerator::Achievements',
         },
+
+		leaderboards  => {
+	        name    => x('Leaderboards'),
+                parent  => 'set_list',
+                kids    => [ qw// ],
+                match   => qr|^leaderboards/|,
+                capture => [ qw// ],
+                produce => 'leaderboards/',
+                display => 'WeBWorK::ContentGenerator::Leaderboards',
+        },
+
 	hardcopy => {
 		name    => x('Hardcopy Generator'),
 		parent  => 'set_list',


### PR DESCRIPTION
Let's try this again:

Based on an externally-funded student intern research project, this branch adds a leaderboard page when Achievements are enabled within a given course. (the sponsor message is necessary for display at our institution, but can be easily configured out if this feature is included in release)

Students select their own display names in "user settings" - which are then stored (for now) in the comment field of the user table. 

Student "progress" is currently measured relative to the highest score present in the course. Future updates will make the final column of the leaderboard table relative to the maximum possible score for the course (once I figure out how to raid the DB for all the values I need: total number of problems present in the course, even unassigned; and the sum of achievement points available for all enabled achievements).

One small pre-config is necessary: htdocs/js/apps/Leaderboard/leaderboard.php must be updated with a username and password for a mySQL account with read access to webwork. This php script checks that the request is coming from a user who is logged into WeBWorK before replying. 

I guess you should probably have php installed as well ;)