### PR TITLE
fixing typo in vector input help file

### DIFF
--- a/htdocs/helpFiles/Entering-Vectors.html
+++ b/htdocs/helpFiles/Entering-Vectors.html
@@ -12,7 +12,7 @@
 </blockquote>
 </li>
 
-<li><u>A vector may be entered using angle brackes and commas, or adding multiples of i, j, and k:</u>
+<li><u>A vector may be entered using angle brackets and commas, or adding multiples of i, j, and k:</u>
 <blockquote>
 <tt>&lt;4.5, 3/7&gt;</tt> &nbsp; and &nbsp; <tt>4.5i + 3/7j</tt> &nbsp; are valid vectors in 2 dimensions<br />
 <tt>&lt;pi,e,2&gt;</tt> &nbsp; and &nbsp; <tt>pi i + e j + 2 k</tt> &nbsp; are valid vectors in 3 dimensions 


### PR DESCRIPTION
The vector input help file for students has a typo. It says `angle brackes` instead of `angle brackets`.