### PR TITLE
Minor fixes to clients/sendXMLRPC.pl for WeBWorK-2.15 branch

### DIFF
--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -269,7 +269,7 @@ BEGIN {
 }
 $ENV{MOD_PERL_API_VERSION} = 2;
 use lib "$main::dirname";
-print "home directory ".$main::dirname;
+print "home directory ".$main::dirname."\n";
 #use lib "."; # is this needed?
 
 # some files such as FormatRenderedProblem.pm may need to be in the same directory
@@ -315,7 +315,7 @@ $Carp::Verbose = 1;
 
 
 ### verbose output when UNIT_TESTS_ON =1;
- our $UNIT_TESTS_ON             = 0;
+our $UNIT_TESTS_ON = 0;
 
 ############################################################
 # Read command line options
@@ -397,9 +397,9 @@ print_help_message() if $print_help_message;
 # credentials file location -- search for one of these files 
 
 
-our @path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
+@path_list = ("$ENV{HOME}/.ww_credentials", "$ENV{HOME}/ww_session_credentials", 'ww_credentials', 'ww_credentials.dist');
 
-my $credentials_string = <<EOF;
+$credentials_string = <<EOF;
 
 The credentials file should contain something like this:
 
@@ -562,9 +562,6 @@ use constant PDF_DISPLAY_COMMAND =>"open -a 'Preview'";
 ### set display mode
 use constant DISPLAYMODE   => 'MathJax';
 use constant PROBLEMSEED   => '987654321';
-
-### verbose output when UNIT_TESTS_ON =1;
-our $UNIT_TESTS_ON             = 0;
 
 ############################################################
 # End configure displays for local operating system

--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -219,7 +219,11 @@ sub new {
 	}
 	# now that we know the name of the pg_dir we can get the pg VERSION file
 	my $PG_version_file = $self->{'pg_dir'}."/VERSION";
-	
+
+	# Try a fallback location
+	if ( !-r $PG_version_file ) {
+	  $PG_version_file = $self->{'webwork_dir'}."/../pg/VERSION";
+	}
 	# #	We'll get the pg version here and read it into the safe symbol table
 	if (-r $PG_version_file){
 		#print STDERR ( "\n\nread PG_version file $PG_version_file\n\n");
@@ -233,7 +237,9 @@ sub new {
 		use strict 'refs';
 		$self->{PG_VERSION}=${*{$symbolHash2{PG_VERSION}}};
 	} else {
-		croak "Cannot read PG version file $PG_version_file";
+		$self->{PG_VERSION}="unknown";
+		#croak "Cannot read PG version file $PG_version_file";
+		warn "Cannot read PG version file $PG_version_file";
 	}
  
 	


### PR DESCRIPTION
Minor fixes to `clients/sendXMLRPC.pl` and `lib/WeBWorK/CourseEnvironment.pm` to fix the main problem reported in https://github.com/openwebwork/webwork2/issues/955 as well as the warnings mentioned there, which were also mentioned in https://github.com/openwebwork/webwork2/pull/956 but which are not related to the main theme of that PR.