### PR TITLE
Add psvn to xmlrpc

### DIFF
--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -258,6 +258,10 @@ on the same computer but does require an internet connection to a remote WeBWorK
                  
        Sets problemSeed to the number contained in string s
 
+=item  --psvn=s
+
+       Sets psvn to the number contained in string s
+
 
 
 =back
@@ -352,6 +356,7 @@ my $print_help_message;
 my $read_list_from_this_file;
 my $path_to_log_file;
 my $problemSeed;
+my $psvn;
 
 our %credentials;
 our @path_list;
@@ -383,6 +388,7 @@ GetOptions(
 	'help'          => \$print_help_message,
 	'log=s'         => \$path_to_log_file,
 	'seed=s'        => \$problemSeed,   
+	'psvn=s'	=> \$psvn,
 );
 
 print_help_message() if $print_help_message;
@@ -630,6 +636,7 @@ my $default_form_data = {
 		displayMode	=> $DISPLAYMODE,
 		outputformat 	=> $format//'standard',
 		problemSeed     => $problemSeed//PROBLEMSEED(),
+		psvn		=> $psvn//'23456',
 		forcePortNumber => $credentials{forcePortNumber}//'',
 		language	=> $lang//'en',
 };
@@ -888,10 +895,16 @@ sub process_problem {
 	my $problemSeed = $form_data->{problemSeed};
 	die "problem seed not defined in sendXMLRPC::process_problem" unless $problemSeed;
 
+	my $local_psvn = '34567';
+	if ( defined( $form_data->{psvn} ) ) {
+	  $local_psvn = $form_data->{psvn};
+	}
+
 	my $updated_input = {%$input, 
 					  envir => $xmlrpc_client->environment(
 							   fileName       => $adj_file_path,
 							   sourceFilePath => $adj_file_path,
+							   psvn		  => $local_psvn,
 							   problemSeed    => $problemSeed,),
 	};
 

--- a/clients/t/show-psvn.pg
+++ b/clients/t/show-psvn.pg
@@ -1,0 +1,19 @@
+##DESCRIPTION
+##  A very simple first problem
+##ENDDESCRIPTION
+##KEYWORDS('algebra')
+DOCUMENT();        # This should be the first executable line in the problem.
+loadMacros(
+"PG.pl",
+"PGbasicmacros.pl",
+);
+
+TEXT(beginproblem());
+
+BEGIN_TEXT
+$PAR
+PSVN is $psvn
+$PAR
+END_TEXT
+
+ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -564,7 +564,7 @@ sub environment {
 		problemSeed  => $self->{inputs_ref}->{problemSeed}//3333,
 		problemValue =>1,
 		probNum => 13,
-		psvn => 54321,
+		psvn => $self->{inputs_ref}->{psvn}//54321,
 		questionNumber => 1,
 		scriptDirectory => 'Not defined',
 		sectionName => 'Gage',
@@ -757,6 +757,7 @@ sub formatRenderedProblem {
 	my $userID           =  $self->{userID};
 	my $course_password  =  $self->{course_password};
 	my $problemSeed      =  $self->{inputs_ref}->{problemSeed}//4444;
+        my $psvn             =  $self->{inputs_ref}->{psvn}//54321;
 	my $session_key      =  $rh_result->{session_key}//'';
 	my $displayMode      =  $self->{inputs_ref}->{displayMode};
 	

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -153,7 +153,7 @@ eval {
 
 
 our %imagesModeOptions = %{$seed_ce->{pg}->{displayModeOptions}->{images}};
-our $site_url = $seed_ce->{server_root_url};	
+our $site_url = $seed_ce->{server_root_url}//'';
 our $imgGen = WeBWorK::PG::ImageGenerator->new(
 		tempDir         => $seed_ce->{webworkDirs}->{tmp},
 		latex	        => $seed_ce->{externalPrograms}->{latex},

--- a/lib/WebworkClient/json_format.pl
+++ b/lib/WebworkClient/json_format.pl
@@ -127,6 +127,7 @@ push( @pairs_for_json, "hidden_input_field_answersSubmitted", '1' );
 push( @pairs_for_json, "hidden_input_field_sourceFilePath", '$sourceFilePath' );
 push( @pairs_for_json, "hidden_input_field_problemSource", '$encoded_source' );
 push( @pairs_for_json, "hidden_input_field_problemSeed", '$problemSeed' );
+push( @pairs_for_json, "hidden_input_field_psvn", '$psvn' );
 push( @pairs_for_json, "hidden_input_field_pathToProblemFile", '$fileName' );
 push( @pairs_for_json, "hidden_input_field_courseName", '$courseID' );
 push( @pairs_for_json, "hidden_input_field_courseID", '$courseID' );

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -49,6 +49,7 @@ $LTIGradeMessage
 	       <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
 	       <input type="hidden" name="problemSource" value="$encoded_source"> 
 	       <input type="hidden" name="problemSeed" value="$problemSeed"> 
+	       <input type="hidden" name="psvn" value="$psvn">
 	       <input type="hidden" name="pathToProblemFile" value="$fileName">
 	       <input type="hidden" name=courseName value="$courseID">
 	       <input type="hidden" name=courseID value="$courseID">

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -47,6 +47,7 @@ $LTIGradeMessage
 	       <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
 	       <input type="hidden" name="problemSource" value="$encoded_source"> 
 	       <input type="hidden" name="problemSeed" value="$problemSeed"> 
+	       <input type="hidden" name="psvn" value="$psvn">
 	       <input type="hidden" name="pathToProblemFile" value="$fileName">
 	       <input type="hidden" name=courseName value="$courseID">
 	       <input type="hidden" name=courseID value="$courseID">

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -61,6 +61,7 @@ $LTIGradeMessage
 <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
 <input type="hidden" name="problemSource" value="$encoded_source"> 
 <input type="hidden" name="problemSeed" value="$problemSeed"> 
+<input type="hidden" name="psvn" value="$psvn">
 <input type="hidden" name="pathToProblemFile" value="$fileName">
 <input type="hidden" name="courseName" value="$courseID">
 <input type="hidden" name="courseID" value="$courseID">


### PR DESCRIPTION
Add `psvn` to `clients/sendXMLRPC.pl` and `lib/WebworkClient.pm` and related files.

This allows these interfaces to control the value of `psvn` which is sometimes used to reseed the random number generator inside a PG file. The use case is to handle groups of problems which need to have the same seed / random numbers.

Along the way a minor issue which would trigger the warning message:
```
Use of uninitialized value $WebworkClient::site_url in concatenation (.) or string at PATH_TO_WW2/webwork2/lib/WebworkClient.pm line 167.
```
when using `clients/sendXMLRPC.pl` was fixed.

A test file was added.

Sample test from inside `webwork2/clients` with credential set up:
```
./sendXMLRPC.pl -b --psvn=123987 t/show-psvn.pg
```