### PR TITLE
Show me another use MathQuill answer boxes if enabled

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -326,6 +326,8 @@ sub pre_header_initialize {
 
 	$self->{showMeAnother} = \%showMeAnother;
 	$self->{pg} = $pg;
+	WeBWorK::ContentGenerator::ProblemUtil::ProblemUtil::insert_mathquill_responses($self, $pg)
+	if ($self->{will}->{useMathQuill});
 }
 
 # We disable showOldAnswers because old answers are answers to the original


### PR DESCRIPTION
Use MathQuill answer boxes on "Show me another" problems if the option to use MathQuill answer boxes is enabled. Currently the input is hidden and no MathQuill answer box is injected.