### PR TITLE
make achievement items have effect on reduced scoring date

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -155,6 +155,7 @@ sub use_item {
     # Set a new close date and answer time for the student and remove the item
     $set->due_date(time()+86400);
     $set->answer_date(time()+86400);
+    $set->reduced_scoring_date(time()+86400);
 
     $db->putUserSet($set);
 	
@@ -246,6 +247,7 @@ sub use_item {
     #add time to the due date and answer date and remove item from inventory
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400);
 
     $db->putUserSet($userSet);
 	
@@ -329,6 +331,7 @@ sub use_item {
     #add time to the due date and answer date and remove item from inventory
     $userSet->due_date($set->due_date()+172800);
     $userSet->answer_date($set->answer_date()+172800);
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+172800);
 
     $db->putUserSet($userSet);
 	
@@ -1515,6 +1518,7 @@ sub use_item {
     #add time to the due date and answer date
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400);
 
     $db->putUserSet($userSet);
 
@@ -1526,6 +1530,7 @@ sub use_item {
 	$set = $db->getSetVersion($userName,$setID,$version);
 	$set->due_date($set->due_date()+86400);
 	$set->answer_date($set->answer_date()+86400);
+	$set->reduced_scoring_date($set->reduced_scoring_date()+86400);
 	$db->putSetVersion($set);
 
     }
@@ -1615,6 +1620,7 @@ sub use_item {
     #add time to the due date and answer date and remove item from inventory
     $set->due_date(time()+86400);
     $set->answer_date(time()+86400);
+    $set->reduced_scoring_date(time()+86400);
 
     $db->putUserSet($set);
 	

--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -152,10 +152,10 @@ sub use_item {
     return "Couldn't find that set!" unless
 	($set);
 
-    # Set a new close date and answer time for the student and remove the item
+    # Set a new reduced scoring date, close date, and answer date for the student; remove the item
+    $set->reduced_scoring_date(time()+86400);
     $set->due_date(time()+86400);
     $set->answer_date(time()+86400);
-    $set->reduced_scoring_date(time()+86400);
 
     $db->putUserSet($set);
 	
@@ -244,10 +244,10 @@ sub use_item {
 	($set);
     my $userSet = $db->getUserSet($userName,$setID);
     
-    #add time to the due date and answer date and remove item from inventory
+    #add time to the reduced scoring date, due date, and answer date; remove item from inventory
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400);
 
     $db->putUserSet($userSet);
 	
@@ -328,10 +328,10 @@ sub use_item {
 	($set);
     my $userSet = $db->getUserSet($userName,$setID);
     
-    #add time to the due date and answer date and remove item from inventory
+    #add time to the reduced scoring date, due date, and answer date; remove item from inventory
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+172800) if defined($set->reduced_scoring_date());
     $userSet->due_date($set->due_date()+172800);
     $userSet->answer_date($set->answer_date()+172800);
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+172800);
 
     $db->putUserSet($userSet);
 	
@@ -1515,22 +1515,22 @@ sub use_item {
 	($set);
     my $userSet = $db->getUserSet($userName,$setID);
     
-    #add time to the due date and answer date
+    #add time to the reduced scoring date, due date, and answer date
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400);
 
     $db->putUserSet($userSet);
 
-    #add time to the due date and answer date of verious verisons
+    #add time to the reduced scoring date, due date, and answer date of various versions
     my @versions = $db->listSetVersions($userName,$setID);
 
     foreach my $version (@versions) {
 
 	$set = $db->getSetVersion($userName,$setID,$version);
+	$set->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
 	$set->due_date($set->due_date()+86400);
 	$set->answer_date($set->answer_date()+86400);
-	$set->reduced_scoring_date($set->reduced_scoring_date()+86400);
 	$db->putSetVersion($set);
 
     }
@@ -1617,10 +1617,10 @@ sub use_item {
     return "Couldn't find that set!" unless
 	($set);
     
-    #add time to the due date and answer date and remove item from inventory
+    #add time to the reduced scoring date, due date, and answer date; remove item from inventory
+    $set->reduced_scoring_date(time()+86400) if defined($set->reduced_scoring_date());
     $set->due_date(time()+86400);
     $set->answer_date(time()+86400);
-    $set->reduced_scoring_date(time()+86400);
 
     $db->putUserSet($set);
 	


### PR DESCRIPTION
Currently if I have a "full credit" date (aka "reduced credit" date) in the middle of the term, with the "close" date at the end of the term, then using any item that extends a due date just pushes back the "close" date. The student feels cheated that the "full credit" date has not also been moved. These edits change that.