### PR TITLE
Fix trying library problems when problem randomization is enabled.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -696,7 +696,7 @@ sub pre_header_initialize {
 			$problem->{problem_seed} = ($problem->{problem_seed} + $problem->num_correct + $problem->num_incorrect) % 10000;
 			$problem->{prCount} = 0;
 		}
-		$db->putUserProblem($problem);
+		$db->putUserProblem($problem) if $problem->{prCount} > -1;
 	}
 	
 	# final values for options

--- a/lib/WeBWorK/Utils/Tasks.pm
+++ b/lib/WeBWorK/Utils/Tasks.pm
@@ -147,7 +147,7 @@ sub fake_problem {
 	$problem->last_answer(""); 
 	$problem->num_correct(1000); 
 	$problem->num_incorrect(1000); 
-	$problem->prCount(0);
+	$problem->prCount(-10); # Negative to detect fake problems and disable problem randomization.
 
 	#for my $key (keys(%{$problem})){
 	#	my $value = '####UNDEF###';


### PR DESCRIPTION
I discovered that an error that occurs if problem randomization is enabled when attempting to view a problem that does not exist in the course (e.g. from the library).  This fixes that problem.

I introduced this bug when I restructured problem randomization.