### PR TITLE
Develop fix copyright

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 
 $WW_VERSION = 'WeBWorK-2.14';
 $WW_COPYRIGHT_YEARS = '1996-2019';
+=======
+$WW_VERSION = 'WeBWorK-2.14';
+$WW_COPYRIGHT_YEARS = '1996-2018';
+>>>>>>> dfa54fad7... Changed copyright date and symbol (use &copy;)
 
 1;

--- a/VERSION
+++ b/VERSION
@@ -1,10 +1,4 @@
-<<<<<<< HEAD
-
-$WW_VERSION = 'WeBWorK-2.14';
+$WW_VERSION = 'develop';
 $WW_COPYRIGHT_YEARS = '1996-2019';
-=======
-$WW_VERSION = 'WeBWorK-2.14';
-$WW_COPYRIGHT_YEARS = '1996-2018';
->>>>>>> dfa54fad7... Changed copyright date and symbol (use &copy;)
 
 1;

--- a/bin/addcourse
+++ b/bin/addcourse
@@ -1,8 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/bin/addcourse,v 1.20 2006/12/09 03:29:56 sh002i Exp $
+# Copyright &copy; 2000-2018 The WeBWorK Project, https://github.com/openwebwork
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/bin/check_latex.tex
+++ b/bin/check_latex.tex
@@ -1,6 +1,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % WeBWorK Online Homework Delivery System
-% Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+% Copyright Â© 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 % $CVSHeader: webwork2/bin/check_latex.tex,v 1.2 2004/10/06 21:09:33 gage Exp $
 % 
 % This program is free software; you can redistribute it and/or modify it under

--- a/bin/delcourse
+++ b/bin/delcourse
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/delcourse,v 1.4 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/dump_past_answers
+++ b/bin/dump_past_answers
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb,v 1.13 2006/01/25 23:13:45 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/integrity_check.pl
+++ b/bin/integrity_check.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb_upgrade,v 1.17 2007/08/13 22:59:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/newpassword
+++ b/bin/newpassword
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/newpassword,v 1.3 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/old_scripts/timing
+++ b/bin/old_scripts/timing
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/timing,v 1.5 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/old_scripts/wwaddindexing
+++ b/bin/old_scripts/wwaddindexing
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwaddindexing,v 1.3 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/old_scripts/wwdb_addgw
+++ b/bin/old_scripts/wwdb_addgw
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb_addgw,v 1.3 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/old_scripts/wwdb_check
+++ b/bin/old_scripts/wwdb_check
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb_check,v 1.7 2006/08/14 17:23:56 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/old_scripts/wwdb_upgrade
+++ b/bin/old_scripts/wwdb_upgrade
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb_upgrade,v 1.16 2007/07/22 05:24:20 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/pg-append-textbook-tags
+++ b/bin/pg-append-textbook-tags
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/pg-append-textbook-tags,v 1.1 2007/10/17 16:56:16 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/pg-find-tags
+++ b/bin/pg-find-tags
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/pg-find-tags,v 1.1 2007/10/17 16:56:16 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/pg-pull
+++ b/bin/pg-pull
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/pg-pull,v 1.3 2007/10/22 20:32:38 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/remove_stale_images
+++ b/bin/remove_stale_images
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/remove_stale_images,v 1.7 2008/06/24 22:54:03 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/newpassword,v 1.3 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/update-OPL-statistics
+++ b/bin/update-OPL-statistics
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb,v 1.13 2006/01/25 23:13:45 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/upgrade_admin_db.pl
+++ b/bin/upgrade_admin_db.pl
@@ -2,7 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb,v 1.13 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/upload-OPL-statistics
+++ b/bin/upload-OPL-statistics
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb,v 1.13 2006/01/25 23:13:45 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/wwapache2ctl.dist
+++ b/bin/wwapache2ctl.dist
@@ -1,7 +1,7 @@
 #!/bin/sh
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwapache2ctl.dist,v 1.3 2007/08/13 22:59:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/wwapachectl.dist
+++ b/bin/wwapachectl.dist
@@ -1,7 +1,7 @@
 #!/bin/sh
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwapachectl.dist,v 1.17 2006/05/31 18:25:18 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/wwdb
+++ b/bin/wwdb
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwdb,v 1.13 2006/01/25 23:13:45 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/bin/wwsh
+++ b/bin/wwsh
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/wwsh,v 1.10 2006/05/31 01:07:25 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/conf/database.conf.dist
+++ b/conf/database.conf.dist
@@ -1,7 +1,7 @@
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/database.conf.dist,v 1.38 2007/08/13 22:59:51 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1,7 +1,7 @@
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/defaults.config,v 1.225 2010/05/18 18:03:31 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -1,7 +1,7 @@
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/site.conf.dist,v 1.225 2010/05/18 18:03:31 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/courses.dist/modelCourse/course.conf
+++ b/courses.dist/modelCourse/course.conf
@@ -1,7 +1,7 @@
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/htdocs/helpFiles/Grades.html
+++ b/htdocs/helpFiles/Grades.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/Grades.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -17,6 +17,7 @@
 ################################################################################
 -->
 <head>
+<meta charset="utf-8" />
 <title>Student Grades Help Page</title>
 </head>
 

--- a/htdocs/helpFiles/InstructorAddUsers.html
+++ b/htdocs/helpFiles/InstructorAddUsers.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorAddUsers.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>Add User Help Page</title>
 </head>
 

--- a/htdocs/helpFiles/InstructorAssigner.html
+++ b/htdocs/helpFiles/InstructorAssigner.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorAssigner.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -17,6 +17,7 @@
 ################################################################################
 -->
 <head>
+<meta charset="utf-8" />
 <title>Set Assigner Help Page</title>
 </head>
 

--- a/htdocs/helpFiles/InstructorConfig.html
+++ b/htdocs/helpFiles/InstructorConfig.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorConfig.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>Course Configuration Help Page</title>
 </head>
 <body>

--- a/htdocs/helpFiles/InstructorFileManager.html
+++ b/htdocs/helpFiles/InstructorFileManager.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorFileManager.html,v 1.3 2006/08/26 17:42:51 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>File Manager Help Page</title>
 </head>
 

--- a/htdocs/helpFiles/InstructorFileTransfer.html
+++ b/htdocs/helpFiles/InstructorFileTransfer.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorFileTransfer.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>File Transfer Help Page</title>
 </head>
 

--- a/htdocs/helpFiles/InstructorIndex.html
+++ b/htdocs/helpFiles/InstructorIndex.html
@@ -6,7 +6,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorIndex.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -22,6 +22,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>Instructor Tools Help Page</title>
 </head>
 <body>

--- a/htdocs/helpFiles/InstructorPGProblemEditor.html
+++ b/htdocs/helpFiles/InstructorPGProblemEditor.html
@@ -6,7 +6,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorPGProblemEditor.html,v 1.4 2007/08/13 22:59:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -22,6 +22,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>PG Problem Editor Help Page</title>
 </head>
 <body>

--- a/htdocs/helpFiles/InstructorProblemSetDetail.html
+++ b/htdocs/helpFiles/InstructorProblemSetDetail.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorProblemSetDetail.html,v 1.4 2006/07/18 16:33:12 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorProblemSetDetail2.html
+++ b/htdocs/helpFiles/InstructorProblemSetDetail2.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorProblemSetDetail.html,v 1.4 2006/07/18 16:33:12 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorProblemSetList.html
+++ b/htdocs/helpFiles/InstructorProblemSetList.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorProblemSetList.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorScoring.html
+++ b/htdocs/helpFiles/InstructorScoring.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorScoring.html,v 1.3 2007/08/13 22:59:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorSendMail.html
+++ b/htdocs/helpFiles/InstructorSendMail.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorSendMail.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorSetMaker.html
+++ b/htdocs/helpFiles/InstructorSetMaker.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorSetMaker.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorStats.html
+++ b/htdocs/helpFiles/InstructorStats.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorStats.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorUserDetail.html
+++ b/htdocs/helpFiles/InstructorUserDetail.html
@@ -6,7 +6,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorUserDetail.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorUserList.html
+++ b/htdocs/helpFiles/InstructorUserList.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorUserList.html,v 1.4 2007/08/13 22:59:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/InstructorUsersAssignedToSet.html
+++ b/htdocs/helpFiles/InstructorUsersAssignedToSet.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorUsersAssignedToSet.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/Levels.html
+++ b/htdocs/helpFiles/Levels.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/InstructorSetMaker.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/Options.html
+++ b/htdocs/helpFiles/Options.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/Options.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/ProblemSets.html
+++ b/htdocs/helpFiles/ProblemSets.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/ProblemSets.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/Problems.html
+++ b/htdocs/helpFiles/Problems.html
@@ -2,7 +2,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/Problems.html,v 1.2 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/helpFiles/instructor_links.html
+++ b/htdocs/helpFiles/instructor_links.html
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/instructor_links.html,v 1.6 2007/08/13 22:59:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -21,6 +21,7 @@
 -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
 <head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>Instructor Links Help Page</title>
 </head>
 <body>

--- a/htdocs/helpFiles/no_help.html
+++ b/htdocs/helpFiles/no_help.html
@@ -4,7 +4,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/htdocs/helpFiles/no_help.html,v 1.3 2006/01/25 23:13:50 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math3/gateway.template
+++ b/htdocs/themes/math3/gateway.template
@@ -3,7 +3,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/gateway.template,v 1.1.2.1 2008/06/24 17:17:36 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math3/system.template
+++ b/htdocs/themes/math3/system.template
@@ -4,7 +4,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math4-ar/gateway.template
+++ b/htdocs/themes/math4-ar/gateway.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/htdocs/themes/math4-ar/simple.template
+++ b/htdocs/themes/math4-ar/simple.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math4-ar/system.template
+++ b/htdocs/themes/math4-ar/system.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -9,7 +9,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/unsupported-themes/math2/gateway.template
+++ b/htdocs/unsupported-themes/math2/gateway.template
@@ -3,7 +3,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/conf/templates/math2/gateway.template,v 1.1.2.1 2008/06/24 17:17:36 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/htdocs/unsupported-themes/ubc/gateway.template
+++ b/htdocs/unsupported-themes/ubc/gateway.template
@@ -5,7 +5,7 @@
 <!--
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: gateway.template $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/Apache/AuthenWeBWorK.pm
+++ b/lib/Apache/AuthenWeBWorK.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/Apache/AuthenWeBWorK.pm,v 1.2 2006/06/28 16:19:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -2,7 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WebworkClient.pm,v 1.1 2010/06/08 11:46:38 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/PG.pm,v 1.76 2009/07/18 02:52:51 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/PG.pm,v 1.76 2009/07/18 02:52:51 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen.pm,v 1.63 2012/06/06 22:03:15 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/Basic_TheLastOption.pm
+++ b/lib/WeBWorK/Authen/Basic_TheLastOption.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Basic.pm,v 1.0 2012/05/26 17:25:00 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/Cosign.pm
+++ b/lib/WeBWorK/Authen/Cosign.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Cosign.pm,v 1.2 2007/03/27 17:06:04 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/LDAP.pm
+++ b/lib/WeBWorK/Authen/LDAP.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/LDAP.pm,v 1.4 2007/08/13 22:59:54 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/Moodle.pm
+++ b/lib/WeBWorK/Authen/Moodle.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Moodle.pm,v 1.14 2007/02/14 19:08:46 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Proctor.pm,v 1.5 2007/04/04 15:05:27 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WeBWorK/Authen/XMLRPC.pm
+++ b/lib/WeBWorK/Authen/XMLRPC.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Proctor.pm,v 1.5 2007/04/04 15:05:27 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authz.pm,v 1.37 2012/06/08 22:59:54 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/CGI.pm
+++ b/lib/WeBWorK/CGI.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/CGI.pm,v 1.27 2006/09/15 22:02:37 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Constants.pm
+++ b/lib/WeBWorK/Constants.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Constants.pm,v 1.62 2010/02/01 01:57:56 apizer Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1099,9 +1099,9 @@ sub footer(){
 	my $ww_version = $ce->{WW_VERSION}||"unknown -- set ww version VERSION";
 	my $pg_version = $ce->{PG_VERSION}||"unknown -- set pg version PG_VERSION link to ../pg/VERSION";
 	my $theme = $ce->{defaultTheme}||"unknown -- set defaultTheme in localOverides.conf";
-	my $copyright_years = $ce->{WW_COPYRIGHT_YEARS}||"1996-2011";
+	my $copyright_years = $ce->{WW_COPYRIGHT_YEARS}||"1996-2019";
 	print CGI::div({-id=>"last-modified"}, $r->maketext("Page generated at [_1]", timestamp($self)));
-	print CGI::div({-id=>"copyright"}, $r->maketext("WeBWorK &#169; [_1]| theme: [_2] | ww_version: [_3] | pg_version [_4]|", 
+	print CGI::div({-id=>"copyright"}, $r->maketext("WeBWorK &copy; [_1]| theme: [_2] | ww_version: [_3] | pg_version [_4]|", 
 	                $copyright_years,$theme, $ww_version, $pg_version), 
 	                CGI::a({-href=>"http://webwork.maa.org/"}, 
 	                $r->maketext("The WeBWorK Project"), ));

--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Skeleton.pm,v 1.5 2006/07/08 14:07:34 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm,v 1.91 2010/06/13 02:25:51 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/EquationDisplay.pm
+++ b/lib/WeBWorK/ContentGenerator/EquationDisplay.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/EquationDisplay.pm,v 1.6 2006/07/12 01:23:54 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm,v 1.54 2008/07/01 13:12:56 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Grades.pm,v 1.35 2007/07/10 14:41:54 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm,v 1.102 2009/09/25 00:39:49 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Home.pm
+++ b/lib/WeBWorK/ContentGenerator/Home.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Home.pm,v 1.19 2006/07/12 01:23:54 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm,v 1.64 2007/08/13 22:59:55 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Skeleton.pm,v 1.5 2006/07/08 14:07:34 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm,v 1.23 2006/09/25 22:14:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm,v 1.24 2007/08/13 22:59:55 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm,v 1.37 2006/09/25 22:14:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Compare.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Compare.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $ $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm,v 1.10 2007/07/26 18:53:06 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/GetTargetSetProblems.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/GetTargetSetProblems.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -1,6 +1,6 @@
  ###############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm,v 1.59 2007/08/13 22:59:55 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm,v 1.99 2010/05/18 18:39:40 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor2.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm,v 1.99 2010/05/18 18:39:40 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor3.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm,v 1.99 2010/05/18 18:39:40 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Preflight.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Preflight.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Preflight.pm,v 1.8 2006/09/25 22:14:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Skeleton.pm,v 1.5 2006/07/08 14:07:34 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -1,7 +1,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1,7 +1,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm,v 1.62 2007/03/07 17:34:42 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm,v 1.7 2006/07/12 04:36:07 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm,v 1.64 2007/08/13 22:59:55 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetsAssignedToUser.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetsAssignedToUser.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetsAssignedToUser.pm,v 1.26 2006/09/25 22:14:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm,v 1.20 2006/10/10 10:58:54 dpvc Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats_old.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm,v 1.68 2007/08/13 22:59:56 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm,v 1.36 2008/06/19 19:34:31 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm,v 1.96 2010/05/14 00:52:48 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm,v 1.96 2010/05/14 00:52:48 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm,v 1.23 2006/09/25 22:14:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Login.pm,v 1.47 2012/06/08 22:59:55 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm,v 1.10 2007/04/04 15:05:26 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Logout.pm,v 1.17 2012/06/08 22:50:50 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Options.pm,v 1.24 2006/07/24 23:28:41 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/PGtoTexRenderer.pm
+++ b/lib/WeBWorK/ContentGenerator/PGtoTexRenderer.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm,v 1.1 2010/05/11 15:27:08 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Problem.pm,v 1.225 2010/05/28 21:29:48 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/ProblemRenderer.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemRenderer.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/ProblemRenderer.pm,v 1.1 2008/04/29 19:27:34 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm,v 1.94 2009/11/02 16:54:15 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm,v 1.94 2010/01/31 02:31:04 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/ProctoredGatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/ProctoredGatewayQuiz.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm,v 1.54 2008/07/01 13:12:56 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Problem.pm,v 1.225 2010/05/28 21:29:48 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Skeleton.pm
+++ b/lib/WeBWorK/ContentGenerator/Skeleton.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Skeleton.pm,v 1.5 2006/07/08 14:07:34 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Test.pm
+++ b/lib/WeBWorK/ContentGenerator/Test.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Test.pm,v 1.16 2006/07/25 23:02:12 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm,v 1.1 2010/05/11 15:27:08 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Cookie.pm
+++ b/lib/WeBWorK/Cookie.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Cookie.pm,v 1.1 2006/06/29 21:10:52 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/CourseEnvironment.pm,v 1.37 2007/08/10 16:37:10 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System>
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB.pm,v 1.112 2012/06/08 22:40:00 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Driver.pm
+++ b/lib/WeBWorK/DB/Driver.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Driver.pm,v 1.3 2006/01/25 23:13:54 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Driver/Null.pm
+++ b/lib/WeBWorK/DB/Driver/Null.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Driver/Null.pm,v 1.5 2006/01/25 23:13:54 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Driver/SQL.pm
+++ b/lib/WeBWorK/DB/Driver/SQL.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Driver/SQL.pm,v 1.15 2007/07/19 21:02:42 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record.pm
+++ b/lib/WeBWorK/DB/Record.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record.pm,v 1.13 2007/07/22 05:25:14 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Achievement.pm
+++ b/lib/WeBWorK/DB/Record/Achievement.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Depths.pm
+++ b/lib/WeBWorK/DB/Record/Depths.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Setting.pm,v 1.2 2007/07/22 05:25:17 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
+++ b/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Key.pm
+++ b/lib/WeBWorK/DB/Record/Key.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Key.pm,v 1.10 2006/10/02 15:04:27 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Password.pm
+++ b/lib/WeBWorK/DB/Record/Password.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Password.pm,v 1.9 2006/10/02 15:04:27 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/PermissionLevel.pm
+++ b/lib/WeBWorK/DB/Record/PermissionLevel.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/PermissionLevel.pm,v 1.10 2006/10/02 15:04:27 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Problem.pm
+++ b/lib/WeBWorK/DB/Record/Problem.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Problem.pm,v 1.9 2006/10/02 15:04:27 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/ProblemVersion.pm
+++ b/lib/WeBWorK/DB/Record/ProblemVersion.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/ProblemVersion.pm,v 1.2 2007/02/22 01:25:11 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Set.pm
+++ b/lib/WeBWorK/DB/Record/Set.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/SetVersion.pm
+++ b/lib/WeBWorK/DB/Record/SetVersion.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/SetVersion.pm,v 1.2 2007/02/22 01:25:11 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Setting.pm
+++ b/lib/WeBWorK/DB/Record/Setting.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Setting.pm,v 1.2 2007/07/22 05:25:17 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/User.pm
+++ b/lib/WeBWorK/DB/Record/User.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/User.pm,v 1.12 2006/10/02 15:04:27 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/UserAchievement.pm
+++ b/lib/WeBWorK/DB/Record/UserAchievement.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/UserProblem.pm
+++ b/lib/WeBWorK/DB/Record/UserProblem.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/UserProblem.pm,v 1.11 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/UserSet.pm
+++ b/lib/WeBWorK/DB/Record/UserSet.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Record/UserSet.pm,v 1.21 2007/08/13 22:59:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema.pm
+++ b/lib/WeBWorK/DB/Schema.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema.pm,v 1.13 2009/01/25 15:30:35 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL.pm,v 1.25 2008/06/21 16:38:49 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm,v 1.11 2007/03/02 23:26:30 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm,v 1.5 2007/08/10 16:44:57 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/Std.pm,v 1.22 2009/02/02 03:18:09 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm,v 1.7 2007/03/02 23:11:42 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm,v 1.1 2007/03/01 22:09:51 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Utils.pm
+++ b/lib/WeBWorK/DB/Utils.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Utils.pm,v 1.24 2007/08/13 22:59:56 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
+++ b/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm,v 1.4 2007/03/02 23:12:28 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Debug.pm
+++ b/lib/WeBWorK/Debug.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Debug.pm,v 1.10 2006/06/28 16:20:39 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/FakeRequest.pm
+++ b/lib/WeBWorK/FakeRequest.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Proctor.pm,v 1.5 2007/04/04 15:05:27 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/File/Classlist.pm
+++ b/lib/WeBWorK/File/Classlist.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/File/Classlist.pm,v 1.10 2007/08/13 22:59:58 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/File/Scoring.pm
+++ b/lib/WeBWorK/File/Scoring.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/File/Scoring.pm,v 1.2 2007/08/09 17:22:37 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Form.pm
+++ b/lib/WeBWorK/Form.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Form.pm,v 1.8 2008/04/26 23:13:59 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/HTML/ComboBox.pm
+++ b/lib/WeBWorK/HTML/ComboBox.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/HTML/DropdownList.pm
+++ b/lib/WeBWorK/HTML/DropdownList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/HTML/InfoBox.pm
+++ b/lib/WeBWorK/HTML/InfoBox.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/HTML/InfoBox.pm,v 1.2 2006/01/25 23:13:55 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/HTML/OptionList.pm
+++ b/lib/WeBWorK/HTML/OptionList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: 
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm,v 1.9 2006/07/11 16:13:10 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/NPL.pm
+++ b/lib/WeBWorK/NPL.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/NPL.pm,v 1.1 2007/10/17 16:56:16 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/PG.pm,v 1.76 2009/07/18 02:52:51 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/PG/Local.pm
+++ b/lib/WeBWorK/PG/Local.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/PG/Local.pm,v 1.28 2009/10/17 15:50:33 apizer Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/PG/Remote.pm
+++ b/lib/WeBWorK/PG/Remote.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/PG/Remote.pm,v 1.6 2007/08/13 22:59:58 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/RPC.pm
+++ b/lib/WeBWorK/RPC.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/RPC.pm,v 1.2 2006/08/05 02:15:31 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/RPC/Request.pm
+++ b/lib/WeBWorK/RPC/Request.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/RPC/Request.pm,v 1.1 2006/07/28 04:33:28 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Request.pm
+++ b/lib/WeBWorK/Request.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Request.pm,v 1.10 2007/07/23 04:06:32 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Template.pm
+++ b/lib/WeBWorK/Template.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Template.pm,v 1.3 2006/01/25 23:13:51 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Upload.pm
+++ b/lib/WeBWorK/Upload.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Upload.pm,v 1.7 2006/01/25 23:13:51 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -3,7 +3,7 @@ use 5.010;
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WebworkClient.pm,v 1.1 2010/06/08 11:46:38 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/CourseIntegrityCheck.pm,v 1.8 2010/06/12 01:44:33 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/CourseManagement.pm,v 1.48 2009/10/01 21:28:46 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/CourseManagement/sql_moodle.pm
+++ b/lib/WeBWorK/Utils/CourseManagement/sql_moodle.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/CourseManagement/sql_moodle.pm,v 1.2 2006/09/29 19:41:36 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/CourseManagement/sql_single.pm
+++ b/lib/WeBWorK/Utils/CourseManagement/sql_single.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/CourseManagement/sql_single.pm,v 1.16 2007/07/21 19:13:10 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/DBImportExport.pm
+++ b/lib/WeBWorK/Utils/DBImportExport.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/DBImportExport.pm,v 1.10 2006/09/26 15:57:41 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/DBUpgrade.pm
+++ b/lib/WeBWorK/Utils/DBUpgrade.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/DBUpgrade.pm,v 1.4 2007/08/13 22:59:59 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/DatePickerScripts.pm
+++ b/lib/WeBWorK/Utils/DatePickerScripts.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/CourseManagement.pm,v 1.48 2009/10/01 21:28:46 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/DelayedMailer.pm
+++ b/lib/WeBWorK/Utils/DelayedMailer.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/DelayedMailer.pm,v 1.2 2007/08/13 22:59:59 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/FilterRecords.pm,v 1.5 2006/09/25 22:14:54 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/FormatRecords.pm
+++ b/lib/WeBWorK/Utils/FormatRecords.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/FormatRecords.pm,v 1.9 2007/04/09 21:01:50 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/RestrictedClosureClass.pm
+++ b/lib/WeBWorK/Utils/RestrictedClosureClass.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/RestrictedClosureClass.pm,v 1.4 2007/08/10 00:27:14 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/RestrictedMailer.pm
+++ b/lib/WeBWorK/Utils/RestrictedMailer.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/RestrictedMailer.pm,v 1.2 2006/12/05 20:57:53 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/SortRecords.pm
+++ b/lib/WeBWorK/Utils/SortRecords.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/SortRecords.pm,v 1.7 2006/09/25 22:14:54 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/Tasks.pm
+++ b/lib/WeBWorK/Utils/Tasks.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -2,7 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WebworkClient.pm,v 1.1 2010/06/08 11:46:38 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -2,7 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WebworkWebservice/RenderProblem.pm,v 1.11 2010/06/08 11:22:43 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/t/grab_course_environment.pl
+++ b/t/grab_course_environment.pl
@@ -2,7 +2,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the


### PR DESCRIPTION
There are many files changed, but the changes are minor and in the commented out header material. 

The copyright symbol from the keyboard often
causes trouble when the file is read with utf8.  Use &copy; instead. 