### PR TITLE
Fix MathQuill for multipage gateway quizzes

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -78,7 +78,7 @@ function createAnswerQuill() {
 		exponent: { latex: '^', tooltip: 'exponent (^)', icon: '\\text{\ \ }^\\text{\ \ }' },
 		infty: { latex: '\\infty', tooltip: 'infinity (inf)', icon: '\\infty' },
 		pi: { latex: '\\pi', tooltip: 'pi (pi)', icon: '\\pi' },
-		vert: { latex: '\\vert', tooltip: 'such that (|)', icon: '|' },
+		vert: { latex: '\\vert', tooltip: 'such that (vert)', icon: '|' },
 		cup: { latex: '\\cup', tooltip: 'union (union)', icon: '\\cup' },
 		// leq: { latex: '\\leq', tooltip: 'less than or equal (\\leq)', icon: '\\leq' },
 		// geq: { latex: '\\geq', tooltip: 'greater than or equal (\\geq)', icon: '\\geq' },

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1284,9 +1284,9 @@ sub pre_header_initialize {
 			$pg = $self->getProblemHTML($self->{effectiveUser},
 						    $set, $formFields,
 						    $ProblemN);
+			WeBWorK::ContentGenerator::ProblemUtil::ProblemUtil::insert_mathquill_responses($self, $pg)
+			if ($self->{will}->{useMathQuill});
 		}
-		WeBWorK::ContentGenerator::ProblemUtil::ProblemUtil::insert_mathquill_responses($self, $pg)
-		if ($self->{will}->{useMathQuill});
 		push(@pg_results, $pg);
 	}
 	$self->{ra_problems} = \@problems;


### PR DESCRIPTION
Only attempt to create a mathquill answer box for problems that are actually on the page.  Otherwise there isn't a pg object to work with.

Also fix the parenthetical in the tooltip for the "such that" button of the toolbar.  The parenthetical should be the keys needed to type the symbol into a mathquill answer box, not a representative symbol.