### PR TITLE
Patch to support email to users with Unicode characters in their name. Also fix mail header to report the body being encoded using UTF-8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ENV WEBWORK_DB_DSN=DBI:mysql:${WEBWORK_DB_NAME}:${WEBWORK_DB_HOST}:${WEBWORK_DB_
     PG_ROOT=$APP_ROOT/pg \
     PATH=$PATH:$APP_ROOT/webwork2/bin
 
+# Ubuntu 18.04 should add libemail-address-xs-perl in the package list below.
+# For Ubuntu 16.04 it is not packed in Ubuntu universe, so installed using CPANM below.
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
        apache2 \
@@ -41,7 +44,6 @@ RUN apt-get update \
        libdancer-perl \
        libdancer-plugin-database-perl \
        libdbd-mysql-perl \
-       libemail-address-perl \
        libexception-class-perl \
        libextutils-xsbuilder-perl \
        libfile-find-rule-perl-perl \
@@ -87,7 +89,7 @@ RUN apt-get update \
 # so it was put into a second "cpanm install" line.
 
 RUN curl -Lk https://cpanmin.us | perl - App::cpanminus \
-    && cpanm install XML::Parser::EasyTree Iterator Iterator::Util Pod::WSDL Array::Utils HTML::Template Mail::Sender Email::Sender::Simple Data::Dump Statistics::R::IO 
+    && cpanm install XML::Parser::EasyTree Iterator Iterator::Util Pod::WSDL Array::Utils HTML::Template Mail::Sender Email::Sender::Simple Data::Dump Statistics::R::IO Email::Address::XS
     
 ##RUN cpanm install XML::Simple \
 #    && rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -37,13 +37,16 @@ my @apache2ModulesList = qw(
 	Apache2::ServerUtil
 );
 
+# Crypt::SSLeay was commented out below, but should the not be
+#   in the array when commented out - remove it.
+# For WW 2.15 replace Email::Address with Email::Address::XS
+
 my @modulesList = qw(
 	Array::Utils
 	Benchmark
 	Carp
 	CGI
 	Class::Accessor
-	#Crypt::SSLeay
 	Dancer
 	Dancer::Plugin::Database
 	Data::Dump
@@ -56,7 +59,7 @@ my @modulesList = qw(
 	DBI
 	Digest::MD5
 	Digest::SHA
-	Email::Address
+	Email::Address::XS
 	Email::Simple
 	Email::Sender::Simple
 	Email::Sender::Transport::SMTP

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -29,7 +29,7 @@ WeBWorK::ContentGenerator::Feedback - Send mail to professors.
 use strict;
 use warnings;
 use utf8;
-use Encode qw(encode_utf8 decode_utf8);
+use Encode qw(encode_utf8 encode);
 use Data::Dumper;
 use Data::Dump qw/dump/;
 use WeBWorK::Debug;
@@ -175,7 +175,9 @@ sub body {
 				$sender = $user->rfc822_mailbox;
 			} else {
 				if ($user->full_name) {
-					$sender = $user->full_name . " <$from>"
+					# Encode the user name using "MIME-Header" encoding,
+					# which allows UTF-8 encoded names.
+					$sender = encode("MIME-Header", $user->full_name) . " <$from>";
 				} else {
 					$sender = $from;
 				}
@@ -259,7 +261,8 @@ sub body {
 		my $email = Email::Simple->create(header => [
 			"To" => join(",", @recipients),
 			"From" => $sender,
-			"Subject" => $subject
+			"Subject" => $subject,
+			"Content-Type" => "text/plain; charset=UTF-8"
 		]);
 
 		# my $header = Email::Simple::Header->new;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -27,14 +27,14 @@ use strict;
 use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
-use Email::Address;
+use Email::Address::XS;
 use HTML::Entities;
 #use Mail::Sender;
 use Email::Simple;
 use Email::Sender::Simple qw(sendmail);
 use Email::Sender::Transport::SMTP qw();
 use Try::Tiny;
-
+use Encode qw(encode_utf8 encode);
 use Data::Dump qw/dump/;
 use WeBWorK::Debug;
 
@@ -118,6 +118,7 @@ sub initialize {
 	my $ur = $self->{db}->getUser($user);
 
 	# store data
+	# rfc822_mailbox was modified to use RFC 2047 "MIME-Header" encoding.
 	$self->{defaultFrom}            =   $ur->rfc822_mailbox;
 	$self->{defaultReply}           =   $ur->rfc822_mailbox;
 	$self->{defaultSubject}         =   $self->r->urlpath->arg("courseID") . " notice";
@@ -388,11 +389,14 @@ sub initialize {
 		#################################################################
 		my $temp_body = ${ $r_text };
 		$temp_body =~ s/\r\n/\n/g;
-		$temp_body = join("",
-				  $r->maketext("From:")," $from \n",
-				  $r->maketext("Reply-To:")," $replyTo\n" ,
-				  $r->maketext("Subject:")," $subject\n" ,
-				  $r->maketext("Message:")," \n    $temp_body");
+		$temp_body = join("\n",
+				  "From: $from",
+				  "Reply-To: $replyTo",
+				  "Subject: $subject",
+				  "Content-Type: text/plain; charset=UTF-8",
+				  "Message:",
+				# Do NOT encode to UTF-8 here.
+				  $temp_body);
 		#warn "FIXME from $from | subject $subject |reply $replyTo|msg $temp_body";
 		#################################################################
 		# overwrite protection
@@ -425,16 +429,16 @@ sub initialize {
 		$self->{response}         = 'preview';
 
 	} elsif ($action eq 'sendEmail') {
-		# verify format of From address (one valid rfc2822 address)
-		my @parsed_from_addrs = Email::Address->parse($self->{from});
+		# verify format of From address (one valid rfc2822/rfc5322 address)
+		my @parsed_from_addrs = Email::Address::XS->parse($self->{from});
 		unless (@parsed_from_addrs == 1) {
 			$self->addbadmessage($r->maketext("From field must contain one valid email address."));
 			return;
 		}
 
-		# verify format of Reply-to address (zero or more valid rfc2822 addresses)
+		# verify format of Reply-to address (zero or more valid rfc2822/ref5322 addresses)
 		if (defined $self->{replyTo} and $self->{replyTo} ne "") {
-			my @parsed_replyto_addrs = Email::Address->parse($self->{replyTo});
+			my @parsed_replyto_addrs = Email::Address::XS->parse($self->{replyTo});
 			unless (@parsed_replyto_addrs > 0) {
 				$self->addbadmessage($r->maketext("Invalid Reply-to address."));
 				return;
@@ -558,18 +562,29 @@ sub print_preview {
 	$msg = wrap("","",$msg);
 
 	$msg = join("",
-		    $errorMessage,
-		    $preview_header,
-		    $r->maketext("To:")," ", $ur->email_address,"\n",
-		    $r->maketext("From:")," ", $self->{from} , "\n" ,
-		    $r->maketext("Reply-To:")," ", $self->{replyTo} , "\n" ,
-		    $r->maketext("Subject:"),"  ", $self->{subject} , "\n" ,"\n" ,
-	   $msg , "\n"
+		    "To: ", $ur->email_address,"\n",
+		    "From: ", "$self->{from}" , "\n",
+		    "Reply-To: ", $self->{replyTo} , "\n",
+		    "Subject: ", $self->{subject} , "\n",
+		    # In a real mails we would UTF-8 encode the message
+		    # and give the Content-Type header, for the preview which
+		    # is displayed - just add the header, but do NOT use
+		    # encode_utf8($msg) as it will be done late.
+		    "Content-Type: text/plain; charset=UTF-8\n\n",
+		    $msg, # will be in HTML output, and gets encoded to UTF-8 later on
+		    "\n"
 	);
 
-#	return join("", '<pre>',wrap("","",$msg),"\n","\n",
-	return join("", '<pre>',$msg,"\n","\n",
-				   '</pre>',
+
+	# The content in message is going to be put in HTML.
+	# It needs to be encoded to avoid problems with things like
+	# <user@domain.com>.
+	$msg = encode_entities($msg);
+
+	$msg = join("",$errorMessage,$preview_header,$msg);
+
+	return join("", '<div dir="ltr"><pre>',$msg,"\n","\n",
+				   '</pre></div>',
 				   CGI::p($r->maketext('Use browser back button to return from preview mode')),
 				   CGI::h3($r->maketext('Emails to be sent to the following:')),
 				   $recipients, "\n",
@@ -672,9 +687,18 @@ sub print_form {
 				 "\n",
 				 #CGI::hr(),
 				 CGI::div(
-					 "\n", $r->maketext('From:'),'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',  CGI::textfield(-name=>"from", -size=>30, -value=>$from, -override=>1),
-					 "\n", CGI::br(),$r->maketext('Reply-To:'),' ', CGI::textfield(-name=>"replyTo", -size=>30, -value=>$replyTo, -override=>1),
-					 "\n", CGI::br(),$r->maketext('Subject: ').' ', CGI::br(), CGI::textarea(-name=>'subject', -default=>$subject, -rows=>3,-cols=>30, -override=>1),
+					 "\n", $r->maketext('From:'),'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+						CGI::textfield(-name=>"from", -size=>30,
+							-maxlength=>120,
+							-value=>$from, -override=>1),
+					 "\n", CGI::br(),$r->maketext('Reply-To:'),' ',
+						CGI::textfield(-name=>"replyTo", -size=>30,
+							-maxlength=>120,
+							-value=>$replyTo, -override=>1),
+					 "\n", CGI::br(),$r->maketext('Subject: ').' ', CGI::br(),
+						CGI::textarea(-name=>'subject',
+							-default=>$subject, -override=>1,
+							-rows=>3, -cols=>30 ),
 				),
 				#CGI::hr(),
 				$r->maketext("Editor rows:").' ', CGI::textfield(-name=>'rows', -size=>3, -value=>$rows),
@@ -707,6 +731,7 @@ sub print_form {
 
 				#CGI::i('Press any action button to update display'),CGI::br(),
 			#show available macros
+			CGI::span({dir=>"ltr"}, # Put the popup in a LTR span
 				CGI::popup_menu(
 						-name=>'dummyName',
 						-values=>['', '$SID', '$FN', '$LN', '$SECTION', '$RECITATION','$STATUS', '$EMAIL', '$LOGIN', '$COL[n]', '$COL[-1]'],
@@ -723,7 +748,7 @@ sub print_form {
 							'$COL[-1]'=>'$COL[-1] - '.$r->maketext('Last column of merge file')
 							}
 				), "\n",
-			),
+			)),
 	);
 
 	print CGI::end_table();
@@ -773,10 +798,10 @@ sub print_form {
 ##############################################################################
 
 sub saveProblem {
-    my $self      = shift;
+	my $self = shift;
 	my ($body, $probFileName)= @_;
 	local(*PROBLEM);
-	open (PROBLEM, ">:utf8",$probFileName) ||
+	open (PROBLEM, ">:encoding(UTF-8)",$probFileName) ||
 		$self->addbadmessage(CGI::p("Could not open $probFileName for writing.
 						Check that the  permissions for this problem are 660 (-rw-rw----)"));
 	print PROBLEM $body if -w $probFileName;
@@ -794,7 +819,7 @@ sub read_input_file {
 	my ($subject, $from, $replyTo);
 	local(*FILE);
 	if (-e "$filePath" and -r "$filePath") {
-		open FILE, "<:utf8", $filePath || do { $self->addbadmessage(CGI::p($r->maketext("Can't open [_1]",$filePath))); return};
+		open FILE, "<:encoding(UTF-8)", $filePath || do { $self->addbadmessage(CGI::p($r->maketext("Can't open [_1]",$filePath))); return};
 		while ($header !~ s/Message:\s*$//m and not eof(FILE)) { 
 			$header .= <FILE>; 
 		}
@@ -869,8 +894,10 @@ sub mail_message_to_recipients {
 			my $email = Email::Simple->create(
 				header => [
 					To => $ur->email_address,
-					From => $from, Subject => $subject ],
-				body => $msg
+					From => $from,
+					Subject => $subject,
+					"Content-Type" => "text/plain; charset=UTF-8" ],
+				body => encode_utf8($msg)
 			);
 			$email->header_set("X-Remote-Host: ",$self->{remote_host});
 
@@ -925,8 +952,9 @@ sub email_notification {
 			To => $self->{defaultFrom},
 			From => $self->{defaultFrom},
 			Subject => $subject,
+			"Content-Type" => "text/plain; charset=UTF-8"
 		],
-		body => $result_message,
+		body => encode_utf8($result_message),
 	);
 	$email->header_set("X-Remote-Host: ",$self->{remote_host});
 

--- a/lib/WeBWorK/DB/Record/User.pm
+++ b/lib/WeBWorK/DB/Record/User.pm
@@ -80,6 +80,22 @@ sub full_name {
 # CR          =  <ASCII CR, carriage return>  ; (     15,      13.)
 # quoted-pair =  "\" CHAR                     ; may quote any char
 
+# 2019 rfc822_mailbox was modified for UTF-8 support:
+#   If the full_name is set it will use the RFC 2047 "MIME-Header" encoding
+#   for the full_name, so that UTF-8 characters can be "sent" via the
+#   permitted ASCII encoding.
+# When "international emails" (RFC 6532 and RFC 6531) which allow Unicode in
+#   the address become widely accepted, and are well supported by the public
+#   SMTP mail infrastructure - a different approach will be needed, and
+#   WW will need to validate email addresses when they are set/saved to the
+#   DB based on the new standards.
+# References:
+#	https://tools.ietf.org/html/rfc822
+#	https://tools.ietf.org/html/rfc2047
+#	https://tools.ietf.org/html/rfc6531
+#	https://tools.ietf.org/html/rfc6532
+#	https://en.wikipedia.org/wiki/International_email#UTF-8_headers
+
 sub rfc822_mailbox {
 	my ($self) = @_;
 	
@@ -89,10 +105,7 @@ sub rfc822_mailbox {
 	if (defined $address and $address ne "") {
 		if (defined $full_name and $full_name ne "") {
 			# Encode the user name using "MIME-Header" encoding,
-			# which allows UTF-8 encoded names. Given this change,
-			# the code to escape backslash, double quote, and \r
-			# was removed. Any such characters will be handled by
-			# the MIME-Header encoding.
+			# which allows UTF-8 encoded names.
 			return encode("MIME-Header", $full_name) . " <$address>";
 		} else {
 			return $address;

--- a/lib/WeBWorK/DB/Record/User.pm
+++ b/lib/WeBWorK/DB/Record/User.pm
@@ -25,6 +25,7 @@ WeBWorK::DB::Record::User - represent a record from the user table.
 
 use strict;
 use warnings;
+use Encode qw(encode);
 
 BEGIN {
 	__PACKAGE__->_fields(
@@ -87,13 +88,12 @@ sub rfc822_mailbox {
 	
 	if (defined $address and $address ne "") {
 		if (defined $full_name and $full_name ne "") {
-			# see if we need to quote the phrase
-			# (this regex matches CTL, SPACE, and specials)
-			if ($full_name =~ /[\0-\037\177 ()<>@,;:\\".\[\]]/) {
-				$full_name =~ s/(["\\\r])/\\$1/g; # escape <">, "\", or CR
-				$full_name = "\"$full_name\"";
-			}
-			return "$full_name <$address>";
+			# Encode the user name using "MIME-Header" encoding,
+			# which allows UTF-8 encoded names. Given this change,
+			# the code to escape backslash, double quote, and \r
+			# was removed. Any such characters will be handled by
+			# the MIME-Header encoding.
+			return encode("MIME-Header", $full_name) . " <$address>";
 		} else {
 			return $address;
 		}


### PR DESCRIPTION
The first 2 commits were focused on fixes to messages generated by `lib/WeBWorK/ContentGenerator/Feedback.pm` and the third commit addresses code in 2 other places which generate email messages.

The changes are to allow emails to be sent when the `$user->full_name` is in Unicode and to support Unicode characters in the message text (which was already added to `lib/WeBWorK/ContentGenerator/Feedback.pm` but not to the other 2 email generating files.)

We also set the email header
```
	Content-Type: text/plain; charset=UTF-8
```
as the message body is already set to be encoded in UTF-8, and it helps some email clients to see that set properly in the headers.

Most of the chnages have been tested successfully on my servers which are running the WW 2.15 branch, but I did not test the changes to `jitar_send_warning_email` from `lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm`.

---

Before this change, on a site which has UTF-8 support in the database, and the student's name is in Unicode, "Feedback" email could not be sent. An error message:
```
    Failed to send message: Wide character in syswrite at /usr/local/share/perl/5.22.1/Net/Cmd.pm line 210.
```
would be given. However, mail to users with only 7-bit characters in the name would work fine, but some older mail clients (ex. Alpine) would show gibberish instead of the characters encoded in UTF-8 in the message body.

With this change: the email should be properly sent (if the system is able to send emails), and simple clients should understand that the message body is UTF-8 encoded.

---

Prior changes  https://github.com/mgage/webwork2/commit/f9c5c5f9e841418e49546acb0670f26e23fd085f#diff-d7212ed759de7d3a30aa6dadc29f25f7https://github.com/mgage/webwork2/commit/f9c5c5f9e841418e49546acb0670f26e23fd085f#diff-d7212ed759de7d3a30aa6dadc29f25f7 already allowed the use of UTF-8 text in the message body, but the correct `Content-Type` mail header was not being set.

---

References:
  - https://2rfc.net/2047
  - https://juerd.nl/site.plp/perluniadvice
  - https://ncona.com/2011/06/using-utf-8-characters-on-an-e-mail-subject/
  - https://stackoverflow.com/questions/7266935/how-to-send-utf-8-email
  - https://stackoverflow.com/questions/30734516/send-utf-8-encoded-mail-with-emailsender
 
About the future Unicode support for international email addresses where the address itself can be UTF-8 encoded:
 - https://en.wikipedia.org/wiki/International_email#UTF-8_headers