### PR TITLE
Check for proper action (non-capitalized) in getFile().

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -239,6 +239,7 @@ sub HiddenFlags {
 #
 # Display the directory listing and associated buttons
 #
+
 sub Refresh {
  	my $self = shift;
 	my $r = $self->r;
@@ -1001,23 +1002,23 @@ sub getFile {
 	my @files = $self->r->param("files");
 	if (scalar(@files) > 1) {
 		$self->addbadmessage($r->maketext("You can only [_1] one file at a time.",$action));
-		$self->Refresh unless ($action eq 'Download' || $action eq $r->maketext('Download'));
+		$self->Refresh unless $action eq 'download';
 		return;
 	}
 	if (scalar(@files) == 0 || $files[0] eq "") {
 		$self->addbadmessage($r->maketext("You need to select a file to [_1].",$action));
-		$self->Refresh unless ($action eq 'Download' || $action eq $r->maketext('Download'));
+		$self->Refresh unless $action eq 'download';
 		return;
 	}
 	my $pwd = $self->checkPWD($self->{pwd} || $self->r->param('pwd') || HOME) || '.';
 	if ($self->isSymLink($pwd.'/'.$files[0])) {
 		$self->addbadmessage($r->maketext("That symbolic link takes you outside your course directory"));
-		$self->Refresh unless ($action eq 'Download' || $action eq $r->maketext('Download'));
+		$self->Refresh unless $action eq 'download';
 		return;
 	}
 	unless ($self->checkPWD($pwd.'/'.$files[0],1)) {
 		$self->addbadmessage($r->maketext("You have specified an illegal file"));
-		$self->Refresh unless ($action eq 'Download' || $action eq $r->maketext('Download'));
+		$self->Refresh unless $action eq 'download';
 		return;
 	}
 	return $files[0];


### PR DESCRIPTION
This undoes incorrect localization from commit 2a4ceac7d. The `$action` variable here is not from the UI, but is a hard-coded constant passed to `getFile()` at each invocation, e.g., `$self->getFile("download')`.  The change to capitalization caused the `Refresh()` method to be called when it should not be.  Also, there is no need to localize the action, since its value is never localized initially.  (It may want to be, since it is inserted into a message, but that is a different question; it is usually a bad idea to localize a single word inserted into a sentence like this, so the whole thing may need to be adjusted, for example, taking localized complete sentences from a hash indexed by $action, for example.)

Resolves issue #1022.