### PR TITLE
execute update-OPL-statistics.pl in docker-entrypoint.sh

### DIFF
--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -140,6 +140,7 @@ if [ "$1" = 'apache2' ]; then
         wait_for_db
         $WEBWORK_ROOT/bin/restore-OPL-tables.pl
         $WEBWORK_ROOT/bin/load-OPL-global-statistics.pl
+        $WEBWORK_ROOT/bin/update-OPL-statistics.pl
         if [ -d $APP_ROOT/libraries/webwork-open-problem-library/JSON-SAVED ]; then
           # Restore saved JSON files
           echo "Restoring JSON files from JSON-SAVED directory"


### PR DESCRIPTION
Without this, you may end up with the following error when trying to browse the library browser.

Warning messages

    Couldn't find the OPL local statistics table. Did you download the latest OPL and run update-OPL-statistics.pl? at /opt/webwork/webwork2/lib/WeBWorK/Utils/LibraryStats.pm line 69. 

Error messages

    Table 'webwork.OPL_local_statistics' doesn't exist at /opt/webwork/webwork2/lib/WeBWorK/Utils/LibraryStats.pm line 71. 

