### PR TITLE
rename ADD_PACKAGES to ADD_APT_PACKAGES

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@
 #          will set the system timezone to zone/city
 #          Make sure to use a valid setting.
 #          "/usr/bin/timedatectl list-timezones" on Ubuntu will find valid values
-#        ADD_PACKAGES="package1 package2 package3"
+#        ADD_APT_PACKAGES="package1 package2 package3"
 #	   will have these additional Ubuntu packages installed at startup.
 #
 # ==================================================================
@@ -332,7 +332,7 @@ ENV SSL=0 \
     PAPERSIZE=letter \
     SYSTEM_TIMEZONE=UTC \
     ADD_LOCALES=0 \
-    ADD_PACKAGES=0
+    ADD_APT_PACKAGES=0
 
 # ================================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
       #ADD_LOCALES: he_IL ISO-8859-8,he_IL.UTF-8 UTF-8
 
       # Extra Ubuntu packages to install during startup
-      #ADD_PACKAGES: mc vim telnet
+      #ADD_APT_PACKAGES: vim telnet
 
       # The system timezone for the container can be set using
       #SYSTEM_TIMEZONE: zone/city

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -45,9 +45,9 @@ debconf-set-selections /tmp/preseed.txt
 dpkg-reconfigure -f noninteractive libpaper1
 
 # Install some extra packages
-if [ "$ADD_PACKAGES" != "0" ]; then
+if [ "$ADD_APT_PACKAGES" != "0" ]; then
   apt-get update
-  apt-get install -y --no-install-recommends --no-install-suggests $ADD_PACKAGES
+  apt-get install -y --no-install-recommends --no-install-suggests $ADD_APT_PACKAGES
 fi
 
 # If necessary, install the OPL in the running container, hopefully in persistent storage


### PR DESCRIPTION
Reason: I hope the change of the name adds clarity, also in view of a possible addition of a similar variable controlling the installation of additional CPAN packages.