### PR TITLE
Stop search engines indexing individual courses

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Login.pm,v 1.47 2012/06/08 22:59:55 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
@@ -147,6 +147,10 @@ sub pre_header_initialize {
 	}
 }
 
+sub head {
+        print '<meta name="robots" content="noindex" />';
+        return "";
+}
 
 sub body {
 	my ($self) = @_;


### PR DESCRIPTION
I have multiple _hidden_ model courses on my WeBWorK server.

These courses are not intended for students or professors, but they are indexed by Google and seem **very** appealing in a search... 

<img width="661" alt="result of search" src="https://user-images.githubusercontent.com/3912882/64492273-4e9a8480-d240-11e9-9d1d-b25c57a96069.png">

Students' logins fail (because they're logging into the model course, rather than their professor's section) and confusion ensues.

This PR adds a meta tag to the header of all sections' login pages, thereby preventing individual courses from being indexed by (most) search engines. (I'm already using this code, I don't know if anyone else has run into a similar problem...)
