### PR TITLE
Meta Robots tags for hiding individual courses from search engines

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -317,4 +317,13 @@ $siteDefaults{timezone} = "America/New_York";
 # If you do not fill this in, the system will default to "en_US"
 $siteDefaults{locale}="";
 
+################################################################################
+# Search Engine Indexing Enable/Disable
+################################################################################
+# sets the default meta robots content for individual course pages
+# this will not stop your main course listing page from being indexed
+# valid contents: index, noindex, follow, nofollow, noarchive, and
+# unavailable_after (example: "index, unavailable_after: 23-Jul-2007 18:00:00 EST")
+$options{metaRobotsContent}='noindex, nofollow';
+
 1; #final line of the file to reassure perl that it was read properly.

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -151,6 +151,13 @@ sub pre_header_initialize {
 	}
 }
 
+sub head {
+	my ($self) = @_;
+	my $ce = $self->r->ce;
+	my $contents = $ce->{options}{metaRobotsContent} // 'none';
+        print '<meta name="robots" content="'.$contents.'" />';
+        return "";
+}
 
 sub body {
 	my ($self) = @_;


### PR DESCRIPTION
The course environment will support a new option: `$ce{options}{metaRobotsContent}`, which allows individual courses to control whether or not they are indexed by search engines.

The value of `$ce{options}{metaRobotsContent}` should be a comma-separated list of valid options for the meta robots tag. This list of widely-supported options includes: index, noindex, follow, nofollow, and noarchive. Google additionally supports the "unavailable_after:" option with a date in RFC850 format. For example, "index, unavailable_after: 20-Sep-2019 18:00:00 EST"

This PR replaces #1005 and rebases onto WW-2.15