### PR TITLE
Fix HEADER_TEXT in gateway quizzes

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -52,8 +52,8 @@
 <!-- [gateway] since the left-side menus are gone, don't indent the main content area -->
 
 <title><!--#path style="text" text=" : " textonly="1"--></title>
-<!--#head-->
 <!--#output_JS-->
+<!--#head-->
 </head>
 <body>
 <a href="#content" id="stmc-link" class="sr-only sr-only-focusable">Skip to main content</a>

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1300,10 +1300,15 @@ sub pre_header_initialize {
 }
 
 sub head {
-        my ($self) = @_;
-        my $ce = $self->r->ce;
-        my $webwork_htdocs_url = $ce->{webwork_htdocs_url};
-        return $self->{pg}->{head_text} if defined($self->{pg}->{head_text});
+	my ($self) = @_;
+	return if !defined($self->{ra_pg_results});
+	my $head_text = "";
+	for (@{$self->{ra_pg_results}})
+	{
+		next if !ref($_);
+		$head_text .= $_->{head_text} if $_->{head_text};
+	}
+	return $head_text;
 }
 
 sub path {


### PR DESCRIPTION
Make the HEADER_TEXT method work for gateway quizzes.  This is one piece of the puzzle needed to fix issue #1020.

The head method defined on line 1302 of GatewayQuiz.pm was apparently copied from Problem.pm and not modified to actually work.