### PR TITLE
Fix extended response group questions in multi page gateway quizzes.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1538,7 +1538,7 @@ sub body {
 					# ref($pg) eq "WeBWorK::PG::Local";
 			} else {
 				my $prefix = sprintf('Q%04d_',$i+1);
-				my @fields = sort grep {/^$prefix/} (keys %{$self->{formFields}});
+				my @fields = sort grep {/^(?!previous).*$prefix/} (keys %{$self->{formFields}});
 				my %answersToStore = map {$_ => $self->{formFields}->{$_}} @fields;
 				my @answer_order = @fields;
 				$encoded_ans_string = encodeAnswers( %answersToStore, 
@@ -1667,7 +1667,7 @@ sub body {
 					$answerString =~ s/\t+$/\t/;
 				} else {
 					my $prefix = sprintf('Q%04d_', ($probOrder[$i]+1));
-					my @fields = sort grep {/^$prefix/} (keys %{$self->{formFields}});
+					my @fields = sort grep {/^(?!previous).*$prefix/} (keys %{$self->{formFields}});
 					foreach ( @fields ) {
 						$answerString .= $self->{formFields}->{$_} . "\t";
 						$scores .= $self->{formFields}->{"probstatus" . ($probOrder[$i]+1)} >= 1 ? "1" : "0" if ( $submitAnswers );
@@ -2190,7 +2190,7 @@ sub body {
 				# and print out hidden fields with the current 
 				#    last answers
 				my $curr_prefix = 'Q' . sprintf("%04d", $probOrder[$i]+1) . '_';
-				my @curr_fields = grep /^$curr_prefix/, keys %{$self->{formFields}};
+				my @curr_fields = grep {/^(?!previous).*$curr_prefix/} keys %{$self->{formFields}};
 				foreach my $curr_field ( @curr_fields ) {
  					foreach ( split(/\0/, $self->{formFields}->{$curr_field} // '') ) {
  						print CGI::hidden({-name=>$curr_field, 


### PR DESCRIPTION
If a problem uses an extended response group for its answers (like
multianswers with the single result option, answer arrays, or mathquill
answers) and a quiz has multiple pages, then the extended answers are
lost every time the page is changed.

The intended result is that the quiz would create a hidden input for
every given answer that is not on the current page.  It detects these
answers by looking for the quiz prefix in the input names.  However, it
was previously assumed that the quiz prefix would be at the beginning of
the input name, which is incorrect.  Extended response group answers add
a prefix in front of the the quiz prefix.

This fixes the problem by finding all inputs that contain the quiz
prefix, but excludes the previous answer inputs.

This fixes issue #924.

This is a submission from @drgrice1 originally made as a hotfix to master.  This PR is 
a duplicate fix cherry-picked from the original and rebased onto develop. 