### PR TITLE
Problem randomization clear answers

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -708,10 +708,15 @@ sub pre_header_initialize {
 
 	##### sticky answers #####
 
-	if (not ($submitAnswers or $previewAnswers or $checkAnswers) and $will{showOldAnswers}) {
-		# do this only if new answers are NOT being submitted
+	if (!($submitAnswers || $previewAnswers || $checkAnswers) && $will{showOldAnswers}) {
 		my %oldAnswers = decodeAnswers($problem->last_answer);
-		$formFields->{$_} = $oldAnswers{$_} foreach keys %oldAnswers;
+		# Do this only if new answers are NOT being submitted
+		if ($prEnabled && !$problem->{prCount}) {
+			# Clear answers if this is a new problem version
+			delete $formFields->{$_} foreach keys %oldAnswers;
+		} else {
+			$formFields->{$_} = $oldAnswers{$_} foreach keys %oldAnswers;
+		}
 	}
 
 	##### translation #####


### PR DESCRIPTION
When a new version of a problem is presented with problem randomization enabled, clear out the answers that were submitted for the previous problem.  This could be made an option if the old behaviour is desired, but it seems a bit silly to me to show the answers to a previous version.  

Showing old answers can cause some undesirable effects particularly when scaffolding is used in a problem.  If there are parts that have radio answers, pop up boxes, or generally few possible answers, then the odds are pretty high that the last problem's answer is correct for the new version.  Scaffolding then marks the part green to indicate it is already correct.