### PR TITLE
LTI authentication patch - to handle multi-byte characters

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -116,6 +116,27 @@ $preferred_source_of_username = "lis_person_contact_email_primary";
 
 #$preferred_source_of_student_id = "ext_d2l_orgdefinedid";
 
+
+################################################################################
+# LTI - Should an attempt be made to "fix" multi-byte characters in the
+# $r->{paramcache} which would otherwise trigger errors in the Net:OAuth code.
+# Set to 1 to enable the beta code for the fix to this issue.
+#
+# Error message that had been triggered:
+#      Net::OAuth warning: your OAuth message appears to contain some multi-byte
+#      characters that need to be decoded via Encode.pm or a PerlIO layer first.
+#      This may result in an incorrect signature.
+#      at /usr/share/perl5/Net/OAuth/Message.pm line 106.
+#
+# See: https://metacpan.org/pod/release/KGRENNAN/Net-OAuth-0.28/lib/Net/OAuth.pm
+#      http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4484
+#      http://webwork.maa.org/moodle/mod/forum/discuss.php?d=3949
+#      http://webwork.maa.org/moodle/mod/forum/discuss.php?d=3985
+#
+
+# This is NOT turned on by default. Try it if needed, but it may break something (hopefully not).
+#$allow_WW_LTI_code_to_fix_what_appear_as_multi_byte_characters = 1;
+
 ################################################################################
 # LTI Basic Authentication Parameters 
 ################################################################################

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -450,6 +450,27 @@ sub authenticate
 		$request_hash{$key} =  $r -> param($key); 
 		#debug("$key -> |" . $requestHash -> {$key} . "|");
 	}	
+
+	# Try to fix issues with non-ASCII characters in LTI data
+	#     BUT only when the course environment has allow_WW_LTI_code_to_fix_what_appear_as_multi_byte_characters set to 1
+	# The documentation at https://metacpan.org/pod/release/KGRENNAN/Net-OAuth-0.28/lib/Net/OAuth.pm
+	# says "Per the OAuth spec, when making the signature Net::OAuth first encodes parameters to UTF-8.
+	#       This means that any parameters you pass to Net::OAuth, if they might be outside of ASCII character set,
+	#       should be run through Encode::decode() (or an equivalent PerlIO layer) first to decode them to
+	#       Perl's internal character structure."
+
+	if ( defined($ce->{allow_WW_LTI_code_to_fix_what_appear_as_multi_byte_characters})
+	     and ( $ce->{allow_WW_LTI_code_to_fix_what_appear_as_multi_byte_characters} == 1 ) ) {
+	    my ( $key, $val );
+	    foreach $key ( keys( %request_hash ) ) {
+		$val = $request_hash{$key} ;
+		if ( ($val =~ /[\x80-\xFF]/ and !utf8::is_utf8($val)) ) {
+		    debug("Key ${key} : Detected what appears to be a UTF8 multi-byte characters which would have been passed to OAuth and triggered an error. Applying utf8::decode to the relevant value.\n");
+		    utf8::decode($request_hash{$key});
+		}
+	    }
+	}
+
 	my $requestHash = \%request_hash;
 	my $path = $ce->{server_root_url}.$ce->{webwork_url}.$r->urlpath()->path;
 	$path = $ce->{LTIBasicToThisSiteURL} ? 


### PR DESCRIPTION
This is a proposed patch to fix https://github.com/openwebwork/webwork2/issues/915 but has not yet been tested on a real system, as I am not using LTI in practice yet.

Testing instructions are given at https://github.com/openwebwork/webwork2/issues/915 .

**Pay attention** that the special setting `$allow_WW_LTI_code_to_fix_what_appear_as_multi_byte_characters = 1;`
needs to be enabled in `conf/authen_LTI.conf` to allow the patch to run. Without that variable defined and turned out the code is inactive. A commented out settings line is in the included version of `conf/authen_LTI.conf.dist`.