### PR TITLE
Fix typo in bin/OPL-update (utf8mb4 switch)

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -99,7 +99,7 @@ my $dbh = DBI->connect(
         {
             PrintError => 0,
             RaiseError => 1,
-            ($ENABLE_UTF8MB)?(mysql_enable_utf8mb4 =>1):(mysql_enable_utf8 => 1),
+            ($ENABLE_UTF8MB4)?(mysql_enable_utf8mb4 =>1):(mysql_enable_utf8 => 1),
         },
 );
 


### PR DESCRIPTION
Fix typo in bin/OPL-update which was reported by Peter Staab in https://github.com/openwebwork/webwork2/issues/958