### PR TITLE
Fix feedback warnings with hidden answer blanks

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -503,7 +503,7 @@ sub format_userproblem {
 	if (%last_answer) {
 		$result .= "Last answer:\n";
 		foreach my $key (sort keys %last_answer) {
-			$result .= "\t$key: $last_answer{$key}\n";
+			$result .= "\t$key: $last_answer{$key}\n" if $last_answer{$key};
 		}
 	} else {
 		$result .= "Last answer:                  none\n";


### PR DESCRIPTION
This is discussed on http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4668.

If a student attempts to email the instructor/ta via the feedback button and the problem has parts that are hidden and unanswered (like the latter parts of a scaffolding problem), then the value for that key in the database is null and that causes an error to be displayed for the student.  This is an easy fix.

If it is desired that all answer labels are shown in the email even if there is not answer, this could be slightly modified to achieve that.