### PR TITLE
Tweak formats to work better with problems embedded in HTML

### DIFF
--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -227,8 +227,7 @@ var tabberOptions = {manualStartup:true};
 	</div>
 	<!--#endif-->
 	</div>
-	<!--#endif-->  
-
+	<!--#endif--> 
 <!--			      ==============END BODY OF PROBLEM===============      -->
 
  		
@@ -239,9 +238,23 @@ var tabberOptions = {manualStartup:true};
 </div> <!-- row-fluid -->
 </div> <!-- container-fluid -->
 
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
 
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
 <!-- Footer -->
-<div id="footer" role="contentinfo">
+<div id="footer" role="contentinfo" style="display: none">
 	<!--#footer-->
 </div>
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2252,6 +2252,11 @@ sub output_JS{
         print qq{
            <script type="text/javascript" src="$site_url/js/vendor/underscore/underscore.js"></script>
            <script type="text/javascript" src="$site_url/js/legacy/vendor/knowl.js"></script>};
+           
+    # This is for when the problem is embedded in an iframe
+    	print qq{
+    		<script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
+    	};
 
 	# This is for tagging menus (if allowed)
 	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -39,11 +39,9 @@ $problemHeadText
 <body>
 <div class="container-fluid">
 <div class="row-fluid">
-<div class="span12 problem">	
-<hr/>		
+<div class="span12 problem">		
 $answerTemplate
-<hr/>
-<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
+<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post" style="margin-bottom:-20px">
 <div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 $problemText
 </div>
@@ -84,9 +82,26 @@ $LTIGradeMessage
 </div>
 </div>
 </div>
-<div id="footer">
+
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
+
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
+<div id="footer" style="display:none">
 WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky | theme: math4
 </div>
+
 <!-- Activate local storage js -->
 <script type="text/javascript">WWLocalStorage();</script>
 </body>


### PR DESCRIPTION
This pull request contains tweaks to the simple_format  themes which are used when embedding problems into Libretext and other HTML pages. In particular the final lines of a problem listing the webwork and pg release numbers and copyright info are hidden inside a knowl so that they don't distract when several problems are embedded in a page