### PR TITLE
Drop an excess maketext call in Login.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -209,7 +209,7 @@ sub body {
 			if ($r -> authen() eq "WeBWorK::Authen::LTIBasic") {
 				print CGI::p({}, $r->maketext('[_1] uses an external authentication system (e.g., Oncourse,  CAS,  Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try again.', CGI::strong($course)));
 			} else {
-				print CGI::p({}, $r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($r->maketext($course))));
+				print CGI::p({}, $r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course)));
 			}
 		} else {
 		    print CGI::p({}, $r->maketext('[_1] uses an external authentication system (e.g., Oncourse,  CAS,  Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try again.', CGI::strong($course)));


### PR DESCRIPTION
Calling `CGI::strong($r->maketext($course)))` on the modified line causes an error. 

The courseID `$course` is not in and not expected to be in the translation PO/POT files, so drop the $r->maketext().

This change has been in production for the several months on my servers.