### PR TITLE
Fix gateway correct/partialy correct/incorrect message.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -417,7 +417,7 @@ sub attemptResults {
 	    my $correctAnswer = $answerResult->{correct_ans};
 	    $answerScore = $answerResult->{score}//0;
 	    my $answerMessage = $showMessages ? $answerResult->{ans_message} : "";
-	    $numCorrect += $answerScore > 0;
+	    $numCorrect += ($answerScore >= 1) ? 1 : 0;
 	    $numEssay += ($answerResult->{type}//'') eq 'essay';
 	    $numBlanks++ unless $studentAnswer =~/\S/ || $answerScore >= 1;
 	    


### PR DESCRIPTION
This is a continual source of confusion to students.  They take a gateway quiz and it shows that they have missed some points, but on reviewing the quiz they see at the bottom "All of the answers are correct" on all problems.  This is an obvious bug that needs to be fixed.  A score greater than zero is not the correct condition for "completely" correct.

There is really more that needs to be done here.  Line 471 doesn't work right.  It is using the score on the last question in the problem only to determine "complete" correctness of all questions in the problem.