### PR TITLE
Use a fallback timezone instead of a die in lib/WeBWorK/Utils.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1986,10 +1986,29 @@ sub readSetDef {
 		}
 
 		# validate reduced credit date
-		$reducedScoringDate = $self->parseDateTime($reducedScoringDate) if ($reducedScoringDate);
+
+		# Special handling for values which seem to roughly correspond to epoch 0.
+		#    namely if the date string contains 12/31/1969 or 01/01/1970
+		if ($reducedScoringDate) {
+			if ( ( $reducedScoringDate =~ m+12/31/1969+ ) || ( $reducedScoringDate =~ m+01/01/1970+ ) ) {
+				my $origReducedScoringDate = $reducedScoringDate;
+				$reducedScoringDate = $self->parseDateTime($reducedScoringDate);
+				if ( $reducedScoringDate != 0 ) {
+					# In this case we want to treat it BY FORCE as if the value did correspond to epoch 0.
+					warn $r->maketext("The reduced credit date [_1] in the file probably was generated from the Unix epoch 0 value and is being treated as if it was Unix epoch 0.", $origReducedScoringDate );
+					$reducedScoringDate = 0;
+				}
+			} else {
+				# Original behavior, which may cause problems for some time-zones when epoch 0 was set and does not parse back to 0
+				$reducedScoringDate = $self->parseDateTime($reducedScoringDate);
+			}
+		}
 
 		if ($reducedScoringDate && ($reducedScoringDate < $time1 || $reducedScoringDate > $time2)) {
 		    warn $r->maketext("The reduced credit date should be between the open date [_1] and close date [_2]", $openDate, $dueDate);
+		} elsif ( $reducedScoringDate == 0 && $enableReducedScoring ne 'Y' ) {
+			# In this case - the date in the file was Unix epoch 0 (or treated as such),
+			# and unless $enableReducedScoring eq 'Y' we will leave it as 0.
 		} elsif (!$reducedScoringDate) {
 		    $reducedScoringDate = $time2 - 60*$r->{ce}->{pg}{ansEvalDefaults}{reducedScoringPeriod};
 		}

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -573,8 +573,26 @@ sub parseDateTime($;$) {
 			#warn "\t\$utc_epoch = $utc_epoch\n";
 
 			# get offset for supplied timezone and utc_epoch
-			my $offset = tz_offset($zone, $utc_epoch) or die "Time zone '$zone' not recognized.\n";
-			#warn "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n";
+			# fall back to $display_tz if that fails
+			#my $offset = tz_offset($zone, $utc_epoch) or die "Time zone '$zone' not recognized.\n";
+
+			my $offset;
+			if( $offset = tz_offset($zone, $utc_epoch) ) {
+			  #warn "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n";
+			} else {
+			  warn "Time zone '$zone' not recognized, falling back to using $display_tz.\n";
+			  $dt = new DateTime(
+			      year      => $year,
+			      month     => $month,
+			      day       => $day,
+			      hour      => $hour,
+			      minute    => $minute,
+			      second    => $second,
+			      time_zone => $display_tz,
+			      );
+			  $epoch = $dt->epoch;
+			  return $epoch;
+			}
 
 			#$epoch = $utc_epoch + $offset;
 			##warn "\t\$epoch = \$utc_epoch + \$offset = $epoch\n";

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -533,92 +533,75 @@ sub parseDateTime($;$) {
 		}
 	}
 
-	my $epoch;
+	my $epoch; # The value we need to calculate and return
 
+	# Determine the best possible time-zone string to use in the (first) call to DateTime()
+	my $tz_to_use = $display_tz;
+	my $is_valid_zone_name = 1; # when later set to 0, we will try the "offset" approach
 	if (defined $zone and $zone ne "") {
-		if (DateTime::TimeZone->is_valid_name($zone)) {
-			#warn "\t\$zone is valid according to DateTime::TimeZone\n";
-
-			my $dt = new DateTime(
-				year      => $year,
-				month     => $month,
-				day       => $day,
-				hour      => $hour,
-				minute    => $minute,
-				second    => $second,
-				time_zone => $zone,
-			);
-			#warn "\t\$dt = ", $dt->strftime(DATE_FORMAT), "\n";
-
-			$epoch = $dt->epoch;
-			#warn "\t\$dt->epoch = $epoch\n";
+		$is_valid_zone_name = DateTime::TimeZone->is_valid_name($zone);
+		if ( $is_valid_zone_name ) {
+			#warn "\t\$zone=$zone is valid according to DateTime::TimeZone\n";
+			$tz_to_use = $zone;
 		} else {
-			#warn "\t\$zone is invalid according to DateTime::TimeZone, so we ask Time::Zone\n";
-
-			# treat the date/time as UTC
-			my $dt = new DateTime(
-				year      => $year,
-				month     => $month,
-				day       => $day,
-				hour      => $hour,
-				minute    => $minute,
-				second    => $second,
-				time_zone => "UTC",
-			);
-			#warn "\t\$dt = ", $dt->strftime(DATE_FORMAT), "\n";
-
-			# convert to an epoch value
-			my $utc_epoch = $dt->epoch
-				or die "Date/time '$string' not representable as an epoch. Get more bits!\n";
-			#warn "\t\$utc_epoch = $utc_epoch\n";
-
-			# get offset for supplied timezone and utc_epoch
-			# fall back to $display_tz if that fails
-			#my $offset = tz_offset($zone, $utc_epoch) or die "Time zone '$zone' not recognized.\n";
-
-			my $offset;
-			if( $offset = tz_offset($zone, $utc_epoch) ) {
-				#warn "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n";
-			} else {
-				warn "Time zone '$zone' not recognized, falling back to using $display_tz.\n";
-				$dt = new DateTime(
-					year      => $year,
-					month     => $month,
-					day       => $day,
-					hour      => $hour,
-					minute    => $minute,
-					second    => $second,
-					time_zone => $display_tz,
-				);
-				$epoch = $dt->epoch;
-				return $epoch;
-			}
-
-			#$epoch = $utc_epoch + $offset;
-			##warn "\t\$epoch = \$utc_epoch + \$offset = $epoch\n";
-
-			$dt->subtract(seconds => $offset);
-			#warn "\t\$dt - \$offset = ", $dt->strftime(DATE_FORMAT), "\n";
-
-			$epoch = $dt->epoch;
-			#warn "\t\$epoch = $epoch\n";
+			#warn "\t\$zone=$zone is invalid according to DateTime::TimeZone, so we will attempt to treat the date/time as UTC and then apply an offset for the zone $zone.\n";
+			$tz_to_use = "UTC";
+			# When the offset approach fails, we will overriden again and use $display_tz instead
 		}
 	} else {
 		#warn "\t\$zone not supplied, using \$display_tz\n";
+		$tz_to_use = $display_tz;
+	}
 
-		my $dt = new DateTime(
-			year      => $year,
-			month     => $month,
-			day       => $day,
-			hour      => $hour,
-			minute    => $minute,
-			second    => $second,
-			time_zone => $display_tz,
-		);
-		#warn "\t\$dt = ", $dt->strftime(DATE_FORMAT), "\n";
+	my $dt = new DateTime(
+		year      => $year,
+		month     => $month,
+		day       => $day,
+		hour      => $hour,
+		minute    => $minute,
+		second    => $second,
+		time_zone => $tz_to_use,
+	);
+	my @offset_approach_msg = (); # Will be non-empty and collect parts for warn message when needed
+	if ( ! $is_valid_zone_name ) {
+		# We used "UTC" and need to do an offset, or fail to a different approach
 
-		$epoch = $dt->epoch;
-		#warn "\t\$epoch = $epoch\n";
+		# convert to an epoch value
+		my $utc_epoch = $dt->epoch
+			or die "Date/time '$string' not representable as an epoch. Get more bits!\n";
+		push( @offset_approach_msg, "\t\$utc_epoch = $utc_epoch\n" );
+
+		# get offset for supplied timezone and utc_epoch
+		# fall back to $display_tz if that fails
+		my $offset;
+		if( $offset = tz_offset($zone, $utc_epoch) ) {
+			push( @offset_approach_msg, "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n");
+
+			$epoch = $utc_epoch + $offset;
+			push( @offset_approach_msg, "\t\$epoch = \$utc_epoch + \$offset = $epoch\n");
+
+			$dt->subtract(seconds => $offset);
+			push( @offset_approach_msg, "\t\$dt - \$offset = " . $dt->strftime(DATE_FORMAT) . "\n");
+		} else {
+			@offset_approach_msg = (); # Offset approach failed
+			warn "Time zone '$zone' not recognized, falling back to parsing using $display_tz instead of applying an offset from UTC.\n";
+			$dt = new DateTime(
+				year      => $year,
+				month     => $month,
+				day       => $day,
+				hour      => $hour,
+				minute    => $minute,
+				second    => $second,
+				time_zone => $display_tz,
+			);
+		}
+	}
+	$epoch = $dt->epoch;
+
+	if ( @offset_approach_msg ) {
+		#warn join("", @offset_approach_msg);
+	} else {
+		#warn "\t\$dt = ", $dt->strftime(DATE_FORMAT), "\n\t\$dt->epoch = $epoch\n";
 	}
 
 	return $epoch;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -578,20 +578,20 @@ sub parseDateTime($;$) {
 
 			my $offset;
 			if( $offset = tz_offset($zone, $utc_epoch) ) {
-			  #warn "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n";
+				#warn "\t\$zone is valid according to Time::Zone (\$offset = $offset)\n";
 			} else {
-			  warn "Time zone '$zone' not recognized, falling back to using $display_tz.\n";
-			  $dt = new DateTime(
-			      year      => $year,
-			      month     => $month,
-			      day       => $day,
-			      hour      => $hour,
-			      minute    => $minute,
-			      second    => $second,
-			      time_zone => $display_tz,
-			      );
-			  $epoch = $dt->epoch;
-			  return $epoch;
+				warn "Time zone '$zone' not recognized, falling back to using $display_tz.\n";
+				$dt = new DateTime(
+					year      => $year,
+					month     => $month,
+					day       => $day,
+					hour      => $hour,
+					minute    => $minute,
+					second    => $second,
+					time_zone => $display_tz,
+				);
+				$epoch = $dt->epoch;
+				return $epoch;
 			}
 
 			#$epoch = $utc_epoch + $offset;


### PR DESCRIPTION
Have `parseDateTime()` in `lib/WeBWorK/Utils.pm` fall back to using the value of `$display_tz` (possibly the local time-zone) as a fallback when the time-zone in the string being parsed would not be recognized by `tz_offset()`. This is meant to allow set definition files with an invalid `%Z` generated short time-zone code to be read in using the "display" time-zone, rather than the import being cancelled by the `die` which used to be called when this issue was encountered.

Note: The `reducedScoringDate` may be misinterpreted as a result, as when the included time-zone is dropped the time given in the file may not be the "correct" special value(the zero value of Unix time): `01/01/1970 at 12:00am`. I think this is a relatively small price to pay for getting the files to import, and manual corrections can be made to the various dates as needed. 