### PR TITLE
feedback_form revision modification

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1735,7 +1735,7 @@ sub fetchEmailRecipients {
 					and defined $validRecipient->section and defined $sender->section
 					and $validRecipient->section ne $sender->section;
 			if ($validRecipient and $validRecipient->email_address) {
-					push @recipients, $validRecipient->rfc822_mailbox;
+					push @recipients, $validRecipient->email_address;
 			}
 		}
 	}


### PR DESCRIPTION
use $user->email_address instead of rfc822_mailbox, which (MIME-header) encodes the user's full name - but seems to fail in returning the email address along with the encoded full name.

I have instead switched to only send a semi-colon separated list of email addresses instead.

Refer to #986 for prior work on this functionality.