### PR TITLE
Use current time for submission time for un-proctored gateway quizzes

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -183,9 +183,9 @@ sub can_recordAnswers {
    # get the sag time after the due date in which we'll still grade the test
 	my $grace = $self->{ce}->{gatewayGracePeriod};
 
-	my $submitTime = ( defined($Set->version_last_attempt_time()) &&
-			   $Set->version_last_attempt_time() ) ? 
-			   $Set->version_last_attempt_time() : $timeNow;
+	my $submitTime = ($Set->assignment_type eq 'proctored_gateway' &&
+		defined($Set->version_last_attempt_time()) && $Set->version_last_attempt_time())
+			? $Set->version_last_attempt_time() : $timeNow;
 
 	if ($User->user_id ne $EffectiveUser->user_id) {
 		my $recordAsOther = $authz->hasPermissions($User->user_id, "record_answers_when_acting_as_student");
@@ -252,9 +252,9 @@ sub can_checkAnswers {
    # get the sag time after the due date in which we'll still grade the test
 	my $grace = $self->{ce}->{gatewayGracePeriod};
 	
-	my $submitTime = ( defined($Set->version_last_attempt_time()) &&
-			   $Set->version_last_attempt_time() ) ? 
-			   $Set->version_last_attempt_time() : $timeNow;
+	my $submitTime = ($Set->assignment_type eq 'proctored_gateway' &&
+		defined($Set->version_last_attempt_time()) && $Set->version_last_attempt_time())
+			? $Set->version_last_attempt_time() : $timeNow;
 
 	# this is further complicated by trying to address hiding scores by 
 	#    problem---that is, if $set->hide_score_by_problem and 


### PR DESCRIPTION
When checking to see if answers for a gateway quiz can be recorded or
checked, only use the version_last_attempt_time for the submission time
if the gateway quiz is proctored.  For un-proctored gateway quizzes
always use the current time.

If multiple attempts are allowed, then this was making it possible for
students that had graded the test at least once (but had not exhausted
attempts) to continue to grade the test after the quiz time had expired.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4756 for the discussion that led to this pull request.