### PR TITLE
Set $ENABLE_UTF8MB4=1 by default.

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -184,7 +184,7 @@ $database_storage_engine = 'myisam';
 # encoding utf8mb4 which allows the encoding of characters from many languages
 # including chinese, arabic and hebrew.
 
-$ENABLE_UTF8MB4 =0;    # setting this to 1 enables utf8mb4 encoding, setting this to 
+$ENABLE_UTF8MB4 =1;    # setting this to 1 enables utf8mb4 encoding, setting this to 
 					   # 0 sets this for older mysql (pre 5.3) which cannot
 					   # handle utf8mb4 characters.
 


### PR DESCRIPTION
Modern systems have versions of mySQL or MariaDB with uft8mb4 support, and should default to using utf8mb4 as the character set of the tables.

Older systems with mySQL too old to have this support (which was added to mySQL version 5.5.3 in early 2010) **must** change to `$ENABLE_UTF8MB4=0` in `con/site.conf`.

See:
  - https://dev.mysql.com/doc/relnotes/mysql/5.5/en/news-5-5-3.html
  - https://mathiasbynens.be/notes/mysql-utf8mb4
  - https://www.eversql.com/mysql-utf8-vs-utf8mb4-whats-the-difference-between-utf8-and-utf8mb4/