### PR TITLE
Gateway resultstable update

### DIFF
--- a/htdocs/themes/math3/gateway.css
+++ b/htdocs/themes/math3/gateway.css
@@ -68,8 +68,8 @@ html>body #gwScoreSummary {
 
 span.resultsWithError { background-color: #ffcccc; color: black; }
 span.resultsWithoutError { background-color: #66ff99; color: black; }
-div.gwCorrect { background-color: #66ff99; color: black; }
-div.gwIncorrect { background-color: #ff9999; color: black; }
+div.ResultsWithoutError { background-color: #66ff99; color: black; }
+div.ResultsWithError { background-color: #ff9999; color: black; }
 
 div.gwProblem {
         clear: both;

--- a/htdocs/themes/math4/gateway.css
+++ b/htdocs/themes/math4/gateway.css
@@ -64,26 +64,22 @@ div#gwScoreSummary {
     margin-left:.2em;
 }
 
-span.resultsWithError, .ResultsWithoutError {
+span.resultsWithError, span.resultsWithoutError {
 	padding: 0.2em 1em;
 	box-shadow: 2px 2px 3px darkgray;
 	margin-bottom: 0.5em;
 	margin-right: 1em;
 	border-radius: 3px;
 }
-span.resultsWithError { 
-	background-color: #d69191;
-}
-.ResultsWithoutError 
-{ 
-	background-color: #88ff88;  
-}
-div.gwCorrect { background-color: #88ff88; }
-div.gwIncorrect { background-color: #d69191; }
-div.gwCorrect, div.gwIncorrect {
+span.resultsWithError { background-color: #d69191; }
+span.resultsWithoutError { background-color: #88ff88;  }
+div.ResultsWithoutError { background-color: #88ff88; }
+div.ResultsWithError { background-color: #d69191; }
+div.ResultsWithoutError, div.ResultsWithError {
 	padding: 0.5em;
 	box-shadow: 3px 3px 3px darkgray;
 	border-radius: 3px;
+	color: black;
 }
 
 div.gwProblem 

--- a/htdocs/themes/math4/gateway.css
+++ b/htdocs/themes/math4/gateway.css
@@ -64,6 +64,8 @@ div#gwScoreSummary {
     margin-left:.2em;
 }
 
+table.attemptResults { width: unset; }
+
 span.resultsWithError, span.resultsWithoutError {
 	padding: 0.2em 1em;
 	box-shadow: 2px 2px 3px darkgray;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -41,6 +41,7 @@ use WeBWorK::Utils::Tasks qw(fake_set fake_set_version fake_problem);
 use WeBWorK::Debug;
 use WeBWorK::ContentGenerator::Instructor qw(assignSetVersionToUser);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
+use WeBWorK::Utils::AttemptsTable;
 use PGrandom;
 
 # template method
@@ -340,8 +341,6 @@ sub can_useMathQuill {
 # output utilities
 ################################################################################
 
-# subroutine is modified from that in Problem.pm to produce a different 
-#    table format
 sub attemptResults {
 	my $self = shift;
 	my $pg = shift;
@@ -351,134 +350,52 @@ sub attemptResults {
 	my $showSummary = shift;
 	my $showAttemptPreview = shift || 0;
 	my $colorAnswers = $showAttemptResults;
-
-	my $r = $self->{r};
-	my $setName = $r->urlpath->arg("setID");
 	my $ce = $self->{ce};
-	my $root = $ce->{webworkURLs}->{root};
-	my $courseName = $ce->{courseName};
-	my @links = ("Homework Sets" , "$root/$courseName", "navUp");
-	my $tail = "";
-	
-	my $problemResult = $pg->{result}; # the overall result of the problem
-	my @answerNames = @{ $pg->{flags}->{ANSWER_ENTRY_ORDER} };
-	
-	my $showMessages = $showAttemptAnswers && grep { $pg->{answers}->{$_}->{ans_message} } @answerNames;
 
 	# for color coding the responses.
 	$self->{correct_ids} = [] unless $self->{correct_ids};
 	$self->{incorrect_ids} = [] unless $self->{incorrect_ids};
 
-  # present in ver 1.10; why is this checked here?
-	#	return CGI::p(CGI::font({-color=>"red"}, "This problem is not available because the homework set that contains it is not yet open."))
-	#	unless $self->{isOpen};
-
-	my $basename = "equation-" . $self->{set}->psvn. "." . $self->{problem}->problem_id . "-preview";
-
 	# to make grabbing these options easier, we'll pull them out now...
-	my %imagesModeOptions = %{$ce->{pg}->{displayModeOptions}->{images}};
-	
+	my %imagesModeOptions = %{$ce->{pg}{displayModeOptions}{images}};
+
 	my $imgGen = WeBWorK::PG::ImageGenerator->new(
-		tempDir         => $ce->{webworkDirs}->{tmp},
-		latex	        => $ce->{externalPrograms}->{latex},
-		dvipng          => $ce->{externalPrograms}->{dvipng},
+		tempDir         => $ce->{webworkDirs}{tmp},
+		latex	        => $ce->{externalPrograms}{latex},
+		dvipng          => $ce->{externalPrograms}{dvipng},
 		useCache        => 1,
-		cacheDir        => $ce->{webworkDirs}->{equationCache},
-		cacheURL        => $ce->{webworkURLs}->{equationCache},
-		cacheDB         => $ce->{webworkFiles}->{equationCacheDB},
+		cacheDir        => $ce->{webworkDirs}{equationCache},
+		cacheURL        => $ce->{webworkURLs}{equationCache},
+		cacheDB         => $ce->{webworkFiles}{equationCacheDB},
 		dvipng_align    => $imagesModeOptions{dvipng_align},
 		dvipng_depth_db => $imagesModeOptions{dvipng_depth_db},
 	);
 
-	my @rows;
-	my @row;
-	
-	push @row, CGI::th({scope=>"col"},$r->maketext('Entered')) if $showAttemptAnswers;
-	push @row, CGI::th({scope=>"col"},$r->maketext('Answer Preview')) if $showAttemptPreview;
-	push @row, CGI::th({scope=>"col"},$r->maketext('Correct')) if $showCorrectAnswers;
-	push @row, CGI::th({scope=>"col"},$r->maketext('Result')) if $showAttemptResults;
-	push @row, CGI::th({scope=>"col"},$r->maketext('Messages')) if $showMessages;
+	my $showEvaluatedAnswers = $ce->{pg}{options}{showEvaluatedAnswers} // '';
 
-	push @rows, CGI::Tr(@row);
+	# Create AttemptsTable object	
+	my $tbl = WeBWorK::Utils::AttemptsTable->new(
+		$pg->{answers},
+		answersSubmitted       => 1,
+		answerOrder            => $pg->{flags}{ANSWER_ENTRY_ORDER},
+		displayMode            => $self->{displayMode},
+		showAnswerNumbers      => 0,
+		showAttemptAnswers     => $showAttemptAnswers && $showEvaluatedAnswers,
+		showAttemptPreviews    => $showAttemptPreview,
+		showAttemptResults     => $showAttemptResults,
+		showCorrectAnswers     => $showCorrectAnswers,
+		showMessages           => $showAttemptAnswers, # internally checks for messages
+		showSummary            => $showSummary,
+		imgGen                 => $imgGen, # not needed if ce is present ,
+		ce                     => '',	   # not needed if $imgGen is present
+		maketext               => WeBWorK::Localize::getLoc($ce->{language}),
+	);
 
-	my $answerScore = 0;
-	my $numCorrect = 0;
-	my $numAns = 0;
-	my $numBlanks = 0;
-	my $numEssay = 0;
-	foreach my $name (@answerNames) {
-
-	    @row = ();
-	    my $answerResult  = $pg->{answers}->{$name};
-	    my $studentAnswer = $answerResult->{student_ans}//''; # original_student_ans
-	    my $preview       = ($showAttemptPreview
-				 ? $self->previewAnswer($answerResult, $imgGen)
-				 : "");
-	    my $correctAnswer = $answerResult->{correct_ans};
-	    $answerScore = $answerResult->{score}//0;
-	    my $answerMessage = $showMessages ? $answerResult->{ans_message} : "";
-	    $numCorrect += ($answerScore >= 1) ? 1 : 0;
-	    $numEssay += ($answerResult->{type}//'') eq 'essay';
-	    $numBlanks++ unless $studentAnswer =~/\S/ || $answerScore >= 1;
-	    
-	    my $resultString;
-	    if ($answerScore >= 1) {
-		$resultString = $r->maketext("correct");
-		push @{$self->{correct_ids}}, $name if $colorAnswers;
-	    } elsif (($answerResult->{type}//'') eq 'essay') {
-		$resultString =  $r->maketext("Ungraded");
-		$self->{essayFlag} = 1;
-	    } elsif (defined($answerScore) and $answerScore == 0) {
-		$resultString = $r->maketext("incorrect");
-		push @{$self->{incorrect_ids}}, $name if $colorAnswers;
-	    } else {
-		$resultString =  $r->maketext("[_1]% correct", int($answerScore*100));
-		push @{$self->{incorrect_ids}}, $name if $colorAnswers;
-	    }
-	    
-	    push @row, CGI::td({scope=>"col"},$self->nbsp($studentAnswer)) if $showAttemptAnswers;
-	    push @row, CGI::td({scope=>"col"}, $self->nbsp($preview)) if $showAttemptPreview;
-	    push @row, CGI::td({scope=>"col"}, $self->nbsp($correctAnswer)) if $showCorrectAnswers;
-	    push @row, CGI::td({scope=>"col"}, $self->nbsp($resultString)) if $showAttemptResults;
-	    push @row, CGI::td({scope=>"col"},  $self->nbsp($answerMessage)) if $showMessages;
-	    
-	    push @rows, CGI::Tr(@row);
-	    $numAns++;
-
-	}
-
-	# render equation images
-	$imgGen->render(refresh => 1);
-
-	my $summary = "";
-	if (scalar @answerNames == 1) { #Here there is just one answer blank
-		if ($numCorrect == 1) { #The student might be totally right
-			$summary .= CGI::div({class=>"gwCorrect"},$r->maketext("This answer is correct."));
-		} elsif ($self->{essayFlag}) {
-			$summary .= $r->maketext("The answer will be graded later.");
-		} elsif ($answerScore > 0 && $answerScore < 1) { #The student might be partially right
-			$summary .= CGI::div({class=>"gwIncorrect"},$r->maketext("This answer is NOT completely correct."));
-		} else { #The student might be completely wrong.
-		 	 $summary .= CGI::div({class=>"gwIncorrect"},$r->maketext("This answer is NOT correct."));
-		}
-	} else {
-		if ($numCorrect + $numEssay == scalar @answerNames) {
-			$summary .= CGI::div({class=>"gwCorrect"},$r->maketext(
-				$numEssay ? "All of the gradeable answers are correct." :
-					    "All of the answers are correct."));
-		} elsif ($numBlanks + $numEssay != scalar(@answerNames)) {
-			$summary .= CGI::div({class=>"gwIncorrect"},$r->maketext(
-				$answerScore > 0 && $answerScore < 1 ?
-				      "At least one of these answers is NOT completely correct." :
-				      "At least one of these answers is NOT correct."));
-		}
-	}
-
-	return
-
-	    CGI::table({-class=>"gwAttemptResults"}, @rows).
-
-	    ($showSummary ? CGI::p({class=>'attemptResultsSummary'},$summary) : "");
+	my $answerTemplate = $tbl->answerTemplate; 
+	$tbl->imgGen->render(refresh => 1) if $tbl->displayMode eq 'images';
+	push(@{$self->{correct_ids}}, @{$tbl->correct_ids}) if $colorAnswers;
+	push(@{$self->{incorrect_ids}}, @{$tbl->incorrect_ids}) if $colorAnswers;
+	return $answerTemplate;
 }
 
 sub handle_input_colors {
@@ -499,41 +416,6 @@ sub handle_input_colors {
 	        "]\n);",
 	      CGI::end_script();
 }
-
-# *BeginPPM* ###################################################################
-# this code taken from Problem.pm; excerpted section ends at *EndPPM*
-# modifications are flagged with comments *GW*
-
-sub previewAnswer {
-	my ($self, $answerResult, $imgGen) = @_;
-	my $ce            = $self->r->ce;
-	my $EffectiveUser = $self->{effectiveUser};
-	my $set           = $self->{set};
-	my $problem       = $self->{problem};
-	my $displayMode   = $self->{displayMode};
-	
-	# note: right now, we have to do things completely differently when we are
-	# rendering math from INSIDE the translator and from OUTSIDE the translator.
-	# so we'll just deal with each case explicitly here. there's some code
-	# duplication that can be dealt with later by abstracting out tth/dvipng/etc.
-	
-	my $tex = $answerResult->{preview_latex_string};
-	
-	return "" unless defined $tex and $tex ne "";
-	
-	if ($displayMode eq "plainText") {
-		return $tex;
-	} elsif ($displayMode eq "images") {
-		$imgGen->add($tex);
-	} elsif ($displayMode eq "MathJax") {
-		return '<span class="MathJax_Preview">[math]</span><script type="math/tex; mode=display">'.$tex.'</script>';
-	} elsif ($displayMode eq "jsMath") {
-		$tex =~ s/&/&amp;/g; $tex =~ s/</&lt;/g; $tex =~ s/>/&gt;/g;
-		return '<SPAN CLASS="math">\\displaystyle{'.$tex.'}</SPAN>';
-	}
-}
-
-# *EndPPM ######################################################################
 
 ################################################################################
 # Template escape implementations

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -379,6 +379,7 @@ sub attemptResults {
 		answersSubmitted       => 1,
 		answerOrder            => $pg->{flags}{ANSWER_ENTRY_ORDER},
 		displayMode            => $self->{displayMode},
+		showHeadline           => 0,
 		showAnswerNumbers      => 0,
 		showAttemptAnswers     => $showAttemptAnswers && $showEvaluatedAnswers,
 		showAttemptPreviews    => $showAttemptPreview,

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -298,8 +298,6 @@ sub can_showMeAnother {
 # output utilities
 ################################################################################
 
-# Note: the substance of attemptResults is lifted into GatewayQuiz.pm,
-# with some changes to the output format
 sub attemptResults {
 	my $self = shift;
 	my $r = $self->r;

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -57,6 +57,7 @@ answer to a WeBWorK problem.  It is used in Problem.pm, OpaqueServer.pm, standAl
 		answersSubmitted       => 1,
 		answerOrder            => $pg->{flags}->{ANSWER_ENTRY_ORDER},
 		displayMode            => 'MathJax',
+		showHeadline           => 1,
 		showAnswerNumbers      => 0,
 		showAttemptAnswers     => $showAttemptAnswers && $showEvaluatedAnswers,
 		showAttemptPreviews    => $showAttemptPreview,
@@ -75,6 +76,8 @@ answer to a WeBWorK problem.  It is used in Problem.pm, OpaqueServer.pm, standAl
 	answerOrder       -- an array indicating the order the answers appear on the page.
 	displayMode       'MathJax' and 'images' are the most common
 	
+	showHeadline       Show the header line 'Results for this submission'
+
 	showAnswerNumbers, showAttemptAnswers, showAttemptPreviews,showAttemptResults,
 	showCorrectAnswers and showMessages control the display of each column in the table.
 	
@@ -168,6 +171,7 @@ sub new {
 		answersSubmitted    => $options{answersSubmitted}//0,
 		summary             => $options{summary}//'', # summary provided by problem grader
 	    displayMode 		=> $options{displayMode} || "MathJax",
+		showHeadline        => $options{showHeadline} // 1,
 	    showAnswerNumbers    => $options{showAnswerNumbers}//1,
 	    showAttemptAnswers =>  $options{showAttemptAnswers}//1,    # show student answer as entered and simplified 
 	                                                               #  (e.g numerical formulas are calculated to produce numbers)
@@ -182,7 +186,7 @@ sub new {
 	bless $self, $class;
 	# create read only accessors/mutators
 	$self->mk_ro_accessors(qw(answers answerOrder answersSubmitted displayMode imgGen maketext));
-	$self->mk_ro_accessors(qw(showAnswerNumbers showAttemptAnswers 
+	$self->mk_ro_accessors(qw(showAnswerNumbers showAttemptAnswers showHeadline
 	                          showAttemptPreviews showAttemptResults 
 	                          showCorrectAnswers showSummary));
 	$self->mk_accessors(qw(correct_ids incorrect_ids showMessages  summary));
@@ -322,8 +326,9 @@ sub answerTemplate {
     	push @incorrect_ids,   $ans_id if ($rh_answers->{$ans_id}->{score}//0) < 1;
     	#$self->{essayFlag} = 1;
     }
-	my $answerTemplate = CGI::h3($self->maketext("Results for this submission")) .
-    	CGI::table({class=>"attemptResults"},@tableRows);
+	my $answerTemplate = "";
+	$answerTemplate .= CGI::h3($self->maketext("Results for this submission")) if $self->showHeadline;
+	$answerTemplate .= CGI::table({class=>"attemptResults"},@tableRows);
     ### "results for this submission" is better than "attempt results" for a headline
     $answerTemplate .= ($self->showSummary)? $self->createSummary() : '';
     $answerTemplate = "" unless $self->answersSubmitted; # only print if there is at least one non-blank answer


### PR DESCRIPTION
It is time that gateway quizzes got a bit of a facelift.  It looks like AttemptsTable.pm was created in 2015, and it usage implemented in Problem.pm at that time.  However, it was not implemented in GatewayQuiz.pm.  It works there and so it should be used there also.  That table is much nicer, and aligns homework gateway quiz experience.  This pull request does that.