### PR TITLE
Problem randomization: Show correct answers after the last attempt before a new version must be requested.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -217,6 +217,9 @@ $pg{options}{enablePeriodicRandomization} = 0;
 # course-wide default period for re-randomization, should be an integer
 # the value of 0 disables re-randomization
 $pg{options}{periodicRandomizationPeriod} = 5;
+# Show the correct answer after a student's last attempt at the current version
+# and before a new version is requested.
+$pg{options}{showCorrectOnRandomize} = 0;
 
 ################################################################################
 # Language
@@ -1610,6 +1613,11 @@ $ConfigValues = [
 		doc => 'The default number of attempts between re-randomization of the problems ( 0 => never)',
 		doc2 => 'The default number of attempts before the problem is re-randomized. ( 0 => never )',
 		type => 'number'
+	},
+	{	var => 'pg{options}{showCorrectOnRandomize}',
+		doc => 'Show the correct answer to the current problem before re-randomization.',
+		doc2 => 'Show the correct answer to the current problem on the last attempt before a new version is requestion.',
+		type => 'boolean'
 	},
  	],		  
 	['Permissions',

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -748,6 +748,7 @@ sub pre_header_initialize {
 		$can{requestNewSeed} = 1;
 		$want{requestNewSeed} = 1;
 		$will{requestNewSeed} = 1;
+		$self->{showCorrectOnRandomize} = $ce->{pg}{options}{showCorrectOnRandomize};
 		# If this happens, it means that the page was refreshed.  So prevent the answers from
 		# being recorded and the number of attempts from being increased.
 		if ($problem->{prCount} > $rerandomizePeriod) {
@@ -1919,7 +1920,7 @@ sub output_summary{
 	    # print this if user submitted answers OR requested correct answers	    
 	    my $results = $self->attemptResults($pg, 
 	                    1,   # showAttemptAnswers --display the unformatted submitted answer attempt
-						$will{showCorrectAnswers}, # showCorrectAnswers
+						$self->{showCorrectOnRandomize} // $will{showCorrectAnswers}, # showCorrectAnswers
 						$pg->{flags}->{showPartialCorrectAnswers}, # showAttemptResults
 			            1, # showSummary
 			            1  # showAttemptPreview

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -289,6 +289,11 @@ my $ConfigStrings = [
 		doc2 => x('The default number of attempts before the problem is re-randomized. ( 0 => never )'),
 		type => 'number'
 	},
+	{	var => 'pg{options}{showCorrectOnRandomize}',
+		doc => 'Show the correct answer to the current problem before re-randomization.',
+		doc2 => 'Show the correct answer to the current problem on the last attempt before a new version is requestion.',
+		type => 'boolean'
+	},
  	],		  
 	[x('Permissions'),
 		{ var => 'permissionLevels{login}',


### PR DESCRIPTION
This is a new option to use when problem randomization is enabled.  If the option is enabled, the students will be shown the correct answer for a problem version after the last attempt and before a new version is shown.

There are most likely those that will not want this feature, so this is a course option.