### PR TITLE
Scripts to release versions of webwork problem libraries and to download metadata from such releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,6 +211,7 @@ RUN apt-get update \
 	fonts-linuxlibertine \
 	lmodern \
 	zip \
+	jq \
     && apt-get clean \
     && rm -fr /var/lib/apt/lists/* /tmp/*
 

--- a/bin/OPL_releases/Makefile
+++ b/bin/OPL_releases/Makefile
@@ -1,0 +1,21 @@
+RELEASE_FILENAME=webwork-open-problem-library-METADATA.tar.gz
+GITHUB_USERNAME=heiderich
+GITHUB_REPO=webwork-open-problem-library
+JSON_FILENAME=latest_release.json
+RELEASE_TAG=latest_release.tag
+
+${JSON_FILENAME}:
+	@echo "Download a JSON containing information on the latest release"
+	curl -s https://api.github.com/repos/${GITHUB_USERNAME}/${GITHUB_REPO}/releases/latest > ${JSON_FILENAME}
+
+${RELEASE_TAG}: ${JSON_FILENAME}
+	jq -r '.tag_name' ${JSON_FILENAME} > ${RELEASE_TAG}
+
+${RELEASE_FILENAME}: ${JSON_FILENAME}
+	curl -L `jq -r '[.assets | .[] | select(.name == "${RELEASE_FILENAME}" ) | .browser_download_url][0]' ${JSON_FILENAME}` -o ${RELEASE_FILENAME}
+
+extract: ${RELEASE_FILENAME}
+	tar xfz ${RELEASE_FILENAME}
+
+clean:
+	rm -f ${RELEASE_FILENAME} ${RELEASE_TAG} ${JSON_FILENAME}

--- a/bin/OPL_releases/release.sh
+++ b/bin/OPL_releases/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Shell script to make releases of webwork problem libraries, heavily inspired
 # by https://github.com/gap-system/ReleaseTools/blob/master/release
@@ -299,6 +299,26 @@ if [ x"$RELEASE_ID" = x ] ; then
     error "creating release on GitHub failed: no release id"
 fi
 
+
+######################################################################
+#
+# Test whether ARCHIVE_FORMATS contains at least one valid format
+#
+
+FOUND_VALID_FORMAT=0
+VALID_ARCHIVE_FORMATS='.tar.gz .tar.bz2 .zip'
+for VALID_FORMAT in $VALID_ARCHIVE_FORMATS
+do
+	if [[ $ARCHIVE_FORMATS =~ $VALID_FORMAT ]]
+	then
+		FOUND_VALID_FORMAT=1;
+	fi;
+done;
+if [[ $FOUND_VALID_FORMAT == "0" ]]
+then
+	warning "No valid archive format specified." ;
+	exit 1;
+fi;
 
 ######################################################################
 #

--- a/bin/OPL_releases/release.sh
+++ b/bin/OPL_releases/release.sh
@@ -1,0 +1,345 @@
+#!/bin/sh
+#
+# Shell script to make releases of webwork problem libraries, heavily inspired
+# by https://github.com/gap-system/ReleaseTools/blob/master/release
+
+set -e
+
+######################################################################
+#
+# Usage information
+#
+help() {
+cat <<EOF
+Usage: $0 [OPTIONS]
+
+A tool for making releases of webwork problem libraries on GitHub.
+
+Run this from within a git clone of your webwork problem library repository, checked out
+at the revision you want to release.
+
+Actions
+  -h,  --help                      display this help text and exit
+  -f, --force                      if a release with the same name already exists: overwrite it
+
+Paths
+  --librarydir <path>              directory containing the library [Default: current directory]
+  --tmpdir <path>                  to a temporary directory [Default: tmp subdirectory of current directory]
+  --libraryname <name>             library name
+
+Custom settings
+  -t,  --tag <tag>                 git tag for the release
+  -r,  --repository <repository>   set GitHub repository (as USERNAME/REPONAME)
+  --token <oauth>                  GitHub access token
+
+Notes:
+* To learn how to create a GitHub access token, please consult
+  https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+EOF
+    exit 0
+}
+
+######################################################################
+#
+# Various little helper functions
+
+
+# print notices in green
+notice() {
+    printf '\033[32m%s\033[0m\n' "$*"
+}
+
+# print warnings in yellow
+warning() {
+    printf '\033[33mWARNING: %s\033[0m\n' "$*"
+}
+
+# print error in red and exit
+error() {
+    printf '\033[31mERROR: %s\033[0m\n' "$*"
+    exit 1
+}
+
+# check for uncommitted changes
+verify_git_clean() {
+    git update-index --refresh
+    git diff-index --quiet HEAD -- ||
+        error "uncommitted changes detected"
+}
+
+# helper function for parsing GitHub's JSON output. Right now,
+# we only extra the value of a single key at a time. This means
+# we may end up parsing the same JSON data two times, but that
+# doesn't really matter as it is tiny.
+json_get_key() {
+    echo "$response" | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj.get("'"$1"'",""))'
+}
+
+# On Mac OS X, tar stores extended attributes in ._FOO files inside archives.
+# Setting COPYFILE_DISABLE prevents that. See <http://superuser.com/a/260264>
+export COPYFILE_DISABLE=1
+
+
+######################################################################
+#
+# Command line processing
+#
+CONTENT="METADATA"
+LIBRARY_DIR="$PWD"
+TMP_DIR="$PWD/tmp"
+
+FORCE=no
+while [ x"$1" != x ]; do
+  option="$1" ; shift
+  case "$option" in
+    -h | --help ) help ;;
+
+    --librarydir ) LIBRARY_DIR="$1"; shift ;;
+    --libraryname ) LIBRARY_NAME="$1"; shift ;;
+    --tmpdir ) TMP_DIR="$1"; shift ;;
+
+    -t | --tag ) TAG="$1"; shift ;;
+    -r | --repository ) REPO="$1"; shift ;;
+    --token ) TOKEN="$1"; shift ;;
+
+    -f | --force ) FORCE=yes ;;
+    --no-force ) FORCE=no ;;
+
+    -- ) break ;;
+    * ) error "unknown option '$option'" ;;
+  esac
+done
+
+
+######################################################################
+#
+# Some initial sanity checks
+#
+
+command -v curl >/dev/null 2>&1 ||
+    error "the 'curl' command was not found, please install it"
+
+command -v git >/dev/null 2>&1 ||
+    error "the 'git' command was not found, please install it"
+
+command -v python >/dev/null 2>&1 ||
+    error "the 'python' command was not found, please install it"
+
+cd $LIBRARY_DIR
+#verify_git_clean
+
+
+######################################################################
+#
+# Determine the basename for the package archives
+#
+#
+
+notice "Library path: " $LIBRARY_DIR
+notice "Dumping OPL tables"
+dump-OPL-tables.pl
+
+######################################################################
+#
+# Fetch GitHub oauth token, used to authenticate the following commands.
+# See https://help.github.com/articles/git-automation-with-oauth-tokens/
+#
+if [ "x$TOKEN" = x ] ; then
+    TOKEN=$(git config --get github.token || echo)
+fi
+if [ "x$TOKEN" = x ] && [ -r ~/.github_shell_token ] ; then
+    TOKEN=$(cat ~/.github_shell_token)
+fi
+if [ "x$TOKEN" = x ] ; then
+    error "could not determine GitHub access token"
+fi
+
+
+######################################################################
+#
+# Determine GitHub repository and username, and the current branch
+#
+if [ x"$REPO" = "x" ] ; then
+    error "could not guess GitHub repository"
+fi
+notice "Using GitHub repository $REPO"
+
+GITHUB_USER=$(dirname "$REPO")
+notice "Using GitHub username $GITHUB_USER"
+
+
+######################################################################
+#
+# Derive API urls
+#
+API_URL=https://api.github.com/repos/$REPO/releases
+UPLOAD_URL=https://uploads.github.com/repos/$REPO/releases
+
+
+######################################################################
+#
+# Determine the tag, and validate it
+#
+#verify_git_clean
+
+cd $LIBRARY_DIR
+
+if git show-ref -q "$TAG" ; then
+    notice "Using git tag $TAG"
+else
+    notice "Creating git tag $TAG"
+    git tag "$TAG"
+fi;
+
+HEAD_REF=$(git rev-parse --verify HEAD)
+TAG_REF=$(git rev-parse --verify "$TAG^{}")
+
+if [ "x$TAG_REF" != "x$HEAD_REF" ] ; then
+    error "tag $TAG is not the HEAD commit -- did you tag the right commit?"
+fi
+
+
+echo ""
+
+
+######################################################################
+#
+# Get fresh (unmodified) copies of the files, and generate some stuff
+#
+
+# Clean any remains of previous export attempts
+mkdir -p "$TMP_DIR"
+rm -rf "${TMP_DIR:?}/$LIBRARY_NAME"*
+
+# Set umask to ensure the file permissions in the release
+# archives are sane.
+umask 0022
+
+notice "Preparing content"
+mkdir "$TMP_DIR/$LIBRARY_NAME"
+cp -r $LIBRARY_DIR/TABLE-DUMP "$TMP_DIR/$LIBRARY_NAME/TABLE-DUMP"
+cp -r $LIBRARY_DIR/JSON-SAVED "$TMP_DIR/$LIBRARY_NAME/JSON-SAVED"
+
+#notice "Removing unnecessary files"
+#rm -f .git* .hg* .cvs*
+#rm -f .appveyor.yml .codecov.yml .travis.yml
+
+
+######################################################################
+#
+# Push commits to GitHub
+#
+
+cd "$LIBRARY_DIR"
+
+# construct GitHub URL for pusing
+REMOTE="https://$GITHUB_USER:$TOKEN@github.com/$REPO"
+
+# Make sure the branch is on the server
+notice "Pushing your branch to GitHub"
+notice "Remote: $REMOTE"
+
+# Make sure the tag is on the server
+notice "Pushing your tag to GitHub"
+if [ "x$FORCE" = xyes ] ; then
+    git push --force "$REMOTE" "$TAG"
+else
+    git push "$REMOTE" "$TAG"
+fi
+
+######################################################################
+#
+# Create the GitHub release
+#
+
+# check if release already exists
+response=$(curl -s -S -X GET "$API_URL/tags/$TAG?access_token=$TOKEN")
+MESSAGE=$(json_get_key message)
+RELEASE_ID=$(json_get_key id)
+
+if [ "$MESSAGE" = "Not Found" ] ; then
+    MESSAGE=  # release does not yet exist -> that's how we like it
+elif [ x"$RELEASE_ID" != x ] ; then
+    # release already exists -> error out or delete it
+    if [ "x$FORCE" = xyes ] ; then
+        notice "Deleting existing release $TAG from GitHub"
+        response=$(curl --fail -s -S -X DELETE "$API_URL/$RELEASE_ID?access_token=$TOKEN")
+        MESSAGE=
+    else
+        error "release $TAG already exists on GitHub, aborting (use --force to override this)"
+    fi
+fi
+
+if [ x"$MESSAGE" != x ] ; then
+    error "accessing GitHub failed: $MESSAGE"
+fi
+
+# Create the release by sending suitable JSON
+DATA=$(cat <<EOF
+{
+  "tag_name": "$TAG",
+  "name": "$TAG",
+  "body": "Release for $LIBRARY_NAME",
+  "draft": false,
+  "prerelease": false
+}
+EOF
+)
+
+notice "Creating new release $TAG on GitHub"
+response=$(curl -s -S -H "Content-Type: application/json" \
+ -X POST --data "$DATA" "$API_URL?access_token=$TOKEN")
+
+MESSAGE=$(json_get_key message)
+if [ x"$MESSAGE" != x ] ; then
+    error "creating release on GitHub failed: $MESSAGE"
+fi
+RELEASE_ID=$(json_get_key id)
+if [ x"$RELEASE_ID" = x ] ; then
+    error "creating release on GitHub failed: no release id"
+fi
+
+
+######################################################################
+#
+# Create and upload all requested archive files (as per ARCHIVE_FORMATS)
+#
+cd "$TMP_DIR"
+echo ""
+for EXT in $ARCHIVE_FORMATS ; do
+    ARCHIVENAME=$LIBRARY_NAME-$CONTENT$EXT
+    FULLNAME="$TMP_DIR/$ARCHIVENAME"
+    notice "Creating $ARCHIVENAME ..."
+    case $EXT in
+    .tar.gz)
+        tar cf - "$LIBRARY_NAME" | gzip -9c > "$ARCHIVENAME"
+        MIMETYPE="application/x-gzip"
+        ;;
+    .tar.bz2)
+        tar cf - "$LIBRARY_NAME" | bzip2 -9c > "$ARCHIVENAME"
+        MIMETYPE="application/x-bzip2"
+        ;;
+    .zip)
+        zip -r9 --quiet "$ARCHIVENAME" "$LIBRARY_NAME"
+        MIMETYPE="application/zip"
+        ;;
+    *)
+        warning "unsupported archive format $EXT"
+        continue
+        ;;
+    esac
+    if [ ! -f "$FULLNAME" ] ; then
+        error "failed creating $FULLNAME"
+    fi
+    notice "Uploading $ARCHIVENAME with mime type $MIMETYPE"
+    response=$(curl --fail --progress-bar -o "$TMP_DIR/upload.log" \
+        -X POST "$UPLOAD_URL/$RELEASE_ID/assets?name=$ARCHIVENAME" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token $TOKEN" \
+        -H "Content-Type: $MIMETYPE" \
+        --data-binary @"$FULLNAME")
+done
+
+
+
+exit 0

--- a/bin/OPL_releases/release.sh
+++ b/bin/OPL_releases/release.sh
@@ -136,6 +136,10 @@ cd $LIBRARY_DIR
 #
 
 notice "Library path: " $LIBRARY_DIR
+
+notice "Updating OPL tables"
+OPL-update
+
 notice "Dumping OPL tables"
 dump-OPL-tables.pl
 

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -56,10 +56,6 @@ if [ ! -d "$APP_ROOT/libraries/webwork-open-problem-library/OpenProblemLibrary" 
   cd $APP_ROOT/libraries/
   /usr/bin/git clone -v --progress --single-branch --branch master https://github.com/openwebwork/webwork-open-problem-library.git
 
-  # FIXME / TO-DO : Download a saved version of the OPL sql table data to be loaded and extract
-  #    it in the appropriate location.This would avoid the need for a length run of OPL-update.
-  # At present, a distribution point has not been set up for such data.
-
   # The next line forces the system to run OPL-update or load saved OPL tables below, as we just installed it
   touch "$APP_ROOT/libraries/Restore_or_build_OPL_tables"
 fi
@@ -135,6 +131,22 @@ if [ "$1" = 'apache2' ]; then
       touch "$APP_ROOT/libraries/Restore_or_build_OPL_tables"
     fi
     if [ -f "$APP_ROOT/libraries/Restore_or_build_OPL_tables" ]; then
+      if [ ! -f "$APP_ROOT/libraries/webwork-open-problem-library/TABLE-DUMP/OPL-tables.sql" ]; then
+        # Download a saved version of the OPL sql table data to be loaded and extract
+        cd $WEBWORK_ROOT/bin/OPL_releases/
+        make extract
+        cp -r webwork-open-problem-library $APP_ROOT/libraries/
+        # check out commit corresponding to the release
+        make latest_release.tag
+        OPL_TAG=`cat $WEBWORK_ROOT/bin/OPL_releases/latest_release.tag`
+        cd $APP_ROOT/libraries/webwork-open-problem-library/
+        git remote rm heiderich || true
+        git remote add heiderich https://github.com/heiderich/webwork-open-problem-library.git
+        git fetch --tags heiderich
+        echo "Checking out tag $OPL_TAG"
+        git checkout $OPL_TAG
+      fi
+
       if [ -f "$APP_ROOT/libraries/webwork-open-problem-library/TABLE-DUMP/OPL-tables.sql" ]; then
         echo "Restoring OPL tables from the TABLE-DUMP/OPL-tables.sql file"
         wait_for_db


### PR DESCRIPTION
This adds the script `bin/OPL_releases/release.sh` that creates releases of webwork problem libraries such as the Open Problem Library on GitHub. Those releases contain archives of metadata of the library.

In addition, scripts are added to download the metadata from the latest such release.
They are used in `docker-config/docker-entrypoint.sh` to avoid rebuilding the OPL tables in the sql database, which takes a considerable amount of time.
This should therefore significantly speed up the time to get a docker container up and running for the first time.

As the docker configuration in its current form uses a hardcoded branch of webwork2, in order to test this you have to include some new scripts in your container (as long as this is not merged, afterwards this will not be needed anymore). This can be achieved using bind mounts. Just add the following lines to the `volumes` section of the service `app` in your `docker-compose.yml` file:

      - "./bin/OPL_releases:/opt/webwork/webwork2/bin/OPL_releases"
      - "./bin/restore-OPL-tables.pl:/opt/webwork/webwork2/bin/restore-OPL-tables.pl"
      - "./bin/load-OPL-global-statistics.pl:/opt/webwork/webwork2/bin/load-OPL-global-statistics.pl"
      - "./bin/update-OPL-statistics.pl:/opt/webwork/webwork2/bin/update-OPL-statistics.pl"

Note that currently metadata is retrieved from the repository https://github.com/heiderich/webwork-open-problem-library.git. This should be changed once https://github.com/heiderich/webwork-open-problem-library receives regular updates.