### PR TITLE
Correct way to access ENV variable

### DIFF
--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -75,9 +75,9 @@ sub get_credentials {
 			return $self->SUPER::get_credentials( @_ );
 		}
 		
-		if ( defined ($ENV{$ce->{shibboleth}{session_header}}) && defined( $ENV{$ce->{shibboleth}{mapping}{user_id}} ) ) {
+		if ( defined ($ce->{shibboleth}{session_header}) && defined( $ce->{shibboleth}{mapping}{user_id} ) ) {
 			debug('Got shib header and user_id');
-			my $user_id = $ENV{$ce->{shibboleth}{mapping}{user_id}};
+			my $user_id = $ce->{shibboleth}{mapping}{user_id};
 			if ( defined ($ce->{shibboleth}{hash_user_id_method}) && 
 			     $ce->{shibboleth}{hash_user_id_method} ne "none" && 
 			     $ce->{shibboleth}{hash_user_id_method} ne "" ) {


### PR DESCRIPTION
This duplicates the original PR to master #1044.  The changes make sense -- it seems unlikely that the original code would have worked well. However since I can't test shibboleth directly I'm submitting this pull request to develop and holding the hotfix to master for now. I don't want to risk breaking code that is actively being used. 