### PR TITLE
Remove mod perl ww2.15

### DIFF
--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -38,7 +38,7 @@ use WeBWorK;
 use Encode;
 use utf8;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # load correct modules

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -61,7 +61,7 @@ use URI::Escape;
 use Carp;
 use Scalar::Util qw(weaken);
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 #####################

--- a/lib/WeBWorK/Authen/CAS.pm
+++ b/lib/WeBWorK/Authen/CAS.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -34,7 +34,6 @@ use WeBWorK::Localize;
 use WeBWorK::ContentGenerator::Instructor;
 use URI::Escape;
 use Net::OAuth;
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -1,6 +1,6 @@
 ###############################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -1,13 +1,13 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: /webwork/cvs/system/webwork2/lib/WeBWorK/Authen/LTIBasic.pm,v 1.1 2012/05/17 18:50:11 wheeler Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -34,7 +34,6 @@ use WeBWorK::Utils qw(formatDateTime);
 use WeBWorK::Localize;
 use URI::Escape;
 use Net::OAuth;
-use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;

--- a/lib/WeBWorK/Authen/Moodle.pm
+++ b/lib/WeBWorK/Authen/Moodle.pm
@@ -41,7 +41,7 @@ use WeBWorK::Cookie;
 use WeBWorK::Debug;
 use Date::Parse; # for moodle 1.7 date parsing
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 sub new {

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -54,7 +54,7 @@ use WeBWorK::PG;
 use MIME::Base64;
 use WeBWorK::Template qw(template);
 use WeBWorK::Localize;
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Scalar::Util qw(weaken);
 use HTML::Entities;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2012 The WeBWorK Project, http://github.com/openwebwork
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://github.com/openwebwork
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator.pm,v 1.196 2009/06/04 01:33:15 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -45,7 +45,7 @@ use Socket qw/unpack_sockaddr_in inet_ntoa/; # for remote host/port info
 use Text::Wrap qw(wrap);
 use WeBWorK::Utils qw/ decodeAnswers/;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # request paramaters used

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm,v 1.45 2008/03/13 22:22:23 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -44,7 +44,7 @@ use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
 use WeBWorK::Utils qw/readFile readDirectory/;
 use WeBWorK::Utils::FilterRecords qw/filterRecords/;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker3.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker3.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm,v 1.85 2008/07/01 13:18:52 glarose Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm,v 1.68 2007/08/13 22:59:56 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -31,7 +31,7 @@ use WeBWorK::CGI;
 use WeBWorK::Utils qw(readFile dequote jitar_id_to_seq);
 use Encode;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Encode;
 

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -31,7 +31,7 @@ use WeBWorK::Utils qw(readFile dequote);
 use WeBWorK::DB::Utils qw(grok_vsetID);
 use WeBWorK::ContentGenerator::GatewayQuiz qw(can_recordAnswers);
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # This content generator is NOT logged in.

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Problem.pm,v 1.225 2010/05/28 21:29:48 gage Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Cookie.pm
+++ b/lib/WeBWorK/Cookie.pm
@@ -32,7 +32,7 @@ Given C<$r>, a WeBWorK::Request object
 use strict;
 use warnings;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 # This class inherits from Apache::Cookie under mod_perl and Apache2::Cookie under mod_perl2

--- a/lib/WeBWorK/DB/Record/LocationAddresses.pm
+++ b/lib/WeBWorK/DB/Record/LocationAddresses.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/Locations.pm
+++ b/lib/WeBWorK/DB/Record/Locations.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/SetLocations.pm
+++ b/lib/WeBWorK/DB/Record/SetLocations.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/DB/Record/UserSetLocations.pm
+++ b/lib/WeBWorK/DB/Record/UserSetLocations.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Request.pm
+++ b/lib/WeBWorK/Request.pm
@@ -26,7 +26,7 @@ Apache::Request with additional WeBWorK-specific fields.
 use strict;
 use warnings;
 
-use mod_perl;
+
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 use Encode;
 

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The openWeBWorK Project, http://github.com/openwebwork
+# Copyright &copy; 2000-2012 The openWeBWorK Project, http://github.com/openwebwork
 # $CVSHeader: webwork2/lib/WeBWorK/URLPath.pm,v 1.36 2008/04/29 19:27:34 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1,7 +1,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils.pm,v 1.83 2009/07/12 23:48:00 gage Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/DetermineProblemLangAndDirection.pm
+++ b/lib/WeBWorK/Utils/DetermineProblemLangAndDirection.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WeBWorK/Utils/Grades.pm
+++ b/lib/WeBWorK/Utils/Grades.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/ListingDB.pm,v 1.19 2007/08/13 22:59:59 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/WeBWorK/Utils/LibraryStats.pm
+++ b/lib/WeBWorK/Utils/LibraryStats.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-1307 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-1307 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/ListingDB.pm,v 1.19 2007/08/13 22:59:59 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
This removes all of the use mod_perl lines from the webwork code and replaces #983.  Since everyone should be using apache2, therefore mod_perl2 instead and mod_perl2 is loaded from the webwork2/conf/webwork.apache2.4-config configuration file. This is mainly to remove some old code that shouldn't be necessary.

I was getting errors along the lines of mod_perl.pm not found, which shouldn't be necessary. I stopgapped this by making a link to mod_perl2.pm, not a good fix.

I'm not sure how to best test this. I removed the link from mod_perl.pm to mod_perl2.pm. There are no errors on startup and visiting all links.