### PR TITLE
When the enter key is pressed in a MathQuill answer box trigger an answer preview.

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -139,6 +139,16 @@ function createAnswerQuill() {
 		}, 200);
 	});
 
+	// Trigger an answer preview when the enter key is pressed in an answer box.
+	answerQuill.on('keypress.preview', function(e) {
+		if (e.key == 'Enter' || e.which == 13 || e.keyCode == 13) {
+			// For homework
+			$("#previewAnswers_id").trigger('click');
+			// For gateway quizzes
+			$("input[name=previewAnswers]").trigger('click');
+		}
+	});
+
 	answerQuill.mathField.latex(answerQuill.latexInput.val());
 	answerQuill.mathField.moveToLeftEnd();
 	answerQuill.mathField.blur();


### PR DESCRIPTION
This emulates the behavior of the original text input.
This was requested by Andrew Parker and Sean Fitzpatrick in
http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4623#p13683