### PR TITLE
Hotfix to mqeditor.css

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -31,7 +31,7 @@ span[id^=mq-answer]
     margin-left: 0
 }
 
-input[type=text]
+.codeshard
 {
     display: none !important;
 }

--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -31,7 +31,7 @@ span[id^=mq-answer]
     margin-left: 0
 }
 
-.codeshard
+input[type=text].codeshard
 {
     display: none !important;
 }


### PR DESCRIPTION
The mqeditor.css hides all `<INPUT type='text'>` fields, but this is problematic for problems that use javascript with interactive text fields that are not submitted to WeBWorK for grading... (see Library/Rochester/setMAAtutorial/javascriptexample1.pg for one example)

This PR instead identifies the input fields to be hidden by their 'codeshard' class instead of hiding all text input fields.

Is anyone aware of other objects that might share the 'codeshard' class - causing conflict with this approach?

(This is submitted as a hot fix, as I have multiple 'oracle'-style problems in my current curriculum)