### PR TITLE
Code to support adding additional CSS files requested by problems

### DIFF
--- a/htdocs/css/rtl.css
+++ b/htdocs/css/rtl.css
@@ -1,0 +1,19 @@
+/* WeBWorK Online Homework Delivery System
+ * Copyright © 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of either: (a) the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version, or (b) the "Artistic License" which comes with this package.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+ * Artistic License for more details.
+ */
+
+/* --- Modify some CSS for Right to left courses/problems ---------------------------------------------------- */
+
+input[type="radio"], input[type="checkbox"] {
+  float: right !important;
+}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2268,20 +2268,46 @@ sub output_CSS {
 	my $site_url = $ce->{webworkURLs}->{htdocs};
 
         # Javascript and style for knowls
-        print qq{
-           <link href="$site_url/css/knowlstyle.css" rel="stylesheet" type="text/css" />};
+        print "<link href=\"$site_url/css/knowlstyle.css\" rel=\"stylesheet\" type=\"text/css\" />\n";
 
 	#style for mathview
 	if ($self->{will}->{useMathView}) {
-	    print "<link href=\"$site_url/js/apps/MathView/mathview.css\" rel=\"stylesheet\" />";
+	    print "<link href=\"$site_url/js/apps/MathView/mathview.css\" rel=\"stylesheet\" />\n";
 	}
 	
 	#style for mathquill
 	if ($self->{will}->{useMathQuill}) {
-		print "<link href=\"$site_url/js/apps/MathQuill/mathquill.css\" rel=\"stylesheet\" />";
-		print "<link href=\"$site_url/js/apps/MathQuill/mqeditor.css\" rel=\"stylesheet\" />";
+		print "<link href=\"$site_url/js/apps/MathQuill/mathquill.css\" rel=\"stylesheet\" />\n";
+		print "<link href=\"$site_url/js/apps/MathQuill/mqeditor.css\" rel=\"stylesheet\" />\n";
 	}
-	
+
+	# Add CSS files requested by problems via ADD_CSS_FILE() in the PG file
+	# or via a setting of $ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}
+	# which can be set in course.conf (the value should be an anon array).
+	my $pg = $self->{pg};
+	if ( defined( $pg->{flags}{extra_css_files} ) ) {
+		my $baseDir = $ce->{webwork_htdocs_url};
+		my $webwork_dir  = $WeBWorK::Constants::WEBWORK_DIRECTORY;
+		my $cssFile;
+		my %cssFiles;
+		# Avoid duplicates
+		my @courseCssRequests = ();
+		if ( defined($ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files} ) ) {
+			@courseCssRequests = ( @{$ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}
+} );
+		}
+		foreach $cssFile ( @courseCssRequests, @{$pg->{flags}{extra_css_files}} ) {
+			$cssFiles{$cssFile} = 1;
+		}
+		foreach $cssFile ( keys( %cssFiles ) ) {
+			if ( -f "$webwork_dir/htdocs/css/$cssFile" ) { # FIXME - test for existence
+				print "<link rel=\"stylesheet\" type=\"text/css\" href=\"${baseDir}/css/$cssFile\" />\n";
+			} else {
+				print "<!-- $cssFile is not available in htdocs/css/ on this server -->\n";
+			}
+		}
+	}
+
 	return "";
 }
 


### PR DESCRIPTION
The webwork2 code added to provides mechanisms to add CSS files request by a specific PG file (by use of the new `ADD_CSS_FILE()` method in PG) or "globally" requested via `course.conf` (or even via `conf/localOverrides.conf`) by setting a value of `$pg{specialPGEnvironmentVars}{extra_css_files}`. The value should be an anonymous array. Ex:
```
$pg{specialPGEnvironmentVars}{extra_css_files} = ['file1.css', 'file2.css'];
```

The requested CSS files need to be stored in `webwork2/htdocs/css`.

The pg side is in https://github.com/openwebwork/pg/pull/428 and depends on this PR. However, this PR does not depend on the PR for pg.

Motivation: http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4624

A sample `htdocs/css/rtl.css` is included with a very preliminary bit of CSS code for RTL courses, in this case to move radio buttons to the right of the text.

---

A small amount of cleanup work was done to existing nearby code.