### PR TITLE
This is the initial version of code to support html2xml using LTI

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -129,6 +129,19 @@ $preferred_source_of_username = "lis_person_contact_email_primary";
 
 $LTIBasicConsumerSecret = "";  #This must be set  
 
+################################################################################
+
+# List key + secret pairs for html2xml LTI support in the hash below.
+# This is the location from which lib/FormatRenderedProblem.pm
+# can get a LTI secret using a "seed_ce".
+#   A sample pair is provided.
+
+%LISConsumerKeyHash = (
+  "key_for_html2xml_LTI_course1" => "secret_for_html2xml_LTI_course1",
+);
+
+################################################################################
+
 # The purpose of the LTI nonces is to prevent man-in-the-middle attacks.
 # The NonceLifeTime (in seconds) must be short enought to prevent
 # at least casual man-in-the-middle attacks but

--- a/lib/WeBWorK/Authen/XMLRPC.pm
+++ b/lib/WeBWorK/Authen/XMLRPC.pm
@@ -15,7 +15,7 @@
 ################################################################################
 
 package WeBWorK::Authen::XMLRPC;
-use parent "WeBWorK::Authen";
+use base "WeBWorK::Authen";
 
 =head1 NAME
 
@@ -26,6 +26,8 @@ WeBWorK::Authen::XMLRPC - Authenticate xmlrpc requests.
 use strict;
 use warnings;
 use WeBWorK::Debug;
+use Digest::SHA qw(sha256_hex);
+use Encode qw(encode);
 
 # Instead of being called with an apache request object $r 
 # this authentication method gets its data  
@@ -42,6 +44,340 @@ use WeBWorK::Debug;
 # 	my $authen = $user_authen_module->new($fake_r);
 # 	return $authen;
 # }
+
+# ==========================================================================
+
+# This code was inspired by approach used in lib/WeBWorK/Authen/Proctor.pm.
+# Rewrite the userID to have the structure
+#    userID,sessionDataHash,x
+# where sessionDataHash is the 64 hex character output from applying
+# Digest::SHAsha256_hex() to a string with all the "protected" session
+# settings.
+# The third field ",x" is required as used by lib/WeBWorK/DB.pm to
+# recognize this usage of a special string, and differentiate it from
+# the format used by lib/WeBWorK/Authen/Proctor.pm.
+
+# sessionDataHash key ID rewriter
+sub sessionDataHash_key_id {
+	my $r = shift;
+
+	my $sd_key_id = join( ",", ( $r->{user_id},
+		$r->{sessionDataHash}, "x" ) );
+
+        return $sd_key_id;
+}
+
+sub getIDtoUse {
+	my $self = shift;
+	my $id_to_use = shift;
+	my $r = shift;
+	if ( defined( $r->{use_sessionDataHash} ) &&
+	     ( $r->{use_sessionDataHash} == 1 ) &&
+	     defined( $r->{user_id} ) &&
+	     defined( $r->{sessionDataHash} ) &&
+	     ( $r->{sessionDataHash} =~ /^[0-9a-f]{64}$/ )
+	   ) {
+		$id_to_use = sessionDataHash_key_id( $r );
+	}
+	debug("getIDtoUse setting result to $id_to_use");
+	return $id_to_use;
+}
+
+# create_session and check_session use
+#     sessionDataHash_key_id()
+# to set the first parameter IF use_sessionDataHash is 1
+# and all the data seems available
+
+sub create_session {
+	my ($self, $userID, $newKey) = @_;
+	my $r = $self->{r};
+	my $id_to_use = $self->getIDtoUse( $userID, $self->{r} );
+	debug("called create_session for $userID ($id_to_use)");
+	return $self->SUPER::create_session( $id_to_use, $newKey );
+}
+
+# rewrite the userID to include bith the proctor's and the student's user ID
+# and then call the default check_session method.
+sub check_session {
+	my ($self, $userID, $possibleKey1, $updateTimestamp) = @_;
+	my $r = $self->{r};
+
+	# Note $possibleKey1 which arrives here seems to be the session_key
+	# from the front end connection, we prefer to try to use the
+	# session_key sent in the form submission.
+	my $possibleKey2 = $r->{session_key} // "no second session key";
+
+	my $currTime = time; # used as current "time" for this entire call instead of calling time again and again
+
+	my $id_to_use = $self->getIDtoUse( $userID, $r );
+
+	debug("Starting checksession for userID = $userID, possibleKey1 = $possibleKey1, possibleKey2 = $possibleKey2, and id_to_use = $id_to_use");
+
+	# ====================================================================================
+
+	if ( $id_to_use eq $userID ) {
+		# We want the regular behavior in this case
+		debug("called check_session for $possibleKey1 and need regular behavior. ($id_to_use)");
+		return $self->SUPER::check_session($id_to_use, $possibleKey1, $updateTimestamp);
+	}
+
+	# ====================================================================================
+
+	# On the initial login we probably have a session for the "plain" user_id.
+	my $ce = $r->ce;
+	my $db = $r->db;
+
+	my $skto = $ce->{sessionKeyTimeout};
+	my $sktoMin = $skto / 60;
+	debug("sessionKeyTimeout for this course is $sktoMin minutes ($skto seconds)");
+
+	my $had_Valid_internal_WW2_secret = $r->{had_Valid_internal_WW2_secret} // 0;
+
+	my $Key1 = $db->getKey( $userID    );
+	my $Key2 = $db->getKey( $id_to_use );
+	my $Key3; # for internal use and to be the one we will eventually save
+
+	my $key_string = "";
+	my $make_new_key_string = 0;
+	my $needToSearchForAltKeys = 0;
+
+	if ( defined( $Key2 ) ) {
+		# If Key2 is defined, then there was an authenticated "session"
+		# for THIS data, but it may have a different session_key and
+		# it might have expired.
+
+		my $keyMatches = (defined $possibleKey2 and $possibleKey2 eq $Key2->key);
+		my $timestampValid = ( $currTime <= ( $Key2->timestamp() + $ce->{sessionKeyTimeout} ) );
+
+		$keyMatches = 0 if ( ! $keyMatches );         # Make it visible in the logs as "0:
+		$timestampValid = 0 if ( ! $timestampValid ); #   same
+
+		debug("extended session_key exists: keyMatches = $keyMatches timestampValid = $timestampValid ($id_to_use)");
+
+		if ( $timestampValid ) {
+			# Valid, so keep it, and if necessary replace the session_key parameters to use it
+			my $tmpKey = $Key2->key;
+			$self->{session_key} = $Key2->key;
+			if ( ! $keyMatches ) {
+				# We received a different session_id for the same userID+sessionDataHash
+				# data, so adopt this one. In principle this allows session hijacking
+				# if the connection authenticated and got passed on to WebworkWebService.pm.
+				# This would only allow someone who guesses that a given other user has an open
+				# session for this particular "problem" = sessionDataHash, in which case the
+				# hijacker could then impersonate the target. Given that XMLRPC does not limit
+				# the number of attempts, and that scores would be passed back to the credit of
+				# the target in the originating LMS - we are not considering this a terribly
+				# damaging problem.
+				debug("For $id_to_use replace no-longer existent key $possibleKey2 with current key2 $tmpKey");
+			} else {
+				debug("key2 $tmpKey for ${id_to_use} matches and still valid");
+			}
+			if ( $updateTimestamp ) {
+				debug("updating key timestamp on $tmpKey for $id_to_use");
+				$Key2->timestamp( $currTime );
+				eval { $db->putKey( $Key2 ) };
+				if ( $@ ) {
+					my $tmp1 = $@;
+					debug("Couldn't put timestamp updated key2 $tmpKey for userID+sessionDataHash for ${id_to_use}: $tmp1");
+					return (1, 1,  $timestampValid);
+				} else {
+					return (1, 1, 1);
+				}
+			} else {
+				return (1, 1, $timestampValid);
+			}
+		} else {
+			# No longer valid, so the session has timed-out
+			my $tmpKey = $Key2->key;
+			debug("Session $tmpKey for $id_to_use has timed-out, key is being deleted");
+			$self->{session_key} = "";
+			eval { $db->deleteKeyForSession( $id_to_use,$Key2->key) }; # delete the old key
+			if ( $@ ) {
+				debug("Error deleting $tmpKey for ${id_to_use}: $@ ");
+			}
+
+			# Are we starting a new session or is there a parallel recent session ?
+			if ( $had_Valid_internal_WW2_secret ) {
+				# If WebworkWebserver.pm received the valid internal_WW2_secret we accept that as a valid authentication
+				$make_new_key_string = 1;
+			} else {
+				# Since there was a key in the database for this sessionDataHash,
+				# we assume that the data was NOT tampered with, so we are willing to
+				# authenticate the user is there is a recent key for the user.
+				$needToSearchForAltKeys = 1;
+			}
+		}
+		# End of handling of case where there is a Key2 (which depends on the sessionDataHash).
+	} else {
+		# Key2 does NOT exist, so there is no authenticated session on the "back-end"
+		# html2xml / WebworkWebservice side. In this case we ideally want authentication
+		# to depend on a valid Key1, but since many LMS calls can arrive in a short period
+		# of time, Key1 may not have the $possibleKey1 anymore.
+
+		# Since there is NO Key2, we have not authenticated the sessionDataHash to prevent
+		# tampering with the critical parameters. As such - we should NOT allow
+		# authentication to occur based on a parallel session key UNLESS this is
+		# the ORIGINAL request after the LTI authentication.
+
+		# See what we can do with a Key1 if we got one
+		if (  defined( $Key1 ) ) {
+			# This may or may not be the key from the original LTI authentication
+			# depending on the speed/order of LTI requests
+
+			my $timestampValid = ( $currTime <= ( $Key1->timestamp() + $ce->{sessionKeyTimeout} ) );
+			$timestampValid = 0 if ( ! $timestampValid ); # Make it visible in the logs as "0:
+
+			if ( ! $timestampValid ) {
+				debug("Saw expired key for plain user $userID ... ($id_to_use)");
+				# Make sure to only delete THIS specific key
+				eval { $db->deleteKeyForSession($userID,$Key1->key) }; # delete the key
+				my $tmpKey = $Key1->key;
+				if ( $@ ) {
+					debug("Error deleting expired $tmpKey for ${userID}: $@ ");
+				}
+				if ( $had_Valid_internal_WW2_secret ) {
+					# since this is an ORIGINAL LTI connection we will accept
+					# the sessionDataHash data and authenticate if we can find
+					# ANY recent parallel key.
+					debug("   since this was an original LTI connection - we will try to authenticate using a recent parallel key. ($id_to_use)");
+					$needToSearchForAltKeys = 1;
+				} else {
+					# but if it is NOT an original LTI connection - we declare an authentication failure.
+					debug("   since this was NOT an original LTI connection - we cannot authenticate using a recent parallel key as that would permit tampering with the critical data. ($id_to_use)");
+					$needToSearchForAltKeys = 0;
+					$self->{session_key} = "";
+					return 0; # so we declare an authentication failure
+				}
+			} else {
+				# Key1 is still valid
+				my $tmpKey = $Key1->key;
+				if (   defined( $possibleKey1 )       &&
+					 ( $possibleKey1 eq $Key1->key )     ) {
+					# We have a matching key (should be from the initial LTI authentication)
+					# and need to replace it with one for the id+sessionDataHash instead
+					# but can reuse the session_key string
+					debug("Found a current key for the plain user $userID with $possibleKey1 and will try to use that session_key and delete the plain id version. ($id_to_use)");
+					# Make sure to only delete THIS specific key
+					$key_string = $possibleKey1;
+					eval { $db->deleteKeyForSession($userID,$Key1->key) }; # delete the key
+					if ( $@ ) {
+						debug("Error deleting prior $tmpKey for ${userID}: $@ ($id_to_use)");
+					}
+				} else {
+					# The key proves succesful authentication on the front-end
+					# leave it alone for the session it is part of.
+					debug("Found a current key for the plain user with a different key1 $tmpKey. We can only allow authentication if this is an initial LTI connection, otherwise data tampering would be possible. ($id_to_use)");
+
+					if ( $had_Valid_internal_WW2_secret ) {
+						# If WebworkWebserver.pm received the valid internal_WW2_secret we accept that as a
+						# valid authentication for the critical session data passed in.
+						$make_new_key_string = 1;
+						debug("   since this was an original LTI connection - we authenticate but need to create a new session_key. ($id_to_use)");
+					} else {
+						# We did NOT find any key for this sessionDataHash in the database,
+						# so we have NO reason to assume the data was NOT tampered with, so we
+						# CANNOT authenticate this connection.
+						$needToSearchForAltKeys = 0;
+						debug("   since this was NOT an original LTI connection - we cannot authenticate using a recent parallel key as that would permit tampering with the critical data. ($id_to_use)");
+						$self->{session_key} = "";
+						return 0; # so we declare an authentication failure
+					}
+				}
+			}
+		} else {
+			# We did not find any "plain" key (Key1) for the user or one for this sessionData (Key2)
+			$self->{session_key} = "";
+			if ( $had_Valid_internal_WW2_secret ) {
+				# If WebworkWebserver.pm received the valid internal_WW2_secret we accept that as a valid authentication
+				debug("We did not find any valid session key but since this was an original LTI connection - we authenticate and must create a new session_key. ($id_to_use)");
+				$make_new_key_string = 1;
+			} else {
+				# We did NOT find any key for this sessionDataHash in the database,
+				# and this is NOT an original LTI connection,
+				# so we have NO reason to assume the data was NOT tampered with,
+				# and thus we CANNOT authenticate this connection.
+				$needToSearchForAltKeys = 0;
+				debug("We did not find a key to use to authenticate and since this was NOT an original LTI connection - we cannot authenticate using a recent parallel key as that would permit tampering with the critical data. ($id_to_use)");
+				return 0; # so we declare an authentication failure
+			}
+		}
+		# End handling case where there is no Key2
+	}
+
+
+	# If we need to search for other recent keys
+	if ( $needToSearchForAltKeys ) {
+		# Get all keys for this user.
+		my @allUserKeys = $db->getKeysExtended( $userID );
+		my $mostRecentTimeStamp = -1;
+		my $mostRecentSessionKey = "";
+		foreach $Key3 ( @allUserKeys ) {
+			if ( ( $currTime <= ( $Key3->timestamp() + $ce->{sessionKeyTimeout} ) ) &&
+				   ( $Key3->timestamp() > $mostRecentTimeStamp ) ) {
+				$mostRecentTimeStamp  = $Key3->timestamp();
+				$mostRecentSessionKey = $Key3->key;
+			}
+		}
+		# Did we find a sufficiently recent one?
+		if (    ( $mostRecentTimeStamp > -1 )
+			 && ( $currTime <= ( $mostRecentTimeStamp + 30 ) ) ) {
+			# is recent enough to accept (at most 30 seconds old)
+			debug("Found a recent key for the user $userID with a different key $mostRecentSessionKey and timestamp $mostRecentTimeStamp. Accepting authentication. ($id_to_use)");
+			$make_new_key_string = 1;
+		} else {
+			debug("Did not find any sufficiently recent key for the user $userID - rejecing authentication. ($id_to_use)");
+			$make_new_key_string = 0;
+			$self->{session_key} = "";
+			return 0; # so we declare an authentication failure
+		}
+	}
+
+	if ( $make_new_key_string ) {
+		my @chars = @{ $ce->{sessionKeyChars} };
+		my $length = $ce->{sessionKeyLength};
+		srand;
+		$key_string = join ("", @chars[map rand(@chars), 1 .. $length]);
+		debug("Creating a new key for userID+sessionDataHash $id_to_use with session_id $key_string");
+	}
+
+	if ( $key_string ne "" ) {
+		# We found or created a key_string to use
+		$Key3 = $db->newKey(user_id=>$id_to_use, key=>$key_string, timestamp=>$currTime);
+
+		# DBFIXME this should be a REPLACE
+		eval { $db->deleteKeyForSession( $id_to_use,$key_string) }; # delete if it already exists
+		eval { $db->addKey( $Key3 ) };
+		if ( $@ ) {
+			my $msg = $@;
+			debug("addKey failed on the new key with $key_string for userID+sessionDataHash $id_to_use: $msg ");
+			eval { $db->putKey( $Key3 ) };
+			if ( $@ ) {
+				$msg = $@;
+				debug("putKey failed on the new key with $key_string for userID+sessionDataHash $id_to_use: $msg");
+				debug("FAILED to create the session");
+				$self->{session_key} = "";
+				return 0;
+			} else {
+				# putKey succeeded
+				debug("putKey succeeded on the new key with $key_string for userID+sessionDataHash $id_to_use.");
+				$self->{session_key} = $key_string;
+				return (1, 1, 1);
+			}
+		} else {
+			# addKey succeeded
+			debug("addKey succeeded on the new key with $key_string for userID+sessionDataHash $id_to_use.");
+			$self->{session_key} = $key_string;
+			return (1, 1, 1);
+		}
+	}
+
+	debug("Reached end of check_session with no valid authentication or session_key. ($id_to_use)");
+	$self->{session_key} = "";
+	return 0; # If we got here nothing worked
+}
+
+# ==========================================================================
+
 
 # disable cookie functionality for xmlrpc
 sub connection {

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -500,6 +500,7 @@ sub header {
 	my $r = $self->r;
 
 	$r->content_type("text/html; charset=utf-8");
+	$r->headers_out->add("Access-Control-Allow-Origin" => '*');
 	$r->send_http_header unless MP2;
 	return MP2 ? Apache2::Const::OK : Apache::Constants::OK;
 }

--- a/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
@@ -31,12 +31,27 @@ use base qw(WeBWorK::ContentGenerator);
 #use XMLRPC::Lite;
 #use MIME::Base64 qw( encode_base64 decode_base64);
 
+use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
 use strict;
 use warnings;
 use WebworkClient;
 use WeBWorK::Debug;
 use CGI;
+use Digest::SHA qw(sha256_hex);
+use Encode qw(encode);
+
+
+BEGIN {
+	if (MP2) {
+		require Apache2::Const;
+		Apache2::Const->import(-compile => qw/OK NOT_FOUND FORBIDDEN SERVER_ERROR REDIRECT/);
+	} else {
+		require Apache::Constants;
+		Apache::Constants->import(qw/OK NOT_FOUND FORBIDDEN SERVER_ERROR REDIRECT/);
+	}
+}
+
 
 =head1 Description
 
@@ -132,6 +147,35 @@ our @COMMANDS = qw( listLibraries    renderProblem  ); #listLib  readFile tex2pd
 # end configuration section
 ##################################################
 
+sub create_hash_from_string {
+	my $to_digest = shift; # String we will feed in
+	my $digest = sha256_hex( encode("UTF-8", $to_digest ) );
+	return $digest;
+}
+
+sub create_seed_from_string {
+	my $to_digest = shift; # String we will feed in
+
+	my $digest = create_hash_from_string( $to_digest );
+
+	# Ideas taken from pg/lib/PGrandom.pm
+	my $multiplier = 69069;
+	my $modulus = 2**30; # Keep to 2^32
+
+	# The result was a 256 bits number, given as 64 hex digits
+	# and we need a 32 bit integer.
+	my @pieces = unpack("(a6)*", $digest); # We'll handle 6 hex digits at a time
+
+	my $seed = 0;
+	my $piece;
+
+	foreach $piece ( @pieces ) {
+	    $seed += $multiplier * hex($piece);
+	    $seed %= $modulus;
+	}
+
+	return $seed;
+}
 
 sub pre_header_initialize {
 	my ($self) = @_;
@@ -140,33 +184,186 @@ sub pre_header_initialize {
 	my %inputs_ref =  WeBWorK::Form->new_from_paramable($r)->Vars ;
 
 	# When passing parameters via an LMS you get "custom_" put in front of them. So lets
-	# try to clean that up
-	$inputs_ref{userID} = $inputs_ref{custom_userid} if $inputs_ref{custom_userid};
-	$inputs_ref{courseID} = $inputs_ref{custom_courseid} if $inputs_ref{custom_courseid};
-	$inputs_ref{displayMode} = $inputs_ref{custom_displaymode} if $inputs_ref{custom_displaymode};
-	$inputs_ref{course_password} = $inputs_ref{custom_course_password} if $inputs_ref{custom_course_password};
-	$inputs_ref{answersSubmitted} = $inputs_ref{custom_answerssubmitted} if $inputs_ref{custom_answerssubmitted};
-	$inputs_ref{problemSeed} = $inputs_ref{custom_problemseed} if $inputs_ref{custom_problemseed};
-	$inputs_ref{problemUUID} = $inputs_ref{problemUUID}//$inputs_ref{problemIdentifierPrefix}; # earlier version of problemUUID
-	$inputs_ref{sourceFilePath} = $inputs_ref{custom_sourcefilepath} if $inputs_ref{custom_sourcefilepath};
-	$inputs_ref{outputformat} = $inputs_ref{custom_outputformat} if $inputs_ref{custom_outputformat};
-	
-	
+	# try to clean that up. In order to handle possible alternate options for the
+	# parameter names - we provide a conversion table as a hash. Some special
+	# cases are handled separately.
+	my %fix_custom = (
+		"custom_userid"                  => "userID",
+		"custom_userID"                  => "userID",
+		"custom_language"                => "language",
+		"custom_outputformat"            => "outputformat",
+		"custom_answerssubmitted"        => "answersSubmitted",
+		"custom_answersSubmitted"        => "answersSubmitted",
+		"custom_problemseed"             => "problemSeed",
+		"custom_problemSeed"             => "problemSeed",
+		"custom_psvn"                    => "psvn",
+		"custom_displaymode"             => "displayMode",
+		"custom_displayMode"             => "displayMode",
+		"custom_courseid"                => "courseID",
+		"custom_courseID"                => "courseID",
+		"custom_sourcefilepath"          => "sourceFilePath",
+		"custom_sourceFilePath"          => "sourceFilePath",
+		"custom_course_password"         => "course_password", # used by the non-LTI html2xml
+		"custom_problemuuid"             => "problemUUID",
+		"custom_problemUUID"             => "problemUUID",
+		"custom_resetseedandpsvnfromuid" => "resetSeedandPsvnFromUID",
+		"custom_resetSeedandPsvnFromUID" => "resetSeedandPsvnFromUID",
+		"custom_forcePortNumber"         => "forcePortNumber",
+		"custom_forceportnumber"         => "forcePortNumber",
+		"custom_internal_WW2_secret"     => "internal_WW2_secret",
+	);
+	my $key;
+	foreach $key ( keys( %fix_custom ) ) {
+		if ( defined($inputs_ref{$key}) ) {
+			$inputs_ref{$fix_custom{$key}} = $inputs_ref{$key};
+		}
+	}
+	if (  defined( $inputs_ref{custom_problemIdentifierPrefix} ) &&
+	     !defined( $inputs_ref{custom_problemUUID} ) ) {
+		$inputs_ref{problemUUID} = $inputs_ref{custom_problemIdentifierPrefix}; # earlier version of problemUUID
+	}
+
+	# Fixme - should we be using lis_person_whatever values???
+
+	if (  defined( $inputs_ref{user_id} ) &&
+	     !defined( $inputs_ref{custom_userid} ) &&
+	     !defined( $inputs_ref{custom_userID} )
+	   ) {
+		# Fall back to LTI "user_id" if we did not receive a "custom_" field to set it
+		$inputs_ref{userID} = $inputs_ref{user_id};
+	}
+
+	if (  defined( $inputs_ref{resetSeedandPsvnFromUID} ) &&
+	      $inputs_ref{resetSeedandPsvnFromUID} == 1 ) {
+		# LTI requested using the selected "userID" to generate psuedo-random
+		# values for the following
+
+		my @items_to_use;
+		my $to_digest;
+
+		# 1. psvn
+		# usually would be for a user's entire problem set, in this
+		# context, we do not have problem sets, so it needs to be depend
+		# ONLY on the user information and NOT on any problem data.
+
+		# From https://perldoc.perl.org/Digest/SHA.html
+		# The Digest::SHA routines do not handle wide Unicode characters.
+		# From https://perldoc.perl.org/Digest/SHA.html
+		# "Since a wide character does not fit into a byte, the Digest::SHA routines croak if they encounter one."
+		# Thus we must encode into UTF-8 before calling the Digest::SHA function.
+
+		push ( @items_to_use, $inputs_ref{courseID} );
+		push ( @items_to_use, $inputs_ref{user_id} );
+
+		$to_digest = join( "", @items_to_use );
+
+		if ( defined( $inputs_ref{psvn} ) ) {
+			warn "pre-LTI override had psvn = $inputs_ref{psvn}";
+		}
+
+		$inputs_ref{psvn} = create_seed_from_string( $to_digest );
+
+		warn "LTI set psvn to $inputs_ref{psvn}";
+
+		# 2. problemSeed
+		# should depend on user and on problem specific values.
+
+		# sourceFilePath          = html2xml setting - path the PG file
+		# pathToProblemFile       = html2xml setting
+		# context_id              = LTI identified of context from which launch occurred (recommended)
+		#    See: http://www.imsglobal.org/specs/ltiv1p0/implementation-guide
+		# resource_link_id        = LTI parameter should be unique per launch item (required)
+		#    See: http://www.imsglobal.org/specs/ltiv1p0/implementation-guide
+
+		# lis_outcome_service_url = URL used for LTI grade passback - fixed for a given item
+		#    Is NOT currently included, in case some systems used multiple URLs which are
+		#    all valid.
+
+		# Do NOT include:
+		# lis_result_sourcedid    = LTI identifier used for LTI grade passback
+		# in Moodle this is NOT constant for 2 launches of the same item. Cannot be used.
+
+		# Do NOT include:
+		# problemSource - would change if the PG code was edited on the provider side
+
+		my $item1;
+		my @more_items = qw(
+			sourceFilePath
+			pathToProblemFile
+			context_id
+			resource_link_id
+			);
+		foreach $item1 ( @more_items ) {
+			if ( defined( $inputs_ref{$item1} ) ) {
+				push ( @items_to_use, $inputs_ref{$item1} );
+			}
+		}
+
+		$to_digest = join( "", @items_to_use );
+
+		if ( defined( $inputs_ref{problemSeed} ) ) {
+			warn "pre-LTI override had problemSeed = $inputs_ref{problemSeed}";
+		}
+
+		$inputs_ref{problemSeed} = create_seed_from_string( $to_digest );
+
+		warn "LTI set problemSeed to $inputs_ref{problemSeed}";
+
+		# If we do not already have a value for problemUUID, set on based on the LTI data
+		# but without dependence on the student.
+
+		if ( !defined( $inputs_ref{problemUUID} ) ) {
+
+		    @items_to_use = (); # Clear it
+		    push ( @items_to_use, $inputs_ref{courseID} );
+
+		    foreach $item1 ( @more_items ) {
+				if ( defined( $inputs_ref{$item1} ) ) {
+					push ( @items_to_use, $inputs_ref{$item1} );
+				}
+		    }
+
+		    $to_digest = join( "", @items_to_use );
+
+		    # Here we can use a sting hash value and not an integer, as it is
+		    # really used in pg/lib/PGalias.pm where a string value is allowed.
+		    $inputs_ref{problemUUID} = create_hash_from_string( $to_digest );
+
+		    warn "LTI set problemUUID to $inputs_ref{problemUUID}";
+		}
+
+	}
+
+	if ( !defined( $inputs_ref{problemUUID} ) || ( $inputs_ref{problemUUID} eq "" ) ) {
+		$inputs_ref{problemUUID} = 0; # This default would be set later on
+		# and the change would be "late" for the "sessionDataToHash"
+		# so force the fallback value here.
+	}
+
 	my $user_id      = $inputs_ref{userID};
 	my $courseName   = $inputs_ref{courseID};
 	my $displayMode  = $inputs_ref{displayMode};
 	my $problemSeed  = $inputs_ref{problemSeed};
-	
+
 	# FIXME -- it might be better to send this error if the input is not all correct
 	# rather than trying to set defaults such as displaymode
 	unless ( $user_id && $courseName && $displayMode && $problemSeed) {
-		print CGI::ul( 
-		      CGI::h1("Missing essential data in web dataform:"),
-			  CGI::li(CGI::escapeHTML([
-		      	"userID: |$user_id|", 
-		      	"courseID: |$courseName|",	
-		        "displayMode: |$displayMode|", 
-		        "problemSeed: |$problemSeed|"
+		my @tmp;
+		my $k1;
+		foreach $k1 ( keys( %inputs_ref ) ) {
+		  if ( $k1 =~ /password/i || $k1 =~ /secret/i) {
+		    push( @tmp, "${k1}: redacted" );
+		  } else {
+		    push( @tmp, "${k1}: |$inputs_ref{$k1}|" );
+		  }
+		}
+		CGI::h1("Missing essential data in web dataform:");
+		print CGI::ul( CGI::li(CGI::escapeHTML([
+			"userID: |$user_id|",
+			"courseID: |$courseName|",
+			"displayMode: |$displayMode|",
+			"problemSeed: |$problemSeed|",
+			@tmp
 		      ])));
 		return;
 	}
@@ -175,8 +372,8 @@ sub pre_header_initialize {
     #######################
     my $xmlrpc_client = new WebworkClient;
 
-	$xmlrpc_client ->encoded_source($r->param('problemSource')) ; # this source has already been encoded
-	$xmlrpc_client-> site_url($SITE_URL);
+	$xmlrpc_client->encoded_source($r->param('problemSource')) ; # this source has already been encoded
+	$xmlrpc_client->site_url($SITE_URL);
 	$xmlrpc_client->{form_action_url} = $FORM_ACTION_URL;
 	$xmlrpc_client->{userID}          = $inputs_ref{userID};
 	$xmlrpc_client->{course_password} = $inputs_ref{course_password};
@@ -187,7 +384,7 @@ sub pre_header_initialize {
 	$xmlrpc_client->{sourceFilePath}  = $inputs_ref{sourceFilePath};
 	$xmlrpc_client->{inputs_ref} = \%inputs_ref;  # contains form data
 	# print STDERR WebworkClient::pretty_print($r->{paramcache});
-	
+
 	##############################
 	# xmlrpc_client calls webservice to have problem rendered
 	#
@@ -200,9 +397,18 @@ sub pre_header_initialize {
 	} else {
 		$self->{output}= $xmlrpc_client->return_object;  # error report
 	}
-	
+
 	################################
  }
+
+sub header {
+	my $self = shift;
+	my $r = $self->r;
+	$r->content_type("text/html; charset=utf-8");
+	$r->headers_out->add("Access-Control-Allow-Origin" => '*');
+	$r->send_http_header unless MP2;
+	return MP2 ? Apache2::Const::OK : Apache::Constants::OK;
+}
 
 sub content {
    ###########################

--- a/lib/WeBWorK/DB/Schema/NewSQL.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL.pm
@@ -137,6 +137,12 @@ sub where_permission_in_range {
 	}
 }
 
+# can be used for key
+sub where_user_id_eq_key_eq {
+    my ($self, $flags, $user_id, $key_string) = @_;
+    return {user_id=>$user_id, key=>$key_string};
+}
+
 # can be used for set,set_user,problem,problem_user
 sub where_set_id_eq {
 	my ($self, $flags, $set_id) = @_;


### PR DESCRIPTION
This is the initial version of code to support `html2xml` using LTI authentication and grade-passback.

It has been used by several small test courses (with real students) on open-edX using LTI embedding of problems.

The LTI URL had the form: `https://webwork.technion.ac.il/webwork2/html2xml` and the following array for custom parameters was provided to edX (one sample case):
```
["sourceFilePath=Technion/prep/ComplexNumbers/AlgebraicForm/Addition1/q01/he/part01.pg", "courseid=justcomplex_daemon", "language=heb", "displayMode=MathJax", "outputformat=simple2", "resetSeedandPsvnFromUID=1", "answersSubmitted=0"]
```

It was used with inline embedding, and with open-edX set to receive a score.

---
`resetSeedandPsvnFromUID` is a new feature to set a seed and psvn based on the user ID, as LTI cannot provide different values for different user. The code to support this in in the PR.

**Note:** unlike prior use of `html2xml` to embed problems, no password is provided in the URL, just the LTI key+secret are set in the LMS so it can "sign" the initial LTI connection data which provides the authentication.

**More work is needed to improve this code.**