### PR TITLE
For WW 2.15 continue to use MathJax v2 and not MathJax v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN echo Cloning branch $PG_BRANCH_ENV branch from $PG_GIT_URL_ENV \
   && git clone --single-branch --branch ${PG_BRANCH_ENV} --depth 1 $PG_GIT_URL_ENV \
   && rm -rf  pg/.git
 
-RUN git clone --single-branch --branch master --depth 1 https://github.com/mathjax/MathJax \
+RUN git clone --single-branch --branch legacy-v2 --depth 1 https://github.com/mathjax/MathJax \
   && rm -rf MathJax/.git
 
 # Optional - include OPL (also need to uncomment further below when an included OPL is desired):


### PR DESCRIPTION
MathJax has release version 3:
  - https://github.com/mathjax/MathJax/releases/tag/3.0.0
  - https://www.mathjax.org/news/  (currently only mentioned as planned for Sept 2019).
  - https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html#whats-new-3-0

The transition to MathJax version 3 requires configuration changes not yet made to WeBWorK - see https://docs.mathjax.org/en/latest/upgrading/v2.html  so at present, WeBWorK should continue to use version 2.7.x of MathJax.

This forces the Docker configuration to use the `legacy-v2` branch of MathJax at GitHub, so installation will pull in the latest release of version 2.