### PR TITLE
Revert to base class title behaviour in Login.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -61,7 +61,8 @@ sub title {
 	return $r->maketext("[_1]: Problem [_2]",$setID, $problemID);
     }
 
-    return $r->urlpath->name;
+    my $ref = $self->SUPER::title();
+    return $ref;
 }
 
 sub info {


### PR DESCRIPTION
Previously login page would display course title instead of just URL path. This change reverts to that behaviour.