### PR TITLE
MathQuill style change to support use with right-to-left languages

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -24,6 +24,7 @@ span[id^=mq-answer].incorrect /* red */
 
 span[id^=mq-answer]
 {
+    direction: ltr;
     padding: 4px 5px 2px 5px;
     border-radius: 4px !important;
     background-color: white;
@@ -40,6 +41,7 @@ input[type=text].codeshard
 {
     font-size: .75em;
     display: inline-block;
+    direction: ltr;
     position: fixed;
     top: 50%;
     transform: translateY(-55%);


### PR DESCRIPTION
Force 2 MathQuill CSS style items to set left-to-right text direction, so MathQuill (input boxes and the toolbar) will work properly in courses whose primary HTML text direction is right-to-left (ex. Hebrew courses). This has been in use for a while in production in Hebrew courses, and should not have any operational effect on courses whose default text direction is left-to-right.