### PR TITLE
"weed out" include

### DIFF
--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -202,7 +202,7 @@ sub new {
 	my $self = {};
 	foreach my $name (keys %symbolHash) {
 		# weed out internal symbols
-		next if $name =~ /^(INC|_.*|__ANON__|main::)$/;
+		next if $name =~ /^(INC|_.*|__ANON__|main::|include)$/;
 		# pull scalar, array, and hash values for this symbol
 		my $scalar = ${*{$symbolHash{$name}}};
 		my @array = @{*{$symbolHash{$name}}};


### PR DESCRIPTION
This was suggested by Jeremy Sylvestre:
http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4607#p13521

This addresses an incompatibility of WeBWorK with newer versions of Perl (in particular 5.28.1).
(see also https://github.com/openwebwork/webwork2/issues/938 )