### PR TITLE
Remove hack that worked around glitches in using utf8 in xmlrpc. This…

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -437,11 +437,6 @@ EOS
 	my $STRING_ShowCorrect = $mt->maketext("Show correct answers");
 	my $STRING_Submit      = $mt->maketext("Check Answers");
 
-# With these values - things work, but the button text is English
-# with the localized values, or any answers in UTF-8 - thing break
-$STRING_Preview = "Preview My Answers";
-$STRING_ShowCorrect = "Show correct answers";
-$STRING_Submit = "Check Answers";
 
 ######################################################
 # Return interpolated problem template


### PR DESCRIPTION
… appears to work alright now.

To test:
```
<!DOCTYPE html>
<html lang="es"><head>
<meta http-equiv="content-type" content="text/html; charset=UTF-8">
  <meta charset="utf-8">

  <title>Título</title>
  <meta name="author" content="GrupoLEMA">
</head>

<body>
   <h1>Hello world</h1>
   <p>
      Here is some text.
   </p>
   <iframe src="https://demo.webwork.rochester.edu/webwork2/html2xml?
   &amp;answersSubmitted=0&amp;
   &amp;sourceFilePath=local/problema.pg&amp;
   &amp;problemSeed=123567&amp;
   &amp;courseID=spanish_language_course&amp;
   &amp;userID=anonymous&amp;
   &amp;course_password=test&amp;
   &amp;showSummary=1&amp;
   &amp;displayMode=MathJax&amp;
   &amp;problemIdentifierPrefix=102&amp;
   &amp;language=es&amp;
   &amp;outputformat=sticky" width="800" height="400">
   </iframe>

</body></html>
```

The buttons will appear in English before the fix.  After the fix they will appear in Spanish except possibly for "Show correct answers" which doesn't seem to have been translated yet.


