### PR TITLE
In bin/OPL-update, change keyword table's keyword column to varchar(2…

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -201,7 +201,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{keyword}, '
 	keyword_id int(15) NOT NULL auto_increment,
-	keyword varchar(256) NOT NULL,
+	keyword varchar(245) NOT NULL,
 	KEY (keyword),
 	PRIMARY KEY (keyword_id)
 '],


### PR DESCRIPTION
…45) so that mysql 5.7 doesn't complain about keys being to long.

Fix for #1007 . 