### PR TITLE
Hotfix correct model course initial values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 applets
 tmp
 logs
-courses.dist
 library-directory-tree.json
 library-subject-tree.json
 textbook-tree.json

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1174,13 +1174,15 @@ $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
  $pg{specialPGEnvironmentVars}{DragMath} = 0;
  $pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools/",
  $pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools/",
- $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/CAPA_Graphics/",
+ $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Graphics/",
+ $pg{specialPGEnvironmentVars}{CAPA_Graphics_URL}      = "$webworkURLs{htdocs}/CAPA_Graphics/",
+
  push @{$pg{directories}{macrosPath}},  
    "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools",
    "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools";
 
  # The link Contrib in the course templates directory should point to ../webwork-open-problem-library/Contrib 
-
+ # The link webwork2/htdocs/CAPA_Graphics should point to ../webwork-open-problem-library/Contrib/CAPA/macros/CAPA_graphics
 # Size in pixels of dynamically-generated images, i.e. graphs.
 $pg{specialPGEnvironmentVars}{onTheFlyImageSize}      = 400,
  

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1167,10 +1167,19 @@ $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 
 # Locations of CAPA resources. (Only necessary if you need to use converted CAPA
 # problems.)
-$pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/capaLibrary/macros/CAPA_Tools/",
-$pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/capaLibrary/macros/CAPA_MCTools/",
-$pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$webworkDirs{htdocs}/CAPA_Graphics/",
-$pg{specialPGEnvironmentVars}{CAPA_Graphics_URL}      = "$webworkURLs{htdocs}/CAPA_Graphics/",
+################################################################################
+# "Special" PG environment variables. (Stuff that doesn't fit in anywhere else.)
+################################################################################
+
+ $pg{specialPGEnvironmentVars}{DragMath} = 0;
+ $pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools/",
+ $pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools/",
+ $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/CAPA_Graphics/",
+ push @{$pg{directories}{macrosPath}},  
+   "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools",
+   "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools";
+
+ # The link Contrib in the course templates directory should point to ../webwork-open-problem-library/Contrib 
 
 # Size in pixels of dynamically-generated images, i.e. graphs.
 $pg{specialPGEnvironmentVars}{onTheFlyImageSize}      = 400,

--- a/conf/snippets/ASimpleCombinedHeaderFile.pg
+++ b/conf/snippets/ASimpleCombinedHeaderFile.pg
@@ -7,6 +7,8 @@ DOCUMENT();
 loadMacros(
 	"PG.pl",
 	"PGbasicmacros.pl",
+	"PGML.pl",
+	#"source.pl", #uncommenting this will display "show source" button if that is permitted
 	"PGcourse.pl",
 );
 
@@ -78,9 +80,9 @@ EOT
 #
 ####################################################
 
-BEGIN_TEXT
+BEGIN_PGML
 
-END_TEXT
+END_PGML
 
 
 TEXT($END_ONE_COLUMN);

--- a/courses.dist/modelCourse/templates/ASimpleCombinedHeaderFile.pg
+++ b/courses.dist/modelCourse/templates/ASimpleCombinedHeaderFile.pg
@@ -7,9 +7,9 @@ DOCUMENT();
 loadMacros(
 	"PG.pl",
 	"PGbasicmacros.pl",
-        "PGML.pl",
-        # "source.pl",
-        PGcourse.pl",
+	"PGML.pl",
+	# "source.pl",
+	"PGcourse.pl",
 );
 
 TEXT($BEGIN_ONE_COLUMN);

--- a/courses.dist/modelCourse/templates/ASimpleCombinedHeaderFile.pg
+++ b/courses.dist/modelCourse/templates/ASimpleCombinedHeaderFile.pg
@@ -7,7 +7,9 @@ DOCUMENT();
 loadMacros(
 	"PG.pl",
 	"PGbasicmacros.pl",
-
+        "PGML.pl",
+        # "source.pl",
+        PGcourse.pl",
 );
 
 TEXT($BEGIN_ONE_COLUMN);
@@ -78,9 +80,9 @@ EOT
 #
 ####################################################
 
-BEGIN_TEXT
+BEGIN_PGML
 
-END_TEXT
+END_PGML
 
 
 TEXT($END_ONE_COLUMN);

--- a/courses.dist/modelCourse/templates/Contrib
+++ b/courses.dist/modelCourse/templates/Contrib
@@ -1,0 +1,1 @@
+../../../libraries/webwork-open-problem-library/Contrib

--- a/courses.dist/modelCourse/templates/Library
+++ b/courses.dist/modelCourse/templates/Library
@@ -1,0 +1,1 @@
+../../../libraries/webwork-open-problem-library/OpenProblemLibrary

--- a/courses.dist/modelCourse/templates/capaLibrary
+++ b/courses.dist/modelCourse/templates/capaLibrary
@@ -1,0 +1,1 @@
+Contrib/CAPA

--- a/htdocs/CAPA_Graphics
+++ b/htdocs/CAPA_Graphics
@@ -1,0 +1,1 @@
+../../libraries/webwork-open-problem-library/Contrib/CAPA/graphics/CAPA_Graphics

--- a/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/GetLibrarySetProblems.pm
@@ -75,7 +75,7 @@ use constant MOVED => (1 << 4);
 my %problib;	## This is configured in defaults.config
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'graphics' => 1, 'email' => 1, '.svn' => 1,
 );
 
 sub prepare_activity_entry {

--- a/lib/WeBWorK/ContentGenerator/Instructor/GetTargetSetProblems.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/GetTargetSetProblems.pm
@@ -67,7 +67,7 @@ use constant LIB2_DATA => {
 my %problib;	## This is configured in defaults.conf
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'graphics'=>1, 'email' => 1, '.svn' => 1,
 );
 
 sub prepare_activity_entry {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -77,7 +77,7 @@ use constant SUCCESS => (1 << 2);
 my %problib;	## This is configured in defaults.config
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1, 'achievements' => 1,
+	'headers' => 1, 'macros' => 1, 'email' => 1, 'graphics'=>1, '.svn' => 1, 'achievements' => 1,
 );
 
 sub prepare_activity_entry {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker2.pm
@@ -75,7 +75,7 @@ use constant MOVED => (1 << 4);
 my %problib;	## this is configured in defaults.config
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'email' => 1, 'graphics'=>1, '.svn' => 1,
 );
 
 sub prepare_activity_entry {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker3.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker3.pm
@@ -67,7 +67,7 @@ use constant LIB2_DATA => {
 my %problib;	## This is configured in defaults.config
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'email' => 1, 'graphics'=>1,'.svn' => 1,
 );
 
 # template method

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMakernojs.pm
@@ -73,7 +73,7 @@ use constant SUCCESS => (1 << 2);
 my %problib;	## This is configured in defaults.config
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'email' => 1, 'graphics'=>1, '.svn' => 1,
 );
 
 sub prepare_activity_entry {

--- a/lib/WebworkWebservice/LibraryActions.pm
+++ b/lib/WebworkWebservice/LibraryActions.pm
@@ -48,7 +48,7 @@ my %problib;	## This is configured in defaults.config
 
 my %ignoredir = (
 	'.' => 1, '..' => 1, 'Library' => 1, 'CVS' => 1, 'tmpEdit' => 1,
-	'headers' => 1, 'macros' => 1, 'email' => 1, '.svn' => 1,
+	'headers' => 1, 'macros' => 1, 'email' => 1, 'graphics'=>1, '.svn' => 1,
 );
 
 


### PR DESCRIPTION
* Change ASimpleCombinedHeaderFile.pg
	* Add PGML.pl 
	* loadMacros(
        "PG.pl",
        "PGbasicmacros.pl",
        "PGML.pl",
        \# "source.pl",
        "PGcourse.pl",
	);
	* Also change `BEGIN_TEXT/END_TEXT` to `BEGIN_PGML/END_PGML`
* Move CAPA_GRAPHICS
	* Moved to Contrib/CAPA/graphics/CAPA_Graphics
		* This hides the individual graphics so that they don't appear in the LibraryBrowser listing of CAPA problems.
* Updated paths to CAPA problems in default.config to correspond to default values in localOverrides
* Added link to CAPA_Graphics in webwork2/htdocs
#### This fix started with an observation of Arnie Pizer:

Somebody tried to set up links to the Contrib and CAPA libraries but messed up.
In the templates directory of the model course we have:
```
lrwxrwxrwx 1 wwadmin wwdata   20 Nov 30 16:26 CAPA -> Library/Contrib/CAPA
lrwxrwxrwx 1 wwadmin wwdata   15 Nov 30 16:26 Contrib -> Library/Contrib
```
but when a course is set up we have
```
lrwxrwxrwx  1 www-data wwdata   70 Dec  9 16:45 Library -> /opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary/
```
as it should be.

But Contrib is under  webwork-open-problem-library/   NOT UNDER   OpenProblemLibrary/

#### To test

From CourseAdmin 

1. Add a new course.
2. Using LibraryBrowser inspect that CAPA and Contrib buttons are visible
3. Check that these button each lead to lists of problems in the Contrib and Contrib/CAPA directories
4. Check that in the CAPA directory the contents of the graphics subdirectory (Gtype... ) are not listed.
5. create a capa_problems homework in the LibraryBrowser
6. From the CAPA directory (type05)list add some problems that include graphics
7. Make sure that the graphics appear in 
	1. the library browser
	2. in the homework editor for 	capa_problems	 when "render all" button is pushed
	3. look at the capa_problems homework set directly and make sure the graphics appear in each of the pg problems.