### PR TITLE
removed use mod_perl lines from code

### DIFF
--- a/bin/dump_past_answers
+++ b/bin/dump_past_answers
@@ -17,7 +17,7 @@
 ##############################################################################
 
 # This script dumps the course information from all unarchived courses into
-# a single csv file.  The csv file has the following columns. 
+# a single csv file.  The csv file has the following columns.
 #
 # ID Info
 # 0 - Answer ID hash
@@ -44,7 +44,7 @@
 # 18 - Final Incorrect Attempts
 # 19 - Final Correct Attempts
 # 20 - Final Status
-# OPL Info 
+# OPL Info
 # 21 - Subject
 # 22 - Chapter
 # 23 - Section
@@ -54,26 +54,26 @@
 # 26 - Attempt Number
 # 27 - Raw status of attempt (percentage of correct blanks)
 # 28 - Number of Answer Blanks
-# 29/30 etc... - The following columns will come in pairs.  The first will be 
+# 29/30 etc... - The following columns will come in pairs.  The first will be
 #                the text of the answer contained in the answer blank
 #                and the second will be the binary 0/1 status of the answer
-#                blank.  There will be as many pairs as answer blanks. 
+#                blank.  There will be as many pairs as answer blanks.
 
 
-use strict; 
+use strict;
 
 BEGIN{ die('You need to set the WEBWORK_ROOT environment variable.\n')
 	   unless($ENV{WEBWORK_ROOT});}
 use lib "$ENV{WEBWORK_ROOT}/lib";
 use WeBWorK::CourseEnvironment;
 
-BEGIN{ 
+BEGIN{
     my $ce = new WeBWorK::CourseEnvironment({
 	webwork_dir => $ENV{WEBWORK_ROOT},
 					 });
-    
+
     my $pg_dir = $ce->{pg_dir};
-    eval "use lib '$pg_dir/lib'"; 
+    eval "use lib '$pg_dir/lib'";
     die $@ if $@;
 }
 
@@ -84,7 +84,6 @@ use WeBWorK::Utils::CourseManagement qw/listCourses/;
 use WeBWorK::Utils::Tags;
 use WeBWorK::PG;
 
-use mod_perl2;
 use Text::CSV;
 use Digest::SHA qw(sha256_hex);
 use Net::Domain;
@@ -96,13 +95,13 @@ my $upload_result = 1;
 
 my $domainname = Net::Domain::domainname;
 my $time = time();
-    
-# define and open the output file. 
+
+# define and open the output file.
 if (!$output_file) {
     $output_file = "$domainname-$time.csv";
 }
 
-my $salt; 
+my $salt;
 my $SALTFILE;
 my $saltfilename = $ENV{WEBWORK_ROOT}.'/.dump_past_answers_salt';
 
@@ -128,7 +127,7 @@ print "Dumping answer data to $output_file\n";
 # set up various variables and utilities that we will need
 my ($db, @wheres);
 my $max_answer_blanks = 0;
-my $csv = new Text::CSV->new ( { binary => 1 } ) 
+my $csv = new Text::CSV->new ( { binary => 1 } )
     or die "Cannot use CSV: ".Text::CSV->error_diag ();
 $csv->eol("\n");
 
@@ -158,14 +157,14 @@ foreach my $courseID (@courses) {
     }
 
     print "Dumping $courseID\n";
-    
+
     my $templateDir = $ce->{courseDirs}->{templates};
-    
+
     my $sCourseID = sha256_hex($salt.$domainname.$courseID);
 
     $row[1] = $sCourseID;
     $row[5] = $time;
-    
+
     my @userIDs = $db->listUsers();
     my @users = $db->getUsers(@userIDs);
 
@@ -173,21 +172,21 @@ foreach my $courseID (@courses) {
     foreach my $user (@users) {
       my $userID = $user->user_id;
 
-        #skip proctor users 
+        #skip proctor users
         next if $user->user_id =~ /^set_id:/;
-      
+
 	my $sUserID = sha256_hex($salt.$domainname.$courseID.$userID);
-	
+
 	# get user specific info
 	$row[2] = $sUserID;
 	my $permissionLevel = $db->getPermissionLevel($userID);
 	$row[6] = $permissionLabels{$permissionLevel->permission};
 	$row[7] = $ce->status_abbrev_to_name($user->{status});
-	
+
 	my @setIDs = $db->listUserSets($userID);
 	@wheres = map {[$userID,$_]} @setIDs;
 	my @sets = $db->getMergedSets(@wheres);
-	
+
 	# go through sets
 	foreach my $set (@sets) {
 	    # skip gateways
@@ -195,21 +194,21 @@ foreach my $courseID (@courses) {
 		$set->set_id !~ /,v\d+$/) {
 		next;
 	    }
-	    
+
 	    my $setID = $set->set_id;
 	    my $sSetID = sha256_hex($salt.$domainname.$courseID.$setID);
-	    
+
 	    # get set specific info
 	    $row[3] = $sSetID;
 	    $row[8] = $set->assignment_type;
 	    $row[9] = $set->open_date;
 	    $row[10] = $set->due_date;
 	    $row[11] = $set->answer_date;
-	    
+
 	    my @problemIDs = $db->listUserProblems($userID,$setID);
 	    @wheres = map {[$userID, $setID, $_]} @problemIDs;
 	    my @problems = $db->getMergedProblems(@wheres);
-	    
+
 	    # compute set score
 	    my $total = 0;
 	    my $correct = 0;
@@ -218,7 +217,7 @@ foreach my $courseID (@courses) {
 		$correct += $problem->value*$problem->status;
 	    }
 	    $row[12] = $total ? $correct/$total:0;
-	    
+
 	    # go through each problem
 	    foreach my $problem (@problems) {
 		my $problemID = $problem->problem_id;
@@ -234,7 +233,7 @@ foreach my $courseID (@courses) {
 		$row[18] = $problem->num_incorrect;
 		$row[19] = $problem->num_correct;
 		$row[20] = $problem->status;
-		
+
 		# get OPL data
 		my $file = $templateDir.'/'.$problem->source_file();
 		if (-e $file) {
@@ -242,14 +241,14 @@ foreach my $courseID (@courses) {
 		    $row[21] = $tags->{DBsubject};
 		    $row[22] = $tags->{DBchapter};
 		    $row[23] = $tags->{DBsection};
-		    $row[24] = defined($tags->{keywords}) ? 
+		    $row[24] = defined($tags->{keywords}) ?
 			join(',',@{$tags->{keywords}}) : '';
 		}
 
 		my @answerIDs = $db->listProblemPastAnswers($courseID,$userID,
 							    $setID,$problemID);
 		my @answers = $db->getPastAnswers(\@answerIDs);
-		
+
 		# go through attempts
 		my $attempt_number = 0;
 		foreach my $answer (@answers) {
@@ -268,16 +267,16 @@ foreach my $courseID (@courses) {
 			    $row[21] = $tags->{DBsubject};
 			    $row[22] = $tags->{DBchapter};
 			    $row[23] = $tags->{DBsection};
-			    $row[24] = defined($tags->{keywords}) ? 
+			    $row[24] = defined($tags->{keywords}) ?
 				join(',',@{$tags->{keywords}}) : '';
 			}
 		    }
-		    
+
 		    # input answer specific info
 		    $row[0] = $sAnswerID;
 		    $row[25] = $answer->timestamp;
 		    $row[26] = $attempt_number;
-		    
+
 		    my @scores = split('',$answer->scores,-1);
 		    my @answers = split("\t",$answer->answer_string,-1);
 
@@ -287,8 +286,8 @@ foreach my $courseID (@courses) {
 			next;
 		    }
 		    my $num_blanks = scalar(@scores);
-		    
-		    $max_answer_blanks = $num_blanks 
+
+		    $max_answer_blanks = $num_blanks
 			if ($num_blanks > $max_answer_blanks);
 
 		    # compute the raw status
@@ -296,13 +295,13 @@ foreach my $courseID (@courses) {
 		    foreach (@scores) {
 			$score += $_;
 		    }
-		    
+
 		    $row[27] = $num_blanks ? $score/$num_blanks : 0;
-		    
-		    # we leave the computed status blank for now. 
-		    
+
+		    # we leave the computed status blank for now.
+
 		    $row[28] = $num_blanks;
-		    
+
 		    for (my $i=0; $i<$num_blanks; $i++) {
 			$row[29+2*$i] = $answers[$i];
 			$row[30+2*$i] = $scores[$i];
@@ -322,7 +321,7 @@ close($OUT) or die("Couldn't close $output_file");
 
 if ($zip_result) {
     print "Zipping file\n";
-    
+
     `gzip $output_file`;
 
     $output_file = $output_file.".gz";
@@ -330,7 +329,7 @@ if ($zip_result) {
 
 if ($upload_result) {
     print "Uploading file\n";
-    
+
     `echo "put $output_file" | sftp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oPort=57281 wwdata\@52.88.32.79`;
 }
 

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -38,7 +38,6 @@ use WeBWorK;
 use Encode;
 use utf8;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # load correct modules
@@ -85,23 +84,23 @@ sub handler($) {
 			#$warnings .= "$backtrace\n\n";
 			$warnings = Encode::encode_utf8($warnings);
 			$r->notes->set(warnings => $warnings);
-			
+
 			$log->warn("[$uri] $warning");
 		};
 	} else {
 		$warning_handler = sub {
 			my ($warning) = @_;
 			chomp $warning;
-			
+
 			my $warnings = $r->notes("warnings");
 			$warnings .= "$warning\n";
 			#my $backtrace = join("\n",backtrace());
 			#$warnings .= "$backtrace\n\n";
 			$r->notes("warnings" => $warnings);
-			
+
 			$log->warn("[$uri] $warning");
 		};
-		
+
 		# the exception handler generates a backtrace when catching an exception
 		my @backtrace;
 		my $exception_handler = sub {
@@ -109,24 +108,24 @@ sub handler($) {
 			die @_;
 		};
 	}
-	
+
 	# the exception handler generates a backtrace when catching an exception
 	my @backtrace;
 	my $exception_handler = sub {
 		@backtrace = backtrace();
 		die @_;
 	};
-	
+
 	my $result = do {
 		local $SIG{__WARN__} = $warning_handler;
 		local $SIG{__DIE__} = $exception_handler;
-		
+
 		eval { WeBWorK::dispatch($r) };
 	};
-	
+
 	if ($@) {
 		my $exception = $@;
-		
+
 		my $warnings = MP2 ? $r->notes->get("warnings") : $r->notes("warnings");
 		my $htmlMessage = htmlMessage($r, $warnings, $exception, @backtrace);
 		unless ($r->bytes_sent) {
@@ -134,7 +133,7 @@ sub handler($) {
 			$r->send_http_header unless MP2; # not needed for Apache2
 			$htmlMessage = "<html><body>$htmlMessage</body></html>";
 		}
-		
+
 		# log the error to the apache error log
 		my $textMessage = textMessage($r, $warnings, $exception, @backtrace);
 		$log->error($textMessage);
@@ -143,7 +142,7 @@ sub handler($) {
 
 		$result = FORBIDDEN;
 	}
-	
+
 	return $result;
 }
 
@@ -167,12 +166,12 @@ Apache::WeBWorK.
 sub backtrace {
 	my $frame = 2;
 	my @trace;
-	
+
 	while (my ($pkg, $file, $line, $subname) = caller($frame++)) {
 		last if $pkg eq "Apache::WeBWorK";
 		push @trace, "in $subname called at line $line of $file";
 	}
-	
+
 	return @trace;
 }
 
@@ -195,9 +194,9 @@ associated warnings.
 
 sub htmlMessage($$$@) {
 	my ($r, $warnings, $exception, @backtrace) = @_;
-	
-	# Warnings have html and look better scrubbed. 
-	
+
+	# Warnings have html and look better scrubbed.
+
 	my $scrubber = HTML::Scrubber->new(
 	    default => 1,
 	    script => 0,
@@ -212,7 +211,7 @@ sub htmlMessage($$$@) {
 
 	$warnings = $scrubber->scrub($warnings);
 	$exception = $scrubber->scrub($exception);
-	
+
 	my @warnings = defined $warnings ? split m|<br />|, $warnings : ();  #fragile
 	$warnings = htmlWarningsList(@warnings);
 	my $backtrace = htmlBacktrace(@backtrace);
@@ -220,9 +219,9 @@ sub htmlMessage($$$@) {
 	# $ENV{WEBWORK_SERVER_ADMIN} is set from $webwork_server_admin_email in site.conf
 	# and $ENV{SERVER_ADMIN} which is set by ServerAdmin in httpd.conf is used as a backup
 	# if an explicit email address has not been set.
-	
+
 	$ENV{WEBWORK_SERVER_ADMIN} = ($ENV{WEBWORK_SERVER_ADMIN}) ?$ENV{WEBWORK_SERVER_ADMIN}:$ENV{SERVER_ADMIN};
-	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined. 
+	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined.
 
 	my $admin = ($ENV{WEBWORK_SERVER_ADMIN}
 		? " (<a href=\"mailto:$ENV{WEBWORK_SERVER_ADMIN}\">$ENV{WEBWORK_SERVER_ADMIN}</a>)"
@@ -235,7 +234,7 @@ sub htmlMessage($$$@) {
 		join("", map { "<tr><td><small>" . htmlEscape($_). "</small></td><td><small>" .
 		                htmlEscape($headers{$_}) . " </small></td></tr>" } keys %headers);
 	};
-	
+
 	return <<EOF;
 <div style="text-align:left">
  <h2>WeBWorK error</h2>
@@ -273,13 +272,13 @@ associated warnings.
 
 sub textMessage($$$@) {
 	my ($r, $warnings, $exception, @backtrace) = @_;
-	
+
 	#my @warnings = defined $warnings ? split m/\n+/, $warnings : ();
 	#$warnings = textWarningsList(@warnings);
 	chomp $exception;
 	my $backtrace = textBacktrace(@backtrace);
 	my $uri = $r->uri;
-	
+
 	return "[$uri] $exception\n$backtrace";
 }
 

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen.pm,v 1.63 2012/06/06 22:03:15 wheeler Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -24,19 +24,19 @@ WeBWorK::Authen - Check user identity, manage session keys.
 
  # get the name of the appropriate Authen class, based on the %authen hash in $ce
  my $class_name = WeBWorK::Authen::class($ce, "user_module");
- 
+
  # load that class
  require $class_name;
- 
+
  # create an authen object
  my $authen = $class_name->new($r);
- 
+
  # verify credentials
  $authen->verify or die "Authentication failed";
- 
+
  # verification status is stored for quick retrieval later
  my $auth_ok = $authen->was_verified;
- 
+
  # for some reason, you might want to clear that cache
  $authen->forget_verification;
 
@@ -61,7 +61,6 @@ use URI::Escape;
 use Carp;
 use Scalar::Util qw(weaken);
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 #####################
@@ -71,7 +70,7 @@ use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VE
 #use vars qw($GENERIC_ERROR_MESSAGE);
 our $GENERIC_ERROR_MESSAGE = "";  # define in new
 
-## WeBWorK-tr end modification 
+## WeBWorK-tr end modification
 #####################
 
 use constant COOKIE_LIFESPAN => 60*60*24*30; # 30 days
@@ -108,7 +107,7 @@ the %authen hash, an exception is thrown.
 
 sub class {
 	my ($ce, $type) = @_;
-	
+
 	if (exists $ce->{authen}{$type}) {
 		if (ref $ce->{authen}{$type} eq "ARRAY") {
 			my $authen_type = shift @{$ce ->{authen}{$type}};
@@ -146,7 +145,7 @@ sub call_next_authen_method {
 	my $ce = $r -> {ce};
 
 	my $user_authen_module = WeBWorK::Authen::class($ce, "user_module");
-	#debug("user_authen_module = |$user_authen_module|");	
+	#debug("user_authen_module = |$user_authen_module|");
 	if (!defined($user_authen_module) or ($user_authen_module eq "")) {
 		$self->{error} = $r->maketext("No authentication method found for your request.  If this recurs, please speak with your instructor.");
 		$self->{log_error} .= "None of the specified authentication modules could handle the request.";
@@ -216,13 +215,13 @@ sub verify {
 	my $result = $self->do_verify;
 	my $error = $self->{error};
 	my $log_error = $self->{log_error};
-	
+
 	$self->{was_verified} = $result ? 1 : 0;
-	
+
 	if ($self->can("site_fixup")) {
 		$self->site_fixup;
 	}
-	
+
 	if ($result) {
 		$self->write_log_entry("LOGIN OK") if $self->{initial_login};
 		$self->maybe_send_cookie;
@@ -231,7 +230,7 @@ sub verify {
 		if (defined $log_error) {
 			$self->write_log_entry("LOGIN FAILED $log_error");
 		}
-		if (defined($error) and $error=~/\S/) { # if error message has a least one non-space character. 
+		if (defined($error) and $error=~/\S/) { # if error message has a least one non-space character.
 			if ( defined( $log_error ) and $log_error eq "inactivity timeout" ) {
 				# We don't want to override the localized inactivity timeout message.
 				# so do not check next "if" in this case.
@@ -242,12 +241,12 @@ sub verify {
 		}
         #warn "LOGIN FAILED: log_error: $log_error; user error: $error";
 		$self->maybe_kill_cookie;
-		if (defined($error) and $error=~/\S/ and $r->can('notes') ) { # if error message has a least one non-space character. 
+		if (defined($error) and $error=~/\S/ and $r->can('notes') ) { # if error message has a least one non-space character.
 			MP2? $r->notes->set(authen_error => $error) : $r->notes("authen_error" => $error);
 		      # FIXME this is a hack to accomodate the webworkservice remixes
 		}
 	}
-	
+
 	debug("END VERIFY");
 	debug("result $result");
 	return $result;
@@ -261,7 +260,7 @@ Returns true if verify() returned true the last time it was called.
 
 sub was_verified {
 	my ($self) = @_;
-	
+
 	return 1 if exists $self->{was_verified} and $self->{was_verified};
 	return 0;
 }
@@ -276,9 +275,9 @@ sub forget_verification {
 	my ($self) = @_;
 	my $r = $self -> {r};
 	my $ce = $r -> {ce};
-	
+
 	$self->{was_verified} = 0;
-	
+
 }
 
 =back
@@ -294,7 +293,7 @@ sub do_verify {
 	my $r = $self->{r};
 	my $ce = $r->ce;
 	my $db = $r->db;
-	
+
 	return 0 unless $db;
 	debug("db ok");
 	return 0 unless $self->get_credentials;
@@ -341,7 +340,7 @@ sub get_credentials {
 			if (not $self->unexpired_session_exists($userID)) {
 				my $newKey = $self->create_session($userID);
 				$self->{initial_login} = 1;
-				
+
 				$self->{user_id} = $userID;
 				$self->{session_key} = $newKey;
 				$self->{login_type} = "guest";
@@ -350,12 +349,12 @@ sub get_credentials {
 				return 1;
 			}
 		}
-		
+
 		$self->{log_error} = "no guest logins are available";
 		$self->{error} = $r->maketext("No guest logins are available. Please try again in a few minutes.");
 		return 0;
 	}
-	
+
 	my ($cookieUser, $cookieKey, $cookieTimeStamp) = $self->fetchCookie;
 
 	if (defined $cookieUser and defined $r->param("user") ) {
@@ -419,7 +418,7 @@ sub get_credentials {
 			debug("params and cookie user '", $self->{user_id}, "' params and cookie session key = '",
 				 $self->{session_key}, "' cookie_timestamp '", $self->{cookieTimeStamp}, "'");
 			return 1;
-		}	
+		}
 	}
 	# at least the user ID is available in request parameters
 	if (defined $r->param("user")) {
@@ -434,7 +433,7 @@ sub get_credentials {
 		debug("params password '", $self->{password}, "' key '", $self->{session_key}, "'");
 		return 1;
 	}
-	
+
 	if (defined $cookieUser) {
 		$self->{user_id} = $cookieUser;
 		$self->{session_key} = $cookieKey;
@@ -453,37 +452,37 @@ sub check_user {
 	my $ce = $r->ce;
 	my $db = $r->db;
 	my $authz = $r->authz;
-	
+
 	my $user_id = $self->{user_id};
-	
+
 	if (defined $user_id and $user_id eq "") {
 		$self->{log_error} = "no user id specified";
 		$self->{error} .= $r->maketext("You must specify a user ID.");
 		return 0;
 	}
-	
+
 	my $User = $db->getUser($user_id);
-	
+
 	unless ($User) {
 		$self->{log_error} = "user unknown";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	# FIXME "fix invalid status values" used to be here, but it needs to move to $db->getUser
-	
+
 	unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {
 		$self->{log_error} = "user not allowed course access";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	unless ($authz->hasPermissions($user_id, "login")) {
 		$self->{log_error} = "user not permitted to login";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	return 1;
 }
 
@@ -491,13 +490,13 @@ sub verify_practice_user {
 	my $self = shift;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $user_id = $self->{user_id};
 	my $session_key = $self->{session_key};
-	
+
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 1);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	if ($sessionExists) {
 		if ($keyMatches) {
 			if ($timestampValid) {
@@ -535,18 +534,18 @@ sub verify_practice_user {
 sub verify_normal_user {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	my $user_id = $self->{user_id};
 	my $session_key = $self->{session_key};
-	
+
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 1);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	if ($sessionExists and $keyMatches and $timestampValid) {
 		return 1;
 	} else {
 		my $auth_result = $self->authenticate;
-		
+
 		if ($auth_result > 0) {
 			$self->{session_key} = $self->create_session($user_id);
 			$self->{initial_login} = 1;
@@ -571,10 +570,10 @@ sub verify_normal_user {
 sub authenticate {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	my $user_id = $self->{user_id};
 	my $password = $self->{password};
-	
+
 	if (defined $password) {
 		return $self->checkPassword($user_id, $password);
 	} else {
@@ -586,32 +585,32 @@ sub maybe_send_cookie {
 	my $self = shift;
 	my $r = $self->{r};
 	my $ce = $r -> {ce};
-	
+
 	my ($cookie_user, $cookie_key, $cookie_timestamp) = $self->fetchCookie;
-	
+
 	# we send a cookie if any of these conditions are met:
-	
+
 	# (a) a cookie was used for authentication
 	my $used_cookie = ($self->{credential_source} eq "cookie");
-	
+
 	# (b) a cookie was sent but not used for authentication, and the
 	#     credentials used for authentication were the same as those in
 	#     the cookie
 	my $unused_valid_cookie = ($self->{credential_source} ne "cookie"
 		and defined $cookie_user and $self->{user_id} eq $cookie_user
 		and defined $cookie_key and $self->{session_key} eq $cookie_key);
-	
+
 	# (c) the user asked to have a cookie sent and is not a guest user.
 	my $user_requests_cookie = ($self->{login_type} ne "guest"
 		and ( $r->param("send_cookie")//0 )); # prevent warning if "send_cookie" param is not defined.
 
 	# (d) session management is done via cookies.
-	my $session_management_via_cookies = 
+	my $session_management_via_cookies =
 		$ce -> {session_management_via} eq "session_cookie";
-	
-	debug("used_cookie='", $used_cookie, "' unused_valid_cookie='", $unused_valid_cookie, "' user_requests_cookie='", $user_requests_cookie, 
+
+	debug("used_cookie='", $used_cookie, "' unused_valid_cookie='", $unused_valid_cookie, "' user_requests_cookie='", $user_requests_cookie,
 			"' session_management_via_cookies ='", $session_management_via_cookies, "'");
-	
+
 	if ($used_cookie or $unused_valid_cookie or $user_requests_cookie or $session_management_via_cookies) {
 		#debug("Authen::maybe_send_cookie is sending a cookie");
 		$self->sendCookie($self->{user_id}, $self->{session_key});
@@ -628,12 +627,12 @@ sub maybe_kill_cookie {
 sub set_params {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	# A2 - params are not non-modifiable, with no explanation or workaround given in docs. WTF!
 	$r->param("user", $self->{user_id});
 	$r->param("key", $self->{session_key});
 	$r->param("passwd", "");
-	
+
 	debug("params user='", $r->param("user"), "' key='", $r->param("key"), "'");
 }
 
@@ -644,16 +643,16 @@ sub set_params {
 sub checkPassword {
 	my ($self, $userID, $possibleClearPassword) = @_;
 	my $db = $self->{r}->db;
-	
+
 	my $Password = $db->getPassword($userID); # checked
 	if (defined $Password) {
 		# check against WW password database
 		my $possibleCryptPassword = crypt $possibleClearPassword, $Password->password;
 		my $dbPassword = $Password->password;
-		# This next line explicitly insures that 
-		# blank or null passwords from the database can never 
+		# This next line explicitly insures that
+		# blank or null passwords from the database can never
 		# succeed in matching an entered password
-		# Use case: Moodle wwassignment stores null passwords and forces the creation 
+		# Use case: Moodle wwassignment stores null passwords and forces the creation
 		# of a key -- Moodle wwassignment does not use  passwords for authentication, only keys.
 		# The following line was modified to also reject cases when the database has a crypted password
 		# which matches a submitted all white-space or null password by requiring that the
@@ -683,12 +682,12 @@ sub checkPassword {
 }
 
 # Site-specific password checking
-# 
+#
 # The site_checkPassword routine can be used to provide a hook to your institution's
 # authentication system. If authentication against the  course's password database, the
 # method $self->site_checkPassword($userID, $clearTextPassword) is called. If this
 # method returns a true value, authentication succeeds.
-# 
+#
 # Here is an example site_checkPassword which checks the password against the Ohio State
 # popmail server:
 # 	sub site_checkPassword {
@@ -700,7 +699,7 @@ sub checkPassword {
 # 		}
 # 		return 0;
 # 	}
-# 
+#
 # Since you have access to the WeBWorK::Authen object, the possibilities are limitless!
 # This example checks the password against the system password database and updates the
 # user's password in the course database if it succeeds:
@@ -730,7 +729,7 @@ sub unexpired_session_exists {
 	my ($self, $userID) = @_;
 	my $ce = $self->{r}->ce;
 	my $db = $self->{r}->db;
-	
+
 	my $Key = $db->getKey($userID); # checked
 	return 0 unless defined $Key;
 	if (time <= $Key->timestamp()+$ce->{sessionKeyTimeout}) {
@@ -753,16 +752,16 @@ sub create_session {
 	my ($self, $userID, $newKey) = @_;
 	my $ce = $self->{r}->ce;
 	my $db = $self->{r}->db;
-	
+
 	my $timestamp = time;
 	unless ($newKey) {
 		my @chars = @{ $ce->{sessionKeyChars} };
 		my $length = $ce->{sessionKeyLength};
-		
+
 		srand;
 		$newKey = join ("", @chars[map rand(@chars), 1 .. $length]);
 	}
-	
+
 	my $Key = $db->newKey(user_id=>$userID, key=>$newKey, timestamp=>$timestamp);
 	# DBFIXME this should be a REPLACE
 	eval { $db->deleteKey($userID) };
@@ -792,7 +791,7 @@ sub check_session {
 	my $Key = $db->getKey($userID); # checked
 	return 0 unless defined $Key;
 	my $keyMatches = (defined $possibleKey and $possibleKey eq $Key->key);
-	
+
 	my $timestampValid=0;
 # first part of if clause is disabled for now until we figure out long term fix for using cookies
 # safely (see pull request #576)   This means that the database key time is always being used
@@ -837,16 +836,16 @@ sub fetchCookie {
 	my $r = $self->{r};
 	my $ce = $r->ce;
 	my $urlpath = $r->urlpath;
-	
+
 	my $courseID = $urlpath->arg("courseID");
-	
+
 	# AP2 - Apache2::Cookie needs $r, Apache::Cookie doesn't
     #my %cookies = WeBWorK::Cookie->fetch( MP2 ? $r : () );
     #my $cookie = $cookies{"WeBWorKCourseAuthen.$courseID"};
-	
+
 	my $cookie = undef;
 	if (MP2) {
-		
+
 		my $jar = undef;
  		eval {
        			$jar = $r->jar; #table of cookies
@@ -890,11 +889,11 @@ sub sendCookie {
 	my ($self, $userID, $key) = @_;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $courseID = $r->urlpath->arg("courseID");
-	
+
  	my $timestamp = time();
-	
+
 	my $cookie = WeBWorK::Cookie->new($r,
 		-name    => "WeBWorKCourseAuthen.$courseID",
  		-value   => "$userID\t$key\t$timestamp",
@@ -909,7 +908,7 @@ sub sendCookie {
  	if ($r->hostname ne "localhost" && $r->hostname ne "127.0.0.1") {
  		$cookie -> domain($r->hostname);    # if $r->hostname = "localhost" or "127.0.0.1", then this must be omitted.
 	}
-	
+
 	#debug("about to add Set-Cookie header with this string: '", $cookie->as_string, "'");
  	eval {$r->headers_out->set("Set-Cookie" => $cookie->as_string);};
  	if ($@) {croak $@; }
@@ -919,9 +918,9 @@ sub killCookie {
 	my ($self) = @_;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $courseID = $r->urlpath->arg("courseID");
-	
+
 	my $expires = time2str("%a, %d-%h-%Y %H:%M:%S %Z", time-60*60*24, "GMT");
 	my $cookie = WeBWorK::Cookie->new($r,
 		-name => "WeBWorKCourseAuthen.$courseID",
@@ -933,7 +932,7 @@ sub killCookie {
  	if ($r->hostname ne "localhost" && $r->hostname ne "127.0.0.1") {
  		$cookie -> domain($r->hostname);  # if $r->hostname = "localhost" or "127.0.0.1", then this must be omitted.
 	}
-	
+
 	#debug( "killCookie is about to set an expired cookie");
 	#debug("about to add Set-Cookie header with this string: '", $cookie->as_string, "'");
  	eval {$r->headers_out->set("Set-Cookie" => $cookie->as_string);};
@@ -948,11 +947,11 @@ sub write_log_entry {
 	my ($self, $message) = @_;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $user_id = defined $self->{user_id} ? $self->{user_id} : "";
 	my $login_type = defined $self->{login_type} ? $self->{login_type} : "";
 	my $credential_source = defined $self->{credential_source} ? $self->{credential_source} : "";
-	
+
 	my ($remote_host, $remote_port);
 
 	my $APACHE24 = 0;
@@ -965,7 +964,7 @@ sub write_log_entry {
 		$ce->{server_apache_version}) {
 		$version = $ce->{server_apache_version};
 	    # otherwise try and get it from the banner
-	    } elsif (Apache2::ServerUtil::get_server_banner() =~ 
+	    } elsif (Apache2::ServerUtil::get_server_banner() =~
 	  m:^Apache/(\d\.\d+):) {
 		$version = $1;
 	    }
@@ -982,7 +981,7 @@ sub write_log_entry {
 		$remote_host = "UNKNOWN" unless defined $remote_host;
 		$remote_port = "UNKNOWN" unless defined $remote_port;
 		$user_agent = "UNKNOWN";
-	} else { 
+	} else {
 		if ($APACHE24) {
 			$remote_host = $r->connection->client_addr->ip_get || "UNKNOWN";
 			$remote_port = $r->connection->client_addr->port   || "UNKNOWN";
@@ -1003,4 +1002,3 @@ sub write_log_entry {
 }
 
 1;
-

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -1,12 +1,12 @@
 ###############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
-# 
+# Copyright ï¿½ 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -34,7 +34,6 @@ use WeBWorK::Localize;
 use WeBWorK::ContentGenerator::Instructor;
 use URI::Escape;
 use Net::OAuth;
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;
@@ -95,7 +94,7 @@ sub  request_has_data_for_this_verification_module {
   debug("LTIAdvanced has been called for data verification");
   my $self = shift;
   my $r = $self->{r};
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     debug("LTIAdvanced returning 1 because it is an xmlrpc call");
@@ -119,14 +118,14 @@ sub get_credentials {
   my $self = shift;
   my $r = $self->{r};
   my $ce = $r->{ce};
-  
+
   debug("LTIAdvanced::get_credentials has been called\n");
-	
+
   ## Printing parameters to main page can help people set things up
   ## so we dont use the debug channel here
   if ( $ce->{debug_lti_parameters} ) {
     my $rh_headers = $r->headers_in;  #request headers
-    
+
     my @parameter_names = $r->param;       # form parameter names
     my $parameter_report = '';
     foreach my $key (@parameter_names) {
@@ -146,16 +145,16 @@ sub get_credentials {
   # when authenticating javascript web service requests (e.g., the
   # Library Browser).
   # Similar changes are needed in check_user() and verify_normal_user().
-  
+
   if ($r->{xmlrpc}) {
     debug("falling back to superclass get_credentials (xmlrpc call)");
     return $self->SUPER::get_credentials(@_);
   }
 
   # if at least the user ID is available in request parameters
-  if (defined $r->param("user_id")) 
+  if (defined $r->param("user_id"))
     {
-      map {$self->{$_->[0]} = $r->param($_->[1]);} 
+      map {$self->{$_->[0]} = $r->param($_->[1]);}
 	(
 	 ['role', 'roles'],
 	 ['last_name' , 'lis_person_name_family'],
@@ -173,27 +172,27 @@ sub get_credentials {
       # Some LMS's misspell the lis_person_sourcedid parameter name
       # so we try a number of variations here
       if (defined($r->param("lis_person_sourced_id"))) {
-	$self->{user_id} = $r->param("lis_person_sourced_id"); 
+	$self->{user_id} = $r->param("lis_person_sourced_id");
       } elsif (defined($r->param("lis_person_sourcedid"))) {
-	$self->{user_id} = $r->param("lis_person_sourcedid"); 
+	$self->{user_id} = $r->param("lis_person_sourcedid");
       } elsif (defined($r->param("lis_person_source_id"))) {
-	$self->{user_id} = $r->param("lis_person_source_id"); 
+	$self->{user_id} = $r->param("lis_person_source_id");
       } elsif (defined($r->param("lis_person_sourceid"))) {
-	$self->{user_id} = $r->param("lis_person_sourceid"); 
+	$self->{user_id} = $r->param("lis_person_sourceid");
       } else {
 	undef($self ->{user_id});
       }
-      
+
       $self->{email} = uri_unescape($r->param("lis_person_contact_email_primary"));
 
       # if preferred_source_of_username eq "lis_person_contact_email_primary"
-      # or if the user_id is still undefined at this point 
-      # then replace the user_id with the full email address. 
+      # or if the user_id is still undefined at this point
+      # then replace the user_id with the full email address.
       # if strip_address_from_email ==1  strip off the part of the address
       # after @
 
       if (!defined($self->{user_id})
-	  or (defined($self->{email})  
+	  or (defined($self->{email})
 	      and defined($ce->{preferred_source_of_username})
 	      and $ce->{preferred_source_of_username} eq "lis_person_contact_email_primary")) {
 	$self->{user_id} = $self->{email};
@@ -206,9 +205,9 @@ sub get_credentials {
        my $user_id_lti_param_name = $ce->{preferred_source_of_student_id};
        $self->{student_id} = $r->param($user_id_lti_param_name);
      }
-      
+
       # For setting up its helpful to print out what the system think the
-      # User id and address is at this point 
+      # User id and address is at this point
       if ( $ce->{debug_lti_parameters} ) {
 	warn "=========== summary ============";
 	warn "User id is |$self->{user_id}|\n";
@@ -221,7 +220,7 @@ sub get_credentials {
       if (!defined($self->{user_id})) {
 	croak "LTIAdvanced was unable to create a username from the user_id or from the mail address. Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
       }
-      
+
       $self->{login_type} = "normal";
       $self->{credential_source} = "LTIAdvanced";
       debug("LTIAdvanced::get_credentials is returning a 1\n");
@@ -236,9 +235,9 @@ sub check_user {
   my $self = shift;
   my $r = $self->{r};
   my ($ce, $db, $authz) = map {$r->$_ ;} ('ce', 'db', 'authz');
-  
+
   my $user_id = $self->{user_id};
-  
+
   debug("LTIAdvanced::check_user has been called for user_id = |$user_id|");
 
   # See comment in get_credentials()
@@ -246,20 +245,20 @@ sub check_user {
     #debug("falling back to superclass check_user (xmlrpc call)");
     return $self->SUPER::check_user(@_);
   }
-  
+
   if (!defined($user_id) or (defined $user_id and $user_id eq "")) {
     $self->{log_error} .= "no user id specified";
     $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
     return 0;
   }
-  
+
   my $User = $db->getUser($user_id);
-  
+
   if (!$User) {
     if ( defined($r->param("lis_person_sourcedid"))
 	 or defined($r->param("lis_person_sourced_id"))
 	 or defined($r->param("lis_person_source_id"))
-	 or defined($r->param("lis_person_sourceid")) 
+	 or defined($r->param("lis_person_sourceid"))
 	 or defined($r->param("lis_person_contact_email_primary")) ) {
       debug("User |$user_id| is unknown but may be an new user from an LSM via LTI. About to return a 1");
       return 1;  #This may be a new user coming in from a LMS via LTI.
@@ -269,20 +268,20 @@ sub check_user {
       return 0;
     }
   }
-  
+
   unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {
     $self->{log_error} .= "LOGIN FAILED $user_id - course access denied";
     $self->{error} = $r->maketext("Authentication failed.  Please speak to your instructor.");
     return 0;
   }
-  
+
   unless ($authz->hasPermissions($user_id, "login")) {
     $self->{log_error} .= "LOGIN FAILED $user_id - no permission to login";
     $self->{error} = $r->maketext("Authentication failed.  Please speak to your instructor.");
     return 0;
   }
-  
-  debug("LTIAdvanced::check_user is about to return a 1.");	
+
+  debug("LTIAdvanced::check_user is about to return a 1.");
   return 1;
 }
 
@@ -291,29 +290,29 @@ sub verify_practice_user { return(0) ;}
 
 sub verify_normal_user {
   my $self = shift;
-  my ($r, $user_id, $session_key) 
+  my ($r, $user_id, $session_key)
     = map {$self->{$_};} ('r', 'user_id', 'session_key');
-  
+
   debug("LTIAdvanced::verify_normal_user called for user |$user_id|");
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     #debug("falling back to superclass verify_normal_user (xmlrpc call)");
     return $self->SUPER::verify_normal_user(@_);
   }
-  
+
   # Call check_session in order to destroy any existing session cookies and Key table sessions
   my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 0);
 
   debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-  
+
   my $auth_result = $self->authenticate;
-  
-  debug("auth_result=|${auth_result}|");	
+
+  debug("auth_result=|${auth_result}|");
 
   # Parameters CANNOT be modified until after LTIAdvanced authentication
   # has been done, because the parameters passed with the request
-  # are used in computing the OAuth_signature.  If there  
+  # are used in computing the OAuth_signature.  If there
   # are any changes in $r->{paramcache} (see Request.pm)
   # before authentication occurs, then authentication will FAIL
   # even if the consumer_secret is correct.
@@ -328,19 +327,19 @@ sub verify_normal_user {
       $self->{error} = $auth_result;
       $self-> {log_error} .= "$user_id - authentication failed: ". $self->{error};
       return 0;
-    } 
+    }
 }
 
 sub authenticate {
   my $self = shift;
   my ($r, $user ) = map {$self->{$_};} ('r', 'user_id');
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     #debug("falling back to superclass authenticate (xmlrpc call)");
     return $self->SUPER::authenticate(@_);
   }
-  
+
   debug("LTIAdvanced::authenticate called for user |$user|");
   debug "ref(r) = |". ref($r) . "|";
   debug "ref of r->{paramcache} = |" . ref($r->{paramcache}) . "|";
@@ -348,10 +347,10 @@ sub authenticate {
   my $ce = $r->ce;
   my $db = $r->db;
   my $courseName = $r->ce->{'courseName'};
-  
+
   # Check nonce to see whether request is legitimate
   debug("Nonce = |" . $self-> {oauth_nonce} . "|");
-  my $nonce = WeBWorK::Authen::LTIAdvanced::Nonce->new($r, $self->{oauth_nonce}, $self->{oauth_timestamp}); 
+  my $nonce = WeBWorK::Authen::LTIAdvanced::Nonce->new($r, $self->{oauth_nonce}, $self->{oauth_timestamp});
   if (!($nonce->ok ) ) {
     $self->{error} .=  $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator if this recurs.");
     debug("Failed to verify nonce");
@@ -362,15 +361,15 @@ sub authenticate {
   my %request_hash;
   my @keys = keys %{$r-> {paramcache}};
   foreach my $key (@keys) {
-    $request_hash{$key} =  $r->param($key); 
+    $request_hash{$key} =  $r->param($key);
     debug("$key->|" . $request_hash{$key} . "|");
-  }	
+  }
   my $requestHash = \%request_hash;
 
   # We need to provide the request URL when verifying the OAuth request.
   # We use the url request by default, but also allow it to be overriden
   my $path = $ce->{server_root_url}.$ce->{webwork_url};
-  $path = $ce->{LTIBasicToThisSiteURL} ? 
+  $path = $ce->{LTIBasicToThisSiteURL} ?
     $ce->{LTIBasicToThisSiteURL} : $path;
 
   # append the path the the server url
@@ -380,20 +379,20 @@ sub authenticate {
       warn("The following path was reconstructed by WeBWorK.  It should match the path in the LMS:");
       warn($path);
   }
-  
+
   # We also try a version without the trailing / in case that was not
-  # included when the LMS user created the LMS link 
+  # included when the LMS user created the LMS link
   my $altpath = $path;
   $altpath =~ s/\/$//;
-  
+
   my ($request, $altrequest);
-  eval { 
+  eval {
     $request = Net::OAuth->request("request token")->from_hash($requestHash,
 	       request_url => $path,
 	       request_method => "POST",
 	       consumer_secret => $ce->{LTIBasicConsumerSecret},
 							      );
-    
+
     $altrequest = Net::OAuth->request("request token")->from_hash($requestHash,
 		  request_url => $altpath,
 		  request_method => "POST",
@@ -411,7 +410,7 @@ sub authenticate {
     } elsif (! $request->verify && ! $altrequest->verify) {
       debug("LTIAdvanced::authenticate request-> verify failed");
       debug("OAuth verification Failed ");
-      
+
       $self->{error} .= $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
       $self->{log_error} .= "OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.";
       if ( $ce->{debug_lti_parameters} ) {
@@ -420,7 +419,7 @@ sub authenticate {
       return 0;
     } else {
       debug("OAuth verification SUCCEEDED !!");
-      
+
       my $userID = $self->{user_id};
       if (! $db->existsUser($userID) ) { # New User. Create User record
 	unless ($self->create_user()) {
@@ -452,13 +451,13 @@ sub authenticate {
 
       return 1;
     }
-  
+
   debug("LTIAdvanced is returning a failed authentication");
   $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
   return(0);
 }
 
-# create a new user trying to log in 
+# create a new user trying to log in
 sub create_user {
   my $self = shift;
   my $r = $self->{r};
@@ -473,25 +472,25 @@ sub create_user {
   ############################################################
   my $LTIrolesString = $r->param("roles");
   my @LTIroles = split /,/, $LTIrolesString;
-  
+
   #remove the urn string if its present
   s/^urn:lti:.*:ims\/lis\/// for @LTIroles;
-  
+
   if ( $ce->{debug_lti_parameters} ) {
     warn "The adjusted LTI roles defined for this user are: \n--",
       join("\n--", @LTIroles), "\n",
       "Any initial ^urn:lti:.*:ims/lis/ segments have been stripped off.\n",
       "The user will be assigned the highest role defined for them\n",
-      "========================\n"		
+      "========================\n"
     }
-  
+
   my $nr = scalar(@LTIroles);
   if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
     croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
 	  . $LTIroles[0] .".");
   }
-  
-  my $LTI_webwork_permissionLevel 
+
+  my $LTI_webwork_permissionLevel
     = $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}};
   if ($nr > 1) {
     for (my $j =1; $j < $nr; $j++) {
@@ -499,17 +498,17 @@ sub create_user {
       next unless defined $wwRole;
       if ($LTI_webwork_permissionLevel < $ce->{userRoles}->{$wwRole}) {
 	$LTI_webwork_permissionLevel = $ce->{userRoles}->{$wwRole};
-      }	
+      }
     }
   }
-  
+
   ####### End defining roles and $LTI_webwork_permissionLevel#######
-  
-  
+
+
   warn "New user: $userID -- requested permission level is $LTI_webwork_permissionLevel." if ( $ce->{debug_lti_parameters} );
 
   # We dont create users with too high of a permission level
-  # for security reasons. 
+  # for security reasons.
   if ($LTI_webwork_permissionLevel > $ce->{userRoles}->{$ce->{LTIAccountCreationCutoff}}) {
     $self->{log_error}.= "userID: $userID -- Unknown instructor attempting to log in via LTI.  Instructor accounts must be created manually";
     croak $r->maketext("The instructor account with user id [_1] does not exist.  Please create the account manually via WeBWorK.",$userID);
@@ -544,11 +543,11 @@ sub create_user {
   $db->addPermissionLevel($newPermissionLevel);
   $r->authz->{PermissionLevel} = $newPermissionLevel;  #cache the Permission Level Record.
 
-  
+
   # Assign existing sets
   my $instructorTools = WeBWorK::ContentGenerator::Instructor->new($r);
   my @setsToAssign = ();
-  
+
   my @globalSetIDs = $db->listGlobalSets;
   my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
   foreach my $globalSet (@GlobalSets) {
@@ -560,12 +559,12 @@ sub create_user {
   }
   $self->{numberOfSetsAssigned} = scalar @setsToAssign;
 
-  # Give schools the chance to modify newly added sets 
+  # Give schools the chance to modify newly added sets
   if (defined($ce->{LTI_modify_user_set})) {
     foreach my $globalSet (@setsToAssign) {
       my $userSet = $db->getUserSet($userID,$globalSet->set_id);
       next unless $userSet;
-      
+
       $ce->{LTI_modify_user_set}($self,$globalSet,$userSet);
       $db->putUserSet($userSet);
     }
@@ -589,7 +588,7 @@ sub maybe_update_user {
   my $permissionLevel = $db->getPermissionLevel($userID);
   # We don't alter records of users with too high a permission
   unless (defined($permissionLevel->permission) &&
-	  $permissionLevel->permission > $ce->{userRoles}->{$ce->{LTIAccountCreationCutoff}}) {  
+	  $permissionLevel->permission > $ce->{userRoles}->{$ce->{LTIAccountCreationCutoff}}) {
     # Create a temp user and run it through the create process
     my $tempUser = $db->newUser();
     $tempUser->user_id($userID);
@@ -604,14 +603,14 @@ sub maybe_update_user {
     $tempUser-> section($self->{section} // "");
     $tempUser->recitation($self->{recitation} // "");
     $tempUser->student_id($self->{student_id} // "");
-    
+
     # Allow sites to customize the temp user
     if (defined($ce->{LTI_modify_user})) {
       $ce->{LTI_modify_user}($self,$tempUser);
     }
 
-    my @elements = qw(last_name first_name 
-		      email_address status 
+    my @elements = qw(last_name first_name
+		      email_address status
 		      section recitation student_id);
 
     my $change_made = 0;
@@ -619,7 +618,7 @@ sub maybe_update_user {
     for my $element (@elements) {
       if ($user->$element ne $tempUser->$element) {
 	$change_made = 1;
-	warn "WeBWorK User has $element: ".$user->$element." but LMS user has $element ".$tempUser->$element."\n" 
+	warn "WeBWorK User has $element: ".$user->$element." but LMS user has $element ".$tempUser->$element."\n"
 	  if ( $ce->{debug_lti_parameters} );
       }
     }
@@ -631,7 +630,7 @@ sub maybe_update_user {
       warn "Existing user: $userID updated.\n"
 	if ( $ce->{debug_lti_parameters} );
     }
-      
+
     $self->{initial_login} = 1;
   }
 
@@ -644,7 +643,7 @@ sub maybe_update_user {
 
 package WeBWorK::Authen::LTIAdvanced::Nonce;
 
-# This controls how often the key database is scrubbed for old nonce's 
+# This controls how often the key database is scrubbed for old nonce's
 use constant NONCE_LIFETIME => 86400; #24 hours
 
 sub new {
@@ -666,20 +665,20 @@ sub ok {
   my $db = $self->{r}->{db};
 
   $self->maybe_purge_nonces();
-  
+
   if ($self->{timestamp} < time() - $ce->{NonceLifeTime}) {
     if ( $ce->{debug_lti_parameters} ) {
       warn("Nonce Expired.  Your NonceLifeTime may be too short");
     }
     return 0;
   }
-  
+
   my $Key = $db->getKey($self->{nonce});
-  # If we *haven't* used this nonce before then we are OK. 
+  # If we *haven't* used this nonce before then we are OK.
   if (! defined($Key) ) {
     # nonce, timestamp are ok.	Add the nonce so its not used again
-    $Key = $db->newKey(user_id=>$self->{nonce}, 
-		       key=>"nonce", 
+    $Key = $db->newKey(user_id=>$self->{nonce},
+		       key=>"nonce",
 		       timestamp=>$self->{"timestamp"},
 		      );
     $db->addKey($Key);
@@ -720,4 +719,3 @@ sub maybe_purge_nonces {
 }
 
 1;
-

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -1,13 +1,13 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright ï¿½ 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: /webwork/cvs/system/webwork2/lib/WeBWorK/Authen/LTIBasic.pm,v 1.1 2012/05/17 18:50:11 wheeler Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -34,7 +34,6 @@ use WeBWorK::Utils qw(formatDateTime);
 use WeBWorK::Localize;
 use URI::Escape;
 use Net::OAuth;
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;
@@ -52,20 +51,20 @@ BEGIN {
 	}
 }
 
-our $GENERIC_ERROR_MESSAGE = 
+our $GENERIC_ERROR_MESSAGE =
 	"Your authentication failed.  Please return to "
 	. "your Course Management System (e.g., Oncourse, Moodle, "
 	. "Blackboard, Canvas, Sakai, etc.)  and login again.";
-our $GENERIC_MISSING_USER_ID_ERROR_MESSAGE = 
+our $GENERIC_MISSING_USER_ID_ERROR_MESSAGE =
 	"Your authentication failed.  Please return to "
 	. "your Course Management System (e.g., Oncourse, Moodle, "
 	. "Blackboard, Canvas, Sakai, etc.)  and login again.";
-our $GENERIC_DENIED_LOGIN_ERROR_MESSAGE = 
+our $GENERIC_DENIED_LOGIN_ERROR_MESSAGE =
 	"You are not permitted to login into this site at this time. "
 	. "Please speak with your instructor.";
-our $GENERIC_UNKNOWN_USER_ERROR_MESSAGE = 
+our $GENERIC_UNKNOWN_USER_ERROR_MESSAGE =
 	"This username does not appear on the roster for this WeBWorK site." ;
-our $GENERIC_UNKNOWN_INSTRUCTOR_ERROR_MESSAGE = 
+our $GENERIC_UNKNOWN_INSTRUCTOR_ERROR_MESSAGE =
 	"You have attemped to access this site as an instructor without prior authorization.";
 
 =head1 CONSTRUCTOR
@@ -111,7 +110,7 @@ sub new {
 #         $Key -> key = "nonce"
 #         $Key -> timestamp = the nonce's timestamp
 #  3. when this method is used, there needs to be a CRON job
-#     to delete old nonce records 
+#     to delete old nonce records
 #  4. A program ww_purge_old_nonces is available for
 #     deleting old nonce records.  It should be placed
 #     in webwork2/system/bin
@@ -182,13 +181,13 @@ sub get_credentials {
 	my $self = shift;
 	my $r = $self->{r};
 	my $ce = $r -> {ce};
-	
+
 	#debug("LTIBasic::get_credentials has been called\n");
-	
+
 	## debug code MEG
 	if ( $ce->{debug_lti_parameters} ) {
 		my $rh_headers = $r->headers_in;  #request headers
-	
+
 		my @parameter_names = $r->param;       # form parameter names
 		my $parameter_report = '';
 		foreach my $key (@parameter_names) {
@@ -197,10 +196,10 @@ sub get_credentials {
 		warn ("===== parameters received =======\n", $parameter_report);
 	}
 	###
-	
-	
-	
-	
+
+
+
+
 	#disable password login
 	$self->{external_auth} = 1;
 
@@ -219,9 +218,9 @@ sub get_credentials {
 	}
 
 	# if at least the user ID is available in request parameters
-	if (defined $r->param("user_id")) 
+	if (defined $r->param("user_id"))
 		{
-		map {$self -> {$_ -> [0]} = $r -> param($_ -> [1]);} 
+		map {$self -> {$_ -> [0]} = $r -> param($_ -> [1]);}
 						(
 						#['user_id', 'lis_person_sourcedid'],
 						['role', 'roles'],
@@ -240,37 +239,37 @@ sub get_credentials {
 		# The following lines were substituted for the commented out line above
 		# because some LMS's misspell the lis_person_sourcedid parameter name
 		if (defined($r -> param("lis_person_sourced_id"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourced_id"); 
+			$self -> {user_id} = $r -> param("lis_person_sourced_id");
 		} elsif (defined($r -> param("lis_person_sourcedid"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourcedid"); 
+			$self -> {user_id} = $r -> param("lis_person_sourcedid");
 		} elsif (defined($r -> param("lis_person_source_id"))) {
-			$self -> {user_id} = $r -> param("lis_person_source_id"); 
+			$self -> {user_id} = $r -> param("lis_person_source_id");
 		} elsif (defined($r -> param("lis_person_sourceid"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourceid"); 
+			$self -> {user_id} = $r -> param("lis_person_sourceid");
 		} else {
 			undef($self ->{user_id});
 		}
 		###############
-		# if get_username_from_email == 1 then replace user_id with the full email address if possible 
+		# if get_username_from_email == 1 then replace user_id with the full email address if possible
 		# or if the user_id is still undefined try to set the user_id to full the email address
-		
+
 		$self -> {email} = uri_unescape($r -> param("lis_person_contact_email_primary"));
 # 		if (!defined($self->{user_id})
 # 		    or defined($self -> {email}) and $ce -> {get_username_from_email} )  {
 # 		    $self->{user_id} = $self -> {email};
-# 
+#
 # 		}
-		
+
 		#############
 		# if preferred_source_of_username eq "lis_person_contact_email_primary"
-		# then replace the user_id with the full email address. 
-		
+		# then replace the user_id with the full email address.
+
 		# or if the user_id is still undefined try to set the user_id to full the email address
-		
+
 		# if strip_address_from_email ==1  strip off the part of the address after @
 		#############
 		if (!defined($self->{user_id})
-			or (defined($self -> {email})  
+			or (defined($self -> {email})
 				and defined($ce -> {preferred_source_of_username})
 				and $ce -> {preferred_source_of_username} eq "lis_person_contact_email_primary")) {
 			$self->{user_id} = $self -> {email};
@@ -310,7 +309,7 @@ sub check_user {
 	my $self = shift;
 	my $r = $self->{r};
 	my ($ce, $db, $authz) = map {$r -> $_ ;} ('ce', 'db', 'authz');
-	
+
 	my $user_id = $self->{user_id};
 
 	#debug("LTIBasic::check_user has been called for user_id = |$user_id|");
@@ -326,14 +325,14 @@ sub check_user {
 		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE);
 		return 0;
 	}
-	
+
 	my $User = $db->getUser($user_id);
-	
+
 	if (!$User) {
 		if ( defined($r -> param("lis_person_sourcedid"))
 			or defined($r -> param("lis_person_sourced_id"))
 			or defined($r -> param("lis_person_source_id"))
-			or defined($r -> param("lis_person_sourceid")) 
+			or defined($r -> param("lis_person_sourceid"))
 			or defined($r -> param("lis_person_contact_email_primary")) ) {
 			#debug("User |$user_id| is unknown but may be an new user from an LSM via LTI.  About to return a 1");
 			return 1;  #This may be a new user coming in from a LMS via LTI.
@@ -349,23 +348,23 @@ sub check_user {
 		$self->{error} = $r->maketext($GENERIC_DENIED_LOGIN_ERROR_MESSAGE);
 		return 0;
 	}
-	
+
 	unless ($authz->hasPermissions($user_id, "login")) {
 		$self->{log_error} .= "LOGIN FAILED $user_id - no permission to login";
 		$self->{error} = $r->maketext($GENERIC_DENIED_LOGIN_ERROR_MESSAGE);
 		return 0;
 	}
-	#debug("LTIBasic::check_user is about to return a 1.");	
+	#debug("LTIBasic::check_user is about to return a 1.");
 	return 1;
 }
 
 # disable practice users
 sub verify_practice_user { return(0) ;}
 
-sub verify_normal_user 
+sub verify_normal_user
 {
 	my $self = shift;
-	my ($r, $user_id, $session_key) 
+	my ($r, $user_id, $session_key)
 			= map {$self -> {$_};} ('r', 'user_id', 'session_key');
 
 
@@ -380,10 +379,10 @@ sub verify_normal_user
     # Call check_session in order to destroy any existing session cookies and Key table sessions
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 0);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	my $auth_result = $self->authenticate;
 
-	#debug("auth_result=|${auth_result}|");	
+	#debug("auth_result=|${auth_result}|");
 
 	# Parameters CANNOT be modified until after LTIBasic authentication
 	# has been done, because the parameters passed with the request
@@ -396,26 +395,26 @@ sub verify_normal_user
 
 	$r -> param("user" => $user_id);
 
-	if ($auth_result eq "1") 
+	if ($auth_result eq "1")
 		{
 		#debug("About to call create_session.");
 		$self->{session_key} = $self->create_session($user_id);
 		#debug("session_key=|" . $self -> {session_key} . "|.");
 		return 1;
 		}
-	else  
+	else
 		{
 		$self->{error} = $r->maketext($auth_result);
 		$self-> {log_error} .= "$user_id - authentication failed: ". $self->{error};
 		return 0;
-		} 
+		}
 }
 
 sub authenticate
 {
 	my $self = shift;
 	my ($r, $user ) = map {$self -> {$_};} ('r', 'user_id');
-	
+
 	# See comment in get_credentials()
 	if ($r->{xmlrpc}) {
 		#debug("falling back to superclass authenticate (xmlrpc call)");
@@ -435,10 +434,10 @@ sub authenticate
 
 	# Check nonce to see whether request is legitimate
 	#debug("Nonce = |" . $self-> {oauth_nonce} . "|");
-	my $nonce = WeBWorK::Authen::LTIBasic::Nonce -> new($r, $self -> {oauth_nonce}, $self -> {oauth_timestamp}); 
+	my $nonce = WeBWorK::Authen::LTIBasic::Nonce -> new($r, $self -> {oauth_nonce}, $self -> {oauth_timestamp});
 	if (!($nonce -> ok ) )
 		{
-		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r);); 
+		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r););
 		$self -> {error} .= $r->maketext($GENERIC_ERROR_MESSAGE
 				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor");
 		return 0;
@@ -447,39 +446,39 @@ sub authenticate
 	my %request_hash;
 	my @keys = keys %{$r-> {paramcache}};
 	foreach my $key (@keys) {
-		$request_hash{$key} =  $r -> param($key); 
+		$request_hash{$key} =  $r -> param($key);
 		#debug("$key -> |" . $requestHash -> {$key} . "|");
-	}	
+	}
 	my $requestHash = \%request_hash;
 	my $path = $ce->{server_root_url}.$ce->{webwork_url}.$r->urlpath()->path;
-	$path = $ce->{LTIBasicToThisSiteURL} ? 
+	$path = $ce->{LTIBasicToThisSiteURL} ?
 	    $ce->{LTIBasicToThisSiteURL} : $path;
-	
+
 	my $altpath = $path;
 	$altpath =~ s/\/$//;
 
 	my ($request, $altrequest);
-	eval 
-		{ 
+	eval
+		{
 		$request = Net::OAuth -> request("request token") -> from_hash($requestHash,
 			request_url => $path,
-									       
-        		request_method => "POST",                                    
+
+        		request_method => "POST",
         		consumer_secret => $ce -> {LTIBasicConsumerSecret},
         	);
 
 		$altrequest = Net::OAuth -> request("request token") -> from_hash($requestHash,
 			request_url => $altpath,
-									       
-        		request_method => "POST",                                    
+
+        		request_method => "POST",
         		consumer_secret => $ce -> {LTIBasicConsumerSecret},
         	);
 		};
 
-	if ($@) 
+	if ($@)
 		{
 		#debug("construction of Net::OAuth object failed: $@");
-		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r);); 
+		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r););
 		$self -> {error} .= $r->maketext("Your authentication failed.  Please return to Oncourse and login again.");
 		$self -> {error} .= $r->maketext("Something was wrong with your LTI parameters.  If this recurs, please speak with your instructor");
 		$self -> {log_error} .= "Construction of OAuth request record failed";
@@ -487,7 +486,7 @@ sub authenticate
 		}
 	else
 		{
-		if (! $request -> verify && ! $altrequest -> verify) 
+		if (! $request -> verify && ! $altrequest -> verify)
 			{
 			#debug("LTIBasic::authenticate request-> verify failed");
 			#debug("<h2> OAuth verification Failed</h2> "; print_keys($r));
@@ -514,15 +513,15 @@ sub authenticate
 				       join("\n--", @LTIroles), "\n",
 				       "Any initial ^urn:lti:.*:ims/lis/ segments have been stripped off.\n",
 				       "The user will be assigned the highest role defined for them\n",
-				       "========================\n"		
+				       "========================\n"
 			}
-			
+
 			my $nr = scalar(@LTIroles);
 			if (! defined($ce -> {userRoles} -> {$ce -> {LMSrolesToWeBWorKroles} -> {$LTIroles[0]}})) {
 				croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
 						. $LTIroles[0] .".");
 			}
-			my $LTI_webwork_permissionLevel 
+			my $LTI_webwork_permissionLevel
 				= $ce -> {userRoles} -> {$ce -> {LMSrolesToWeBWorKroles} -> {$LTIroles[0]}};
 			if ($nr > 1) {
 				for (my $j =1; $j < $nr; $j++) {
@@ -530,18 +529,18 @@ sub authenticate
 					next unless defined $wwRole;
 					if ($LTI_webwork_permissionLevel < $ce -> {userRoles} -> {$wwRole}) {
 						$LTI_webwork_permissionLevel = $ce -> {userRoles} -> {$wwRole};
-					}	
+					}
 				}
 			}
 			####### End defining roles and $LTI_webwork_permissionLevel#######
-			
+
 			##################################################################
 			# Determine the section name provided by lti
 			# This may vary widely from LTI provider to LTI provider
 			# If custom_section item is provided by the LTI then nothing needs to be done
 			# The code works for the U. of Rochester Blackboard
 			##################################################################
-		
+
 # 			my $LTI_section = $r->param("context_label");   #  for example: MTH208.2014FALL.54648
 # 			my ($course_number, $semester, $CRN) = split(/\./, $LTI_section);
 # 			if ($self->{section} eq "unknown" and $CRN ) {
@@ -554,10 +553,10 @@ sub authenticate
 # 				warn "CRN $CRN\n";
 # 				warn "section $self->{section}";
 # 			}
-			########### end determine section name	
+			########### end determine section name
 			if (! $db -> existsUser($userID) )
-				{ # New User. Create User record 
-				warn "New user: $userID -- requested permission level is $LTI_webwork_permissionLevel. 
+				{ # New User. Create User record
+				warn "New user: $userID -- requested permission level is $LTI_webwork_permissionLevel.
 				      Only new users with permission levels less than or equal to 'ta = 5' can be created." if ( $ce->{debug_lti_parameters} );
 				if ($LTI_webwork_permissionLevel > $ce ->{userRoles} -> {"ta"}) {
 				    $self->{log_error}.= "userID: $userID --".' '. $GENERIC_UNKNOWN_INSTRUCTOR_ERROR_MESSAGE;
@@ -586,7 +585,7 @@ sub authenticate
 				  # Assign existing sets
 				  # This module is not a subclass of WeBWorK::ContentGenerator::Instuctor,
 				  #  do the methods defined therein for assigning problem sets and problems
-				  #  to users are not available for use here.  
+				  #  to users are not available for use here.
 				  #  Therefore, we have to resort to the lower level methods in WeBWorK::DB.
 				my $numberOfProblemsAssigned = 0;
 				my %globalProblemsBySet=();
@@ -613,15 +612,15 @@ sub authenticate
 				my $due_cut = time() + 2*24*3600;
 				my $userSet;
 				my $userProblem;
-				foreach $globalSet (@GlobalSets) 
+				foreach $globalSet (@GlobalSets)
 					{
-					if (defined($globalSet)) 
+					if (defined($globalSet))
 						{
 						if (defined($ce -> {"adjustDueDatesForLateAdds"}) and $ce -> {"adjustDueDatesForLateAdds"}
 							and $globalSet -> open_date < $open_cut and $globalSet -> due_date < $due_cut
-							) 
+							)
 							{
-							if (not $db -> existsUserSet($userID, $globalSet -> set_id ) ) 
+							if (not $db -> existsUserSet($userID, $globalSet -> set_id ) )
 								{
 								$userSet = $db -> newUserSet();
 								$userSet -> user_id($userID);
@@ -668,34 +667,34 @@ sub authenticate
 				}
 				$self -> {initial_login} = 1;
 			}
-		else 
+		else
 			{ # Existing user.  Possibly modify demographic information and permission level.
 			my $user = $db -> getUser($userID);
 			my $permissionLevel = $db -> getPermissionLevel($userID);
 			if (($user -> last_name() eq "Teacher" and $user -> first_name() eq "The")
-					or (defined($permissionLevel -> permission) 
-							and $permissionLevel -> permission > $ce -> {userRoles} -> {professor})) 
-				{  #This is the instructor of record or an administrator.  No changes permitted via LTI.	
+					or (defined($permissionLevel -> permission)
+							and $permissionLevel -> permission > $ce -> {userRoles} -> {professor}))
+				{  #This is the instructor of record or an administrator.  No changes permitted via LTI.
 				}
-			else 
+			else
 				{
 				my $change_made = 0;
 				$self -> {last_name} =~ s/\+/ /g;
 				if (defined($user -> last_name) and defined($self -> {last_name})
-					and $user -> last_name ne $self -> {last_name}) 
+					and $user -> last_name ne $self -> {last_name})
 					{
 					$user -> last_name($self -> {last_name});
 					$change_made = 1;
 					}
 				$self -> {first_name} =~ s/\+/ /g;
 				if (defined($user -> first_name) and defined($self -> {first_name})
-					and $user -> first_name ne $self -> {first_name}) 
+					and $user -> first_name ne $self -> {first_name})
 					{
 					$user -> first_name($self -> {first_name});
 					$change_made = 1;
 					}
 				if (defined($user -> email_address) and defined($self -> {email})
-					and $user -> email_address ne $self -> {email}) 
+					and $user -> email_address ne $self -> {email})
 					{
 					$user -> email_address($self -> {email});
 					$change_made = 1;
@@ -707,22 +706,22 @@ sub authenticate
 					}
 				if (defined($permissionLevel -> permission)
 					and $permissionLevel -> permission > $ce ->{userRoles} -> {"student"})
-						{if ($user -> section ne "Admin") 
+						{if ($user -> section ne "Admin")
 							{
 							$user -> section("Admin");
 							$change_made = 1;
 							}
 						}
-				elsif ($LTI_webwork_permissionLevel > $ce -> {userRoles}->{"student"} 
+				elsif ($LTI_webwork_permissionLevel > $ce -> {userRoles}->{"student"}
 					and (!defined($user -> section) or $user -> section ne "Admin") )
 						{
 						$user -> section("Admin");
 						$change_made = 1;
 						}
-				elsif (defined ($self -> {"section"}) 
-					and (! defined($user -> section) 
+				elsif (defined ($self -> {"section"})
+					and (! defined($user -> section)
 						or ($user -> section ne $self -> {"section"}
-							and $self -> {"section"} ne "" 
+							and $self -> {"section"} ne ""
 							and $user -> section ne "Admin"
 							)
 						)
@@ -736,7 +735,7 @@ sub authenticate
 					{$user -> recitation($self ->{"recitation"});
 					$change_made = 1;
 				}
-				if ($change_made) 
+				if ($change_made)
 					{
 					$user -> comment(formatDateTime(time, "local"));
 					$db -> putUser($user);
@@ -747,7 +746,7 @@ sub authenticate
 #				if (!defined($permissionLevel -> permission) or $permissionLevel -> permission != $LTI_webwork_permissionLevel)
 
 # you seldom fine a defined user without a permissionLevel assigned
-# I don'think the following if statement is ever run. 
+# I don'think the following if statement is ever run.
 				if (!defined($permissionLevel -> permission) )
 #################################################################
 					{
@@ -758,7 +757,7 @@ sub authenticate
 					warn "Setting permission level for $userID to $LTI_webwork_permissionLevel" if ( $ce->{debug_lti_parameters} );
 				}
 				warn "Existing user: $userID updated.\n  LTIpermission level is $LTI_webwork_permissionLevel.
-				      webwork level is ". $permissionLevel -> permission. ".\n". 
+				      webwork level is ". $permissionLevel -> permission. ".\n".
 				      "User section is |".$user->{section}. "|\n recitation is |".$user->{recitation}."|\n" if ( $ce->{debug_lti_parameters} );
 			}
 			$self -> {initial_login} = 1;
@@ -803,8 +802,8 @@ sub ok {
 	my $Key = $db -> getKey($self -> {nonce});
 	if (! defined($Key) ) {
 		# nonce, timestamp are ok
-		$Key = $db -> newKey(user_id=>$self->{nonce}, 
-							key=>"nonce", 
+		$Key = $db -> newKey(user_id=>$self->{nonce},
+							key=>"nonce",
 							timestamp=>$self->{"timestamp"},
 					);
 		$db -> addKey($Key);
@@ -835,11 +834,10 @@ sub print_keys {
 	my %request_hash;
 	my $key;
 	foreach $key (@keys) {
-		$request_hash{$key} =  $r -> param($key); 
+		$request_hash{$key} =  $r -> param($key);
 		warn("$key -> |" . $request_hash{$key} . "|");
 	}
 	my $requestHash = \%request_hash;
 }
 
 1;
-

--- a/lib/WeBWorK/Authen/Moodle.pm
+++ b/lib/WeBWorK/Authen/Moodle.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Authen/Moodle.pm,v 1.14 2007/02/14 19:08:46 gage Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -41,14 +41,13 @@ use WeBWorK::Cookie;
 use WeBWorK::Debug;
 use Date::Parse; # for moodle 1.7 date parsing
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 sub new {
 	my $self = shift->SUPER::new(@_);
-	
+
 	$self->init_mdl_session;
-	
+
 	return $self;
 }
 
@@ -58,20 +57,20 @@ sub new {
 sub get_credentials {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	my $super_result = $self->SUPER::get_credentials;
 	if ($super_result) {
 		debug("Superclass's get_credentials found credentials. Using them.\n");
 		return $super_result;
 	}
-	
+
 	my ($moodle_user_id, $moodle_expiration_time) = $self->fetch_moodle_session;
 	#debug("fetch_moodle_session returned: moodle_user_id='$moodle_user_id' moodle_expiration_time='$moodle_expiration_time'.\n"); # causes errors when undefined
-	
+
 	if (defined $moodle_user_id and defined $moodle_expiration_time and time <= $moodle_expiration_time) {
 		my $newKey = $self->create_session($moodle_user_id);
 		debug("Unexpired moodle session found. Created new WeBWorK session with newKey='$newKey'.\n");
-		
+
 		$self->{user_id} = $moodle_user_id;
 		$self->{session_key} = $newKey;
 		$self->{login_type} = "normal";
@@ -80,17 +79,17 @@ sub get_credentials {
 	} else {
 		debug("No moodle session found or moodle session expired. No credentials to be had.\n");
 		warn("No moodle session found or moodle sessioin expired.  If this happens repeatedly and you are constantly being asked
-		      to log back in ask your moodle admin to check that the Moodle item: 
+		      to log back in ask your moodle admin to check that the Moodle item:
 		      Server -> Session Handling -> dbsessions (Use database for session information) has been checked.");
 	}
-	
+
 	return 0;
 }
 
 # extend the moodle session if authentication succeeded
 sub site_fixup {
 	my $self = shift;
-	
+
 	if ($self->was_verified) {
 		debug("User was verified, updating moodle session.\n");
 		$self->update_moodle_session;
@@ -102,9 +101,9 @@ sub site_fixup {
 sub checkPassword {
 	my ($self, $userID, $possibleClearPassword) = @_;
 	my $db = $self->{r}->db;
-	
+
 	debug("Moodle module is doing the password checking.\n");
-	
+
 	my $Password = $db->getPassword($userID); # checked
 	if (defined $Password) {
 		# check against Moodle password database
@@ -123,16 +122,16 @@ sub checkPassword {
 				return 0;
 			}
 		}
-		
+
 	}
 }
 
 sub check_session {
 	my ($self, $user_id, $session_key, $update_timestamp) = @_;
-	
+
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->SUPER::check_session($user_id, $session_key, $update_timestamp);
 	debug("SUPER::check_session returned: sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	if ($update_timestamp and $sessionExists and $keyMatches and not $timestampValid) {
 		debug("special case: webwork key matches an expired session (check for a unexpired moodle session)");
 		my ($moodle_user_id, $moodle_expiration_time) = $self->fetch_moodle_session;
@@ -143,7 +142,7 @@ sub check_session {
 			$timestampValid = 1;
 		}
 	}
-	
+
 	return $sessionExists, $keyMatches, $timestampValid;
 }
 
@@ -156,12 +155,12 @@ use constant DEFAULT_EXPIRY => 7200;
 
 sub init_mdl_session {
 	my $self = shift;
-	
+
 	# version-specific stuff
 	$self->{moodle17} = $self->{r}->ce->{authen}{moodle_options}{moodle17};
 	$self->{sql_session_table} = $self->{moodle17} ? "sessions2" : "sessions";
 	$self->{sql_data_field} = $self->{moodle17} ? "sessdata" : "data";
-	
+
 	$self->{mdl_dbh} = DBI->connect_cached(
 		$self->{r}->ce->{authen}{moodle_options}{dsn},
 		$self->{r}->ce->{authen}{moodle_options}{username},
@@ -182,30 +181,30 @@ sub fetch_moodle_session {
 	my ($self) = @_;
 	my $r = $self->{r};
 	my $db = $r->db;
-	
+
 	my %cookies = WeBWorK::Cookie->fetch( MP2 ? $r : () );
 	my $cookie = $cookies{"MoodleSession"};
 	return unless $cookie;
-	
+
 	my $session_table = $self->prefix_table($self->{sql_session_table});
 	my $data_field = $self->{sql_data_field};
 	my $stmt = "SELECT `expiry`,`$data_field` FROM `$session_table` WHERE `sesskey`=?";
 	my @bind_vals = $cookie->value;
-	
+
 	my $sth = $self->{mdl_dbh}->prepare_cached($stmt, undef, 3); # 3: see DBI docs
 	$sth->execute(@bind_vals);
 	my $row = $sth->fetchrow_arrayref;
 	$sth->finish;
 	return unless defined $row;
-	
+
 	my ($expires, $data_string) = @$row;
-	
+
 	# Moodle 1.7 stores expiry as a DATETIME, but WeBWorK wants a UNIX timestamp.
 	$expires = str2time($expires) if $self->{moodle17};
-	
+
 	my $data = unserialize_session($data_string);
 	my $username = $data->{"USER"}{"username"};
-	
+
 	return $username, $expires;
 }
 
@@ -214,25 +213,25 @@ sub update_moodle_session {
 	my ($self) = @_;
 	my $r = $self->{r};
 	my $db = $r->db;
-	
+
 	my %cookies = WeBWorK::Cookie->fetch( MP2 ? $r : () );
 	my $cookie = $cookies{"MoodleSession"};
 	return unless $cookie;
-	
+
 	my $config_table = $self->prefix_table("config");
 	my $value = "IFNULL((SELECT `value` FROM `$config_table` WHERE `name`=?),?)+?";
-	
+
 	# Moodle 1.7 stores expiry as a DATETIME, but WeBWorK supplies a UNIX timestamp.
 	$value = "FROM_UNIXTIME($value)" if $self->{moodle17};
-	
+
 	my $session_table = $self->prefix_table($self->{sql_session_table});
 	my $stmt = "UPDATE `$session_table` SET `expiry`=$value WHERE `sesskey`=?";
 	my @bind_vals = ("sessiontimeout", DEFAULT_EXPIRY, time, $cookie->value);
-	
+
 	my $sth = $self->{mdl_dbh}->prepare_cached($stmt, undef, 3); # 3: see DBI docs
 	my $result = $sth->execute(@bind_vals);
 	$sth->finish;
-	
+
 	return defined $result;
 }
 

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright � 2000-2012 The WeBWorK Project, http://github.com/openwebwork
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator.pm,v 1.196 2009/06/04 01:33:15 gage Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -23,9 +23,9 @@ WeBWorK::ContentGenerator - base class for modules that generate page content.
 =head1 SYNOPSIS
 
  # start with a WeBWorK::Request object: $r
- 
+
  use WeBWorK::ContentGenerator::SomeSubclass;
- 
+
  my $cg = WeBWorK::ContentGenerator::SomeSubclass->new($r);
  my $result = $cg->go();
 
@@ -54,14 +54,14 @@ use WeBWorK::PG;
 use MIME::Base64;
 use WeBWorK::Template qw(template);
 use WeBWorK::Localize;
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Scalar::Util qw(weaken);
 use HTML::Entities;
 use HTML::Scrubber;
 use WeBWorK::Utils qw(jitar_id_to_seq);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
-use Encode; 
+use Encode;
 
 our $TRACE_WARNINGS = 0;   # set to 1 to trace channel used by warning message
 
@@ -173,10 +173,10 @@ sub go {
 	if ($ce->{LTIGradeMode} and ref($r->{db}//'')  ) {
 
 	  my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($r);
-	  
+
 	  my $post_connection_action = sub {
 	    my $grader = shift;
-	    
+
 	    # catch exceptions generated during the sending process
 	    my $result_message = eval { $grader->mass_update() };
 	    if ($@) {
@@ -200,9 +200,9 @@ sub go {
 	#    check $self->{invalidSet} and react correctly)
 	my $authz = $r->authz;
 	$self->{invalidSet} = $authz->checkSet();
-	
+
 	my $returnValue = MP2 ? Apache2::Const::OK : Apache::Constants::OK;
-	
+
 	# We only write to the activity log if it has been defined and if
 	# we are in a specific course.  The latter check is to prevent attempts
 	# to write to a course log file when viewing the top-level list of
@@ -212,26 +212,26 @@ sub go {
 			$r->ce->{courseFiles}->{logs}->{activity_log});
 
 	$self->pre_header_initialize(@_) if $self->can("pre_header_initialize");
-	
+
 	# send a file instead of a normal reply (reply_with_file() sets this field)
 	defined $self->{reply_with_file} and do {
 		return $self->do_reply_with_file($self->{reply_with_file});
 	};
-	
+
 	# send a Location: header instead of a normal reply (reply_with_redirect() sets this field)
 	defined $self->{reply_with_redirect} and do {
 		return $self->do_reply_with_redirect($self->{reply_with_redirect});
 	};
-	
+
 	my $headerReturn = $self->header(@_);
 	$returnValue = $headerReturn if defined $headerReturn;
 	# FIXME: we won't need noContent after reply_with_redirect() is adopted
 	return $returnValue if $r->header_only or $self->{noContent};
-	
+
 	$self->initialize() if $self->can("initialize");
-	
+
 	$self->content();
-	
+
 	return $returnValue;
 }
 
@@ -244,7 +244,7 @@ instance.
 
 sub r {
 	my ($self) = @_;
-	
+
 	return $self->{r};
 }
 
@@ -257,43 +257,43 @@ Handler for reply_with_file(), used by go(). DO NOT CALL THIS METHOD DIRECTLY.
 sub do_reply_with_file {
 	my ($self, $fileHash) = @_;
 	my $r = $self->r;
-	
+
 	my $type = $fileHash->{type};
 	my $source = $fileHash->{source};
 	my $name = $fileHash->{name};
 	my $delete_after = $fileHash->{delete_after};
-	
+
 	# if there was a problem, we return here and let go() worry about sending the reply
 	return MP2 ? Apache2::Const::NOT_FOUND : Apache::Constants::NOT_FOUND unless -e $source;
 	return MP2 ? Apache2::Const::FORBIDDEN : Apache::Constants::FORBIDDEN unless -r $source;
-	
+
 	my $fh;
 	if (!MP2) {
 		# open the file now, so we can send the proper error status is we fail
 		open $fh, "<", $source or return Apache::Constants::SERVER_ERROR;
 	}
-	
+
 	# send our custom HTTP header
 	$r->content_type($type);
 	$r->headers_out->{"Content-Disposition"} = "attachment; filename=\"$name\"";
 	$r->send_http_header unless MP2;
-	
+
 	# send the file
 	if (MP2) {
 		$r->sendfile($source);
 	} else {
 		$r->send_fd($fh);
 	}
-	
+
 	if (!MP2) {
 		# close the file and go home
 		close $fh;
 	}
-	
+
 	if ($delete_after) {
 		unlink $source or warn "failed to unlink $source after sending: $!";
 	}
-	
+
 	return; # (see comment on return statement in do_reply_with_redirect, below.)
 }
 
@@ -306,17 +306,17 @@ Handler for reply_with_redirect(), used by go(). DO NOT CALL THIS METHOD DIRECTL
 sub do_reply_with_redirect {
 	my ($self, $url) = @_;
 	my $r = $self->r;
-	
+
 	$r->status(MP2 ? Apache2::Const::REDIRECT : Apache::Constants::REDIRECT);
 	$r->headers_out->{"Location"} = $url;
 	$r->send_http_header unless MP2;
-	
+
 	return; # we need to explicitly return noting here, otherwise we return $url under Apache2.
 	        # the return value from the mod_perl handler is used to set the HTTP status code,
 	        # but we're setting it explicitly above. i think we should dispense with setting it
 	        # with the return value altogether, and always do it with $r->status. the other way
 	        # is too oblique and error-prone. this is probably a FIXME.
-	        # 
+	        #
 	        # Apache::WeBWorK::handler always returns the value it got from WeBWorK::dispatch
 	        # WeBWorK::dispatch always returns the value it got from WW::ContentGenerator::go
 	        # WW::ContentGenerator::go works like this:
@@ -358,7 +358,7 @@ pre_header_initialize().
 sub reply_with_file {
 	my ($self, $type, $source, $name, $delete_after) = @_;
 	$delete_after ||= "";
-	
+
 	$self->{reply_with_file} = {
 		type => $type,
 		source => $source,
@@ -379,7 +379,7 @@ pre_header_initialize().
 
 sub reply_with_redirect {
 	my ($self, $url) = @_;
-	
+
 	$self->{reply_with_redirect} = $url;
 }
 
@@ -395,9 +395,9 @@ Must be called before the message() template escape is invoked.
 
 
 sub addmessage {
-    #addmessages takes html so we use htmlscrubber to get rid of 
+    #addmessages takes html so we use htmlscrubber to get rid of
     # any scripts or html comments.  However, we leave everything else
-    # by default. 
+    # by default.
 
 	my ($self, $message) = @_;
 	return unless defined($message);
@@ -445,11 +445,11 @@ sub addbadmessage {
 }
 
 =item prepare_activity_entry()
-                                                                                
+
 Prepare a string to be sent to the activity log, if it is turned on.
 This can be overriden by different modules.
-                                                                                
-=cut                                                                            
+
+=cut
 
 
 sub prepare_activity_entry {
@@ -498,7 +498,7 @@ type.
 sub header {
 	my $self = shift;
 	my $r = $self->r;
-	
+
 	$r->content_type("text/html; charset=utf-8");
 	$r->send_http_header unless MP2;
 	return MP2 ? Apache2::Const::OK : Apache::Constants::OK;
@@ -581,7 +581,7 @@ sub content {
 	my ($self) = @_;
 	my $r = $self->r;
 	my $ce = $r->ce;
-	
+
 	my $themesDir = $ce->{webworkDirs}{themes};
 	my $theme = $r->param("theme") || $ce->{defaultTheme};
 	$theme = $ce->{defaultTheme} if $theme =~ m!(?:^|/)\.\.(?:/|$)!;
@@ -601,10 +601,10 @@ sub content {
 	   		"simple.conf and on the course configuration page.\n"
 	   	} else {
 			$theme = HTML::Entities::encode_entities($theme);
-	   		die "Neither the theme $theme nor the defaultTheme math4 are available.  ".  
+	   		die "Neither the theme $theme nor the defaultTheme math4 are available.  ".
 	   		"Please notify your site administrator that the structure of the ".
 	   		"themes directory needs attention.";
-	   	
+
 	   	}
 	}
 	template($templateFile, $self);
@@ -666,10 +666,10 @@ sub links {
 	my $authen = $r->authen;
 	my $authz = $r->authz;
 	my $urlpath = $r->urlpath;
-	
+
 	# we don't currently have any links to display if the user's not logged in. this may change, though.
 	#return "" unless $authen->was_verified;
-	
+
 	# grab some interesting data from the request
 	my $courseID = $urlpath->arg("courseID");
 	my $userID = $r->param('user');
@@ -682,7 +682,7 @@ sub links {
 	my $prettyAchievementID = $achievementID;
 	$prettySetID =~ s/_/ /g if defined $prettySetID;
 	$prettyAchievementID =~ s/_/ /g if defined $prettyAchievementID;
-	
+
 	my $prettyProblemID = $problemID;
 
 	# it's possible that the setID and the problemID are invalid, since they're just taken from the URL path info
@@ -700,25 +700,25 @@ sub links {
 			$problemID = undef;
 		}
 	}
-	
+
 	# experimental subroutine for generating links, to clean up the rest of the
 	# code. ignore for now. (this is a closure over $self.)
 	my $makelink = sub {
 		my ($module, %options) = @_;
-		
+
 		my $urlpath_args = $options{urlpath_args} || {};
 		my $systemlink_args = $options{systemlink_args} || {};
 		my $text = HTML::Entities::encode_entities($options{text});
 		my $active = $options{active};
 		my %target = ($options{target} ? (target => $options{target}) : ());
-		
+
 		my $new_urlpath = $self->r->urlpath->newFromModule($module, $r, %$urlpath_args);
 		my $new_systemlink = $self->systemLink($new_urlpath, %$systemlink_args);
 
 		defined $text or $text = $new_urlpath->name;  #too clever
-		
-		
-		# try to set $active automatically by comparing 
+
+
+		# try to set $active automatically by comparing
 		if (not defined $active) {
 			if ($urlpath->module eq $new_urlpath->module) {
 				my @args = sort keys %{{$urlpath->args}};
@@ -736,7 +736,7 @@ sub links {
 				$active = 0;
 			}
 		}
-		
+
 		my $new_anchor;
 		if ($active) {
 			# add active class for current location
@@ -744,14 +744,14 @@ sub links {
 		} else {
 			$new_anchor = CGI::a({href=>$new_systemlink, %target}, "$text");
 		}
-		
+
 		return $new_anchor;
 	};
-	
+
 	# to make things more concise
 	my $pfx = "WeBWorK::ContentGenerator::";
 	my %args = ( courseID => $courseID );
-	
+
 	# we'd like to preserve displayMode and showOldAnswers between pages, and we
 	# don't have a general way of preserving non-authen params between requests,
 	# so here is the hack:
@@ -769,7 +769,7 @@ sub links {
 	# always this value before using it.
 	my %systemlink_args;
 	$systemlink_args{params} = \%params if %params;
-	
+
 	print CGI::start_ul();
 	print CGI::start_li({class => "nav-header"});
 	print CGI::h2($r->maketext("Main Menu"));
@@ -777,7 +777,7 @@ sub links {
 	print CGI::start_li(); # Courses
 	print &$makelink("${pfx}Home", text=>$r->maketext("Courses"), systemlink_args=>{authen=>0});
 	print CGI::end_li(); # end Courses
-	
+
 	if (defined $courseID) {
 		if ($authen->was_verified) {
 			print CGI::start_li(); # Homework Sets
@@ -808,7 +808,7 @@ sub links {
 				    print CGI::start_li();
 					print CGI::start_ul();
 					print CGI::start_li(); # $problemID
-					print &$makelink("${pfx}Problem", text=>$r->maketext("Problem [_1]", $prettyProblemID), urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args);					
+					print &$makelink("${pfx}Problem", text=>$r->maketext("Problem [_1]", $prettyProblemID), urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args);
 					print CGI::end_li(); # end $problemID
 					print CGI::end_ul();
 				    print CGI::end_li();
@@ -817,31 +817,31 @@ sub links {
 			    print CGI::end_li(); # end Homework Sets
 			}
 
-			
+
 				print CGI::li(&$makelink("${pfx}Options", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
-					
+
 			print CGI::li(&$makelink("${pfx}Grades", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
-			
+
 			if ($ce->{achievementsEnabled}) {
-			    print CGI::li(&$makelink("${pfx}Achievements", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args)); 
+			    print CGI::li(&$makelink("${pfx}Achievements", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 
 			}
 
 			if ($authz->hasPermissions($userID, "access_instructor_tools")) {
 				$pfx .= "Instructor::";
-				
+
 				print CGI::start_li(); # Instructor Tools
 				print &$makelink("${pfx}Index", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
 				print CGI::end_li();
 				print CGI::start_li();
 				print CGI::start_ul();
-				
+
                 #class list editor
 				print CGI::li(&$makelink("${pfx}UserList", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args))
 					if $ce->{showeditors}->{classlisteditor1};
 				print CGI::li(&$makelink("${pfx}UserList2", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args))
 					if $ce->{showeditors}->{classlisteditor2};
-				
+
 				# Homework Set Editor
 				print CGI::li(&$makelink("${pfx}ProblemSetList", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args))
 					if $ce->{showeditors}->{homeworkseteditor1};
@@ -872,10 +872,10 @@ sub links {
 							if $ce->{showeditors}->{pgproblemeditor1};
 					    print CGI::li(&$makelink("${pfx}PGProblemEditor2", text=>"$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor2"))
 							if $ce->{showeditors}->{pgproblemeditor2};;
-					    
+
 					    print CGI::li(&$makelink("${pfx}PGProblemEditor3", text=>"--$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"WW_Editor3"))
 						if $ce->{showeditors}->{pgproblemeditor3};;
-	
+
 					    print CGI::li(&$makelink("${pfx}SimplePGEditor", text=>"$prettyProblemID", urlpath_args=>{%args,setID=>$setID,problemID=>$problemID}, systemlink_args=>\%systemlink_args, target=>"Simple_Editor"))
 						if $ce->{showeditors}->{simplepgeditor};;
 					    print CGI::end_ul();
@@ -889,11 +889,11 @@ sub links {
 						print CGI::end_ul();
 					    print CGI::end_li();
 					}
-					
+
 					print CGI::end_ul();
 				    print CGI::end_li();
 				}
-				
+
 				print CGI::li(&$makelink("${pfx}SetMaker", text=>$r->maketext("Library Browser"), urlpath_args=>{%args}, systemlink_args=>\%systemlink_args))
 					if $ce->{showeditors}->{librarybrowser1};
 				print CGI::li(&$makelink("${pfx}SetMaker2", text=>$r->maketext("Library Browser 2"), urlpath_args=>{%args}, systemlink_args=>\%systemlink_args))
@@ -920,7 +920,7 @@ sub links {
 					print CGI::end_ul();
 				}
 				print CGI::end_li(); # end Stats
-				
+
 				print CGI::start_li(); # Student Progress
 				print &$makelink("${pfx}StudentProgress", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
 				if ($userID ne $eUserID or defined $setID) {
@@ -938,11 +938,11 @@ sub links {
 					print CGI::end_ul();
 				}
 				print CGI::end_li(); # end Student Progress
-				
+
 				if ($authz->hasPermissions($userID, "score_sets")) {
 					print CGI::li(&$makelink("${pfx}Scoring", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 				}
-				
+
 				#Show achievement editor for instructors
 				if ($ce->{achievementsEnabled} && $authz->hasPermissions($userID, "edit_achievements")) {
 				    print CGI::li(&$makelink("${pfx}AchievementList", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
@@ -954,17 +954,17 @@ sub links {
 					print CGI::end_ul();
 					print CGI::end_li();
 				    }
-				    
+
 				}
 
 				if ($authz->hasPermissions($userID, "send_mail")) {
 					print CGI::li(&$makelink("${pfx}SendMail", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 				}
-				
+
 				if ($authz->hasPermissions($userID, "manage_course_files")) {
 					print CGI::li(&$makelink("${pfx}FileManager", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 				}
-				
+
 				if ($authz->hasPermissions($userID, "manage_course_files")) {
 					print CGI::li(&$makelink("${pfx}Config", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args));
 				}
@@ -978,19 +978,19 @@ sub links {
 				print CGI::end_ul();
 				print CGI::end_li(); # end Instructor Tools
 			} # /* access_instructor_tools */
-			
+
 			if (exists $ce->{webworkURLs}{bugReporter} and $ce->{webworkURLs}{bugReporter} ne ""
 				and $authz->hasPermissions($userID, "report_bugs")) {
 				print CGI::li({class=>'divider', 'aria-hidden'=>'true'},"");
 				print CGI::li(CGI::a({href=>$ce->{webworkURLs}{bugReporter}}, $r->maketext("Report bugs")));
 			}
-	
+
 		} # /* authentication was_verified */
-				
+
 	} # /* defined $courseID */
 
 	print CGI::end_ul();
-		
+
 
 	return "";
 }
@@ -1010,19 +1010,19 @@ sub loginstatus {
 	my $authen = $r->authen;
 	my $urlpath = $r->urlpath;
 	#This will contain any extra parameters which are needed to make
-	# the page function properly.  This will normally be empty.  
+	# the page function properly.  This will normally be empty.
 	my $extraStopActingParams = $r->{extraStopActingParams};
 
 	if ($authen and $authen->was_verified) {
 		my $courseID = $urlpath->arg("courseID");
 		my $userID = $r->param("user");
 		my $eUserID = $r->param("effectiveUser");
-		
+
 		$extraStopActingParams->{effectiveUser} = $userID;
 		my $stopActingURL = $self->systemLink($urlpath, # current path
 			params=>$extraStopActingParams);
 		my $logoutURL = $self->systemLink($urlpath->newFromModule(__PACKAGE__ . "::Logout", $r, courseID => $courseID));
-		
+
 		if ($eUserID eq $userID) {
 			print $r->maketext("Logged in as [_1].", HTML::Entities::encode_entities($userID)) . CGI::a({href=>$logoutURL}, $r->maketext("Log Out"));
 		} else {
@@ -1033,7 +1033,7 @@ sub loginstatus {
 	} else {
 		print $r->maketext("Not logged in.");
 	}
-	
+
 	return "";
 }
 
@@ -1095,9 +1095,9 @@ associated with the current request.
 sub path {
 	my ($self, $args) = @_;
 	my $r = $self->r;
-	
+
 	my @path;
-	
+
 	my $urlpath = $r->urlpath;
 	do {
 	    my $name = $urlpath->name;
@@ -1113,13 +1113,13 @@ sub path {
 	    }
 	    unshift @path, $name, $r->location . $urlpath->path;
 	} while ($urlpath = $urlpath->parent);
-	
+
 	$path[$#path] = ""; # we don't want the last path element to be a link
-	
+
 	#print "\n<!-- BEGIN " . __PACKAGE__ . "::path -->\n";
 	print $self->pathMacro($args, @path);
 	#print "<!-- END " . __PACKAGE__ . "::path -->\n";
-	
+
 	return "";
 }
 
@@ -1136,7 +1136,7 @@ Print links to siblings of the current object.
 =item footer()
 
 	-by ghe3
-	
+
 	combines timestamp() and other elements of the footer, including the copyright, into one output subroutine,
 =cut
 
@@ -1149,15 +1149,15 @@ sub footer(){
 	my $theme = $ce->{defaultTheme}||"unknown -- set defaultTheme in localOverides.conf";
 	my $copyright_years = $ce->{WW_COPYRIGHT_YEARS}||"1996-2019";
 	print CGI::div({-id=>"last-modified"}, $r->maketext("Page generated at [_1]", timestamp($self)));
-	print CGI::div({-id=>"copyright"}, $r->maketext("WeBWorK &copy; [_1]| theme: [_2] | ww_version: [_3] | pg_version [_4]|", 
-	                $copyright_years,$theme, $ww_version, $pg_version), 
-	                CGI::a({-href=>"http://webwork.maa.org/"}, 
+	print CGI::div({-id=>"copyright"}, $r->maketext("WeBWorK &copy; [_1]| theme: [_2] | ww_version: [_3] | pg_version [_4]|",
+	                $copyright_years,$theme, $ww_version, $pg_version),
+	                CGI::a({-href=>"http://webwork.maa.org/"},
 	                $r->maketext("The WeBWorK Project"), ));
 
 	return ""
 }
 
- 
+
 =item timestamp()
 
 Defined in this package.
@@ -1197,13 +1197,13 @@ $self->{status_message}, if it is present.
 
 sub message {
 	my ($self) = @_;
-	
+
 	print "\n<!-- BEGIN " . __PACKAGE__ . "::message -->\n";
 	print $self->{status_message}
 	    if exists $self->{status_message};
-	
+
 	print "<!-- END " . __PACKAGE__ . "::message -->\n";
-	
+
 	return "";
 }
 
@@ -1226,7 +1226,7 @@ sub title {
 	my $urlpath = $r->urlpath;
 
 	# If the urlpath name is the courseID, and if the course has
-	# a course title then display that instead. 
+	# a course title then display that instead.
 	if (defined($urlpath->arg("courseID")) &&
 	    $urlpath->name eq $urlpath->arg("courseID") &&
 	    $db->settingExists('courseTitle')) {
@@ -1240,7 +1240,7 @@ sub title {
 	    print $name;
 	    #print "<!-- END " . __PACKAGE__ . "::title -->\n";
 	}
-	
+
 	return "";
 }
 
@@ -1264,7 +1264,7 @@ sub warnings {
 	$warnings = Encode::decode_utf8($warnings);
 	print $self->warningOutput($warnings) if $warnings;
 	print "<!-- END " . __PACKAGE__ . "::warnings -->\n";
-	
+
 	return "";
 }
 
@@ -1309,7 +1309,7 @@ sub url {
 	my $ce = $self->r->ce;
 	my $type = $args->{type};
 	my $name = $args->{name};
-	
+
 	if ($type eq "webwork") {
 	    # we have to build this here (and not in say defaults.conf) because
 	    # defaultTheme will chage as late as simple.conf
@@ -1355,7 +1355,7 @@ template:
 
  sub if_can {
  	my ($self, $arg) = @_;
- 	
+
  	if ($arg eq "floobar") {
  		return 0;
  	} else {
@@ -1367,7 +1367,7 @@ template:
 
 sub if_can {
 	my ($self, $arg) = @_;
-	
+
 	return $self->can($arg) ? 1 : 0;
 }
 
@@ -1390,7 +1390,7 @@ retrieve the result of the last call to WeBWorK::Authen::verify().
 
 sub if_loggedin {
 	my ($self, $arg) = @_;
-	
+
 	#return $arg;
 	return 0 unless $self->r->authen;
 	return $self->r->authen->was_verified() ? $arg : !$arg;
@@ -1409,7 +1409,7 @@ redefined to handle that variance:
 
  sub if_message {
  	my ($self, $arg) = @_;
- 	
+
  	my $status = $self->{processReturnValue};
  	if ($status != 0) {
  		return $arg;
@@ -1422,7 +1422,7 @@ redefined to handle that variance:
 
 sub if_message {
 	my ($self, $arg) = @_;
-	
+
 	if (exists $self->{status_message}) {
 		return $arg;
 	} else {
@@ -1445,8 +1445,8 @@ sub if_warnings {
 	my ($self, $arg) = @_;
 	my $r = $self->r;
 
-	if ( (MP2 ? $r->notes->get("warnings") : $r->notes("warnings")) 
-	     or ($self->{pgerrors}) )  
+	if ( (MP2 ? $r->notes->get("warnings") : $r->notes("warnings"))
+	     or ($self->{pgerrors}) )
 	{
 		return $arg;
 	} else {
@@ -1513,7 +1513,7 @@ sub pathMacro {
 	my $r = $self->r;
 	my %args = %$args;
 	$args{style} = "text" if $args{textonly};
-	
+
 	my $auth = $self->url_authen_args;
 	my $sep;
 	if ($args{style} eq "image") {
@@ -1521,7 +1521,7 @@ sub pathMacro {
 	} else {
 		$sep = $args{text};
 	}
-	
+
 	my @result;
 	while (@path) {
 		my $name = shift @path;
@@ -1541,7 +1541,7 @@ sub pathMacro {
 			}
 		}
 	}
-	
+
 	return join($sep, @result), "\n";
 }
 
@@ -1564,10 +1564,10 @@ we have systemLink().
 
 sub siblingsMacro {
 	my ($self, @siblings) = @_;
-	
+
 	my $auth = $self->url_authen_args;
 	my $sep = CGI::br();
-	
+
 	my @result;
 	while (@siblings) {
 		my $name = shift @siblings;
@@ -1578,7 +1578,7 @@ sub siblingsMacro {
 			? CGI::span( {id=>$id}, CGI::a({-href=>"$url?$auth"}, $name) )
 			: CGI::span( {id=>$id},$name );
 	}
-	
+
 	return join($sep, @result) . "\n";
 }
 
@@ -1619,7 +1619,7 @@ sub navMacro {
 		  ? CGI::a({-href=>"$url?$auth$tail", -class=>"nav_button"}, $html)
 		  : CGI::span({-class=>"gray_button"}, $html);
 	      }
-	
+
 	return join($args{separator}, @result) . "\n";
 }
 
@@ -1670,10 +1670,10 @@ sub feedbackMacro {
 	my $r = $self->r;
 	my $authz = $r->authz;
 	my $userID = $r->param("user");
-	
+
 	# don't do anything unless the user has permission to
 	return "" unless $authz->hasPermissions($userID, "submit_feedback");
-	
+
 	my $feedbackURL = $r->ce->{courseURLs}{feedbackURL};
 	my $feedbackFormURL = $r->ce->{courseURLs}{feedbackFormURL};
 	if (defined $feedbackURL and $feedbackURL ne "") {
@@ -1691,26 +1691,26 @@ sub feedbackMacro_email {
 	my $ce = $r->ce;
 	my $urlpath = $r->urlpath;
 	my $courseID = $urlpath->arg("courseID");
-	
+
 	# feedback form url
 	my $feedbackPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::Feedback",  $r, courseID => $courseID);
 	my $feedbackURL = $self->systemLink($feedbackPage, authen => 0); # no authen info for form action
 	my $feedbackName = $r->maketext($ce->{feedback_button_name}) || $r->maketext("Email instructor");
-	
+
 	my $result = CGI::start_form(-method=>"POST", -action=>$feedbackURL) . "\n";
 	#This is being used on forms with hidden_authen_fields already included
 	# in many pages so we need to change the fields to be hidden
 	my $hiddenFields = $self->hidden_authen_fields;
 	$hiddenFields =~ s/\"hidden_/\"email-hidden_/g;
 	$result .=  $hiddenFields."\n";
-	
+
 	while (my ($key, $value) = each %params) {
 	    next if $key eq 'pg_object';    # not used in internal feedback mechanism
 		$result .= CGI::hidden($key, $value) . "\n";
 	}
 	$result .= CGI::p(CGI::submit(-name=>"feedbackForm", -value=>$feedbackName));
 	$result .= CGI::end_form() . "\n";
-	
+
 	return $result;
 }
 
@@ -1720,17 +1720,17 @@ sub feedbackMacro_form {
 	my $ce = $r->ce;
 	my $urlpath = $r->urlpath;
 	my $courseID = $urlpath->arg("courseID");
-	
+
 	# feedback form url
 	my $feedbackName = $r->maketext($ce->{feedback_button_name}) || $r->maketext("Email instructor");
-	
+
 	my $result = CGI::start_form(-method=>"POST", -action=>$feedbackFormURL,-target=>"WW_info") . "\n";
 
-	$result .= $self->hidden_authen_fields . "\n";	
+	$result .= $self->hidden_authen_fields . "\n";
 
 	while (my ($key, $value) = each %params) {
 	    if ($key eq 'pg_object') {
-	        my $tmp = $value->{body_text}; 
+	        my $tmp = $value->{body_text};
 	        $tmp .= CGI::p(CGI::b("Note: "). CGI::i($value->{result}->{msg})) if $value->{result}->{msg} ;
 	        $result .= CGI::hidden($key, encode_base64($tmp, "") );
 	    } else {
@@ -1739,7 +1739,7 @@ sub feedbackMacro_form {
 	}
 	$result .= CGI::p({-align=>"left"}, CGI::submit(-name=>"feedbackForm", -value=>$feedbackName));
 	$result .= CGI::end_form() . "\n";
-	
+
 	return $result;
 }
 
@@ -1773,16 +1773,16 @@ list is empty), taking data from the current request.
 sub hidden_fields {
 	my ($self, @fields) = @_;
 	my $r = $self->r;
-	
+
 	@fields = $r->param unless @fields;
-	
+
 	my $html = "";
 	foreach my $param (@fields) {
 	    my @values = $r->param($param);
 	    foreach my $value (@values) {
 		next unless defined($value);
-#		$html .= CGI::hidden($param, $value); # (can't name these items when using real CGI) 
-		$html .= CGI::hidden(-name=>$param, -default=>$value, -id=>"hidden_".$param); # (can't name these items when using real CGI) 
+#		$html .= CGI::hidden($param, $value); # (can't name these items when using real CGI)
+		$html .= CGI::hidden(-name=>$param, -default=>$value, -id=>"hidden_".$param); # (can't name these items when using real CGI)
 	    }
 	}
 
@@ -1798,7 +1798,7 @@ authentication.
 
 sub hidden_authen_fields {
 	my ($self) = @_;
-	
+
 	return $self->hidden_fields("user", "effectiveUser", "key", "theme");
 }
 
@@ -1828,9 +1828,9 @@ fields.
 
 sub hidden_state_fields {
 	my ($self) = @_;
-	
+
 	return $self->hidden_authen_fields();
-	
+
 	# other things that may be state data:
 	#$self->hidden_fields("displayMode", "showOldAnswers", "showCorrectAnswers", "showHints", "showSolutions");
 }
@@ -1846,9 +1846,9 @@ the current request.
 sub url_args {
 	my ($self, @fields) = @_;
 	my $r = $self->r;
-	
+
 	@fields = $r->param unless @fields;
-	
+
 	my @pairs;
 	foreach my $param (@fields) {
 		my @values = $r->param($param);
@@ -1856,7 +1856,7 @@ sub url_args {
 			push @pairs, uri_escape_utf8($param) . "=" . uri_escape($value);
 		}
 	}
-	
+
 	return join("&", @pairs);
 }
 
@@ -1869,7 +1869,7 @@ authentication.
 
 sub url_authen_args {
 	my ($self) = @_;
-	
+
 	return $self->url_args("user", "effectiveUser", "key", "theme");
 }
 
@@ -1882,9 +1882,9 @@ state. Currently includes authentication fields and display option fields.
 
 sub url_state_args {
 	my ($self) = @_;
-	
+
 	return $self->url_authen_args;
-	
+
 	# other things that may be state data:
 	#$self->url_args("displayMode", "showOldAnswers", "showCorrectAnswers", "showHints", "showSolutions");
 }
@@ -1900,7 +1900,7 @@ sub url_state_args {
 #
 #sub url_display_args {
 #	my ($self) = @_;
-#	
+#
 #	return $self->url_args("displayMode", "showOldAnswer");
 #}
 
@@ -1919,7 +1919,7 @@ sub url_state_args {
 #	my ($self, $begin, $middle, $end, $qr_omit) = @_;
 #	my $r=$self->r;
 #	my @form_data = $r->param;
-#	
+#
 #	my $return_string = "";
 #	foreach my $name (@form_data) {
 #		next if ($qr_omit and $name =~ /$qr_omit/);
@@ -1933,7 +1933,7 @@ sub url_state_args {
 #			$return_string .= "$begin$name$middle$value$end";
 #		}
 #	}
-#	
+#
 #	return $return_string;
 #}
 
@@ -1990,7 +1990,7 @@ via email.
 sub systemLink {
 	my ($self, $urlpath, %options) = @_;
 	my $r = $self->r;
-	
+
 	my %params = ();
 	if (exists $options{params}) {
 		if (ref $options{params} eq "HASH") {
@@ -2002,7 +2002,7 @@ sub systemLink {
 			croak "option 'params' is not a hashref or an arrayref";
 		}
 	}
-	
+
 	my $authen = exists $options{authen} ? $options{authen} : 1;
 	if ($authen) {
 		$params{user}          = undef unless exists $params{user};
@@ -2010,16 +2010,16 @@ sub systemLink {
 		$params{key}           = undef unless exists $params{key};
 		$params{theme}         = undef unless exists $params{theme};
 	}
-	
+
 	my $url;
-	
+
 	$url = $r->ce->{apache_root_url} if $options{use_abs_url};
 	$url .= $r->location . $urlpath->path;
 	my $first = 1;
-	
+
 	foreach my $name (keys %params) {
 		my $value = $params{$name};
-		
+
 		my @values;
 		if (defined $value) {
 			if (ref $value eq "ARRAY") {
@@ -2040,7 +2040,7 @@ sub systemLink {
 		    warn "Parameters are ", join("|",$r->param());
 
 		}
-		 
+
 		if (@values) {
 			if ($first) {
 				$url .= "?";
@@ -2051,7 +2051,7 @@ sub systemLink {
 			$url .= join "&", map { "$name=".HTML::Entities::encode_entities($_) } @values;
 		}
 	}
-	
+
 	return $url;
 }
 
@@ -2134,7 +2134,7 @@ sub errorOutput($$$) {
 	if (ref($details) =~ /SCALAR/i) {
 		$details = [$$details];
 	} elsif (ref($details) =~/ARRAY/i) {
-		# no change needed	
+		# no change needed
 	} else {
 	   $details = [$details];
 	}
@@ -2146,13 +2146,13 @@ sub errorOutput($$$) {
 
 		CGI::p(CGI::code($error)),
 		CGI::h3("Error details"),
-		
+
 		CGI::start_code(), CGI::start_p(),
 		@{ $details },
-		#CGI::code(CGI::p(@expandedDetails)), 
+		#CGI::code(CGI::p(@expandedDetails)),
 		# not using inclusive CGI calls here saves about 30Meg of memory!
 		CGI::end_p(),CGI::end_code(),
-		
+
 		CGI::h3($r->maketext("Request information")),
 		CGI::table({border=>"1"},
 			CGI::Tr({},CGI::td($r->maketext("Time")), CGI::td($time)),
@@ -2162,8 +2162,8 @@ sub errorOutput($$$) {
 				CGI::table($headers),
 			)),
 		),
-	;  
-	
+	;
+
 }
 
 =item warningMessage
@@ -2175,10 +2175,10 @@ Used to print out a generic warning message at the top of the page
 sub warningMessage {
   my $self = shift;
   my $r = $self->r;
-  
+
   return CGI::b($r->maketext("Warning")), ' -- ',
     $r->maketext("There may be something wrong with this question. Please inform your instructor including the warning messages below.");
-  
+
 }
 
 
@@ -2206,15 +2206,15 @@ sub warningOutput($$) {
 		'*' => 1,
 	    }
 	    );
-	
+
 	foreach my $warning (@warnings) {
             # Since these warnings have html they look better scrubbed
-	    #$warning = HTML::Entities::encode_entities($warning);  
+	    #$warning = HTML::Entities::encode_entities($warning);
 	    $warning = $scrubber->scrub($warning);
 	    $warning = CGI::li(CGI::code($warning));
 	}
 	$warnings = join("", @warnings);
-	
+
 	my $time = time2str("%a %b %d %H:%M:%S %Y", time);
 	my $method = $r->method;
 	my $uri = $r->uri;
@@ -2222,7 +2222,7 @@ sub warningOutput($$) {
 	#	my %headers = $r->headers_in;
 	#	join("", map { CGI::Tr(CGI::td(CGI::small($_)), CGI::td(CGI::small($headers{$_}))) } keys %headers);
 	#};
-	
+
 	return
 		CGI::h2($r->maketext("WeBWorK Warnings")),
 		CGI::p($r->maketext('WeBWorK has encountered warnings while processing your request. If this occured when viewing a problem, it was likely caused by an error or ambiguity in that problem. Otherwise, it may indicate a problem with the WeBWorK system itself. If you are a student, report these warnings to your professor to have them corrected. If you are a professor, please consult the warning output below for more information.')),
@@ -2317,11 +2317,11 @@ sub createEmailSenderTransportSMTP {
 			# debug => 1,
 		});
 	}
-# 		warn "port is ", $transport->port(); 
-# 		warn "ssl is ", $transport->ssl(); 
+# 		warn "port is ", $transport->port();
+# 		warn "ssl is ", $transport->ssl();
 # 		warn "tls_allowed is ", $ce->{mail}->{tls_allowed}//'';
 #         warn " smtpPort is set to ", $ce->{mail}->{smtpPort}//'';
-    
+
     return $transport;
 }
 =head1 AUTHOR

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -45,7 +45,6 @@ use Socket qw/unpack_sockaddr_in inet_ntoa/; # for remote host/port info
 use Text::Wrap qw(wrap);
 use WeBWorK::Utils qw/ decodeAnswers/;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # request paramaters used

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -44,7 +44,6 @@ use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
 use WeBWorK::Utils qw/readFile readDirectory/;
 use WeBWorK::Utils::FilterRecords qw/filterRecords/;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 
@@ -795,8 +794,8 @@ sub read_input_file {
 	local(*FILE);
 	if (-e "$filePath" and -r "$filePath") {
 		open FILE, "<:utf8", $filePath || do { $self->addbadmessage(CGI::p($r->maketext("Can't open [_1]",$filePath))); return};
-		while ($header !~ s/Message:\s*$//m and not eof(FILE)) { 
-			$header .= <FILE>; 
+		while ($header !~ s/Message:\s*$//m and not eof(FILE)) {
+			$header .= <FILE>;
 		}
 		$text = join( '', <FILE>);
 		$text =~ s/^\s*//; # remove initial white space if any.
@@ -862,7 +861,7 @@ sub mail_message_to_recipients {
 # 				ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
 # 				timeout => $ce->{mail}->{smtpTimeout}
 # 			});
-# 
+#
 
 #           createEmailSenderTransportSMTP is defined in ContentGenerator
 			my $transport = $self->createEmailSenderTransportSMTP();
@@ -915,8 +914,8 @@ sub email_notification {
 # 		ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
 # 		timeout => $ce->{mail}->{smtpTimeout}
 # 	});
-# 
-# 	$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort}; 
+#
+# 	$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort};
 #           createEmailSenderTransportSMTP is defined in ContentGenerator
 	my $transport = $self->createEmailSenderTransportSMTP();
 

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Login.pm,v 1.47 2012/06/08 22:59:55 wheeler Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -31,7 +31,6 @@ use WeBWorK::CGI;
 use WeBWorK::Utils qw(readFile dequote jitar_id_to_seq);
 use Encode;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Encode;
 
@@ -50,14 +49,14 @@ sub title {
     # using the url arguments won't break if the set/problem are invalid
     my $setID = WeBWorK::ContentGenerator::underscore2nbsp($self->r->urlpath->arg("setID"));
     my $problemID = $self->r->urlpath->arg("problemID");
-    
+
     # if its a problem page for a jitar set we print the pretty version of the id
     if ($problemID) {
 	my $set = $r->db->getGlobalSet($setID);
 	if ($set && $set->assignment_type eq 'jitar') {
 	    $problemID = join('.',jitar_id_to_seq($problemID));
 	}
-    
+
 	return $r->maketext("[_1]: Problem [_2]",$setID, $problemID);
     }
 
@@ -73,18 +72,18 @@ sub info {
 	my ($self) = @_;
 	my $r = $self->r;
 	my $ce = $r->ce;
-	
+
 	my $result;
 	# This section should be kept in sync with the Home.pm version
 	# list the login info first.
-	
+
 	# FIXME this is basically the same code as below... TIME TO REFACTOR!
 	my $login_info = $ce->{courseFiles}->{login_info};
 
 	if (defined $login_info and $login_info) {
 		# login info is relative to the templates directory, apparently
 		$login_info = $ce->{courseDirs}->{templates} . "/$login_info";
-		
+
 		# deal with previewing a temporary file
 		# FIXME: DANGER: this code allows viewing of any file
 		# FIXME: this code is disabled because PGProblemEditor no longer uses editFileSuffix
@@ -92,7 +91,7 @@ sub info {
 		#		and defined $r->param("editFileSuffix")) {
 		#	$login_info .= $r->param("editFileSuffix");
 		#}
-		
+
 		if (-f $login_info) {
 			my $text = eval { readFile($login_info) };
 			if ($@) {
@@ -114,7 +113,7 @@ sub info {
 		#		and defined $r->param("editFileSuffix")) {
 		#	$site_info .= $r->param("editFileSuffix");
 		#}
-		
+
 		if (-f $site_info) {
 			my $text = eval { readFile($site_info) };
 			if ($@) {
@@ -126,9 +125,9 @@ sub info {
 			}
 		}
 	}
-	
 
-	
+
+
 	if (defined $result and $result ne "") {
 #		return CGI::div({-class=>"info-wrapper"},CGI::div({class=>"info-box", id=>"InfoPanel"}, $result));
 	    return $result;
@@ -145,7 +144,7 @@ sub links {
 sub pre_header_initialize {
 	my ($self) = @_;
 	my $authen = $self->r->authen;
-	
+
 	if ( defined($authen->{redirect}) && $authen->{redirect} ) {
 		$self->reply_with_redirect($authen->{redirect});
 	}
@@ -165,26 +164,26 @@ sub body {
 
 	# The following line may not work when a sequence of authentication modules
     # are used, because the preferred module might be external, e.g., LTIBasic,
-    # but a non-external one, e.g., Basic_TheLastChance or 
+    # but a non-external one, e.g., Basic_TheLastChance or
     # even just WeBWorK::Authen, might handle the ongoing session management.
     # So this should be set in the course environment when a sequence of
 	# authentication modules is used..
 	#my $externalAuth = (defined($auth->{external_auth}) && $auth->{external_auth} ) ? 1 : 0;
 	my $externalAuth = ((defined($ce->{external_auth}) && $ce->{external_auth})
  		or (defined($auth->{external_auth}) && $auth->{external_auth}) ) ? 1 : 0;
-	
+
 	# get some stuff together
 	my $user = $r->param("user") || "";
 	my $key = $r->param("key");
 	my $passwd = $r->param("passwd") || "";
 	my $course = $urlpath->arg("courseID");
 	my $practiceUserPrefix = $ce->{practiceUserPrefix};
-	
+
 	# don't fill in the user ID for practice users
 	# (they should use the "Guest Login" button)
 	$user = "" if $user =~ m/^$practiceUserPrefix/;
-	
-	# WeBWorK::Authen::verify will set the note "authen_error" 
+
+	# WeBWorK::Authen::verify will set the note "authen_error"
 	# if invalid authentication is found.  If this is done, it's a signal to
 	# us to yell at the user for doing that, since Authen isn't a content-
 	# generating module.
@@ -206,35 +205,35 @@ sub body {
 			}
 		} else {
 		    print CGI::p({}, $r->maketext('[_1] uses an external authentication system (e.g., Oncourse,  CAS,  Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try again.', CGI::strong($course)));
-		} 
+		}
 	} else {
 		print CGI::p($r->maketext("Please enter your username and password for [_1] below:", CGI::b($course)));
 		if ($ce -> {session_management_via} ne "session_cookie") {
 			print CGI::p($r->maketext("_LOGIN_MESSAGE", CGI::b($r->maketext("Remember Me"))));
 		}
-	
+
 		print CGI::start_form({-method=>"POST", -action=>$r->uri, -id=>"login_form"});
 
-	
+
 		# preserve the form data posted to the requested URI
 		my @fields_to_print = grep { not m/^(user|passwd|key|force_passwd_authen)$/ } $r->param;
-	
+
 		#FIXME:  This next line can be removed in time.  MEG 1/27/2005
 		# warn "Error in filtering fields : |", join("|",@fields_to_print),"|" if grep {m/user/} @fields_to_print;
-		# the above test was an attempt to discover why "user" was 
-		# being multiply defined.  We caught that error, but this 
-		# warning causes trouble with UserList.pm which now has 
+		# the above test was an attempt to discover why "user" was
+		# being multiply defined.  We caught that error, but this
+		# warning causes trouble with UserList.pm which now has
 		# fields visible_users and prev_visible_users
-	
-	
-		# Important note. If hidden_fields is passed an empty array 
-		# it prints ALL parameters as hidden fields.  That is not 
-		# what we want in this case, so we don't print at all if 
+
+
+		# Important note. If hidden_fields is passed an empty array
+		# it prints ALL parameters as hidden fields.  That is not
+		# what we want in this case, so we don't print at all if
 		# @fields_to_print is empty.
 		print $self->hidden_fields(@fields_to_print) if @fields_to_print > 0;
-	
-	
-		# print CGI::table({class=>"FormLayout"}, 
+
+
+		# print CGI::table({class=>"FormLayout"},
 			# CGI::Tr([
 				# CGI::td([
 		  		# "Username:",
@@ -253,7 +252,7 @@ sub body {
 				# ]),
 	  		# ])
 		# );
-		
+
 		print CGI::br(),CGI::br();
 		print WeBWorK::CGI_labeled_input(-type=>"text", -id=>"uname", -label_text=>$r->maketext("Username").": ", -input_attr=>{-name=>"user", -value=>"$user",'aria-required'=>'true'}, -label_attr=>{-id=>"uname_label"});
 		print CGI::br();
@@ -266,7 +265,7 @@ sub body {
 		print WeBWorK::CGI_labeled_input(-type=>"submit", -input_attr=>{-value=>$r->maketext("Continue")});
 		print CGI::br();
 #		print CGI::end_form();
-	
+
 		# figure out if there are any valid practice users
 		# DBFIXME do this with a WHERE clause
 		my @guestUserIDs = grep m/^$practiceUserPrefix/, $db->listUsers;
@@ -278,19 +277,19 @@ sub body {
 			push @allowedGuestUsers, $GuestUser
 				if $ce->status_abbrev_has_behavior($GuestUser->status, "allow_course_access");
 		}
-	
+
 		# form for guest login (it cant' be two forms because of
 		#  duplicate ids
 		if (@allowedGuestUsers) {
 #			print CGI::start_form({-method=>"POST", -action=>$r->uri});
-		
+
 			# preserve the form data posted to the requested URI
 			my @fields_to_print = grep { not m/^(user|passwd|key|force_passwd_authen)$/ } $r->param;
 #			print $self->hidden_fields(@fields_to_print);
 			print CGI::br();
 			print CGI::p($r->maketext("_GUEST_LOGIN_MESSAGE", CGI::b($r->maketext("Guest Login"))));
 			print CGI::input({-type=>"submit", -name=>"login_practice_user", -value=>$r->maketext("Guest Login")});
-	    
+
 	    		print CGI::end_form();
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/LoginProctor.pm,v 1.10 2007/04/04 15:05:26 glarose Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -19,7 +19,7 @@ use base qw(WeBWorK::ContentGenerator);
 
 =head1 NAME
 
-WeBWorK::ContentGenerator::LoginProctor - display a login form for 
+WeBWorK::ContentGenerator::LoginProctor - display a login form for
 GatewayQuiz proctored tests.
 
 =cut
@@ -31,7 +31,6 @@ use WeBWorK::Utils qw(readFile dequote);
 use WeBWorK::DB::Utils qw(grok_vsetID);
 use WeBWorK::ContentGenerator::GatewayQuiz qw(can_recordAnswers);
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # This content generator is NOT logged in.
@@ -40,7 +39,7 @@ use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VE
 # FIXME  for now.
 sub if_loggedin {
 	my ($self, $arg) = @_;
-	
+
 	return !$arg;
 }
 
@@ -48,9 +47,9 @@ sub info {
 	my ($self) = @_;
 	my $r = $self->r;
 	my $ce = $r->ce;
-	
+
 	my $result;
-	
+
 	# This section should be kept in sync with the Home.pm version
 	my $site_info = $ce->{webworkFiles}->{site_info};
 	if (defined $site_info and $site_info) {
@@ -61,7 +60,7 @@ sub info {
 		#		and defined $r->param("editFileSuffix")) {
 		#	$site_info .= $r->param("editFileSuffix");
 		#}
-		
+
 		if (-f $site_info) {
 			my $text = eval { readFile($site_info) };
 			if ($@) {
@@ -73,13 +72,13 @@ sub info {
 			}
 		}
 	}
-	
+
 	# FIXME this is basically the same code as above... TIME TO REFACTOR!
 	my $login_info = $ce->{courseFiles}->{login_info};
 	if (defined $login_info and $login_info) {
 		# login info is relative to the templates directory, apparently
 		$login_info = $ce->{courseDirs}->{templates} . "/$login_info";
-		
+
 		# deal with previewing a temporary file
 		# FIXME: DANGER: this code allows viewing of any file
 		# FIXME: this code is disabled because PGProblemEditor no longer uses editFileSuffix
@@ -87,7 +86,7 @@ sub info {
 		#		and defined $r->param("editFileSuffix")) {
 		#	$login_info .= $r->param("editFileSuffix");
 		#}
-		
+
 		if (-f $login_info) {
 			my $text = eval { readFile($login_info) };
 			if ($@) {
@@ -99,7 +98,7 @@ sub info {
 			}
 		}
 	}
-	
+
 	if (defined $result and $result ne "") {
 #		return CGI::div({class=>"info-box", id=>"InfoPanel"}, $result);
                 return $result;
@@ -114,7 +113,7 @@ sub body {
 	my $ce = $r->ce;
 	my $db = $r->db;
 	my $urlpath = $r->urlpath;
-	
+
   # convenient data variables
 	my $effectiveUser = $r->param("effectiveUser") || "";
 	my $user = $r->param("user");
@@ -135,13 +134,13 @@ sub body {
 	my $EffectiveUser = $db->getUser($effectiveUser);
 	my $User = $db->getUser($user);
 
-	my $effectiveUserFullName = $EffectiveUser->first_name() . " " . 
+	my $effectiveUserFullName = $EffectiveUser->first_name() . " " .
 	    $EffectiveUser->last_name();
 
 	# we need the UserSet to check for a set-restricted login proctor,
 	#    and to show and possibly save the submission time.
 	#    and to get the UserSet, we need to know what set and version
-	#    we're working with.  if the setName and versionName come in 
+	#    we're working with.  if the setName and versionName come in
 	#    with the setID, we're ok; otherwise, get the highest version
 	#    number available and go with that
 	my ($setName, $versionNum) = grok_vsetID($setID);
@@ -159,7 +158,7 @@ sub body {
 			$noSetVersions = 1;
 		}
 	}
-	# get the merged set; if we're not grading a test, 
+	# get the merged set; if we're not grading a test,
 	#    get the merged template set instead
 	my $UserSet;
 	if ( $noSetVersions || ! $submitAnswers ) {
@@ -172,8 +171,8 @@ sub body {
 	# let's just make sure that worked
 	die("Proctor authorization requested for a nonexistent " .
 	    "set?\n") if ( ! defined( $UserSet ) );
-  
-	# now, if we're submitting the set we need to save the 
+
+	# now, if we're submitting the set we need to save the
 	#    submission time.
 	if ( $submitAnswers ) {
 		# this shouldn't ever happen
@@ -182,26 +181,26 @@ sub body {
 			    "any tests have been taken.");
 		}
 		# we save the submission time if the attempt will be recorded,
-		#   so we have to do some research to determine if that's 
+		#   so we have to do some research to determine if that's
 		#   the case
 		my $PermissionLevel = $db->getPermissionLevel($user);
-		my $Problem = 
+		my $Problem =
 		    $db->getMergedProblemVersion($effectiveUser, $setName,
 						 $versionNum, 1);
 		# set last_attempt_time if appropriate
-		if ( WeBWorK::ContentGenerator::GatewayQuiz::can_recordAnswers($self, $User, $PermissionLevel, 
+		if ( WeBWorK::ContentGenerator::GatewayQuiz::can_recordAnswers($self, $User, $PermissionLevel,
 			$EffectiveUser, $UserSet, $Problem) ) {
 			$UserSet->version_last_attempt_time( $timeNow );
-			# FIXME: this saves all of the merged set data into 
+			# FIXME: this saves all of the merged set data into
 			#    the set_user table.  we live with this in other
 			#    places for versioned sets, but it's not ideal
 			$db->putSetVersion( $UserSet );
 		}
 	}
 
-	
+
 	print CGI::p(CGI::strong($r->maketext("Proctor authorization required.")), "\n\n");
-    # WeBWorK::Authen::verifyProctor will set the note "authen_error" 
+    # WeBWorK::Authen::verifyProctor will set the note "authen_error"
     # if invalid authentication is found.  If this is done, it's a signal to
     # us to yell at the user for doing that, since Authen isn't a content-
     # generating module.
@@ -211,8 +210,8 @@ sub body {
 			CGI::p($authen_error)
 		);
 	}
-	
-    # also print a message about submission times if we're submitting 
+
+    # also print a message about submission times if we're submitting
     # an answer
 	if ( $submitAnswers ) {
 	    my $dueTime = $UserSet->due_date();
@@ -225,9 +224,9 @@ sub body {
 	    }
 	    my $style = "background-color: $color; color: black; " .
 		"border: solid black 1px; padding: 2px;";
-	    print CGI::div({-style=>$style}, 
-			   CGI::strong($r->maketext("Grading assignment:")." ", CGI::br(), 
-				       $r->maketext("Submission time:")." ", 
+	    print CGI::div({-style=>$style},
+			   CGI::strong($r->maketext("Grading assignment:")." ", CGI::br(),
+				       $r->maketext("Submission time:")." ",
 				       scalar(localtime($timeNow)), CGI::br(),
 				       $r->maketext("Closes:")." ",
 				       scalar(localtime($dueTime)), $msg));
@@ -236,7 +235,7 @@ sub body {
 	# start printing the form
 	print CGI::start_form({-method=>"POST", -action=>$r->uri});
 	# write out the form data posted to the requested URI
-	my @fields_to_print = 
+	my @fields_to_print =
 	    grep { ! /^(user)|(effectiveUser)|(passwd)|(key)|(force_password_authen)|(proctor_user)|(proctor_key)|(proctor_password)$/ } $r->param();
 
 	print $self->hidden_fields(@fields_to_print) if ( @fields_to_print );
@@ -250,20 +249,20 @@ sub body {
 	# skip printing the user's name and all if we're doing a restricted
 	#    set login
 	my $userNameFields = '';
-	if ( $submitAnswers || 
+	if ( $submitAnswers ||
 	     ( $UserSet->restricted_login_proctor eq '' ||
 	       $UserSet->restricted_login_proctor eq 'No' ) ) {
 		print CGI::div({style=>"background-color:#ddddff;"},
-			       CGI::p($r->maketext("User's username is:")." ", 
+			       CGI::p($r->maketext("User's username is:")." ",
 				      CGI::strong("$effectiveUser"),"\n",
-				      CGI::br(),$r->maketext("User's name is:")." ", 
+				      CGI::br(),$r->maketext("User's name is:")." ",
 				      CGI::strong("$effectiveUserFullName"),
 				      "\n")),"\n";
 		$userNameFields = CGI::td([
 		  CGI::label(
 			     $r->maketext("Proctor username:"),
-			     CGI::input({-type=>"text", 
-					 -name=>"proctor_user", 
+			     CGI::input({-type=>"text",
+					 -name=>"proctor_user",
 					 -value=>""})),
 					  ]);
 	} else {
@@ -274,23 +273,23 @@ sub body {
 				  -value=>"set_id:$setName");
 	}
 
-	# then print out the table for the username, if needed, and 
+	# then print out the table for the username, if needed, and
 	#    password for the proctor
 	print CGI::start_table({class=>"FormLayout"});
 	print CGI::Tr( $userNameFields ) if ( $userNameFields );
 	print CGI::Tr( CGI::td([
 			 CGI::label(
 				    $r->maketext("Proctor password:"),
-				CGI::input({-type=>"password", 
-					    -name=>"proctor_passwd", 
+				CGI::input({-type=>"password",
+					    -name=>"proctor_passwd",
 					    -value=>""})),
 				])
 		       );
 	print CGI::end_table();
-	
+
 	print CGI::input({-type=>"submit", -value=>$r->maketext("Continue")});
 	print CGI::end_form();
-	
+
 	return "";
 }
 

--- a/lib/WeBWorK/Cookie.pm
+++ b/lib/WeBWorK/Cookie.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Cookie.pm,v 1.1 2006/06/29 21:10:52 sh002i Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -32,14 +32,13 @@ Given C<$r>, a WeBWorK::Request object
 use strict;
 use warnings;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # This class inherits from Apache::Cookie under mod_perl and Apache2::Cookie under mod_perl2
 BEGIN {
 	if (MP2) {
 		require Apache2::Cookie;
-        require APR::Request::Error;
+    require APR::Request::Error;
 		Apache2::Cookie->import;
 		push @WeBWorK::Cookie::ISA, "Apache2::Cookie";
 	} else {

--- a/lib/WeBWorK/Request.pm
+++ b/lib/WeBWorK/Request.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Request.pm,v 1.10 2007/07/23 04:06:32 sh002i Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -26,7 +26,6 @@ Apache::Request with additional WeBWorK-specific fields.
 use strict;
 use warnings;
 
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Encode;
 
@@ -56,7 +55,7 @@ BEGIN {
 
 sub mutable_param {
 	my $self = shift;
-	
+
 	if (not defined $self->{paramcache}) {
 	    my @names = $self->SUPER::param();
 	    foreach my $name (@names) {
@@ -67,7 +66,7 @@ sub mutable_param {
 	}
 
 	@_ or return keys %{$self->{paramcache}};
-	
+
 	my $name = shift;
 	if (@_) {
 		my $val = shift;
@@ -215,4 +214,3 @@ sub location {
 =cut
 
 1;
-

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -4,12 +4,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WebworkClient.pm,v 1.1 2010/06/08 11:46:38 gage Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -39,13 +39,13 @@ Remember to configure the local output file and display command !!!!!!!!
 =head1 DESCRIPTION
 
 This script will take a file and send it to a WeBWorK daemon webservice
-to have it rendered.  
+to have it rendered.
 
 The result returned is split into the basic HTML rendering
 and evaluation of answers and then passed to a browser for printing.
 
-The formatting allows the browser presentation to be interactive with the 
-daemon running the script webwork2/lib/renderViaXMLRPC.pm  
+The formatting allows the browser presentation to be interactive with the
+daemon running the script webwork2/lib/renderViaXMLRPC.pm
 and with instructorXMLRPChandler.
 
 See WebworkWebservice.pm  for related modules which operate on the server side
@@ -71,21 +71,21 @@ use warnings;
 #
 #     This url is placed as form action url when the rendered HTML from the original
 #     request is returned to the client from Webservice/RenderProblem. The client
-#     reorganizes the XML it receives into an HTML page (with a WeBWorK form) and 
+#     reorganizes the XML it receives into an HTML page (with a WeBWorK form) and
 #     pipes it through a local browser.
 #
 #     The browser uses this url to resubmit the problem (with answers) via the standard
-#     HTML webform used by WeBWorK to the renderViaXMLRPC.pm handler.  
+#     HTML webform used by WeBWorK to the renderViaXMLRPC.pm handler.
 #
-#     This renderViaXMLRPC.pm handler acts as an intermediary between the browser 
-#     and the webservice.  It interprets the HTML form sent by the browser, 
-#     rewrites the form data in XML format, submits it to the WebworkWebservice.pm 
+#     This renderViaXMLRPC.pm handler acts as an intermediary between the browser
+#     and the webservice.  It interprets the HTML form sent by the browser,
+#     rewrites the form data in XML format, submits it to the WebworkWebservice.pm
 #     which processes it and sends the the resulting HTML back to renderViaXMLRPC.pm
 #     which in turn passes it back to the browser.
-# 3.  The second time a problem is submitted renderViaXMLRPC.pm receives the WeBWorK form 
-#     submitted directly by the browser.  
+# 3.  The second time a problem is submitted renderViaXMLRPC.pm receives the WeBWorK form
+#     submitted directly by the browser.
 #     The renderViaXMLRPC.pm translates the WeBWorK form, has it processes by the webservice
-#     and returns the result to the browser. 
+#     and returns the result to the browser.
 #     The The client renderProblem.pl script is no longer involved.
 # 4.  Summary: renderProblem.pl is only involved in the first round trip
 #     of the submitted problem.  After that the communication is  between the browser and
@@ -93,18 +93,18 @@ use warnings;
 #     module using XML_RPC.
 
 
-our @COMMANDS = qw( listLibraries    renderProblem  ); #listLib  readFile tex2pdf 
+our @COMMANDS = qw( listLibraries    renderProblem  ); #listLib  readFile tex2pdf
 
 
 
 ##################################################
-# XMLRPC client -- 
+# XMLRPC client --
 # this code is identical between renderProblem.pl and renderViaXMLRPC.pm????
 ##################################################
 
 package WebworkClient;
 
-use Crypt::SSLeay;  # needed for https
+# use Crypt::SSLeay;  # needed for https
 use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
 use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";
 use XMLRPC::Lite;
@@ -136,23 +136,23 @@ our $UNIT_TESTS_ON             = 0;
 our $seed_ce;
 
 eval {
-	$seed_ce = WeBWorK::CourseEnvironment->new( 
-				{webwork_dir		=>		$WeBWorK::Constants::WEBWORK_DIRECTORY, 
+	$seed_ce = WeBWorK::CourseEnvironment->new(
+				{webwork_dir		=>		$WeBWorK::Constants::WEBWORK_DIRECTORY,
 				 courseName         =>      '',
 				 webworkURL         =>      '',
 				 pg_dir             =>      $WeBWorK::Constants::PG_DIRECTORY,
 				 });
 };
 	if ($@ or not ref($seed_ce)){
-		warn "Unable to find environment for WebworkClient: 
-			 webwork_dir => $WeBWorK::Constants::WEBWORK_DIRECTORY 
+		warn "Unable to find environment for WebworkClient:
+			 webwork_dir => $WeBWorK::Constants::WEBWORK_DIRECTORY
 			 pg_dir      => $WeBWorK::Constants::PG_DIRECTORY";
 	}
 
 
 
 our %imagesModeOptions = %{$seed_ce->{pg}->{displayModeOptions}->{images}};
-our $site_url = $seed_ce->{server_root_url};	
+our $site_url = $seed_ce->{server_root_url};
 our $imgGen = WeBWorK::PG::ImageGenerator->new(
 		tempDir         => $seed_ce->{webworkDirs}->{tmp},
 		latex	        => $seed_ce->{externalPrograms}->{latex},
@@ -201,31 +201,31 @@ sub new {   #WebworkClient constructor
 our $result;
 
 ##################################################
-# Utilities -- 
+# Utilities --
 #    this code is identical between renderProblem.pl and renderViaXMLRPC.pm
 ##################################################
 
 =head2 xmlrpcCall
 
 
-	
+
     $xmlrpc_client->encodeSource($source);
     $xmlrpc_client->{sourceFilePath}  = $fileName;
-    
- my $input = { 
+
+ my $input = {
         userID                  => $credentials{userID}//'',
         session_key             => $credentials{session_key}//'',
         courseID                => $credentials{courseID}//'',
         courseName              => $credentials{courseID}//'',
-        course_password         => $credentials{course_password}//'',   
+        course_password         => $credentials{course_password}//'',
         site_password           => $XML_PASSWORD//'',
         envir                   => $xmlrpc_client->environment(
                                        fileName       => $fileName,
                                        sourceFilePath => $fileName
                                     ),
- };                          
-    our($output, $return_string, $result);    
-    
+ };
+    our($output, $return_string, $result);
+
 
     if ( $result = $xmlrpc_client->xmlrpcCall('renderProblem', $input) )    {
         $output = $xmlrpc_client->formatRenderedProblem;
@@ -265,10 +265,10 @@ sub xmlrpcCall {
 	$command   = 'listLibraries' unless defined $command;
 	my $default_inputs = $self->default_inputs();
 	$requestObject = {%$default_inputs, %$input};  #input values can override default inputs
-	  
+
 	$self->request_object($requestObject);   # store the request object for later
-	
-	my $requestResult; 
+
+	my $requestResult;
 	my $transporter = TRANSPORT_METHOD->new;
 
 	eval {
@@ -278,17 +278,17 @@ sub xmlrpcCall {
 		-> proxy(($self->url).'/'.REQUEST_URI);
 	};
 	print STDERR "WebworkClient: Initiating xmlrpc request to url ",($self->url).'/'.REQUEST_URI, " \n Error: $@\n" if $@;
-	# turn off verification of the ssl cert 
+	# turn off verification of the ssl cert
 	$transporter->transport->ssl_opts(verify_hostname=>0,
 	    SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE);
-			
+
     if ($UNIT_TESTS_ON) {
         print STDERR  "WebworkClient.pm ".__LINE__." xmlrpcCall sent to ", $self->url,"\n";
     	print STDERR  "WebworkClient.pm ".__LINE__." xmlrpcCall issued with command $command\n";
     	print STDERR  "WebworkClient.pm ".__LINE__." input is: ",join(" ", %{$self->request_object}),"\n";
     	print STDERR  "WebworkClient.pm ".__LINE__." xmlrpcCall $command initiated webwork webservice object $requestResult\n";
     }
- 		
+
 	  local( $result);
 	  # use eval to catch errors
 	  #print STDERR "WebworkClient: issue command ", REQUEST_CLASS.'.'.$command, " ",join(" ", %$input),"\n";
@@ -299,9 +299,9 @@ sub xmlrpcCall {
 
           print CGI::h2("WebworkClient Errors") if $@;
 	  print CGI::p("Errors:",CGI::br(),CGI::blockquote({style=>"color:red"},CGI::code($@)),CGI::br(),"End Errors") if $@;
-	  
+
 	  if (not ref($result) ) {
-	  	my $error_string = "xmlrpcCall to $command returned no result for ". 
+	  	my $error_string = "xmlrpcCall to $command returned no result for ".
 	  	     ($self->{sourceFilePath}//'')."\n";
 	  	print STDERR $error_string;
 	  	$self->error_string($error_string);
@@ -313,7 +313,7 @@ sub xmlrpcCall {
 			  "command:",
 			  $command,
 			  "\n<br/>faultcode:",
-			  $result->faultcode, 
+			  $result->faultcode,
 			  "\n<br/>faultstring:",
 			  $result->faultstring, "\n<br/>End error message<br/>\n"
 		  );
@@ -322,7 +322,7 @@ sub xmlrpcCall {
 		  $self->return_object($result->result());
 		  $self->error_string($error_string);
 		  $self->fault(1); # set fault flag to true
-		  return $self;  
+		  return $self;
 	  } else {
 	      if (ref($result->result())=~/HASH/ and defined($result->result()->{text}) ) {
 		  $result->result()->{text} = decode_utf8_base64($result->result()->{text});
@@ -333,10 +333,10 @@ sub xmlrpcCall {
 
 		$self->return_object($result->result());
 		# print "\n retrieve result ",  keys %{$self->return_object};
-		return $self->return_object; # $result->result();  
+		return $self->return_object; # $result->result();
 		# would it be better to return the entire $result?
-		# probably not, there is no hash directly available from the $result object. 
-	  } 
+		# probably not, there is no hash directly available from the $result object.
+	  }
 
 }
 
@@ -357,12 +357,12 @@ sub jsXmlrpcCall {
 	print "the command was $command";
 
 	my $transporter = TRANSPORT_METHOD->new;
-	
+
 	my $requestResult = $transporter
 	    -> proxy(($self->url).'/'.REQUEST_URI);
 	$transporter->transport->ssl_opts(verify_hostname=>0,
 	     SSL_verify_mode => 'SSL_VERIFY_NONE');
-	
+
 	  local( $result);
 	  # use eval to catch errors
 	  eval { $result = $requestResult->call(REQUEST_CLASS.'.'.$command,$input) };
@@ -376,7 +376,7 @@ sub jsXmlrpcCall {
 	  	my $rh_result = $result->result();
 	  	print "\n success \n";
 	    print pretty_print($rh_result->{'ra_out'});
-		$self->return_object( $rh_result ); 
+		$self->return_object( $rh_result );
 		return 1; # success
 
 	  } else {
@@ -388,10 +388,10 @@ sub jsXmlrpcCall {
 	  }
 }
 
-=head2 encodeSource 
+=head2 encodeSource
 
 
-=cut 
+=cut
 sub encodeSource {
 	my $self = shift;
 	my $source = shift||'';
@@ -399,7 +399,7 @@ sub encodeSource {
 }
 
 =head2  Accessor methods
-	
+
 	encoded_source
 	request_object
 	return_object
@@ -407,8 +407,8 @@ sub encodeSource {
 	fault
 	url
 	form_data
-	
-=cut 
+
+=cut
 
 sub encoded_source {
 	my $self = shift;
@@ -428,13 +428,13 @@ sub return_object {   # out
 	$self->{return_object} =$object if defined $object and ref($object); # source is non-empty
 	$self->{return_object};
 }
-sub error_string {   
+sub error_string {
 	my $self = shift;
 	my $string = shift;
 	$self->{error_string} =$string if defined $string and $string =~/\S/; # source is non-empty
 	$self->{error_string};
 }
-sub fault {   
+sub fault {
 	my $self = shift;
 	my $fault_flag = shift;
 	$self->{fault_flag} =$fault_flag if defined $fault_flag and $fault_flag =~/\S/; # source is non-empty
@@ -475,7 +475,7 @@ sub default_inputs {
  	die "Can't create seed course environment for webwork in $webwork_dir" unless ref($seed_ce);
 
 	$self->{seed_ce} = $seed_ce;
-	
+
 	my @modules_to_evaluate;
 	my @extra_packages_to_load;
 	my @modules = @{ $seed_ce->{pg}->{modules} };
@@ -499,12 +499,12 @@ sub default_inputs {
 		modules_to_evaluate     => [@modules_to_evaluate],
 		envir                   => $self->environment(),
 		problem_state           => {
-		
+
 			num_of_correct_ans  => 0,
 			num_of_incorrect_ans => 4,
 			recorded_score       => 1.0,
 		},
-		source                   => $self->encoded_source,  #base64 encoded		
+		source                   => $self->encoded_source,  #base64 encoded
 	};
 
 	$out;
@@ -568,7 +568,7 @@ sub environment {
 		scriptDirectory => 'Not defined',
 		sectionName => 'Gage',
 		sectionNumber => 1,
-		server_root_url =>"foobarfoobar", 
+		server_root_url =>"foobarfoobar",
 		sessionKey=> 'Not defined',
 		setNumber =>'not defined',
 		studentLogin =>'gage',
@@ -587,7 +587,7 @@ sub environment {
 =item formatRenderedLibraries
 
 =cut
-	
+
 sub formatRenderedLibraries {
 	my $self 			  = shift;
 	#my @rh_result         = @{$self->return_object};  # wrap problem in formats
@@ -700,21 +700,21 @@ sub formatRenderedProblem {
 		             <p >WARNINGS</p><p>".decode_utf8_base64($rh_result->{WARNINGS})."</p></div>";
 	}
 	#warn "keys: ", join(" | ", sort keys %{$rh_result });
-	
-	#################################################	
+
+	#################################################
 	# PG debug messages generated with DEBUG_message();
 	#################################################
-	
+
 	my $debug_messages = $rh_result->{debug_messages} ||     [];
     $debug_messages = join("<br/>\n", @{  $debug_messages }    );
-    
-	#################################################    
+
+	#################################################
 	# PG warning messages generated with WARN_message();
 	#################################################
 
     my $PG_warning_messages =  $rh_result->{warning_messages} ||     [];
     $PG_warning_messages = join("<br/>\n", @{  $PG_warning_messages }    );
-    
+
 	#################################################
 	# internal debug messages generated within PG_core
 	# these are sometimes needed if the PG_core warning message system
@@ -724,7 +724,7 @@ sub formatRenderedProblem {
 
     my $internal_debug_messages = $rh_result->{internal_debug_messages} || [];
     $internal_debug_messages = join("<br/>\n", @{ $internal_debug_messages  } );
-    
+
     my $fileName = $self->{input}->{envir}->{fileName} || "";
 
 
@@ -758,15 +758,15 @@ sub formatRenderedProblem {
 	my $problemSeed      =  $self->{inputs_ref}->{problemSeed}//4444;
 	my $session_key      =  $rh_result->{session_key}//'';
 	my $displayMode      =  $self->{inputs_ref}->{displayMode};
-	
+
 	my $previewMode      =  defined($self->{inputs_ref}->{preview});
 	my $checkMode        =  defined($self->{inputs_ref}->{WWcheck});
 	my $submitMode       =  defined($self->{inputs_ref}->{WWsubmit});
 	my $showCorrectMode  =  defined($self->{inputs_ref}->{WWcorrectAns});
-        # problemIdentifierPrefix can be added to the request as a parameter.  
-        # It adds a prefix to the 
+        # problemIdentifierPrefix can be added to the request as a parameter.
+        # It adds a prefix to the
         # identifier used by the  format so that several different problems
-        # can appear on the same page.   
+        # can appear on the same page.
 	my $problemIdentifierPrefix = $self->{inputs_ref}->{problemIdentifierPrefix} //'';
     my $problemResult    =  $rh_result->{problem_result}//'';
     my $problemState     =  $rh_result->{problem_state}//'';
@@ -789,7 +789,7 @@ sub formatRenderedProblem {
 		showAttemptResults     => ($submitMode or $showCorrectMode),
 		showCorrectAnswers     => ($showCorrectMode),
 		showMessages           => ($previewMode or $submitMode or $showCorrectMode),
-		showSummary            => ( ($showSummary and ($submitMode or $showCorrectMode) )//0 )?1:0,  
+		showSummary            => ( ($showSummary and ($submitMode or $showCorrectMode) )//0 )?1:0,
 		maketext               => WeBWorK::Localize::getLoc($formLanguage//'en'),
 		summary                => ($self->{problem_result}->{summary} )//'', # can be set by problem grader
 	);
@@ -828,14 +828,14 @@ sub formatRenderedProblem {
 	    defined($self->{inputs_ref}->{'oauth_signature_method'}) &&
 	    defined($self->{inputs_ref}->{'lis_result_sourcedid'}) &&
 	    defined($self->{seed_ce}->{'LISConsumerKeyHash'}->{$self->{inputs_ref}->{'oauth_consumer_key'}}) ) {
-	  
+
 	  my $request_url = $self->{inputs_ref}->{lis_outcome_service_url};
-	  my $consumer_key = $self->{inputs_ref}->{'oauth_consumer_key'}; 
+	  my $consumer_key = $self->{inputs_ref}->{'oauth_consumer_key'};
 	  my $signature_method = $self->{inputs_ref}->{'oauth_signature_method'};
 	  my $sourcedid = $self->{inputs_ref}->{'lis_result_sourcedid'};
 	  my $consumer_secret = $self->{seed_ce}->{'LISConsumerKeyHash'}->{$consumer_key};
 	  my $score = $problemResult ? $problemResult->{score} : 0;
-	  
+
 	  # This is boilerplate XML used to submit the $score for $sourcedid
   my $replaceResultXML = <<EOS;
 <?xml version = "1.0" encoding = "UTF-8"?>
@@ -866,15 +866,15 @@ EOS
 
 	  my $bodyhash = sha1_base64($replaceResultXML);
 
-	  # since sha1_base64 doesn't pad we have to do so manually 
+	  # since sha1_base64 doesn't pad we have to do so manually
 	  while (length($bodyhash) % 4) {
 	    $bodyhash .= '=';
 	  }
 
 	  my $requestGen = Net::OAuth->request("consumer");
-  
+
 	  $requestGen->add_required_message_params('body_hash');
-  
+
 	  my $gradeRequest = $requestGen->new(
 		  request_url => $request_url,
 		  request_method => "POST",
@@ -896,9 +896,9 @@ EOS
 					       ],
 					       $replaceResultXML,
 					      );
-	  
+
 	  my $response = LWP::UserAgent->new->request($HTTPRequest);
-	  
+
 	  if ($response->is_success) {
 	    $response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
 	    my $message = $1;
@@ -918,13 +918,13 @@ EOS
 	  $LTIGradeMessage .= CGI::input({type=>'hidden', name=>'oauth_consumer_key', value=>$consumer_key});
 	  $LTIGradeMessage .= CGI::input({type=>'hidden', name=>'oauth_signature_method', value=>$signature_method});
 	  $LTIGradeMessage .= CGI::input({type=>'hidden', name=>'lis_result_sourcedid', value=>$sourcedid});
-	  
+
 	}
 
 	my $localStorageMessages = CGI::start_div({id=>'local-storage-messages'});
 	$localStorageMessages.= CGI::p('Your overall score for this problem is'.'&nbsp;'.CGI::span({id=>'problem-overall-score'},''));
 	$localStorageMessages .= CGI::end_div();
-		
+
 	# my $pretty_print_self  = pretty_print($self);
 
 	# Enable localized strings for the buttons:
@@ -947,7 +947,7 @@ $STRING_Submit = "Check Answers";
 	my $template = do("WebworkClient/${format_name}_format.pl");
 	die "Unknown format name $format_name" unless $template;
 	# interpolate values into template
-	$template =~ s/(\$\w+)/$1/gee;  
+	$template =~ s/(\$\w+)/$1/gee;
 	return $template;
 }
 
@@ -961,7 +961,7 @@ $STRING_Submit = "Check Answers";
 
 =head2 Utility functions:
 
-=over 4 
+=over 4
 
 =item writeRenderLogEntry()
 
@@ -974,7 +974,7 @@ $STRING_Submit = "Check Answers";
 # Information printed in format:
 # [formatted date & time ] processID unixTime BeginEnd $function  $details
 
-=cut 
+=cut
 
 sub writeRenderLogEntry($$$) {
 	my ($function, $details, $beginEnd) = @_;
@@ -999,10 +999,10 @@ sub pretty_print {    # provides html output -- NOT a method
     	$out =~ s/</&lt;/g  ;  # protect for HTML output
     } elsif ("$r_input" =~/hash/i) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_iput).
 	    local($^W) = 0;
-	    
+
 		$out .= "$r_input " ."<TABLE border = \"2\" cellpadding = \"3\" BGCOLOR = \"#FFFFFF\">";
-		
-		
+
+
 		foreach my $key ( sort ( keys %$r_input )) {
 			# Safety feature - we do not want to display the contents of "%seed_ce" which
 			# contains the database password and lots of other things, and explicitly hide
@@ -1031,7 +1031,7 @@ sub pretty_print {    # provides html output -- NOT a method
 		$out = $r_input;
 		$out =~ s/</&lt;/g; # protect for HTML output
 	}
-	
+
 	return $out." ";
 }
 


### PR DESCRIPTION
This removes all of the `use mod_perl` lines from the webwork code.  Since everyone should be using apache2, therefore mod_perl2 instead and mod_perl2 is loaded from the `webwork2/conf/webwork.apache2.4-config` configuration file.  This is mainly to remove some old code that shouldn't be necessary. 

I was getting errors along the lines of `mod_perl.pm not found`, which shouldn't be necessary. I stopgapped this by making a link to `mod_perl2.pm`, not a good fix. 

I'm not sure how to best test this.  I removed the link from `mod_perl.pm` to `mod_perl2.pm`. There are no errors on startup and visiting all links.  