### PR TITLE
Changes to the XMLRPC system to support UTF-8 encoded problems

### DIFF
--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -93,6 +93,7 @@ on the same computer but does require an internet connection to a remote WeBWorK
 	# site_url        => 'http://localhost:80',
 	# form_action_url => 'http://localhost:80/webwork2/html2xml',
 	# site_password   => 'xmlrpc',
+	# forcePortNumber => '80',   # A port number to be forced, when needed.
 
     # Set the identification credential used by the "daemon_course" on the remote site
         courseID        => "daemon_course",
@@ -173,7 +174,7 @@ on the same computer but does require an internet connection to a remote WeBWorK
 	Same as -c but the question is rendered with the correct answers submitted. 
     This succeeds only if the correct answers, as determined from the answer hash, all succeed.
 
-=item	 f=s 
+=item	-f formatName
 
 	Specify the format used by the browser in displaying the question. 
          Choices for s are
@@ -182,6 +183,9 @@ on the same computer but does require an internet connection to a remote WeBWorK
          debug 
          simple
          
+=item -l lang
+
+	Set a language for the HTML rendering to use. Should use a value which would be valid for a course.
 
 =item	-v 
 
@@ -269,7 +273,7 @@ BEGIN {
 }
 $ENV{MOD_PERL_API_VERSION} = 2;
 use lib "$main::dirname";
-print "home directory ".$main::dirname;
+print "home directory ".$main::dirname."\n";
 #use lib "."; # is this needed?
 
 # some files such as FormatRenderedProblem.pm may need to be in the same directory
@@ -332,6 +336,7 @@ my $record_ok2 = '';
 my $verbose = '';
 my $credentials_path;
 my $format = 'standard';
+my $lang = 'en';
 my $edit_source_file = '';
 my $display_tex_output='';
 my $display_pdf_output='';
@@ -350,24 +355,25 @@ my $credentials_string;
 
 
 GetOptions(
-	'a' 			=> \$display_ans_output1,
-	'A' 			=> \$display_ans_output2,
-	'b' 			=> \$display_html_output1,
-	'B' 			=> \$display_html_output2,
-	'h' 			=> \$display_hash_output1,
-	'H' 			=> \$display_hash_output2,
-	'c' 			=> \$record_ok1, # record_problem_ok1 needs to be written
-	'C' 			=> \$record_ok2,
-	'v' 			=> \$verbose,
-	'e' 			=> \$edit_source_file, 
-	'tex' 			=> \$display_tex_output,
-	'pdf' 			=> \$display_pdf_output,
-	'list=s' 		=>\$read_list_from_this_file,   # read file containing list of full file paths
-	'pg' 			=> \$print_pg_hash,
-	'anshash' 		=> \$print_answer_hash,
-	'ansgrp'  		=> \$print_answer_group,
+	'a' 		=> \$display_ans_output1,
+	'A' 		=> \$display_ans_output2,
+	'b' 		=> \$display_html_output1,
+	'B' 		=> \$display_html_output2,
+	'h' 		=> \$display_hash_output1,
+	'H' 		=> \$display_hash_output2,
+	'c' 		=> \$record_ok1, # record_problem_ok1 needs to be written
+	'C' 		=> \$record_ok2,
+	'v' 		=> \$verbose,
+	'e' 		=> \$edit_source_file,
+	'tex' 		=> \$display_tex_output,
+	'pdf' 		=> \$display_pdf_output,
+	'list=s' 	=>\$read_list_from_this_file,   # read file containing list of full file paths
+	'pg' 		=> \$print_pg_hash,
+	'anshash' 	=> \$print_answer_hash,
+	'ansgrp'  	=> \$print_answer_group,
 	'resource'      => \$print_resource_hash,
-	'f=s' 			=> \$format,
+	'f=s' 		=> \$format,
+	'l=s'		=> \$lang,
 	'credentials=s' => \$credentials_path,
 	'help'          => \$print_help_message,
 	'log=s'         => \$path_to_log_file,
@@ -415,6 +421,8 @@ The credentials file should contain something like this:
 	# site_url        => 'http://localhost:80',
 	# form_action_url => 'http://localhost:80/webwork2/html2xml',
 	# site_password   => 'xmlrpc',
+	# forcePortNumber => '80',   # A port number to be forced, when needed.
+
 
     # Set the identification credential used by the "daemon_course" on the remote site
         courseID        => "daemon_course",
@@ -609,17 +617,19 @@ die "You must first create an output file at $path_to_log_file
 ############################################
  
 my $default_input = { 
-		userID      			=> $credentials{userID}//'',
-		session_key	 			=> $credentials{session_key}//'',
-		courseID   				=> $credentials{courseID}//'',
-		courseName   			=> $credentials{courseID}//'',
-		course_password     	=> $credentials{course_password}//'',
- };
+		userID      	=> $credentials{userID}//'',
+		session_key	=> $credentials{session_key}//'',
+		courseID   	=> $credentials{courseID}//'',
+		courseName   	=> $credentials{courseID}//'',
+		course_password	=> $credentials{course_password}//'',
+};
 
 my $default_form_data = { 
-		displayMode				=> $DISPLAYMODE,
-		outputformat 			=> $format//'standard',
-		problemSeed       => $problemSeed//PROBLEMSEED(),
+		displayMode	=> $DISPLAYMODE,
+		outputformat 	=> $format//'standard',
+		problemSeed     => $problemSeed//PROBLEMSEED(),
+		forcePortNumber => $credentials{forcePortNumber}//'',
+		language	=> $lang//'en',
 };
 
 ##################################################
@@ -1123,7 +1133,7 @@ sub	display_html_output {  #display the problem in a browser
 	$file_name =~ s/\.\w+$/\.html/;    # replace extension with html
 	my $output_file = TEMPOUTPUTDIR().$file_name;
 	local(*FH);
-	open(FH, '>', $output_file) or die "Can't open file $output_file for writing";
+	open(FH, '>:encoding(UTF-8)', $output_file) or die "Can't open file $output_file for writing";
 	print FH $output_text;
 	close(FH);
 
@@ -1276,7 +1286,15 @@ sub get_source {
 		if ($file_path eq '-') {
 			$source = <STDIN>;
 		} else {
-			open(FH, '<',$file_path) or die "Couldn't open file $file_path: $!";
+			# To support proper behavior with UTF-8 files, we need to open them with "<:encoding(UTF-8)"
+			# as otherwise, the first HTML file will render properly, but when "Preview" "Submit answer"
+			# or "Show correct answer" is used it will make problems, as in process_problem() the
+			# encodeSource() method is called on a data which is still UTF-8 encoded, and leads to double
+			# encoding and gibberish.
+			# NEW:
+			open(FH, "<:encoding(UTF-8)" ,$file_path) or die "Couldn't open file $file_path: $!";
+			# OLD:
+			#open(FH, "<" ,$file_path) or die "Couldn't open file $file_path: $!";
 			$source   = <FH>; #slurp  input
 			close FH;
 		}

--- a/clients/t/test-utf8-hebrew.pg
+++ b/clients/t/test-utf8-hebrew.pg
@@ -1,0 +1,37 @@
+DOCUMENT();        # This should be the first executable line in the problem.
+
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+);
+
+SET_PROBLEM_TEXTDIRECTION("rtl");
+SET_PROBLEM_LANGUAGE("he-IL");
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$a = random(1,9,1);
+$b = random(1,9,1);
+
+$ans1 = Real("10*$a + $b");
+
+Context()->texStrings;
+BEGIN_TEXT
+
+חשב את \( f(x) = 10 x + $b \) עבור הערך \( x = $a \).
+$PAR
+
+$BCENTER
+\{ openSpan( { "dir" => "ltr" } ) \}
+\( f($a) = \) \{ $ans1->ans_rule(2) \}
+\{ closeSpan() \}
+$ECENTER
+
+END_TEXT
+Context()->normalStrings;
+
+ANS( $ans1->cmp() );
+
+ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -50,6 +50,12 @@ sub getLoc {
 	return sub {$lh->maketext(@_)};
 }
 
+sub getLangHandle {
+	my $lang = shift;
+	my $lh = WeBWorK::Localize::I18N->get_handle($lang);
+	return $lh;
+}
+
 # this is like [quant] but it doesn't write the number
 #  usage: [quant,_1,<singular>,<plural>,<optional zero>]
 

--- a/lib/WeBWorK/Utils/DetermineProblemLangAndDirection.pm
+++ b/lib/WeBWorK/Utils/DetermineProblemLangAndDirection.pm
@@ -51,11 +51,15 @@ our @EXPORT_OK = ();
 
 =item get_problem_lang_and_dir subroutine
 
- @output = get_problem_lang_and_dir( $self, $pg );
+ @output = get_problem_lang_and_dir( $self, $pg [,$requested_mode,$ce_lang] );
 
 returns an array of tagname tagvalue pairs.
 
 In some cases, the result is empty.
+
+Use the optional arguments $requested_mode,$ce_lang when $self
+does not contain a request object. This was required for the
+use of this code in lib/WebworkClient.pm.
 
 =cut
 
@@ -72,15 +76,44 @@ sub get_problem_lang_and_dir {
     
     my @result = ();
     
-    my $ce_requested_mode = $self->r->ce->{perProblemLangAndDirSettingMode}; # Mode requested
-    
+    # Get the value for ce_requested_mode:
+    #   First check for the optional argument.
+    #   Otherwise try getting from $self->r->ce->{perProblemLangAndDirSettingMode}
+    #     if it is defined.
+    #   If those both failed, fall back to "none".
+    my $ce_requested_mode = shift;
+    if ( ! defined($ce_requested_mode ) ) {
+	if ( defined( $self->r ) &&
+	     defined( $self->r->ce ) &&
+	     defined( $self->r->ce->{perProblemLangAndDirSettingMode} ) ) {
+	  $ce_requested_mode = $self->r->ce->{perProblemLangAndDirSettingMode}; # Mode requested
+	} else {
+	  $ce_requested_mode = "none"; # Default
+	}
+    }
+
     if ( $ce_requested_mode eq "none" ) {
 	# Requested mode is "none" so no output should be made.
 	return( @result );
     }
     
-    # Get course-wide language setting
-    my $ce_lang = $self->r->ce->{language}; # Course wide setting
+    # Get course-wide language setting:
+    #   First check for the optional argument.
+    #   Otherwise try getting from $self->r->ce->{language}
+    #     if it is defined.
+    #   If those both failed, fall back to "en".
+    my $ce_lang = shift;
+
+    if ( ! defined($ce_lang ) ) {
+	if ( defined( $self->r ) &&
+	     defined( $self->r->ce ) &&
+	     defined( $self->r->ce->{language} ) ) {
+	  $ce_lang = $self->r->ce->{language}; # Course wide setting
+	} else {
+	  $ce_lang = "en";
+	}
+    }
+
     my $ce_dir = "ltr"; # default
     
     if ( $ce_lang =~ /^he/i ) { # supports also the current "heb" option

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -109,9 +109,10 @@ use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
 use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
 use XMLRPC::Lite;
 use WeBWorK::Utils qw( wwRound encode_utf8_base64 decode_utf8_base64);
+use Encode qw(encode_utf8 decode_utf8);
 use WeBWorK::Utils::AttemptsTable;
 use WeBWorK::CourseEnvironment;
-
+use WeBWorK::Utils::DetermineProblemLangAndDirection;
 use WeBWorK::PG::ImageGenerator;
 use HTML::Entities;
 use WeBWorK::Localize;
@@ -188,6 +189,7 @@ sub new {   #WebworkClient constructor
 				 					 AnSwEr0002 => '',
 				 					 AnSwEr0003 => '',
 				 					 displayMode     => 'no displayMode defined',
+						forcePortNumber => '',
 		},
 		@_,               # options and overloads
 	};
@@ -622,7 +624,73 @@ sub formatRenderedProblem {
 	my $sourceFilePath    = $self->{sourceFilePath}//'';
 	my $warnings          = '';
         my $answerhashXML     = XMLout($rh_answers, RootName => 'answerhashes');
-	
+
+	#################################################
+	# Code to get and set problem language and direction based on flags set by the PG problem.
+	# This uses the same utility function as used by lib/WeBWorK/ContentGenerator/Problem.pm
+	# and various modules in lib/WeBWorK/ContentGenerator/Instructor/ .
+	# However, for technical reasons it requires using additional optional arguments
+	# which were added for the use here as they are not available via an internal
+	# CourseEnvironment where it was available in the other uses.
+	#################################################
+	# Need to set things like $PROBLEM_LANG_AND_DIR = "lang=\"he\" dir=\"rtl\"";
+
+	my $formLanguage     = ($self->{inputs_ref}->{language})//'en';
+
+	my @PROBLEM_LANG_AND_DIR = ();
+
+	my $mode_for_get_problem_lang_and_dir = "auto:en:ltr"; # Will be used to set the default
+	# Setting to force English and LTR always:
+	#     $mode_for_get_problem_lang_and_dir = "force:en:ltr";
+	# Setting to avoid any setting be used:
+	#     $mode_for_get_problem_lang_and_dir = "none";
+
+	my @to_set_lang_dir = get_problem_lang_and_dir( $self, $rh_result, $mode_for_get_problem_lang_and_dir, $formLanguage );
+	   # We are calling get_problem_lang_and_dir() when $self does not
+	   # have a request hash called "r" inside it, so need to set the requested
+	   # and the course-wide language. We request mode $mode_for_get_problem_lang_and_dir
+	   # which by default is set above to "auto:en:ltr" so PG files can request their
+	   # language and text direction be set, but falls back to English and LTR.
+	   # We also do not have access to a default course language in the same sense
+	   # so use the $formLanguage instead.
+
+	while ( scalar(@to_set_lang_dir) > 0 ) {
+	    push( @PROBLEM_LANG_AND_DIR, shift( @to_set_lang_dir ) ); # HTML tag being set
+	    push( @PROBLEM_LANG_AND_DIR, "=\"" );
+	    push( @PROBLEM_LANG_AND_DIR, shift( @to_set_lang_dir ) ); # HTML value being set
+	    push( @PROBLEM_LANG_AND_DIR, "\" " );
+	}
+	my $PROBLEM_LANG_AND_DIR = join("",@PROBLEM_LANG_AND_DIR);
+
+	#################################################
+	# Code to get and set main language and direction for generated HTML pages.
+	# Very similar to the code in output_course_lang_and_dir() of
+	# lib/WeBWorK/ContentGenerator.pm with changes for the XMLRPC on the setting.
+	# It depends on the $formLanguage and not a course setting.
+	#################################################
+
+	my $master_lang_setting = "lang=\"en-US\""; # default setting
+	my $master_dir_setting  = "";               # default is NOT set
+
+	if ( $formLanguage ne "en" ) {
+	  # Attempt to override the defaults
+	  if ( $formLanguage =~ /^he/i ) { # supports also the current "heb" option
+	    # Hebrew - requires RTL direction
+	    $master_lang_setting = "lang=\"he\""; # Hebrew
+	    $master_dir_setting  = " dir=\"rtl\""; # RTL
+	  } elsif ( $formLanguage =~ /^ar/i ) {
+	    # Arabic - requires RTL direction
+	    $master_lang_setting = "lang=\"ar\""; # Arabic
+	    $master_dir_setting  = " dir=\"rtl\""; # RTL
+	  } else {
+	    # Use the $formLanguage without changing the text direction.
+	    # Additional RTL languages should be added above, as needed.
+	    $master_lang_setting = "lang=\"${formLanguage}\"";
+	  }
+	}
+
+	my $COURSE_LANG_AND_DIR = "${master_lang_setting}${master_dir_setting}";
+
 	#################################################
 	# regular Perl warning messages generated with warn
 	#################################################
@@ -666,6 +734,24 @@ sub formatRenderedProblem {
 	$self->{outputformats}={};
 	my $XML_URL      	 =  $self->url;
 	my $FORM_ACTION_URL  =  $self->{form_action_url};
+
+	#################################################
+	# Local docker usage with a port number sometimes misbehaves if the port number
+	# is not forced into $XML_URL and $FORM_ACTION_URL
+	#################################################
+	my $forcePortNumber = ($self->{inputs_ref}->{forcePortNumber})//'';
+	if ( $forcePortNumber =~ /^[0-9]+$/ ) {
+	  $forcePortNumber = 0 + $forcePortNumber;
+	  if ( ! ( $XML_URL =~ /:${forcePortNumber}/ ) ) {
+	    $XML_URL .= ":${forcePortNumber}";
+	  }
+	  if ( ! ( $FORM_ACTION_URL =~ m+:${forcePortNumber}/webwork2/html2xml+ ) ) {
+	    $FORM_ACTION_URL =~ s+/webwork2/html2xml+:${forcePortNumber}/webwork2/html2xml+ ; # Ex: "http://localhost:8080/webwork2/html2xml"
+	  }
+	}
+
+	#################################################
+
 	my $courseID         =  $self->{courseID};
 	my $userID           =  $self->{userID};
 	my $course_password  =  $self->{course_password};
@@ -685,7 +771,9 @@ sub formatRenderedProblem {
     my $problemResult    =  $rh_result->{problem_result}//'';
     my $problemState     =  $rh_result->{problem_state}//'';
     my $showSummary      = ($self->{inputs_ref}->{showSummary})//1; #default to show summary for the moment
-	my $formLanguage     = ($self->{inputs_ref}->{language})//'en';
+
+	# $formLanguage moved above
+	#my $formLanguage     = ($self->{inputs_ref}->{language})//'en';
 
 	my $scoreSummary     =  '';
 
@@ -716,15 +804,17 @@ sub formatRenderedProblem {
 	#warn "answersSubmitted ", $tbl->answersSubmitted;
 	# render equation images
 
-
+	my $mt = WeBWorK::Localize::getLangHandle($formLanguage//'en');
 
 	if ($submitMode && $problemResult) {
-		$scoreSummary = CGI::p('Your score on this attempt is '.wwRound(0, $problemResult->{score} * 100).'%');
+		my $ScoreMsg = $mt->maketext("You received a score of [_1] for this attempt.",wwRound(0, $problemResult->{score} * 100).'%');
+		$scoreSummary = CGI::p($ScoreMsg);
 		if ($problemResult->{msg}) {
 			 $scoreSummary .= CGI::p($problemResult->{msg});
 		}
 
-		$scoreSummary .= CGI::p('Your score on this problem has not been recorded.');
+		my $notRecorded = $mt->maketext("Your score was not recorded.");
+		$scoreSummary .= CGI::p($notRecorded);
 		$scoreSummary .= CGI::hidden({id=>'problem-result-score', name=>'problem-result-score',value=>$problemResult->{score}});
 	}
 
@@ -836,6 +926,17 @@ EOS
 	$localStorageMessages .= CGI::end_div();
 		
 	# my $pretty_print_self  = pretty_print($self);
+
+	# Enable localized strings for the buttons:
+	my $STRING_Preview     = $mt->maketext("Preview My Answers");
+	my $STRING_ShowCorrect = $mt->maketext("Show correct answers");
+	my $STRING_Submit      = $mt->maketext("Check Answers");
+
+# With these values - things work, but the button text is English
+# with the localized values, or any answers in UTF-8 - thing break
+$STRING_Preview = "Preview My Answers";
+$STRING_ShowCorrect = "Show correct answers";
+$STRING_Submit = "Check Answers";
 
 ######################################################
 # Return interpolated problem template

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -1004,6 +1004,17 @@ sub pretty_print {    # provides html output -- NOT a method
 		
 		
 		foreach my $key ( sort ( keys %$r_input )) {
+			# Safety feature - we do not want to display the contents of "%seed_ce" which
+			# contains the database password and lots of other things, and explicitly hide
+			# certain internals of the CourseEnvironment in case one slips in.
+			next if ( ( $key =~ /database/ ) ||
+				  ( $key =~ /dbLayout/ ) ||
+				  ( $key eq "ConfigValues" ) ||
+				  ( $key eq "ENV" ) ||
+				  ( $key eq "externalPrograms" ) ||
+				  ( $key eq "permissionLevels" ) ||
+				  ( $key eq "seed_ce" )
+			);
 			$out .= "<tr><TD> $key</TD><TD>=&gt;</td><td>&nbsp;".pretty_print($r_input->{$key}) . "</td></tr>";
 		}
 		$out .="</table>";

--- a/lib/WebworkClient/debug_format.pl
+++ b/lib/WebworkClient/debug_format.pl
@@ -1,14 +1,15 @@
 $debug_format = 
 q{
 
-	<html>
+	<html $COURSE_LANG_AND_DIR>
 	<head>
+	<meta charset='utf-8'>
 	<base href="$XML_URL">
-	<title>$XML_URL WeBWorK Editor using host: $XML_URL, course: $courseID format: debug</title>
+	<title>$XML_URL WeBWorK using host: $XML_URL, course: $courseID format: debug</title>
 	</head>
 	<body>
 			
-	<h2> WeBWorK Editor using host: $XML_URL,  course: $courseID format: debug</h2>
+	<h2> WeBWorK using host: $XML_URL,  course: $courseID format: debug</h2>
 $pretty_print_self	   
 </body>
 </html>

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -1,8 +1,9 @@
 $simple_format = <<'ENDPROBLEMTEMPLATE';
 
 <!DOCTYPE html>
-<html>
+<html $COURSE_LANG_AND_DIR>
 <head>
+<meta charset='utf-8'>
 <base href="$XML_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 
@@ -31,15 +32,15 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 
-<title>$XML_URL WeBWorK Editor using host: $XML_URL, format: simple seed: $problemSeed</title>
+<title>$XML_URL WeBWorK using host: $XML_URL, format: simple seed: $problemSeed</title>
 </head>
 <body>
 <div class="container-fluid">
 <div class="row-fluid">
 <div class="span12 problem">			
 		    $answerTemplate
-		    <form action="$FORM_ACTION_URL" method="post">
-<div class="problem-content">
+	<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
+<div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 			$problemText
 </div>
 $scoreSummary
@@ -59,17 +60,18 @@ $LTIGradeMessage
 	       <input type="hidden" name="outputformat" value="simple">
 	       <input type="hidden" name="language" value="$formLanguage">
 	       <input type="hidden" name="showSummary" value="$showSummary">
+	       <input type="hidden" name="forcePortNumber" value="$forcePortNumber">
 		   <p>
-		      <input type="submit" name="preview"  value="Preview" /> 
-			  <input type="submit" name="WWsubmit" value="Submit answer"/> 
-		      <input type="submit" name="WWcorrectAns" value="Show correct answer"/>
+		      <input type="submit" name="preview"  value="$STRING_Preview" />
+		      <input type="submit" name="WWsubmit" value="$STRING_Submit"/>
+		      <input type="submit" name="WWcorrectAns" value="$STRING_ShowCorrect"/>
 		   </p>
-	       </form>
+	</form>
 </div>
 </div></div>
 
 <div id="footer">
-WeBWorK &copy 1996-2016 | host: $XML_URL | course: $courseID | format: simple | theme: math4
+WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: simple | theme: math4
 </div>
 
 

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -9,25 +9,24 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 
 <!-- CSS Loads -->
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
-<link href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css"/>
-<link href="/webwork2_files/css/knowlstyle.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
 
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
 <script type="text/javascript" src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
 <script type="text/javascript" src="/webwork2_files/js/jquery-ui-1.9.0.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/bootstrap/js/bootstrap.js"></script>
-<script src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/legacy/java_init.js" type="tesxt/javascript"></script>
-<script src="/webwork2_files/js/apps/InputColor/color.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/apps/Base64/Base64.js" type="text/javascript"></script>
-<script src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full" type="text/javascript"></script>
-<script type="textx/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/legacy/java_init.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/InputColor/color.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Base64/Base64.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
-<script src="/webwork2_files/js/apps/Problem/problem.js" type="text/javascript"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
 <script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -6,25 +6,24 @@ $standard_format = <<'ENDPROBLEMTEMPLATE';
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 <!-- CSS Loads -->
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
-<link href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css"/>
-<link href="/webwork2_files/css/knowlstyle.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
 
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
 <script type="text/javascript" src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
 <script type="text/javascript" src="/webwork2_files/js/jquery-ui-1.9.0.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/bootstrap/js/bootstrap.js"></script>
-<script src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/legacy/java_init.js" type="tesxt/javascript"></script>
-<script src="/webwork2_files/js/apps/InputColor/color.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/apps/Base64/Base64.js" type="text/javascript"></script>
-<script src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full" type="text/javascript"></script>
-<script type="textx/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/legacy/java_init.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/InputColor/color.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Base64/Base64.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
-<script src="/webwork2_files/js/apps/Problem/problem.js" type="text/javascript"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
 <script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -1,15 +1,16 @@
 $standard_format = <<'ENDPROBLEMTEMPLATE';
-<html>
+<html $COURSE_LANG_AND_DIR>
 <head>
+<meta charset='utf-8'>
 <base href="$XML_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 <!-- CSS Loads -->
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
-<link href="$XML_URL/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
-<link rel="stylesheet" type="text/css" href="$XML_URL/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
-<link rel="stylesheet" type="text/css" href="$XML_URL/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
-<link rel="stylesheet" type="text/css" href="$XML_URL/webwork2_files/themes/math4/math4.css"/>
-<link href="$XML_URL/webwork2_files/css/knowlstyle.css" rel="stylesheet" type="text/css" />
+<link href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
+<link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
+<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css"/>
+<link href="/webwork2_files/css/knowlstyle.css" rel="stylesheet" type="text/css" />
 
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
@@ -29,22 +30,22 @@ $standard_format = <<'ENDPROBLEMTEMPLATE';
 $problemHeadText
 
 
-<title>$XML_URL WeBWorK Editor using host: $XML_URL, course: $courseID format: standard</title>
+<title>$XML_URL WeBWorK using host: $XML_URL, format: standard seed: $problemSeed course: $courseID</title>
 </head>
 <body>
 
-<h2> WeBWorK Editor using host: $XML_URL, course: $courseID format: standard</h2>
+<h2> WeBWorK using host: $XML_URL, course: $courseID format: standard</h2>
 		    $answerTemplate
 		    $color_input_blanks_script
-		    <form action="$FORM_ACTION_URL" method="post">
-<div class="problem-content">
+	<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
+<div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 			$problemText
 </div>
 $scoreSummary
 $LTIGradeMessage
 
 	       <input type="hidden" name="answersSubmitted" value="1"> 
-		   <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
+	       <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
 	       <input type="hidden" name="problemSource" value="$encoded_source"> 
 	       <input type="hidden" name="problemSeed" value="$problemSeed"> 
 	       <input type="hidden" name="pathToProblemFile" value="$fileName">
@@ -57,13 +58,14 @@ $LTIGradeMessage
 	       <input type="hidden" name="outputformat" value="standard">
 	       <input type="hidden" name="language" value="$formLanguage">
 	       <input type="hidden" name="showSummary" value="$showSummary">
+	       <input type="hidden" name="forcePortNumber" value="$forcePortNumber">
 	
 		   <p>
-		      <input type="submit" name="preview"  value="Preview" /> 
-			  <input type="submit" name="WWsubmit" value="Submit answer"/> 
-		      <input type="submit" name="WWcorrectAns" value="Show correct answer"/>
+			<input type="submit" name="preview"  value="$STRING_Preview" />
+			<input type="submit" name="WWsubmit" value="$STRING_Submit"/>
+			<input type="submit" name="WWcorrectAns" value="$STRING_ShowCorrect"/>
 		   </p>
-	     </form>
+	</form>
 <HR>
 
 <h3> Perl warning section </h3>
@@ -75,7 +77,7 @@ $debug_messages
 <h3> internal errors </h3>
 $internal_debug_messages
 <div id="footer">
-WeBWorK &copy 1996-2016 | host: $XML_URL | course: $courseID | format: standard | theme: math4
+WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: standard | theme: math4
 </div>
 
 </body>

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -1,8 +1,9 @@
 $sticky_format = <<'ENDPROBLEMTEMPLATE';
 
 <!DOCTYPE html>
-<html>
+<html $COURSE_LANG_AND_DIR>
 <head>
+<meta charset='utf-8'>
 <base href="$XML_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 
@@ -34,7 +35,7 @@ $sticky_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 
-<title>$XML_URL WeBWorK Editor using host: $XML_URL, format: sticky seed: $problemSeed</title>
+<title>$XML_URL WeBWorK using host: $XML_URL, format: sticky seed: $problemSeed</title>
 </head>
 <body>
 <div class="container-fluid">
@@ -44,7 +45,7 @@ $problemHeadText
 $answerTemplate
 <hr/>
 <form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
-<div class="problem-content">
+<div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 $problemText
 </div>
 <p>
@@ -72,18 +73,19 @@ $LTIGradeMessage
 <input type="hidden" name="outputformat" value="sticky">
 <input type="hidden" name="language" value="$formLanguage">
 <input type="hidden" name="showSummary" value="$showSummary">
+<input type="hidden" name="forcePortNumber" value="$forcePortNumber">
 
 <p>
-<input type="submit" name="preview"  value="Preview" /> 
-<input type="submit" name="WWsubmit" value="Submit answer"/> 
-<input type="submit" name="WWcorrectAns" value="Show correct answer"/>
+<input type="submit" name="preview"  value="$STRING_Preview" />
+<input type="submit" name="WWsubmit" value="$STRING_Submit"/>
+<input type="submit" name="WWcorrectAns" value="$STRING_ShowCorrect"/>
 </p>
 </form>
 </div>
 </div>
 </div>
 <div id="footer">
-WeBWorK &copy 1996-2016 | host: $XML_URL | course: $courseID | format: sticky | theme: math4
+WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: sticky | theme: math4
 </div>
 <!-- Activate local storage js -->
 <script type="text/javascript">WWLocalStorage();</script>

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -9,28 +9,27 @@ $sticky_format = <<'ENDPROBLEMTEMPLATE';
 
 <!-- CSS Loads -->
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
-<link href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css"/>
-<link href="/webwork2_files/css/knowlstyle.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
 
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
 <script type="text/javascript" src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
 <script type="text/javascript" src="/webwork2_files/js/jquery-ui-1.9.0.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/bootstrap/js/bootstrap.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/legacy/java_init.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/InputColor/color.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Base64/Base64.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/modules/jquery.json.min.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/modules/jstorage.js"></script>
-<script src="/webwork2_files/js/apps/AddOnLoad/addOnLoadEvent.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/legacy/java_init.js" type="tesxt/javascript"></script>
-<script src="/webwork2_files/js/apps/InputColor/color.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/apps/Base64/Base64.js" type="text/javascript"></script>
-<script src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full" type="text/javascript"></script>
-<script type="textx/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
-<script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
-<script src="/webwork2_files/js/apps/LocalStorage/localstorage.js" type="text/javascript"></script>
-<script src="/webwork2_files/js/apps/Problem/problem.js" type="text/javascript"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/LocalStorage/localstorage.js"></script>
+<script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
 <script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText


### PR DESCRIPTION
Changes to the XMLRPC system to allow it to handle UTF-8 encoded problems.

Rendering works already. However, submitting UTF-8 encoded text which is not English (Latin1) as form values (in particular as answer) is not working yet. Due to this, the values set on the submit buttons are currently forced back into English.

`clients/sendXMLRPC.pl` was extended to take a language setting as an argument.

A sample Hebrew UTF-8 problem was added as `clients/t/test-utf8-hebrew.pg` to allow testing. On my system, testing using
  - `./sendXMLRPC.pl -b -f simple t/test-utf8-hebrew.pg`
  - `./sendXMLRPC.pl -b -l heb -f simple t/test-utf8-hebrew.pg`
both give reasonable behavior, so long as no special characters are used in the answers.

`lib/WebworkClient.pm` contains code to set the HTML language and text direction both at the level of the "page" and at the level of the DIV element enclosing a problem (based on data set in the PG file).

`lib/WeBWorK/Localize.pm` received a new method `getLangHandle()` used by `lib/WebworkClient.pm ` to get access to maketext.

`lib/WeBWorK/Utils/DetermineProblemLangAndDirection.pm` was extended to allow forcing options not available via a request hash when the XMLRPC system is rendering problems.

Small related changes and some cleanup work was done to several of the formats in `lib/WebworkClient/` including changes to support UTF-8, to standardize the title setting, to the copyright dates. Additional settings were added to the <form> element and to the "problem-content"
DIV element to be more similar to what is generated by the regular ContentGenerator system. `forcePortNumber` was added as a new hidden field. The value settings of the submit buttons are set by variables so they can get localized text. At present, this is not in active use as UTF-8 values render properly but then cause problems when the buttons are clicked and the non-English values are sent as form data.

This PR also includes changes to allow forcing a port number to be used by the XMLRPC system. This is intended to help when using the XMLRPC system with a Docker container or a host which requires using a port number for the site_url and form_action_url. This is managed by setting the value of `forcePortNumber` in the credentials and/or in the address used to access `html2xml`. 
Ex: `http://localhost:8080/webwork2/html2xml?&answersSubmitted=0&language=en&sourceFilePath=some_pg_file.pg&problemSeed=123567890&displayMode=MathJax&courseID=daemon_course&userID=daemon&course_password=daemon&outputformat=simple&forcePortNumber=8080`