### PR TITLE
Add htdocs/tmp back develop

### DIFF
--- a/htdocs/tmp/README
+++ b/htdocs/tmp/README
@@ -1,0 +1,1 @@
+Web-accessible temporary files are stored in this directory.


### PR DESCRIPTION
Recreate the htdocs/tmp/README file to have htdocs/tmp/ in the Git repo. Was deleted by https://github.com/openwebwork/webwork2/commit/c616641b69114cebdee0eac61d63ecaf4abdd87a

PR https://github.com/openwebwork/webwork2/pull/1052 does this for master.