### PR TITLE
WeBWork-2.15+instructor xml errors investigation

### DIFF
--- a/clients/hello_world_apps/webwork_xmlrpc_client.pl
+++ b/clients/hello_world_apps/webwork_xmlrpc_client.pl
@@ -29,7 +29,7 @@ use constant  REQUEST_CLASS    =>  'WebworkXMLRPC';  # WebworkXMLRPC is used for
 use constant  REQUEST_URI      =>  'mod_xmlrpc';
 use constant  TEMPOUTPUTFILE   =>  '/Users/gage/Desktop/renderProblemOutput.html';
 
-our	$XML_URL      =  'http://localhost:80';
+our	$SITE_URL      =  'http://localhost:80';
 our	$FORM_ACTION_URL  =  'http://localhost:80/webwork2/html2xml';
 our	$XML_PASSWORD     =  'xmlwebwork';
 our	$XML_COURSE       =  'gage_course';
@@ -98,7 +98,7 @@ our $source;
 # Build client
 ############################################
 our $xmlrpc_client = new WebworkClient (
-	url                    => $XML_URL,
+	site_url               => $SITE_URL,
 	form_action_url        => $FORM_ACTION_URL,
 	displayMode            => DISPLAYMODE(),
 

--- a/clients/sendXMLRPC.pl
+++ b/clients/sendXMLRPC.pl
@@ -878,7 +878,7 @@ sub process_problem {
 
 	### build client
 	my $xmlrpc_client = new WebworkClient (
-		url                    => $credentials{site_url},
+		site_url               => $credentials{site_url},
 		form_action_url        => $credentials{form_action_url},
 		site_password          => $credentials{site_password}//'',
 		courseID               => $credentials{courseID},
@@ -967,7 +967,7 @@ sub process_problem {
 	WebworkClient::writeRenderLogEntry("", 
 	"{script:$scriptName; file:$file_path; ". 
 	sprintf("duration: %.3f sec;", $cg_duration).
-	" url: $credentials{site_url}; }",'');
+	" site_url: $credentials{site_url}; }",'');
 	
 	#######################################################################
 	# End processing of the pg file
@@ -1443,12 +1443,12 @@ DETAILS
         or create a file with this information and specify it with the --credentials option.
     
             %credentials = (
-                            userID                 => "my login name for the webwork course",
-                            course_password        => "my password ",
-                            courseID               => "the name of the webwork course",
-                  XML_URL                  => "url of rendering site
-                  XML_PASSWORD          => "site password" # preliminary access to site
-                  $FORM_ACTION_URL      =  'http://localhost:80/webwork2/html2xml'; #action url for form
+                  userID                 => "my login name for the webwork course",
+                  course_password        => "my password ",
+                  courseID               => "the name of the webwork course",
+                  SITE_URL               => "url of rendering site",
+                  XML_PASSWORD           => "site password", # preliminary access to site
+                  form_action_url        => 'http://localhost:80/webwork2/html2xml' #action url for form
             );
 
   Options

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -43,14 +43,14 @@ sub new {
     my $invocant = shift;
     my $class = ref $invocant || $invocant;
 	$self = {
-		return_object => {},
-		encoded_source => {},
-		sourceFilePath => '',
-		url            => 'https://demo.webwork.rochester.edu',
+		return_object   => {},
+		encoded_source  => {},
+		sourceFilePath  => '',
+		site_url        => 'https://demo.webwork.rochester.edu',
 		form_action_url =>'',
-		maketext   	   => sub {return @_}, 
-		courseID       => 'daemon_course',  # optional?
-		userID         => 'daemon',  # optional?
+		maketext        => sub {return @_}, 
+		courseID        => 'daemon_course',  # optional?
+		userID          => 'daemon',  # optional?
 		course_password => 'daemon',
 		inputs_ref      => {},	  
 		@_,
@@ -69,11 +69,11 @@ sub encoded_source {
 	$self->{encoded_source} =$source if defined $source and $source =~/\S/; # source is non-empty
 	$self->{encoded_source};
 }
-sub url {
+sub site_url {
 	my $self = shift;
 	my $new_url = shift;
-	$self->{url} = $new_url if defined($new_url) and $new_url =~ /\S/;
-	$self->{url};
+	$self->{site_url} = $new_url if defined($new_url) and $new_url =~ /\S/;
+	$self->{site_url};
 }
 sub formatRenderedProblem {
 	my $self 			  = shift;
@@ -137,7 +137,7 @@ sub formatRenderedProblem {
 
 
 	$self->{outputformats}={};
-	my $XML_URL      	 =  $self->url//'';
+	my $SITE_URL      	 =  $self->site_url//'';
 	my $FORM_ACTION_URL  =  $self->{form_action_url}//'';
 	my $courseID         =  $self->{courseID}//'';
 	my $userID           =  $self->{userID}//'';

--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -55,10 +55,11 @@ use JSON;
 =cut
  
 # To configure the target webwork server two URLs are required
-# 1. $XML_URL   http://test.webwork.maa.org/mod_xmlrpc
+# 1.    http://test.webwork.maa.org/mod_xmlrpc 
 #    points to the Webservice.pm and Webservice/RenderProblem modules
 #    Is used by the client to send the original XML request to the webservice
-#
+#    Note: This not the same as the webworkClient->url which should NOT have
+#          the mod_xmlrpc segment. 
 # 2. $FORM_ACTION_URL      http:http://test.webwork.maa.org/webwork2/html2xml
 #    points to the renderViaXMLRPC.pm module.
 #
@@ -112,14 +113,14 @@ unless ($server_root_url) {
 # child
 ############################
 
-our ($XML_URL,$FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
+our ($SITE_URL, $FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
 
 	$XML_PASSWORD     	 =  'xmluser';
 	$XML_COURSE          =  'daemon_course';
 
 
 
-	$XML_URL             =  "$server_root_url/mod_xmlrpc";
+	$SITE_URL            =  "$server_root_url" ; 
 	$FORM_ACTION_URL     =  "$server_root_url/webwork2/instructorXMLHandler";
 
 use constant DISPLAYMODE   => 'images'; #  Mathjax  is another possibilities.
@@ -165,11 +166,10 @@ sub pre_header_initialize {
     #######################
     my $xmlrpc_client = new WebworkClient;
 
-	$xmlrpc_client->url($XML_URL);
+	$xmlrpc_client->site_url($SITE_URL);  # does NOT include mod_xmlrpc ending
+#	$xmlrpc_client->{site_url} ='';   # make this the site without the mod_xmlrpc ending? ~= s/mod_xmlrpc$
 	$xmlrpc_client->{form_action_url}= $FORM_ACTION_URL;
-#	$xmlrpc_client->{displayMode}   = DISPLAYMODE();
 	$xmlrpc_client->{user}          = 'xmluser';
-#	$xmlrpc_client->{password}      = $XML_PASSWORD;
 	$xmlrpc_client->{site_password} = $XML_PASSWORD;
 #	$xmlrpc_client->{course}        = $r->param('courseID');
 	$xmlrpc_client->{courseID}      = $r->param('courseID');
@@ -262,8 +262,8 @@ sub pre_header_initialize {
 
 
 	if ($UNIT_TESTS_ON) {
-		print STDERR "instructorXMLHandler.pm ".__LINE__." values obtained from form parameters\n\t",
-		   format_hash_ref($input);
+		print STDERR "\tinstructorXMLHandler.pm ".__LINE__." values obtained from form parameters\n\t",
+		   format_hash_ref($input),"\n";
 	}
 	my $source = "";
 	#print $r->param('problemPath');

--- a/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
@@ -54,7 +54,7 @@ use CGI;
 =cut
  
 # To configure the target webwork server two URLs are required
-# 1. $XML_URL   http://test.webwork.maa.org/mod_xmlrpc
+# 1.    http://test.webwork.maa.org/mod_xmlrpc
 #    points to the Webservice.pm and Webservice/RenderProblem modules
 #    Is used by the client to send the original XML request to the webservice
 #
@@ -111,14 +111,14 @@ unless ($server_root_url) {
 # child
 ############################
 
-our ($XML_URL,$FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
+our ($SITE_URL,$FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
 
 	$XML_PASSWORD     	 =  'xmlwebwork';
 	$XML_COURSE          =  'daemon_course';
 
 
 
-	$XML_URL             =  "$server_root_url";  #"$server_root_url/mod_xmlrpc";
+	$SITE_URL             =  "$server_root_url"; 
 	$FORM_ACTION_URL     =  "$server_root_url/webwork2/html2xml";
 
 
@@ -171,7 +171,7 @@ sub pre_header_initialize {
     my $xmlrpc_client = new WebworkClient;
 
 	$xmlrpc_client ->encoded_source($r->param('problemSource')) ; # this source has already been encoded
-	$xmlrpc_client-> url($XML_URL);
+	$xmlrpc_client-> site_url($SITE_URL);
 	$xmlrpc_client->{form_action_url} = $FORM_ACTION_URL;
 	$xmlrpc_client->{userID}          = $inputs_ref{userID};
 	$xmlrpc_client->{course_password} = $inputs_ref{course_password};

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -65,7 +65,7 @@ use warnings;
 # 1. $SITE_URL   http://test.webwork.maa.org/mod_xmlrpc
 #    points to the Webservice.pm and Webservice/RenderProblem modules
 #    Is used by the client to send the original XML request to the webservice
-#    Note: This not the same as the webworkClient->url which should NOT have
+#    Note: This is not the same as the webworkClient->url which should NOT have
 #          the mod_xmlrpc segment. 
 #
 # 2. $FORM_ACTION_URL      http:http://test.webwork.maa.org/webwork2/html2xml

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -411,7 +411,7 @@ sub jsXmlrpcCall {
 	return_object
 	error_string
 	fault
-	url  (https://mysite.edu)
+	site_url  (https://mysite.edu)
 	form_data
 	
 =cut 

--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -455,8 +455,8 @@ sub fault {
 sub site_url {  #site_url  https://mysite.edu
 	my $self = shift;
 	my $new_url = shift;
-	$self->{url} = $new_url if defined($new_url) and $new_url =~ /\S/;
-	$self->{url};
+	$self->{site_url} = $new_url if defined($new_url) and $new_url =~ /\S/;
+	$self->{site_url};
 }
 
 sub url {  #site_url  https://mysite.edu

--- a/lib/WebworkClient/debug_format.pl
+++ b/lib/WebworkClient/debug_format.pl
@@ -4,12 +4,12 @@ q{
 	<html $COURSE_LANG_AND_DIR>
 	<head>
 	<meta charset='utf-8'>
-	<base href="$XML_URL">
-	<title>$XML_URL WeBWorK using host: $XML_URL, course: $courseID format: debug</title>
+	<base href="$SITE_URL">
+	<title>$SITE_URL WeBWorK using host: $SITE_URL, course: $courseID format: debug</title>
 	</head>
 	<body>
 			
-	<h2> WeBWorK using host: $XML_URL,  course: $courseID format: debug</h2>
+	<h2> WeBWorK using host: $SITE_URL,  course: $courseID format: debug</h2>
 $pretty_print_self	   
 </body>
 </html>

--- a/lib/WebworkClient/json_format.pl
+++ b/lib/WebworkClient/json_format.pl
@@ -15,7 +15,7 @@
 $nextBlock = <<'ENDPROBLEMTEMPLATE';
 <head>
 <meta charset='utf-8'>
-<base href="TO_SET_LATER_XML_URL">
+<base href="TO_SET_LATER_SITE_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 ENDPROBLEMTEMPLATE
 
@@ -144,7 +144,7 @@ push( @pairs_for_json, "hidden_input_field_forcePortNumber", '$forcePortNumber' 
 # to communicate with WW, while the distant client must use URLs of the
 # intermediate server (the man in the middle).
 
-push( @pairs_for_json, "real_webwork_XML_URL", '$XML_URL' );
+push( @pairs_for_json, "real_webwork_SITE_URL", '$SITE_URL' );
 push( @pairs_for_json, "real_webwork_FORM_ACTION_URL", '$FORM_ACTION_URL' );
 push( @pairs_for_json, "internal_problem_lang_and_dir", '$PROBLEM_LANG_AND_DIR');
 

--- a/lib/WebworkClient/ptx_format.pl
+++ b/lib/WebworkClient/ptx_format.pl
@@ -1,5 +1,5 @@
 $ptx_static_format = <<'ENDPROBLEMTEMPLATE';
-<!--$XML_URL WeBWorK Editor using host: $XML_URL, course: $courseID format: ptx -->
+<!--$SITE_URL WeBWorK Editor using host: $SITE_URL, course: $courseID format: ptx -->
 <!--BEGIN PROBLEM-->
 <webwork>
 $problemText

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -4,7 +4,7 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 <html $COURSE_LANG_AND_DIR>
 <head>
 <meta charset='utf-8'>
-<base href="$XML_URL">
+<base href="$SITE_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 
 <!-- CSS Loads -->
@@ -31,7 +31,7 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 
-<title>$XML_URL WeBWorK using host: $XML_URL, format: simple seed: $problemSeed</title>
+<title>WeBWorK using host: $SITE_URL, format: simple seed: $problemSeed</title>
 </head>
 <body>
 <div class="container-fluid">
@@ -71,7 +71,7 @@ $LTIGradeMessage
 </div></div>
 
 <div id="footer">
-WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: simple | theme: math4
+WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: simple | theme: math4
 </div>
 
 

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -2,7 +2,7 @@ $standard_format = <<'ENDPROBLEMTEMPLATE';
 <html $COURSE_LANG_AND_DIR>
 <head>
 <meta charset='utf-8'>
-<base href="$XML_URL">
+<base href="$SITE_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 <!-- CSS Loads -->
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap.css"/>
@@ -29,11 +29,11 @@ $standard_format = <<'ENDPROBLEMTEMPLATE';
 $problemHeadText
 
 
-<title>$XML_URL WeBWorK using host: $XML_URL, format: standard seed: $problemSeed course: $courseID</title>
+<title>WeBWorK using host: $SITE_URL, format: standard seed: $problemSeed course: $courseID</title>
 </head>
 <body>
 
-<h2> WeBWorK using host: $XML_URL, course: $courseID format: standard</h2>
+<h2> WeBWorK using host: $SITE_URL, course: $courseID format: standard</h2>
 		    $answerTemplate
 		    $color_input_blanks_script
 	<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
@@ -77,7 +77,7 @@ $debug_messages
 <h3> internal errors </h3>
 $internal_debug_messages
 <div id="footer">
-WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: standard | theme: math4
+WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: standard | theme: math4
 </div>
 
 </body>

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -4,7 +4,7 @@ $sticky_format = <<'ENDPROBLEMTEMPLATE';
 <html $COURSE_LANG_AND_DIR>
 <head>
 <meta charset='utf-8'>
-<base href="$XML_URL">
+<base href="$SITE_URL">
 <link rel="shortcut icon" href="/webwork2_files/images/favicon.ico"/>
 
 <!-- CSS Loads -->
@@ -34,7 +34,7 @@ $sticky_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 
-<title>$XML_URL WeBWorK using host: $XML_URL, format: sticky seed: $problemSeed</title>
+<title>WeBWorK using host: $SITE_URL, format: sticky seed: $problemSeed</title>
 </head>
 <body>
 <div class="container-fluid">
@@ -85,7 +85,7 @@ $LTIGradeMessage
 </div>
 </div>
 <div id="footer">
-WeBWorK &copy; 1996-2019 | host: $XML_URL | course: $courseID | format: sticky | theme: math4
+WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky | theme: math4
 </div>
 <!-- Activate local storage js -->
 <script type="text/javascript">WWLocalStorage();</script>

--- a/t/test_formats.pl
+++ b/t/test_formats.pl
@@ -1,10 +1,10 @@
 #!/usr/bin/perl -w
 use strict;
 use 5.10.0;
-my $XML_URL = "foobar";
+my $SITE_URL = "foobar";
 my $template = do("standard_format.pl");
 my %replacement_key_value_pairs =(
-	 XML_URL      	 =>   $XML_URL,
+	 SITE_URL      	 =>   $SITE_URL,
 	 FORM_ACTION_URL  =>  "FORM_ACTION_URL",
 	 courseID         =>  "courseID",
 	 userID           =>  "userID",


### PR DESCRIPTION
This fixes a 10 year old bug -- one that has not been active but was discovered while trying to research some of the instructorXMLHandler errors.  

Due to a faulty description in WebworkClient.pm that $XML_URL contained a tail segment of mod_xmlrpc this was implemented in instructorXMLHandler.  The original uses of $XML_URL
contained https://mysite.edu not https://mysite.edu/mod_xmlrpc. 

This has now been fixed and $XML_URL has been renamed $SITE_URL to avoid confusion.  The accessor for WebworkClient has been changed from ->url to ->site_url.  

To check: (1) In the library make sure that all of the menu buttons work properly, including the ones in the advanced section.  Make sure there are no instructorXMLHandler Forbidden errors which indicate that the AJAX communication back to the server has broken down.  Make sure that the problems display properly when trying to view them.

(2) In the Homeworksets editor the tab "render all problems" uses AJAX to render each of the problems in the set. (Make sure they all display. ) This command goes through renderXMLRPC.pm instead of instructorXMLHandler. 

A future project will be to refactor renderXMLRPC and instructorXMLHandler. 
(3) Temporarily set "UNIT_TESTS_0N=1" in WebworkClient.pm.  Change one or more 
menu buttons on the LibraryBrowser and inspect the error messages in the apache error log.

You should see calls to https://localhost/mod_xmlrpc (or what ever site you are using) but no calls of the form https://localhost/mod_xmlrpc/mod_xmlrpc which you would have seen before the patch was applied.   (The extra mod_xmlrpc been the there for 10 years, but fortunately the last segment has simply been ignored.)

(4) in webwork2/clients run  
`sendXMLRPC.pl -B t/input.pg`
and make sure it renders the input.pg problem.  You can test other commands of sendXMLRPC.pl as well

Since the basic bug is not affecting anything at the moment we'll put off this patch until WeBWorK-2.16. 
