### PR TITLE
Develop+libretexts formats

### DIFF
--- a/htdocs/themes/libretexts/README
+++ b/htdocs/themes/libretexts/README
@@ -1,0 +1,18 @@
+This folder contains the files necessary for the which started as a clone of the math4  theme.  These files are
+tracked by git and any changes made to them will be overwritten when you 
+upgrade.  The two exceptions are libretexts-overrides.css and libretexts-overrides.js.  
+
+These files do not need to be present, but if they are they will be included 
+in system.conf and will override the libretexts.css and libretexts.js theme.  They can 
+created by copying libretexts-overrides.css.dist and libretexts-overrides.js.dist.  This 
+is similar to how localOverrides.conf interacts with defaults.conf and 
+localOverrides.conf.dist.  In particular if you upgrade your server
+libretexts-overrides.js and libretexts-overrides.css  will not change, but their .dist 
+versions and the other math4 theme files may change. This might cause problems 
+until you merge the changes. 
+
+If you want to customize libretexts you should only change libretexts-overrides.css and
+libretexts-overrides.js.  Note: Because you can include arbitrary jQuery in 
+ilbretexts-overrides.js you can actually change pretty much anything, including 
+adding new html or changing existing html. 
+

--- a/htdocs/themes/libretexts/achievements.css
+++ b/htdocs/themes/libretexts/achievements.css
@@ -1,0 +1,143 @@
+.facebookbox {
+    margin-top:7px;
+    text-align:center;
+}
+
+.facebookbox form {
+    margin-bottom:0px;
+}
+
+.cheevobigbox {
+    display:block;
+}
+
+.levelbox {
+    height:100px;
+    margin-bottom:30px;
+}
+
+.levelbox img {
+    float:left;
+    height:100px;
+    width:100px;
+}
+
+.leveldatabox {
+    margin-left:20px;
+    float:left;
+}
+
+.leveldatabox h1 {
+    font-size:35px;
+    font-weight:bold;
+}
+
+.levelouterbar {
+    height:20px;
+    border-style:solid;
+    border-width:2px;
+    width:400px;
+}
+
+.levelinnerbar {
+    height:20px;
+    background-color:#88D;
+}
+
+.cheevoouterbox {
+    height:50px;
+    margin-bottom:15px;
+    clear:both;
+}
+
+.cheevoouterbox img {
+    float:left;
+    height:50px;
+    width:50px;
+    margin-top:5px;
+}
+
+.unlocked {
+    color:black;
+}
+
+.locked { 
+    color:#666666;
+    opacity: 0.5;
+}
+
+.locked img {
+    opacity:0.4;
+    filter:alpha(opacity=40);
+}
+
+.locked h2 {
+    color:#666666;
+}
+
+.cheevotextbox {
+    margin-left:10px;
+    margin-top:5px;
+    float:left;
+}
+
+.cheevotextbox h3 {
+    line-height:15px;
+    font-size:15px;
+    margin-bottom:5px;
+    margin-top:2px;
+    font-weight:bold;
+}
+
+/*width of cheevo progress bar controlled by perl code*/
+.cheevoouterbar {
+    height:10px;
+    border-style:solid;
+    border-width:2px;
+    width:200px;
+}
+
+.cheevoinnerbar {
+    height:10px;
+    background-color:#88D;
+}
+
+#achievementModal {
+    width:50%;
+}
+
+.cheevopopupouter {
+    margin-bottom:10px;
+    margin-right:15px;
+}
+
+.cheevopopupouter img {
+    float:left;
+    height:75px;
+    width:75px;
+}
+
+.cheevopopuptext {
+    margin-left:15px;
+    float:left;
+}
+
+.cheevopopuptext h1 {
+    margin-top:0px;
+    margin-bottom:5px;
+    font-size:20px;
+    font-weight:bold;
+}
+
+.achievement-item {
+    margin-bottom:15px;
+    margin-left:15px;
+}
+
+.achievement-item h3 {
+    line-height:15px;
+    font-size:15px;
+    margin-bottom:5px;
+    margin-top:2px;
+    font-weight:bold;
+}

--- a/htdocs/themes/libretexts/codeshard.js
+++ b/htdocs/themes/libretexts/codeshard.js
@@ -1,0 +1,35 @@
+function getElementsByClassName(searchClass) {
+    var classElements = new Array();
+    var els = document.getElementsByTagName("input");
+    var elsLen = els.length;
+    var pattern = new RegExp("(^|\\s)"+searchClass+"(\\s|$)");
+    for (i = 0, j = 0; i < elsLen; i++) {
+	if ( pattern.test(els[i].className) ) {
+	    classElements[j] = els[i];
+	    j++;
+	}
+    }
+    return classElements;
+}
+
+(function () {
+    // note: these textareas could be input fields also
+    var textareas = getElementsByClassName("codeshard");
+    var editors = [];
+    for (i=0; i<textareas.length; i++) {
+        var ta = textareas[i];
+        var ta_cols;
+        if (ta.type == "text") {
+            ta_cols = ta.size;
+        }
+        else {
+            ta_cols = ta.cols;
+        }
+        editors[i] = CodeMirror.fromTextArea(textareas[i],
+					     {matchBrackets: true,
+					      mode: "text/math",
+					     });
+        // should probably do something cleverer here than assuming 9px chars
+        editors[i].getWrapperElement().setAttribute("class", "CodeMirror AnswerField");
+    }
+})();

--- a/htdocs/themes/libretexts/gateway.css
+++ b/htdocs/themes/libretexts/gateway.css
@@ -1,0 +1,165 @@
+/******************/
+/* gateway styles */
+/******************/
+
+/* update margins to reflect missing left column */
+#content {
+	margin: 1em 1em 1em 0; 
+}
+
+div.gwMessage { 
+	background-color: #ffeeaa;
+	box-shadow: 3px 3px 3px darkgray;
+	margin: 1em 0;
+	padding: 0.5em;
+	border-radius: 3px;
+}
+
+.Message {
+	display: block;
+}
+
+div#gwTimer {
+	background-color:#ffeeaa;
+	color: black;
+	position: fixed; 
+	right: 1em;
+	top: 3.5em;
+	padding: 0.5em;
+	text-align: center;
+	z-index: 2;
+	box-shadow: 3px 3px 0.5em darkgray;
+	-webkit-border-radius: 4px;
+	-moz-border-radius: 4px;
+	border-radius: 4px;
+
+} 
+
+div#gwScoreSummary {
+	background-color:#ffeeaa;
+	color: black;
+	box-shadow: 3px 3px 0.5em darkgray;
+	font-family:Times serif;
+	z-index: 1;
+	font-size: 85%;
+	border-color: #ffeeaa;
+	border: 2px;
+	width: 15em;
+	top: 8em;
+	right: 2em;
+	padding: 10px;
+	position: fixed;
+	-webkit-border-radius: 4px;
+	-moz-border-radius: 4px;
+	border-radius: 4px;
+
+}
+
+#gwScoreSummary table {
+    border:0;
+}
+
+#gwScoreSummary table td,
+#gwScoreSummary table th {
+    margin-left:.2em;
+}
+
+table.attemptResults { width: unset; }
+
+span.resultsWithError, span.resultsWithoutError {
+	padding: 0.2em 1em;
+	box-shadow: 2px 2px 3px darkgray;
+	margin-bottom: 0.5em;
+	margin-right: 1em;
+	border-radius: 3px;
+}
+span.resultsWithError { background-color: #d69191; }
+span.resultsWithoutError { background-color: #88ff88;  }
+div.ResultsWithoutError { background-color: #88ff88; }
+div.ResultsWithError { background-color: #d69191; }
+div.ResultsWithoutError, div.ResultsWithError {
+	padding: 0.5em;
+	box-shadow: 3px 3px 3px darkgray;
+	border-radius: 3px;
+	color: black;
+}
+
+div.gwProblem 
+{
+	background-color: #fafafa;
+	padding: 0.5em;
+	border: 1px solid #ddd;
+	border-radius: 3px;
+}
+.gwProblem h2 {
+    display: inline-block;
+    font-size: 16px;
+    margin-right: 5px;
+}
+
+.gwNavigation {
+    margin-top: 1em;	
+    margin-bottom: 1em;
+}
+
+.gwNavigation th {
+    text-align:right;
+}
+
+
+hr 
+{ 
+	border: none;
+	margin: 0px 0px 10px 0px;
+}
+
+div.gwSoln {
+	/*      background-color: #e0e0ff; */
+	background-color: transparent;
+	/*      padding: 2px; */
+	/*      border: dashed black 1px; */
+}
+div.gwSoln b { color: navy; }
+
+p.gwPreview {
+	text-align: right;
+	margin-top: 1em;
+}
+
+table.gwAttemptResults {
+    margin: 5px;
+    border: solid black 1px;
+}
+
+table.gwAttemptResults>tbody>tr>th,
+table.gwAttemptResults>tbody>tr>td {
+	padding: 5px;
+	border: solid black 1px;
+	background-color: #eeeeee;
+}
+
+/* Print Test & Preview Problems links now look like a button */
+div.gwPrintMe { 
+	float: right;
+	margin-top: 1em;
+}
+
+/*div.gwPrintMe a, p.gwPreview a {
+	color: white;
+	border-radius: 8px;
+	padding: 0.5em 1em;
+	background-color: #038;
+	box-shadow: 3px 3px 3px darkgray;
+}
+
+div.gwPrintMe a:hover, p.gwPreview a:hover {
+	background-color: dodgerblue;
+	text-decoration: none;
+}
+*/
+
+/* Fix checkbox input's label text not aligned with the checkbox. */
+label input[type='checkbox'] {
+	margin: 0 0.2em 0.1em 0;
+
+}

--- a/htdocs/themes/libretexts/gateway.template
+++ b/htdocs/themes/libretexts/gateway.template
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
+<head>
+<meta charset='utf-8'>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- This encourages IE to *not* use compatibility view, which breaks libretexts -->
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+
+<link rel="shortcut icon" href="<!--#url type="webwork" name="htdocs"-->/images/favicon.ico"/>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/vendor/font-awesome/css/font-awesome.min.css"/>
+<link href="<!--#url type="webwork" name="htdocs"-->/css/knowlstyle.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts.css"/>
+<!--#if can="output_achievement_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/achievements.css"/>
+<!--#endif-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/gateway.css"/>
+<!--#if exists="libretexts-coloring.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-coloring.css"/>
+<!--#endif-->
+<!--#if exists="libretexts-overrides.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-overrides.css"/>
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/jquery/jquery.js"></script>
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/jquery-ui-1.8.18.custom.css"/>
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/jquery-ui-1.9.0.js"></script>
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts.js"></script>	
+<!--#if exists="libretexts-overrides.js"-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts-overrides.js"></script>	
+<!--#endif-->
+<!-- [gateway] since the left-side menus are gone, don't indent the main content area -->
+
+<title><!--#path style="text" text=" : " textonly="1"--></title>
+<!--#output_JS-->
+<!--#head-->
+</head>
+<body>
+<a href="#content" id="stmc-link" class="sr-only sr-only-focusable">Skip to main content</a>
+<div class="container-fluid">
+<!-- Header -->
+<div id = "masthead" class="row-fluid">
+	<div class="span2 webwork_logo">
+		<a href="<!--#url type="webwork" name="root"-->"><img src="<!--#url type="webwork" name="htdocs"-->/images/webwork_transparent_logo_small.png" alt="image link to MAA (Mathematical Association of America) main web site" />WeBWorK</a>
+	</div>
+	<div class="span4 maa_logo">
+		<a href="http://www.maa.org"><img src="<!--#url type="webwork" name="htdocs"-->/images/maa_logo_small.png" alt="image link to MAA (Mathematical Association of America) main web site" /></a>
+	</div>
+	<div id="loginstatus" class="offset3 span3">
+		<!--#loginstatus-->
+	</div>
+</div>
+	<!-- Breadcrumb -->
+	<div class="row-fluid"><div class="span12">
+	<ul class="breadcrumb">
+		<!--#path style="bootstrap" text="<li><span class='divider'>/</span></li>"-->
+	</ul>
+	</div></div>
+
+<div class="row-fluid">
+
+<!-- Run masthead class js because it gets rendered early -->
+<script type="text/javascript">
+  // Changes links in masthead
+  $('#loginstatus a').addClass('btn btn-small');
+  $('#loginstatus a').append(' <span class="icon icon-signout" data-alt="signout"></span>'); 
+</script>
+
+  <div id="content" class="span12">
+		
+	<!--#if can="info"-->
+	<!--<div id="page-info">-->
+		<!--<div class="info-box" id="fisheye">-->
+			<!--#info-->
+		<!--</div>-->
+	<!--</div>-->
+	<!--#endif-->
+	
+	<!-- [gateway] removed nav button to go up -->
+	
+	<!--#if can="title"-->
+	<h1 id="content"><!--#title--></h1>
+	<!--#endif-->
+	
+	<!--#if can="message"-->
+		<div class="Message"><!--#message--></div>
+	<!--#endif-->
+
+	<!--#if can="body"-->
+	<div class="Body" <!--#output_problem_lang_and_dir-->>
+		<!--#body-->
+	</div>
+	<!--#endif-->
+	
+	<!--#if warnings="1"-->
+	<div class="Warnings">
+		<!--#warnings-->
+	</div>
+	<!--#endif-->
+	
+</div> <!-- content -->
+
+<!-- Footer -->
+<div id="footer">
+	<!--#footer-->
+</div>
+
+</div></div> <!-- big-wrapper -->
+
+</body>
+</html>
+
+

--- a/htdocs/themes/libretexts/lbtwo.template
+++ b/htdocs/themes/libretexts/lbtwo.template
@@ -1,0 +1,138 @@
+<!DOCTYPE html
+	PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright Â© 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/conf/templates/math/system.template,v 1.11 2008/10/09 02:18:37 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+
+
+<html xmlns="http://www.w3.org/1999/xhtml" <!--#output_course_lang_and_dir-->>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>
+<style>
+    body{
+
+    }
+    input{
+        height:auto;
+    }
+    .navbar {
+        margin-bottom: 0px;
+    }
+    .breadcrumb{
+        margin:0px;
+    }
+    #messages{
+        position:absolute;
+        width:50%;
+        margin-left:25%;
+        margin-right:25%;
+    }
+</style>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
+<script src="<!--#url type="webwork" name="htdocs"-->/js/vendor/jquery/jquery.js"></script><!-- FIXMEJS-->
+<script src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
+<title><!--#path style="text" text=" : " textonly="1"--></title>
+<!--#head-->
+</head>
+
+
+<body bgcolor="white" onload="if (typeof(initializeWWquestion) == 'function') {initializeWWquestion()}">
+    <div id="messages"></div>
+    <div class="navbar">
+        <div class="navbar-inner">
+          <div class="container">
+            <!--#if can="title"-->
+            <a class="brand" href="#"><!--#title--></a>
+            <!--#endif-->
+            <div class="nav-collapse">
+              <ul class="nav pull-right">
+                <li class="dropdown" id="webwork_navigation">
+                  <a href="#webwork_navigation" class="dropdown-toggle" data-toggle="dropdown">Main Menu <b class="caret"></b></a>
+                  <ul class="dropdown-menu">
+                    <!--#if can="links"-->
+                        <!--#links-->
+                    <!--#endif-->
+                     <!--#if can="siblings"-->
+                        <!--#siblings-->
+                     <!--#endif-->
+                     <!--#if can="options"-->
+                        <ul>
+                     	    <h2>Display Options</h2>
+                     		<!--#options-->
+                     	</ul>
+                     <!--#endif-->
+                  </ul>
+                </li>
+              </ul>
+            </div><!-- /.nav-collapse -->
+          </div>
+        </div><!-- /navbar-inner -->
+    </div>
+    <div class="row">
+	<div class="span8">
+	<ul class="breadcrumb">
+		<!--#path style="bootstrap" text="<span class='divider'>&#x2192;</span>"-->
+	</ul>
+	</div>
+	<div class="span4"><button class="btn pull-right" id="help-link">Help</button></div>
+    </div>
+	
+	    <!--#if can="body"-->
+				<!--#if warnings="1"-->
+				  <div class="Body" style="background-color:#ffcccc" <!--#output_problem_lang_and_dir-->>
+				  <p style="font-size:larger">
+				  Warning -- there may be something wrong with this question. Please inform your instructor
+				  including the warning messages below.
+				  </p>
+				<!--#else-->
+				  <div class="Body" style="background-color:#ffffff" <!--#output_problem_lang_and_dir-->>
+				<!--#endif-->
+				
+				<!--#body-->
+				</div>
+			<!--#endif-->
+		
+		<!--#if warnings="1"-->
+		    <div class="Warnings">
+			    <!--#warnings-->
+		    </div>
+		<!--#endif-->
+		
+		<!--#if can="message"-->
+			<div class="Message">
+				<!--#message-->
+			</div>
+		<!--#endif-->
+
+	<footer class="footer">
+        <p class="pull-right"><!--#loginstatus--></p>
+        <p id="last-modified">Page generated at <!--#timestamp--></p>
+        <p>styled using twitter bootstrap</p>
+        <div id="copyright">
+            WeBWorK &#169; 2000-2007 <a href="http://openwebwork.sf.net/">The WeBWorK Project</a>
+        </div>
+    </footer>
+
+    <!--#if can="output_JS"-->
+    	<!--#output_JS-->
+    <!--#endif-->
+
+</body>
+</html>

--- a/htdocs/themes/libretexts/libretexts-coloring.css
+++ b/htdocs/themes/libretexts/libretexts-coloring.css
@@ -1,0 +1,144 @@
+/* This is the coloring file for the green version of math4
+ * this file is tracked by git and changes here will be overwritten
+ * If you would like to alter this theme, make a copy of math4-overrides.css
+ * in this directory and put your changes there. 
+ */
+
+/* Color for links and link hover */
+a {
+  color: #0f67a6;
+}
+
+a:hover,
+a:focus {
+  color: #127bc4;
+}
+
+body{
+  font-family: Roboto;
+}
+
+/* Color for the dark blue buttons */
+.btn-primary {
+  color: #ffffff;
+  background-color: #0f67a6;
+  background-image: none;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary.active,
+.btn-primary.disabled,
+.btn-primary[disabled] {
+  color: #ffffff;
+  background-color: #0f67a6;
+}
+
+/* Colors for the light blue buttons */
+.btn-info {
+  color: #ffffff;
+  background-color: #127bc4;
+  background-image: none;
+}
+.btn-info:hover,
+.btn-info:focus,
+.btn-info:active,
+.btn-info.active,
+.btn-info.disabled,
+.btn-info[disabled] {
+  color: #ffffff;
+  background-color: #57a3d9;
+}
+
+/* colors for the masthead */
+#masthead {
+    background-color: #0f67a6;
+}
+
+/* Color for the background of the webwork logo */
+.webwork_logo {
+    background-color: #0f67a6;
+    border-color: #0f67a6;
+}
+
+.well {
+  background: none;
+  box-shadow: none;
+  border: none;
+}
+
+#masthead a {
+    color: white;
+}
+
+#loginstatus {
+    color: white;
+}
+
+#loginstatus a {
+    color:black;
+}
+
+/* colors for the left hand nav list */
+#site-links ul {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.nav-list > .active > a,
+.nav-list > .active > a:hover,
+.nav-list > .active > a:focus {
+    color: #ffffff;
+    background-color: #0f67a6;
+}
+
+ul.nav li a:hover {
+	background: #e1e1e1;	
+}
+
+/* The breadcrumb nav */
+.breadcrumb {
+	border: 1px solid #e6e6e6;
+}
+
+/* The courses list coloring */
+ul.courses-list a {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+ul.courses-list a:hover {
+	background: #0f67a6;
+	color: white;
+}
+
+/* Info box (right hand box) coloring */
+.info-box {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.info-box h2, .info-box h3, .info-box h4, .info-box h5, .info-box h6 {
+	background: #0f67a6;
+	color: white;
+}
+
+#InfoPanel {
+    background-color: #fffffff;
+}
+
+#loginstatus{
+  margin: 5px;
+  float: right;
+}
+
+/* Achievement bar coloring */
+.levelinnerbar {
+    background-color:#57a3d9;
+}
+
+.cheevoinnerbar {
+    background-color:#57a3d9;
+}
+

--- a/htdocs/themes/libretexts/libretexts-overrides.css
+++ b/htdocs/themes/libretexts/libretexts-overrides.css
@@ -1,0 +1,324 @@
+/* This is the override file for libretexts.css.  If you copy 
+ * libretexts-overrides.css.dist to libretexts-overrides.css you can edit the
+ * values contained in this file and they will override the css values 
+ * normally used for libretexts.  This includes colors, padding, spacing, and
+ * so on.  
+ *
+ * If you upgrade your machine this file will not be overwritten, however, the 
+ * libretexts.css and libretexts-overrides.css.dist file may change.  If this happens it
+ * may cause problems with your theme until your reconcile the changes with 
+ * your modifactions here.  (Similar to how localOverrides.conf works.) 
+ */
+
+/*  These are the "main" colors of the theme.  Use search/replace to override
+ *  them.  
+ *  Dark Blue #003388
+ *  Light Blue #0157E8
+ *  Dark Green #519951
+ *  Light Green #88FF88
+ *  Dark Red #BF5454
+ *  Light Red #D69191
+ *  Dark Yellow #7E7634
+ *  Light Yellow #EDE275
+ */
+
+/* Gotchas:  By default using this file removes much of the "dynamic"
+ * elements of bootstrap, like grading on the buttons, or a slighlty different
+ * highlight color on the buttons. This is done for ease of configuratoin.  
+ * If you copy the code in htdocs/js/vendor/bootstrap/css/bootstrap.css
+ * you could get these features working again with effort.  
+ * 
+ * Using this file also changes some of the libretexts colors to be more uniform.  
+ * This is to make as few colors as possible for ease of changing the
+ */
+
+/* Color for links and link hover */
+.btn:focus,
+a:focus {
+    outline-color:#aaaa00;
+}
+
+a {
+  color: #0f67a6;
+}
+
+a:hover,
+a:focus {
+  color: #0157E8;
+}
+
+/* Color for the dark blue buttons */
+.btn-primary {
+  color: #ffffff;
+  background-color: #003388;
+  background-image: none;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary.active,
+.btn-primary.disabled,
+.btn-primary[disabled] {
+  color: #ffffff;
+  background-color: #003388;
+}
+
+/* Colors for the light blue buttons */
+.btn-info {
+  color: #ffffff;
+  background-color: #0157E8;
+  background-image: none;
+}
+.btn-info:hover,
+.btn-info:focus,
+.btn-info:active,
+.btn-info.active,
+.btn-info.disabled,
+.btn-info[disabled] {
+  color: #ffffff;
+  background-color: #0157E8;
+}
+
+/* colors for the masthead */
+#masthead {
+    background-color: #003388;
+}
+
+/* Color for the background of the webwork logo */
+.webwork_logo {
+    background-color: #003388;
+    border-color: #003388;
+}
+
+#masthead a {
+    color: white;
+}
+
+#loginstatus {
+    color: white;
+}
+
+#loginstatus a {
+    color:black;
+}
+
+/* colors for the left hand nav list */
+#site-links ul {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.nav-list > .active > a,
+.nav-list > .active > a:hover,
+.nav-list > .active > a:focus {
+    color: #ffffff;
+    background-color: #003388;
+}
+
+ul.nav li a:hover {
+	background: #e1e1e1;	
+}
+
+/* The breadcrumb nav */
+.breadcrumb {
+	border: 1px solid #e6e6e6;
+}
+
+/* The courses list coloring */
+ul.courses-list a {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+ul.courses-list a:hover {
+	background: #003388;
+	color: white;
+}
+
+/* Info box (right hand box) coloring */
+.info-box {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.info-box h2, .info-box h3, .info-box h4, .info-box h5, .info-box h6 {
+	background: #003388;
+	color: white;
+}
+
+#InfoPanel {
+    background-color: #fffffff;
+}
+
+/* Problem rendering formatting */
+div.RenderSolo { 
+    background-color: #E0E0E0; 
+    color: black; 
+}
+
+/* problem tag blue color */
+div.AuthorComment { 
+    background-color: #00E0E0; 
+    color: black; 
+}
+
+.RenderSolo hr,
+.problem-content hr {
+  border-top-color: rgb(22,22,22);
+}
+
+/* Colors for "neutral" messages */
+div.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+div.showMeAnotherBox { 
+    background-color: #EDE275; 
+    border-color: #EDE275; 
+} 
+
+label.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+span.ResultsAlert { 
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+div.ResultsAlert { 
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+label.ResultsAlert {
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+span.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+span.unattempted { 
+    color: inherit; 
+    background-color: #EDE275;
+}
+
+td.FeedbackMessage { 
+    background-color:#EDE275;
+} 
+
+div.gwMessage { 
+    background-color: #EDE275;
+}
+
+/* Colors for "green" messages */
+div.ResultsWithoutError { 
+    color: inherit; 
+    background-color: #88FF88; 
+} 
+
+td.ResultsWithoutError { 
+    background-color:#88FF88;
+}
+
+label.ResultsWithoutError { 
+    color: #519951; 
+    background-color: inherit; 
+} 
+
+span.ResultsWithoutError { 
+    color: inherit; 
+    background-color:#88FF88;
+} 
+
+span.correct { 
+    color: inherit; 
+    background-color: #88FF88; 
+}
+
+div.gwCorrect { background-color: #88FF88; }
+
+/* Colors for "red" messages */
+div.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+} 
+
+label.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+}
+
+td.ResultsWithError { 
+    background-color:#D69191; 
+    color: black;
+}
+
+span.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+} 
+
+span.incorrect { 
+    color: #BF5454; 
+    background-color: inherit; 
+}
+
+div.gwIncorrect { background-color: #D69191; }
+
+/* Other formatting for attempt results and the problem page */
+table.attemptResults th {
+	color: inherit;
+	background-color: #DDDDDD;
+}
+
+span.ResultsWithErrorInResultsTable { 
+    color: inherit; 
+    background-color: inherit; } 
+
+
+/* Comment coloration */
+.answerComments {
+    border-color: gray;
+    background-color: #E8E8E8;
+}
+
+/* highlights mistakes */
+.parsehilight { 
+    color: inherit; 
+    background-color: #EDE275; 
+}
+
+/* gw stuff */
+div#gwTimer {
+	background-color:#EDE275;
+}
+div#gwScoreSummary {
+	background-color:#EDE275;
+}
+
+/* Misc */
+.temporaryFile { 
+    color: #FF6600; b
+    background-color: inherit; 
+}
+
+#editor{
+    background-color: #FFFFFF;
+}
+
+.admin-messagebox {
+    background-color: #EDE275;
+}
+
+/* Achievement bar coloring */
+.levelinnerbar {
+    background-color: #0157E8;
+}
+
+.cheevoinnerbar {
+    background-color: #0157E8;
+}

--- a/htdocs/themes/libretexts/libretexts-overrides.css.dist
+++ b/htdocs/themes/libretexts/libretexts-overrides.css.dist
@@ -1,0 +1,324 @@
+/* This is the override file for libretexts.css.  If you copy 
+ * libretexts-overrides.css.dist to libretexts-overrides.css you can edit the
+ * values contained in this file and they will override the css values 
+ * normally used for libretexts.  This includes colors, padding, spacing, and
+ * so on.  
+ *
+ * If you upgrade your machine this file will not be overwritten, however, the 
+ * libretexts.css and libretexts-overrides.css.dist file may change.  If this happens it
+ * may cause problems with your theme until your reconcile the changes with 
+ * your modifactions here.  (Similar to how localOverrides.conf works.) 
+ */
+
+/*  These are the "main" colors of the theme.  Use search/replace to override
+ *  them.  
+ *  Dark Blue #003388
+ *  Light Blue #0157E8
+ *  Dark Green #519951
+ *  Light Green #88FF88
+ *  Dark Red #BF5454
+ *  Light Red #D69191
+ *  Dark Yellow #7E7634
+ *  Light Yellow #EDE275
+ */
+
+/* Gotchas:  By default using this file removes much of the "dynamic"
+ * elements of bootstrap, like grading on the buttons, or a slighlty different
+ * highlight color on the buttons. This is done for ease of configuratoin.  
+ * If you copy the code in htdocs/js/vendor/bootstrap/css/bootstrap.css
+ * you could get these features working again with effort.  
+ * 
+ * Using this file also changes some of the libretexts colors to be more uniform.  
+ * This is to make as few colors as possible for ease of changing the
+ */
+
+/* Color for links and link hover */
+.btn:focus,
+a:focus {
+    outline-color:#aaaa00;
+}
+
+a {
+  color: #003388;
+}
+
+a:hover,
+a:focus {
+  color: #0157E8;
+}
+
+/* Color for the dark blue buttons */
+.btn-primary {
+  color: #ffffff;
+  background-color: #003388;
+  background-image: none;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary.active,
+.btn-primary.disabled,
+.btn-primary[disabled] {
+  color: #ffffff;
+  background-color: #003388;
+}
+
+/* Colors for the light blue buttons */
+.btn-info {
+  color: #ffffff;
+  background-color: #0157E8;
+  background-image: none;
+}
+.btn-info:hover,
+.btn-info:focus,
+.btn-info:active,
+.btn-info.active,
+.btn-info.disabled,
+.btn-info[disabled] {
+  color: #ffffff;
+  background-color: #0157E8;
+}
+
+/* colors for the masthead */
+#masthead {
+    background-color: #003388;
+}
+
+/* Color for the background of the webwork logo */
+.webwork_logo {
+    background-color: #003388;
+    border-color: #003388;
+}
+
+#masthead a {
+    color: white;
+}
+
+#loginstatus {
+    color: white;
+}
+
+#loginstatus a {
+    color:black;
+}
+
+/* colors for the left hand nav list */
+#site-links ul {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.nav-list > .active > a,
+.nav-list > .active > a:hover,
+.nav-list > .active > a:focus {
+    color: #ffffff;
+    background-color: #003388;
+}
+
+ul.nav li a:hover {
+	background: #e1e1e1;	
+}
+
+/* The breadcrumb nav */
+.breadcrumb {
+	border: 1px solid #e6e6e6;
+}
+
+/* The courses list coloring */
+ul.courses-list a {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+ul.courses-list a:hover {
+	background: #003388;
+	color: white;
+}
+
+/* Info box (right hand box) coloring */
+.info-box {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.info-box h2, .info-box h3, .info-box h4, .info-box h5, .info-box h6 {
+	background: #003388;
+	color: white;
+}
+
+#InfoPanel {
+    background-color: #fffffff;
+}
+
+/* Problem rendering formatting */
+div.RenderSolo { 
+    background-color: #E0E0E0; 
+    color: black; 
+}
+
+/* problem tag blue color */
+div.AuthorComment { 
+    background-color: #00E0E0; 
+    color: black; 
+}
+
+.RenderSolo hr,
+.problem-content hr {
+  border-top-color: rgb(22,22,22);
+}
+
+/* Colors for "neutral" messages */
+div.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+div.showMeAnotherBox { 
+    background-color: #EDE275; 
+    border-color: #EDE275; 
+} 
+
+label.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+span.ResultsAlert { 
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+div.ResultsAlert { 
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+label.ResultsAlert {
+    color: #7E7634; 
+    background-color: inherit; 
+} 
+
+span.WarningMessage { 
+    background-color: #EDE275; 
+}
+
+span.unattempted { 
+    color: inherit; 
+    background-color: #EDE275;
+}
+
+td.FeedbackMessage { 
+    background-color:#EDE275;
+} 
+
+div.gwMessage { 
+    background-color: #EDE275;
+}
+
+/* Colors for "green" messages */
+div.ResultsWithoutError { 
+    color: inherit; 
+    background-color: #88FF88; 
+} 
+
+td.ResultsWithoutError { 
+    background-color:#88FF88;
+}
+
+label.ResultsWithoutError { 
+    color: #519951; 
+    background-color: inherit; 
+} 
+
+span.ResultsWithoutError { 
+    color: inherit; 
+    background-color:#88FF88;
+} 
+
+span.correct { 
+    color: inherit; 
+    background-color: #88FF88; 
+}
+
+div.gwCorrect { background-color: #88FF88; }
+
+/* Colors for "red" messages */
+div.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+} 
+
+label.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+}
+
+td.ResultsWithError { 
+    background-color:#D69191; 
+    color: black;
+}
+
+span.ResultsWithError { 
+    color: #BF5454; 
+    background-color: inherit; 
+} 
+
+span.incorrect { 
+    color: #BF5454; 
+    background-color: inherit; 
+}
+
+div.gwIncorrect { background-color: #D69191; }
+
+/* Other formatting for attempt results and the problem page */
+table.attemptResults th {
+	color: inherit;
+	background-color: #DDDDDD;
+}
+
+span.ResultsWithErrorInResultsTable { 
+    color: inherit; 
+    background-color: inherit; } 
+
+
+/* Comment coloration */
+.answerComments {
+    border-color: gray;
+    background-color: #E8E8E8;
+}
+
+/* highlights mistakes */
+.parsehilight { 
+    color: inherit; 
+    background-color: #EDE275; 
+}
+
+/* gw stuff */
+div#gwTimer {
+	background-color:#EDE275;
+}
+div#gwScoreSummary {
+	background-color:#EDE275;
+}
+
+/* Misc */
+.temporaryFile { 
+    color: #FF6600; b
+    background-color: inherit; 
+}
+
+#editor{
+    background-color: #FFFFFF;
+}
+
+.admin-messagebox {
+    background-color: #EDE275;
+}
+
+/* Achievement bar coloring */
+.levelinnerbar {
+    background-color: #0157E8;
+}
+
+.cheevoinnerbar {
+    background-color: #0157E8;
+}

--- a/htdocs/themes/libretexts/libretexts-overrides.js.dist
+++ b/htdocs/themes/libretexts/libretexts-overrides.js.dist
@@ -1,0 +1,21 @@
+/* This is the override file for libretexts.js.  If you copy 
+ * libretexts-overrides.js.dist to libretexts-overrides.js you can edit the
+ * values contained in this file and they will override the css values 
+ * normally used for libretexts.  This includes anything you can accomplish with
+ * jQuery and provides a lot of flexibility.  
+ *
+ * If you upgrade your machine this file will not be overwritten, however, the 
+ * libretexts.js and libretexts-overrides.js.dist file may change.  If this happens it
+ * may cause problems with your theme until your reconcile the changes with 
+ * your modifactions here.  (Similar to how localOverrides.conf works.) 
+ */
+
+
+$(function () {
+
+/* This changes the WeBWorK Logo on the top left to a new image */
+//    $('.webwork_logo a img').attr('src','new-path-here');
+
+/* This changes the MAA Logo on the top to a new image */
+//    $('.maa_logo a img').attr('src','new-path-here');
+});

--- a/htdocs/themes/libretexts/libretexts.css
+++ b/htdocs/themes/libretexts/libretexts.css
@@ -1,0 +1,1301 @@
+/* WeBWorK Online Homework Delivery System
+ * Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
+ * $CVSHeader: webwork2/conf/templates/math2/math2.css,v 1.1.2.1 2008/06/24 17:17:36 gage Exp $
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of either: (a) the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version, or (b) the "Artistic License" which comes with this package.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+ * Artistic License for more details.
+ */
+
+/* CodeMirror overrides */
+ 
+.CodeMirror-code {
+  outline: none;
+  direction: ltr !important;
+}
+
+/* Bootstrap overrides */
+a:focus {
+    outline-style:solid;
+    outline-color:#aaaa00;
+    outline-width:1px;
+}
+
+.btn:focus {
+    outline-style:solid;
+    outline-color:#aaaa00;
+    outline-width:2px;
+}
+
+.row-fluid [class*="span"] {
+    min-height:0px;
+}
+
+input[type="checkbox"] {
+    margin-right:.25em;
+}
+
+legend {
+    margin-bottom: 5px;
+    font-size:18px;
+}
+
+.container-fluid {
+	padding: 0.5em;
+}
+
+/* Basic elements */
+.required-field {
+    color:red;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+.sr-only-glyphicon {
+ position: absolute;
+ width: 1em;
+ height: 1em;
+ padding: 0;
+ margin: 0;
+ margin-left: -1em;
+ overflow: hidden;
+ clip: rect(0px, 0px, 0px, 0px);
+ border: 0 none;
+}
+
+/* Banner */
+#masthead {
+	background-color: #038;
+	margin: 0;
+	padding: 5px 0px 5px 0px;
+}
+
+.webwork_logo {
+	background-color: #1048ae;
+	font-size: 1.6em;
+	font-weight: 500;
+	border: 1px solid #5577b0;
+	padding: 2px 10px 0 6px; /* attempt to even out the blank space so that
+								the logo & text doesn't look lopsided */
+}
+
+.webwork_logo img {
+	padding-right: 5px; /* distance itself to the Webwork text */
+}
+
+.maa_logo img {
+	vertical-align: center;
+}
+
+.webwork_logo a,
+.maa_logo a {
+    display:block;
+}
+
+#masthead a {
+	color: white;
+}
+
+#masthead a:hover {
+	text-decoration: none;
+}
+
+#loginstatus {
+        padding-top:.5ex;
+        padding-right: .5em;
+	color: white;
+	text-align: right;
+	font-size: 0.85em;
+	font-weight: normal;
+} 
+#loginstatus a.btn {
+    margin-bottom:.5ex;
+}
+
+#loginstatus a {
+	color: black;
+}
+
+#loginstatus a .icon-signout {
+	font-size: 1em;
+}
+
+
+/* Nav */
+
+#site-links ul {
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+	overflow: hidden;
+}
+
+#site-links ul ul {
+    border:0px;
+}
+
+ul.nav li a:hover {
+	background: #e1e1e1;	
+}
+
+/* for the side navigation 'fisheye' list of problems */
+li.currentProblem{
+	background: #e1e1e1;	
+}
+
+#site-links h2 {
+    margin-top:0;
+    margin-bottom:0;
+    font-size:13px;
+}
+
+#site-navigation .info-box {
+	margin-top: 0.5em;
+}
+
+#site-navigation .info-box ul {
+        overflow: hidden;
+}
+
+/* Progress Bar */
+div.progress-bar {
+   height: 20px;
+   max-width: 100%;
+   border: 1px solid #B6B6B4;
+   background-color: #DDDDDD;
+   border-radius: 5px;
+   margin-bottom: 10px;
+   position: relative;
+}
+
+div.correct-progress {
+   height: 20px;
+   background-color: #8F8; /*same colour used as 'correct' */
+   border: 2px solid #00FF00; 
+   border-radius: 4px;
+   display: inline-block;
+   float:left;
+   box-sizing:border-box;
+   text-align:center;
+}
+
+div.incorrect-progress {
+   height: 20px;
+   background-color: #FF9494; /* same colour used as 'incorrect' */
+   border: 2px solid #FF0000;
+   border-radius: 4px;
+   display: inline-block;
+   box-sizing:border-box;
+}
+
+div.inprogress-progress {
+   height: 20px;
+   background-color: #FFFF00; /* yellow */
+   border: 2px solid #FBB117; /* beer border*/
+   border-radius: 4px;
+   display: inline-block;
+   box-sizing:border-box;
+}
+
+div.unattempted-progress {
+   height: 20px;
+   display: inline-block;
+   box-sizing:border-box;
+ }
+
+#breadcrumb-row {
+    margin-top:1ex;
+}
+
+#toggle-sidebar {
+    float:left;
+    height:20px;
+    padding-top:8px;
+    padding-bottom:8px;
+}
+
+#breadcrumb-navigation {
+    float:left;
+    display:inline-block;
+    width:90%;
+    width:calc(100% - 40px);
+}
+
+/* Main Content */
+.body {
+	display: inline-block;
+	float: left;
+}
+
+.shrinkbody {
+	width: 72%;
+}
+
+h1.page-title {
+	font-size: 31.5px;
+	line-height: 35px;
+}
+
+h2.page-title {
+	border-bottom: 1px solid #ccc;
+}
+
+#info-panel-right {
+	margin-bottom: 0.5em;
+/*	width: 25%; 8*/
+	overflow: hidden;
+	display: inline-block;
+	vertical-align: top;
+/*	float: right; */
+}
+
+.breadcrumb {
+	border: 1px solid #e6e6e6;
+}
+
+.Warnings {
+	clear: both;
+}
+
+.Warnings code {
+    	white-space: normal;
+}
+
+/* Question nav section */
+.problem-nav {
+	margin-bottom:1ex;
+	display: inline-block;
+	
+}
+
+/* Message section */
+
+.Message {
+    display: inline-block;
+    margin-bottom:1ex;
+}   
+
+.font-visible   { font-weight: bold; }
+.font-hidden { font-style: italic; } 
+
+.admin-messagebox {
+    background-color:#FFFFCC;
+    width:60%;
+    padding: 10px;
+    text-align:center;
+}
+
+/* Home Page */
+ul.courses-list {
+	list-style-type: none;
+	margin: 0;
+}
+
+ul.courses-list a {
+	border: 1px solid #e6e6e6;
+	display: block;
+	padding: 0.5em;
+	margin-bottom: 0.5em;
+	background: #f6f6f6;
+	width: 95%;
+	font-weight: bold;
+}
+
+ul.courses-list a:hover {
+	text-decoration: none;
+	background: #038;
+	color: white;
+}
+
+/* past answers page */
+.past-answer-table td {
+    white-space: nowrap;
+    min-width: 20px;
+}
+
+.past-answer-table .table-rule {
+    border-top: 3px solid #d5d5d5;
+    padding-top: 5px;
+}
+.past-answer-table .essay,
+.past-answer-table .comment {
+    min-width: 400px;
+    white-space: normal;
+}
+
+.past-answer-download {
+    font-weight: bold;
+    font-size: 110%;
+}
+
+/* Classlist Editor */
+/* this table is a pain, it wants to be a certain width and it'll force you
+ * to scroll if you don't have that width, don't know how to fix it */
+.label-with-edit-icon {
+    white-space:nowrap;
+}
+
+.label-with-edit-icon .set-label,
+.label-with-edit-icon div.tooltip {
+    white-space:normal;
+}
+
+table.classlist-table {
+/*	display: block; */
+        max-width: 95%; /* prevent it from violating container-fluid's padding,
+					 only valid in a rare edge case */
+}
+
+table.classlist-table .tbody {
+    width: 100%;
+}
+
+.UserDetail-date-table td {
+    padding-left:.5em;
+}
+
+/* Homework Sets */
+.problem_set_body input[type='checkbox'], .problem_set_body input[type='radio'] {
+    margin-top: 0px;
+}
+
+.problem_set_table td, .problem_set_table th {
+    padding: 8px 3px 8px 3px;
+}
+
+.problem_set_table td a {
+    font-weight:bold;
+    font-size:13px;
+}
+
+.problem_table td {
+    white-space: nowrap;
+}
+
+
+/* these are for indenting problems on jitar sets */
+.problem_set_table .nested-problem-1 {
+    margin-left: 10px;
+}
+
+.problem_set_table .nested-problem-2 {
+    margin-left: 20px;
+}
+
+.problem_set_table .nested-problem-3 {
+    margin-left: 30px;
+}
+
+.problem_set_table .nested-problem-4 {
+    margin-left: 40px;
+}
+
+.problem_set_table .nested-problem-5 {
+    margin-left: 50px;
+}
+
+.problem_set_table .nested-problem-6 {
+    margin-left: 60px;
+}
+
+/* these are for indenting problems on jitar sets */
+.problem-list .nested-problem-1 {
+    padding-left: 20px;
+}
+
+.problem-list .nested-problem-2 {
+    padding-left: 23px;
+}
+
+.problem-list .nested-problem-3 {
+    padding-left: 26px;
+}
+
+.problem-list .nested-problem-4 {
+    padding-left: 29px;
+}
+
+.problem-list .nested-problem-5 {
+    padding-left: 32px;
+}
+
+.problem-list .nested-problem-6 {
+    padding-left: 35px;
+}
+
+.problem_set_table .hardcopy-link {
+    font-size:16px;
+}
+
+/* Info Box */
+.info-box {
+	padding: 0.5em;
+	border-radius: 8px;
+	border: 1px solid #e6e6e6;
+	background: #f6f6f6;
+}
+
+.info-box h2, .info-box h3, .info-box h4, .info-box h5, .info-box h6 {
+	background: #038;
+	border-radius: 8px;
+	color: white;
+	margin: 0;
+	padding: 0;
+	line-height: 30px;
+	margin-bottom: 0.5em;
+	font-size: 1.1em;
+	text-align: center;
+}
+
+.info-box dl {
+	margin: 1ex .5em 1ex 1ex;
+	padding: 0;
+	font-size: 80%;
+}
+.info-box li,
+.info-box dt {
+	margin: 0 0 .5ex 0;
+	padding: 0;
+	line-height: 2.2ex;
+}
+.info-box dt { font-weight: bold }
+.info-box dd {
+	margin: 0 0 .5ex 1em;
+	padding: 0;
+	line-height: 2.2ex;
+}
+.info-box dd p {
+	margin-top: 0;
+}
+.info-box a.more {
+	float: left;
+	font-size: 80%;
+	font-style: italic;
+	margin-bottom: 1ex;
+	margin-right: .5em;
+}
+
+.info-box form {
+    margin-bottom:0px;
+}
+
+/* Gateway Options */
+
+#sp-gateway-form{
+	background-color: #eeeeee;
+	color: black;
+}
+
+#sp-gateway-form label{
+    display: inline-block;
+	padding-right: 15px;    
+}
+
+/* Library Browser */
+.library-browser-table td {
+	padding-top: 0.2em;
+	padding-bottom: 0.2em;
+}
+.library-browser-table .table-separator {
+	border-bottom: 1px solid #ccc;
+}
+
+.library-browser-table-nojs td {
+    padding-right: 0.2em;
+    padding-left: 0.2em;
+}
+
+.lb-problem-header {
+    overflow:auto;
+    background-color: #FFFFFF; 
+    margin: 0px auto;
+    min-height:30px;
+    display:block;
+}
+
+.lb-problem-add {
+    text-align: left;
+}
+
+.lb-problem-path {
+    text-align: left; 
+    cursor: pointer;
+}
+
+.lb-problem-icons {
+    float:right; 
+    text-align: right; 
+    margin-right:.8em;
+}
+
+.lb-problem-stats {
+    float:right; 
+    text-align:right;
+}
+
+.lb-mlt-group {
+    border:2px solid black;
+    width :100%;
+}
+
+/* Footer */
+#footer {
+	clear: both;
+	display: block;
+	font-size: 0.8em;
+	color: #767676;
+	text-align: center;
+	padding: 1em;
+	margin-top: 1em;
+}
+
+#footer p {
+	margin-bottom: 0; /* overrides bootstrap default so there's no weird space*/
+}
+
+#footer a {
+	color: #555;
+}
+
+
+/* --- Standard elements ---------------------------------------------------- */
+
+blockquote {
+  padding: 0 0 0 0;
+  margin: 0 0 0 1em;
+  border-left-width: 0;
+}
+
+label,
+input,
+button,
+select,
+textarea {
+  font-size: 16px;
+  font-weight: normal;
+  line-height: 18px;
+  width: auto;
+}
+
+input {
+	height: auto;
+}
+
+@media (max-width:979px) {
+    input[type="text"],
+    input[type="password"],
+    textarea,
+    select {
+	max-width:95%;
+    }
+}
+
+.barrier {
+	clear:both;
+	border: none; /* 1px solid grey; */
+}
+
+#mini-sitemap {
+	font-family: "Trebuchet MS", "Arial", "Helvetica", sans-serif;
+	padding: 0 0 1ex 0;
+}
+#mini-sitemap a, #mini-sitemap a:link, #mini-sitemap a:visted {
+	text-decoration: none;
+}
+
+#InfoPanel {
+    font-size:100%;
+    float: left; /*was right*/
+    min-width: 0;
+    overflow: hidden; /*was auto*/
+    /*margin-right: -1px;*/
+    background-color: #fff;
+}
+#InfoPanel ol {
+	font-size:100%;
+}
+
+table.FormLayout { border: 0; }
+table.FormLayout tr { vertical-align: top; }
+table.FormLayout th.LeftHeader { text-align: right; white-space: nowrap; }
+table.FormLayout tr.ButtonRow { text-align: left; }
+table.FormLayout tr.ButtonRowCenter { text-align: center; }
+table.FormLayout td { padding-right:10px; padding-bottom:.5ex; }
+
+table.FormLayout tr.ButtonRow,
+table.FormLayout tr.ButtonRowCenter, 
+table.FormLayout tr.ButtonRowCenter tr {
+    vertical-align: middle;
+}
+
+div.RenderSolo { background-color: #E0E0E0; color: black; }
+div.AuthorComment { background-color: #00E0E0; color: black; }
+
+/* minimal style for lists of links (generated by the links escape) */
+/*ul.LinksMenu { list-style: none; margin-left: 0; padding-left: 0; }*/
+/*ul.LinksMenu ul { list-style: none; margin-left: 0.5em; padding-left: 0; }*/
+
+/* background styles for success and failure messages */
+div.WarningMessage { background-color: #D69191; padding: 3px 3px 3px 3px; } /* red */
+div.ResultsWithoutError { color: inherit; background-color: #8F8; } /* green */
+div.ResultsWithError { color: #bf5454; background-color: inherit; } /* red */
+div.ResultsAlert { color: #ca5000; background-color: inherit; } /* orange */
+div.showMeAnotherBox { background-color: #EDE275; border-radius: 5px; border: 2px solid #FDD017; padding: 3px 3px 3px 3px; margin-bottom: 5px} /* bright gold border and harvest gold background*/
+label.WarningMessage { background-color: #D69191; padding: 3px 3px 3px 3px; } /* red */
+label.ResultsWithoutError { color: inherit; background-color: #8F8; } /* green */
+label.ResultsWithError { color: #bf5454; background-color: inherit; } /* red*/
+label.ResultsAlert { color: #ca5000; background-color: inherit; } /* orange */
+span.WarningMessage { background-color: #D69191; padding: 3px 3px 3px 3px; } /* red*/
+span.ResultsWithoutError { color: inherit; background-color: #8F8; } /* green */
+span.ResultsWithError { color: #bf5454; background-color: inherit; } /* red*/
+span.ResultsAlert { color: #ca5000; background-color: inherit; } /* orange */
+span.correct { color: inherit; background-color: #8F8; } /* green */
+span.incorrect { color: #bf5454; background-color: inherit; } /* red */
+span.unattempted { color: inherit; background-color: #88ECFF;}
+input.correct[type="text"]{ /* green */
+    border-color: rgba(81,153,81, 0.8);
+    outline: 0;
+    outline: thin dotted \9;
+    /* IE6-9 */
+    
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81, ,.6);
+    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
+    
+    color:inherit; 
+}
+
+input.incorrect[type="text"] { /* red */
+  border-color: rgba(191, 84, 84, 0.8);
+  outline: 0;
+  outline: thin dotted \9;
+  /* IE6-9 */
+
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
+  -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
+    color:inherit; 
+}
+
+input.changed[type="text"] { /* orange */
+  border-color: #ca5000;
+  outline: 0;
+ outline: thin dotted \9;
+  /* IE6-9 */
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(202, 80, 0, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(202, 80, 0, 0.6);
+  color: inherit;
+}
+
+.results-popover {
+    cursor : pointer;
+}
+
+/* styles used by WeBWorK::HTML::ScrollingRecordList */
+div.ScrollingRecordList { padding: 1em; white-space: nowrap; border: thin solid gray; }
+div.ScrollingRecordList select.ScrollingRecordList { width: 99%; }
+
+/* wraps the View Options form (generated by &optionsMacro) */
+/* FIXME: can't this style information just go in div.Options above? */
+
+.viewOptions  {
+    margin-left:1ex;
+    font-size:small;
+}
+
+.viewOptions label {
+    font-size:small;
+    display:block;
+}
+
+/* messages, attempt results, answer previews, etc. go in this DIV */
+/* this used to be "float:left", but that was suspected of causing MSIE peekaboo bug */
+div.problemHeader {}
+
+/* styles for the attemptResults table */
+table.attemptResults {
+	border-style: outset; 
+	border-width: 1px; 
+	margin-bottom: 1em; 
+	border-spacing: 1px;
+/*      removed float stuff because none of the other elements nearby are
+        floated and it was causing trouble
+	float:left;
+	clear:right; */
+}
+
+table.attemptResults td,
+table.attemptResults th {
+	border-style: inset; 
+	border-width: 1px; 
+	text-align: center; 
+	vertical-align: middle;
+	/*width: 15ex;*/ /* this was erroniously commented out with "#" */
+	padding: 2px 5px 2px 5px;
+	color: inherit;
+	background-color: #DDDDDD;
+}
+
+.attemptResults .popover {
+    max-width: 100%;
+}
+
+table.attemptResults td.FeedbackMessage { background-color:#EDE275;} /* Harvest Gold */
+table.attemptResults td.ResultsWithoutError { background-color:#8F8;}
+span.ResultsWithErrorInResultsTable { color: inherit; background-color: inherit; } /* used to override the older red on white span */ 
+table.attemptResults td.ResultsWithError { background-color:#D69191; color: #000000} /* red */
+
+/*styles for the instructor comment box */
+
+.answerComments {
+    margin-left: 2em;
+    max-width: 80%;
+    border-style: outset;
+    border-width: 1px;
+    border-spacing: 2px;
+    border-color: gray;
+    padding: 2px 5px 2px 5px;
+    margin-bottom:1em;
+    background-color: #E8E8E8;
+}
+
+/* Make hr a black line for problem render areas so that
+ * it can be used for fractions
+ */
+.RenderSolo hr,
+.problem-content hr {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  border-top-color: rgb(22,22,22);
+}
+
+.problem-content label {
+    font-size: 14px;
+}
+
+/* override above settings in tables used to display ans_array results */
+table.attemptResults td td,
+table.attemptResults td th,
+table.ArrayLayout td {
+	border-style: none; 
+	border-width: 0px; 
+	padding: 0px;
+}
+table.attemptResults td.Message {
+   text-align: left; 
+   padding: 2px 5px 2px 5px;
+   width: auto;
+}
+.attemptResultsSummary { margin-bottom: 10px; }
+.parsehilight { color: inherit; background-color: yellow; }
+
+.problem-main-form input {
+    margin-left:.5ex;
+    margin-right:.5ex;
+}
+
+/* the problem TEXT itself goes in this box */
+/* we used to make this a grey box, but surprise, MSIE is bug-ridden. */
+div.problem {  }
+
+/* jsMath emits this class when appropriate math fonts aren't available */
+div.NoFontMessage {
+	padding: 10px;
+	border-style: solid;
+	border-width: 3px;
+	border-color: #DD0000;
+	color: inherit;
+	background-color: #FFF8F8;
+	width: 75%;
+	text-align: left;
+	margin: 10px auto 10px 12%;
+}
+
+/* styles used when editing a temporary file */
+.temporaryFile { font-style: italic; color: #ca5000; background-color: inherit; }
+
+/* text colors for Auditing, Current, and Dropped students */
+.Audit { font-style: normal; color: purple; background-color: inherit; }
+.Enrolled { font-weight: normal; color: black; background-color: inherit; }
+.Drop { font-style: italic; color: gray; background-color: inherit; }
+/* text colors for problem grader page */
+.NeedsGrading { font-weight: bold; }
+
+/*Styles for the login form -- mainly small alignment changes for all of the input elements on the login page*/
+
+#login_form input {
+	margin-top: 7px;
+}
+
+#login_form label{
+	margin-right: 2px;
+}
+
+#login_form #pswd_label{
+	margin-right: 4px;
+}
+
+#login_form #rememberme{
+	margin-left: 75px;
+}
+
+/*Styles for the edit forms, found on the homework sets editor page*/
+
+/*Following are mostly alignment fixes for the input elements and their lables on this page.*/
+.edit_form  input,select{
+	margin-bottom: .5em;
+}
+
+.edit_form label {
+	margin-left: 40px;
+}
+
+.edit_form span {
+    float: none;
+}
+
+.edit_form label.radio_label{
+	margin-left: 0px;
+}
+
+.edit_form  span#filter_err_msg{
+	display: none;
+}
+
+/*Styles for the classlist editor page*/
+
+/*The styles here correctly align the table elements in the set table*/
+.set_table{
+	margin-right: 5px;
+}
+
+.set_table td{
+	padding-right: 5px;
+}
+
+.set_table th{
+	padding-right: 5px;
+	padding-left: 5px;
+}
+
+.set_table label{
+	margin-left: 0px;
+}
+
+/*General styles, for elements such as table captions input buttons, columns, etc.*/
+
+/*General styles for table captions*/
+table caption{
+	font-weight: bold;
+}
+
+/*Styling the content that is found in the login page.*/
+.p_content{
+	width: 640px;
+}
+
+/*General styles for all input buttons*/
+.button_input{
+	margin-right: 5px;
+	margin-left: 5px;
+}
+
+/*General styles for all column divs, for pages which use column layouts*/
+/*.column {
+	float: left;
+	width: 50%;
+	margin-top: 10px;
+}
+
+.column input[type="radio"] {
+    margin-right:1ex;
+}
+*/
+.problemFooter {
+	clear:both;  /* the footer shouldn't float at all */
+
+}
+
+/*General styles for the wrapper div element which goes around the InfoBoxes*/
+.info-wrapper{
+	float: right;
+	min-height: 100px;
+	/* max-width: 40%; */
+	overflow: hidden;
+	margin-left: 5px;
+}
+
+
+#show_hide{
+    margin-bottom:.5ex;
+}
+
+
+#none{
+	/*Please do not do anything with elements with id "none"*/
+}
+
+/*Styles for the PGProblemEditor Page*/
+
+#editor{
+	background-color: #FFFFFF;
+}
+
+#editor #source_and_options{
+	float: left;
+	width: 50%;
+}
+
+#editor #problemContents_label{
+	text-align: center;
+	font-weight: bold;
+	text-decoration: underline;
+	margin-left: 30%;
+}
+
+#editor #problemContents_id{
+	width: 100%;
+	height: 50%;
+}
+
+#editor .editor_form{
+	margin-left: 40px;
+}
+
+#editor #form_div{
+	float: left;
+	width: 100%;
+}
+
+/*Styles specifically for the problem viewer*/
+
+#problem_viewer_form{
+	margin-left: 10px;
+	float: left;
+	width: 45%;
+	height: 100%;
+	border-left: solid;
+	border-width: 1px;
+}
+
+#problem_viewer_form>h3{
+	margin-left: 37%;
+}
+
+#problem_viewer_form #viewer_span{
+	margin-left: 10%;
+}
+
+#problem_viewer_form #reload_button{
+	margin-left: 20%;
+	margin-top: 5%;
+}
+
+#problem_viewer_form #problem_viewer{
+	width: 60%;
+	background-color: #E8E8E8;
+	margin-left: 20%;
+	margin-top: 5%;
+	padding: 1px;
+}
+
+#problem_viewer_form #problem_viewer_content{
+	border-style: solid;
+	padding: 5%;
+	border-width: 1px;
+}
+
+#problem_viewer_form #viewer_note{
+	margin-top: 10%;
+	margin-left: 10%;
+	margin-right: 10%;
+}
+
+#editor{
+	width: 750px;
+}
+
+#editor .pg_editor_input_span{
+	margin-bottom: 10px;
+	display: none;
+}
+
+#editor .pg_editor_input_div{
+	margin-top: 20px;
+	margin-left: 50px;
+}
+
+#editor #submit_input_div{
+	margin-top: 10px;
+	clear: both;
+}
+
+#pg_editor_frame_id{
+    width:95%;
+    height:590px;
+    overflow:scroll;
+}
+
+#render-modal.modal {
+    width:1024px;
+    left:25%;
+}
+
+#render-modal .modal-body {
+    height:95%;
+    width:95%;
+    max-height:600px;
+}
+
+.radio_span, 
+.radio_span input,
+.radio_span label{
+    display:none !important;
+}
+
+table.problem_sets_table {
+	width: 640px;
+	float: left;
+	margin-bottom: 3%;
+	overflow:hidden/*was not here*/;
+}
+
+table.problem_sets_table caption {
+}
+
+table.problem_sets_table th{
+	width: 320px;
+	padding-bottom: 10px;
+}
+
+table.problem_sets_table td{
+	width: 320px;
+}
+
+div.problem_sets_options {
+	clear: both;
+	margin: 1% 1% 1% 1%;
+}
+
+#set_table_id a.set-id-tooltip,
+#set_table_id a.set-id-tooltip:hover {
+    text-decoration: none;
+    color: #000000;
+}
+
+/* ProblemSetDetail2 css */
+#psd_list {
+    padding-left: 0px;
+}
+
+#psd_list li {
+    list-style-type: none;
+}
+
+.pdr_placeholder {
+    height: 100px;
+    width: 90%;
+    border-style: dashed;
+    border-width: 1px;	
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+}
+
+.pdr_handle {    
+    cursor: move;
+    margin-right:2px;
+    font-size:large;
+}
+
+.pdr_collapse {
+    cursor: pointer;
+    width: 10px;
+    font-size:large;
+    display: none;
+    font-family: FontAwesome;
+}
+
+.psd_list_row.mjs-nestedSortable-collapsed > div > div > div > table > tbody > tr > td > span.pdr_collapse:after {
+    content: '\f054';
+}
+
+.psd_list_row.mjs-nestedSortable-expanded > div > div > div > table > tbody > tr > td > span.pdr_collapse:after {
+    content: '\f078';
+}
+
+
+#psd_toolbar {
+    margin-right:10px;
+}
+
+#psd_toolbar a.btn {
+    margin-left:0px;
+    margin-right:0px;
+}
+
+#psd_list li.mjs-nestedSortable-collapsed > ol {
+    display: none;
+    }
+
+#psd_list li.mjs-nestedSortable-branch .pdr_collapse {
+    display: inline-block;
+    }
+
+#psd_list li.mjs-nestedSortable-leaf .pdr_collapse {
+    display: none;
+}
+
+.psr_render_area {
+    margin-top: 10px;
+    overflow: hidden;
+}
+
+.ScrollingRecordList > input[type='submit'] {
+    margin-top: 1ex;
+    margin-bottom: 2ex;
+}
+
+/*This is the styling specifically for the tables of problems displayed for each problem set page*/
+/*BUG FIXES*/
+
+table#grades_table pre{
+	float: left;
+}
+
+.grades-course-total, 
+.grades-course-total th {
+    font-weight: bold;
+    font-size:105%;
+}
+
+#config-form input[type="checkbox"] {
+    margin-right:1.5ex;
+}
+
+.file-manager-btn {
+    margin-bottom:.5ex;
+    margin-top:.5ex;
+}
+
+/*mainform is in the library browser*/
+.setlist-table,
+.setlist-table label,
+.user-list-form,
+.user-list-form label,
+.user-list-form input,
+.user-list-form select,
+.set-list-form,
+.set-list-form label,
+.set-list-form input,
+.set-list-form select,
+#mainform,
+#mainform label,
+#mainform input,
+#mainform select{
+    font-size:small;
+}
+
+#mainform i.icon-random {
+    cursor: pointer;
+}
+
+#send-mail-form input,
+#send-mail-form select,
+.set-list-form input,
+.set-list-form select,
+.set-list-form button,
+.user-list-form input,
+.user-list-form select {
+    margin-top: .15em;
+    margin-bottom: .25em;
+}
+
+.user-list-form select,
+.set-list-form select {
+    height:27px;
+}
+
+.set-list-form select[multiple] {
+    height:auto;
+}
+
+#problem_set_form input[type="submit"] {
+    margin-right:1ex;
+} 
+
+#mainform .btn,
+#problem_set_form .btn {
+    margin-bottom:.25ex;
+    margin-top:.25ex;
+}
+
+#problem_set_form .ui-datepicker-trigger {
+    margin: 0;
+}
+
+#problem_set_form input[type="checkbox"] {
+    margin-bottom:.5ex;
+}
+
+#editor input[type="radio"]{
+    margin-right:.5ex;
+    
+}
+
+#problem-grader-form select {
+    width:60px;
+}
+
+#problem-grader-form .graded-answer,
+#problem-grader-form .essay-answer {
+    border-bottom: 1px solid #d5d5d5;
+    margin-bottom:2px;
+    padding-bottom:5px;
+}
+
+.tab-pane {
+    margin-bottom:10px;
+}
+
+.small-table-text,
+.small-table-text td {
+    font-size:small;
+}
+
+.nav-list li {
+    font-size:small;
+}
+
+/* Equation editor bugfixes */
+#eqEditorDiv {
+    overflow:visible;
+}
+
+#openEqEditor {
+    min-height:35px;
+    min-width:43px;
+}

--- a/htdocs/themes/libretexts/libretexts.css
+++ b/htdocs/themes/libretexts/libretexts.css
@@ -21,6 +21,9 @@
 }
 
 /* Bootstrap overrides */
+body {
+	font-size: 1.1rem;
+}
 a:focus {
     outline-style:solid;
     outline-color:#aaaa00;

--- a/htdocs/themes/libretexts/libretexts.css
+++ b/htdocs/themes/libretexts/libretexts.css
@@ -24,6 +24,13 @@
 body {
 	font-size: 1.1rem;
 }
+
+/* override background and border of problem insert */
+#problem_body { 
+	background-color: #ffffff;
+	border: 0px solid #ffffff;	
+}
+
 a:focus {
     outline-style:solid;
     outline-color:#aaaa00;
@@ -1301,4 +1308,9 @@ table#grades_table pre{
 #openEqEditor {
     min-height:35px;
     min-width:43px;
+}
+/* version and copyright knowl */
+#version {
+	text-align: right;
+
 }

--- a/htdocs/themes/libretexts/libretexts.js
+++ b/htdocs/themes/libretexts/libretexts.js
@@ -1,0 +1,324 @@
+// Object for toggling the sidebar
+var ToggleNavigation = function () {
+    var threshold = 768
+    var windowwidth = $(window).width();
+    var navigation_element = $('#site-navigation');
+    
+    var hideSidebar = function () {
+	$('#site-navigation').remove();
+	$('#toggle-sidebar-icon').removeClass('icon-chevron-left').addClass('icon-chevron-right');	
+	$('#content').removeClass('span10').addClass('span11');
+    }
+
+    var showSidebar = function () {
+	$('#body-row').prepend(navigation_element);
+	$('#toggle-sidebar-icon').addClass('icon-chevron-left').removeClass('icon-chevron-right');
+	$('#content').addClass('span10').removeClass('span11');	
+    }
+
+    var toggleSidebar = function () {
+	if ($('#toggle-sidebar-icon').hasClass('icon-chevron-left')) {
+	    hideSidebar();
+	} else {
+	    showSidebar();
+	}
+    }
+        
+    // if no fish eye then collapse site-navigation 
+    if($('#site-links').length > 0 && !$('#site-links').html().match(/[^\s]/)) {
+	$('#site-navigation').remove();
+	$('#content').removeClass('span10').addClass('span11');
+	$('#toggle-sidebar').addClass('hidden');
+	$('#breadcrumb-navigation').width('100%');
+    } else {
+	// otherwise enable site-navigation toggling
+	if (windowwidth < threshold) {
+	    hideSidebar();
+	}
+	    
+	$('#toggle-sidebar').click(function (event) {
+	    event.preventDefault();
+	    toggleSidebar();
+	});
+	
+	
+	$(window).resize(function(){
+	    if ($(window).width() != windowwidth) {
+		windowwidth = $(window).width();
+		if(windowwidth < threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-left')) {
+		    hideSidebar();
+		} else if (windowwidth >= threshold && $('#toggle-sidebar-icon').hasClass('icon-chevron-right')) {	
+		    showSidebar();
+		}
+	    }
+	}); 
+    }
+}
+
+$(function(){
+    // Initialize navigation menu toggling
+    ToggleNavigation();
+    
+    // Focus on a  results with error if one is around and focussable. 
+    $('.ResultsWithError').first().focus();
+
+    // Fix bug with skip to main content link in chrome
+    $('#stmc-link').click(function() {
+	$('#page-title').attr('tabIndex', -1).focus();
+    });
+
+    // Turn submit inputs into buttons
+    $('input:submit').addClass('btn btn-primary');
+    $('input:submit').mousedown(function () {this.blur(); return false;});
+    $('.nav_button').addClass('btn btn-primary');
+    $('.classlist').addClass('table table-condensed classlist-table');
+
+    // Try to format checkboxes better
+    $('input:checkbox').parent('label').addClass('checkbox');
+    $('input:radio').parent('label').addClass('radio');
+
+    // Make grey_buttons disabled buttons
+    $('.gray_button').addClass('btn disabled').removeClass('gray_button');
+
+    // replace pencil gifs by something prettier
+    $('td a:has(img[src$="edit.gif"])').each(function () { $(this).html($(this).html().replace(/<img.*>/," <span class='icon icon-pencil' data-alt='edit'></span>")); });
+    $('img[src$="question_mark.png"]').replaceWith('<span class="icon icon-question-sign" data-alt="help" style="font-size:16px; margin-right:5px"></span>');
+
+    // Turn summaries and help boxes into popovers
+    // Not sure there are any table-summary classes
+    // loading Sage interacts removes the popover function 
+    //(loads older version of bootstrap?)
+    // so we'll work around that for now
+    if ($.fn.popover) {
+    	$('a.table-summary').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
+		});
+		$('a.help-popup').popover({trigger : 'click'}).click(function (event) {
+		event.preventDefault();
+		}).html('<i class="icon-question-sign"/><span class="sr-only">Help Icon</span>');
+    }
+    // Sets login form input to bigger size
+    $('#login_form input').addClass('input-large');    
+    
+    // Changes edit links in info panels to buttons
+    var editButton = $("#info-panel-right h2:first a:first")
+    editButton.addClass('btn btn-small btn-info');
+    editButton.text(editButton.text().replace(/\[([^\]].*)\]/, '$1'));
+
+    //Problem page
+    $('.currentProblem').addClass('active');
+
+    //Reformats the problem_set_table.  
+    $('#problem-sets-form').addClass('form-inline');
+    $('.body:has(.problem_set_table)').addClass('problem_set_body');
+    $('.problem_set_table').addClass('table');
+    if($('.problem_set_table').find("tr:first th").length > 3) {
+	$('.problem_set_table').addClass('small-table-text');
+    }
+
+    $('#hardcopy-form').addClass('form-inline');
+
+    $('.problem_set_options input').addClass('btn btn-info');
+    $('.problem_set_options a').addClass('btn btn-info');
+
+    // Problem formatting
+    $('#problemMainForm').addClass('problem-main-form form-inline');
+    $('.attemptResults').addClass('table table-condensed table-bordered');
+    $('.problem .problem-content').addClass('well well-small');
+    $('.answerComments').addClass('well');
+    $('#SMA_button').addClass('btn btn-primary');
+    
+
+    // this finds the wztooltips object entries and adds
+    // bootstrap styling using popover to them
+    // check first that popover is defined 
+    // (work around for sage interacts which remove popover for some reason)
+	$("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
+		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);	
+		if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
+		//on the presentation of a matrix  and then causes errors throughout the rest of the script
+		if ($.fn.popover) { 
+			$(this).attr('onmouseover','');
+			if (data) {
+				$(this).wrapInner('<div class="results-popover" />');
+				var popdiv = $('div', this);
+				popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
+			}
+		} 
+	    
+	});
+
+    // sets up problems to rescale the image accoring to attr height width
+    // and not native height width.  
+    var rescaleImage = function (index,element) {
+	if ($(element).attr('height') != $(element).get(0).naturalHeight || 
+	$(element).attr('width') != $(element).get(0).naturalWidth) {
+	    $(element).height($(element).width()*$(element).attr('height')
+			   /$(element).attr('width'));
+	}
+    }
+    
+    $('.problem-content img').each(rescaleImage);
+
+    $(window).resize(function () {
+	$('.problem-content img').each(rescaleImage);
+    });
+    
+    // Grades formatting
+    $('#grades_table').addClass('table table-bordered table-condensed');
+    $('.additional-scoring-msg').addClass('well');
+    
+    //Problem Grader formatting
+    $('#problem-grader-form').addClass('form-inline');
+    $('#problem-grader-form input:button').addClass('btn btn-small');
+    $('#problem-grader-form td').find('p:last').removeClass('essay-answer graded-answer');
+    $('#problem-grader-form .score-selector').addClass('input-min');
+
+    //CourseConfiguration
+    $('#config-form').addClass('form-inline');
+    $('#config-form table').addClass('table table-bordered');
+
+    //Instructor Tools
+    $('#instructor-tools-form input').removeClass('btn-primary');
+
+    //File Manager Configuration
+    $('#FileManager').addClass('form-inline');
+    $('#FileManager .btn').addClass('btn-small file-manager-btn').removeClass('btn-primary');
+    $('#FileManager #Upload').addClass('btn-primary');
+    
+    //Classlist Editor 1&2 configuration
+    $('#classlist-form').addClass('form-inline user-list-form');
+    $('.user-list-form input:button').addClass('btn btn-info');
+    $('.user-list-form input:reset').addClass('btn btn-info');
+    $('.user-list-form').wrapInner('<div />');
+    $('.classlist-table').addClass('table table-condensed table-bordered');
+    $('.classlist-table').attr('border',0);
+    $('.classlist-table').attr('cellpadding',0);
+    $('#show_hide').addClass('btn btn-info');
+    $('#new-users-form table').addClass('table table-condensed');
+    $('#new-users-form .section-input, #new-users-form .recitation-input').attr('size','4');
+    $('#new-users-form .last-name-input, #new-users-form .first-name-input, #new-users-form .user-id-input').attr('size','10');
+
+    //Homework sets editor config
+    $('#problemsetlist').addClass('form-inline set-list-form');
+    $('#problemsetlist2').addClass('form-inline set-list-form');
+    $('#edit_form_id').addClass('form-inline set-list-form');
+    $('.set-id-tooltip').tooltip({trigger: 'hover'});
+    $('.set-list-form input:button').addClass('btn btn-info');
+    $('.set-list-form input:reset').addClass('btn btn-info');
+    $('.set-list-form').wrapInner('<div />');
+    $('.set_table').addClass('small-table-text table-bordered table table-condensed');
+    $('#show_hide').addClass('btn btn-info');
+    $('#problem_set_form').addClass('form-inline');
+    $('#user-set-form').addClass('form-inline user-assign-form');
+    $('#set-user-form').addClass('form-inline user-assign-form');
+    $('.set_table input[name="selected_sets"]').each(function () {
+	var label = $(this).parent().children('label');
+	label.prepend(this);
+	label.addClass('checkbox');
+    });
+    $('#problem_set_form input[name="refresh"]').removeClass("btn-primary");
+    
+    //PG editor styling
+    $('#editor').addClass('form-inline span9');
+    $('#editor a').addClass('btn btn-small btn-info');
+    $('#editor > div').each(function () { $(this).html($(this).html().replace(/\|/g,"")); });
+
+    //Achievement Editor
+    $('#achievement-list').addClass('form-inline user-list-form');
+    $('.user-list-form input:button').addClass('btn btn-info');
+    $('.user-list-form input:reset').addClass('btn btn-info');
+    $('.user-list-form').wrapInner('<div />');
+    $('#show_hide').addClass('btn btn-info');
+    $('#user-achievement-form').addClass('form-inline user-assign-form');
+
+    //email page
+    $('#send-mail-form').addClass('form-inline');
+    $('#send-mail-form .btn').addClass('btn-small').removeClass('btn-primary');
+    $('#send-mail-form #sendEmail_id').addClass('btn-primary');
+
+    //Score sets
+    $('#scoring-form').addClass('form-inline');
+    $('#scoring-form input:submit').addClass('btn-small');
+
+    //Student progress and statistics
+    $('table.progress-table').addClass('table table-bordered table-condensed');
+    $('table.stats-table').addClass('table table-bordered');
+    $('#sp-gateway-form').addClass('well');
+
+    //Library browser tweaks
+    $('#mainform ').addClass('form-inline');
+    $('#mainform input:button').addClass('btn btn-primary');
+    $('#mainform input[type="submit"]').removeClass('btn-primary');
+    $('#mainform input[name="edit_local"]').addClass('btn-primary');    
+    $('#mainform input[name="new_local_set"]').addClass('btn-primary');
+    $('#mainform .btn').addClass('btn-small');
+    $('#mainform .InfoPanel select').addClass('input-xxlarge');
+    $('#mainform select[name=mydisplayMode]').addClass('input-small').removeClass('input-xxlarge');
+    $('#mainform select[name=local_sets]').addClass('input').removeClass('input-xxlarge');
+    $('#mainform select[name=max_shown]').addClass('input-small').removeClass('input-xxlarge');
+
+    //Library browser nojs tweaks
+    $('.library-browser-table-nojs label.checkbox').css('display','inline-block');
+
+    //Change tabber tabs to twitter tabs
+    if ($('div.tabber').length > 0) {tabberAutomatic({});}
+    $('ul.tabbernav').removeClass('tabbernav').addClass('old-tabber nav nav-tabs');
+    $('ul.old-tabber li a').each(function () { $(this).attr('href','#'+$(this).attr('title').replace(/\s+/g, '')).attr('data-toggle','tab');});
+    $('div.tabberlive').removeClass('tabberlive').addClass('tab-content');
+    $('div.tabbertab').each(function() { $(this).removeClass('tabbertab').addClass('tab-pane').attr('id',$(this).find('h3').html().replace(/\s+/g,''))});
+    $('div.tab-pane h3').remove();
+    if ($('li.tabberactive a').length > 0) { 
+        $('li.tabberactive a').tab('show');}
+
+    //past answer table
+    $('.past-answer-table').addClass("table table-striped");
+    $('#past-answer-form').addClass("form-inline");
+
+     //GatewayQuiz
+    $('.gwPrintMe a').addClass('btn btn-info');
+    $('.gwPreview a').addClass('btn');
+
+
+    // the datepicker uses addOnLoadEvent, so if this function isn't defined,
+    // we dont have to worry about the datepicker.
+    if (typeof(addOnLoadEvent) === 'function') {
+	addOnLoadEvent( function () {
+	    $('.ui-datepicker-trigger').addClass('btn').parent().addClass('input-append');
+	});
+    }
+
+    /* For accessibility we need to change single answer aria labels to 
+       "answer" and not "answer 1" */
+    if ($('.codeshard').length == 1) {
+	$('.codeshard').attr('aria-label','answer');
+    }
+
+    /* Glyphicon accessibility */
+    jQuery('span.icon').each(function() {
+        /*
+	 * The glyphicon needs to be formatted as follows.
+	 * <span class="icon icon-close" data-alt="close"></span>
+	 *
+	 * The script takes the contents of the data-alt attribute and presents it as alternative content for screen reader users.
+	 *
+	 */
+        $(this).attr('aria-hidden', 'true'); // hide the pseudo-element from screen readers
+        var alt = jQuery(this).data('alt') // get the data-alt attribute
+        var textSize = jQuery(this).css('font-size'); // get the font size of the glyphicon
+        // if the data-alt attribute exists, write the contents of the attributwe
+        if (typeof alt !== "undefined") {
+            // if the glyphicon font is loaded, write the contents of the data-alt to off-screen screen reader only text
+            // and size the "hidden" text to be the same size as the glyphicon
+            if ($(this).css('font-family') == 'FontAwesome') {
+                $(this).after('<span style="font-size:'+ textSize +'" class="sr-only-glyphicon">' + alt + '</span>');
+
+            } else { // if the glyphicon font is NOT loaded, write the contents of the data-alt to on-screen text because the font is not displaying correctly
+                $(this).after('<span>' + alt + '</span>');
+                $(this).addClass('sr-only'); // make the failing glyphicon hidden off screen so it will not confuse users
+            }
+        }
+    });
+    
+});    
+

--- a/htdocs/themes/libretexts/libretexts.template
+++ b/htdocs/themes/libretexts/libretexts.template
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
+<head>
+<meta charset='utf-8'>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- This encourages IE to *not* use compatibility view, which breaks libretexts -->
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+
+<link rel="icon" type="x-image/icon" href="<!--#url type="webwork" name="htdocs"-->/images/favicon.ico"/>
+
+<!-- CSS Loads -->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>
+<link href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/vendor/font-awesome/css/font-awesome.min.css"/>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts.css"/>
+<!--#if can="output_jquery_ui"-->
+	<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/jquery-ui-1.8.18.custom.css"/>
+<!--#endif-->
+<!--#if can="output_achievement_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/achievements.css"/>
+<!--#endif-->
+<!--#if can="output_tabber_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/tabber.css"/>
+<!--#endif-->
+<!--#if can="output_CSS"-->
+	<!--#output_CSS-->
+<!--#endif-->
+<!--#if exists="libretexts-coloring.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-coloring.css"/>
+<!--#endif-->
+<!--#if exists="libretexts-overrides.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-overrides.css"/>
+<!--#endif-->
+
+<!-- JS Loads -->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/jquery/jquery.js"></script>
+<script type="text/javascript" src="<!--#url type="webwork" name="MathJax"-->"></script>
+<!--#if can="output_jquery_ui"-->
+	<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/jquery-ui-1.9.0.js"></script>
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
+<!--#if can="output_tabber_CSS"-->
+<script type="text/javascript">
+var tabberOptions = {manualStartup:true};
+</script>
+<!--#endif-->
+<!--#if can="output_JS"-->
+	<!--#output_JS-->
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts.js"></script>	
+<!--#if exists="libretexts-overrides.js"-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts-overrides.js"></script>	
+<!--#endif-->
+
+<title><!--#path style="text" text=" : " textonly="1"--></title>
+
+<!--#head-->
+</head>
+
+<body>
+
+<!-- Bootstrap Fluid Layout Scaffolding start -->
+<div class="container-fluid">
+
+<div id="body-row" class="row-fluid">
+
+
+<!-- Main Content Area -->
+
+<div id="content" class="span10" >
+
+	<!-- Header Text for problem --> 
+	<!--#if can="post_header_text"-->
+		<!--#post_header_text-->
+	<!--#endif-->
+
+
+<!--	==============BEGIN BODY OF PROBLEM===============	-->
+
+	<!-- Indicate presence of perl warnings -->
+	<!--#if warnings="1"-->
+	<div class="row-fluid">
+		<div class="span12 alert alert-error">
+			<strong>Warning</strong> -- there may be something wrong with this question. Please inform your instructor including the warning messages below.
+		</div>
+	</div>
+	<!--#endif-->
+    <!--       
+	<!--#if can="output_tag_info"-->
+		<div class="row-fluid">
+		  <div class="span12">
+			<!--#output_tag_info-->
+		</div></div>
+		<!--#endif-->
+	-->
+	 <!--#if can="output_problem_body"--> 
+	    <!-- ==== in this case print body parts ELSE print entire body -->		<div class="row-fluid">
+		  <div class="Body span12">
+
+			<!--#if can="output_custom_edit_message"-->
+			<div class="row-fluid"><div class="span10">
+				<!--#output_custom_edit_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			<!--#if can="output_summary"-->
+			<div class="row-fluid"><div class="span10">
+					<!--#output_summary-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+
+			<!--#if can="output_achievement_message"-->
+			<div class="row-fluid"><div class="span10">
+					<!--#output_achievement_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			
+			<!--#if can="output_comments" "-->
+			<div class="row-fluid"><div class="span10">
+				  <!--#output_comments-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+				
+
+
+
+			<!--#if can="output_form_start"-->
+			<div class="row-fluid">
+			  <div class="span10">
+				<!--#output_form_start-->
+			    <!--#if can="output_hidden_info"-->
+				     <!--#output_hidden_info-->
+			    <!--#endif-->
+
+				<!--#if can="output_problem_body" can="output_message" can="output_editorLink"-->
+					<div class="problem">
+						<!--#if can="output_problem_body"-->
+						<div id="problem_body" class="problem-content" <!--#output_problem_lang_and_dir--> >
+							<!--#output_problem_body-->
+						</div>
+						<!--#endif-->
+						<!--#if can="output_message"-->
+							<!--#output_message-->
+						<!--#endif-->
+						<!--
+							<!--#if can="output_editorLink"-->
+								<!--#output_editorLink-->
+							<!--#endif-->
+						-->
+					</div>
+				<!--#endif-->
+
+				<!--#if can="output_checkboxes" can="output_submit_buttons"-->
+				 
+					<p> <!--
+								<!--#if can="output_checkboxes"-->
+									<!--#output_checkboxes-->
+								<!--#endif-->
+							-->
+						<!--#if can="output_submit_buttons"-->
+							<!--#output_submit_buttons-->
+						<!--#endif-->
+					</p>
+				
+				<!--#endif-->
+				<!--
+					<!--#if can="output_score_summary"-->
+						<div class="scoreSummary">
+							<!--#output_score_summary-->
+						</div>
+					<!--#endif-->
+					<!--#if can="output_misc"-->
+						<!--#output_misc-->
+					<!--#endif-->
+				-->
+				</form>
+			<!--#endif-->
+
+		<!-- inserted problem piece by piece -->
+
+		<!--#if can="info"-->
+			<p>Form2</p>
+			<!--  styles could be different for different pages so they are not set here -->
+			<div id="info-panel-right" >
+			<!--#info-->
+			</div>
+		<!--#endif-->
+
+		</div><div class="span2"></div></div>
+                </div></div>
+
+	<!-- ====  end printing body parts   -->
+	<!--#else-->
+	<!-- ==== couldn't print body parts so we'll print entire body -->	         <div class="row-fluid">
+	  <!--#if can="info"-->
+	  <div class="body span8">
+	  <!--#else-->
+	    <div class="body span12">
+	  <!--#endif-->
+	      <!--#body-->
+	</div>
+	<!-- inserted body as a whole -->
+	<!--#if can="info"-->
+	<div id="info-panel-right" class="span4 info-box">
+	  <!--  styles could be different for different pages so they are not set here -->
+	  <!--#info-->
+	</div>
+	<!--#endif-->
+	</div>
+	<!--#endif--> 
+<!--			      ==============END BODY OF PROBLEM===============      -->
+
+ 		
+</div><!--content-->
+
+<!-- Bootstrap Fluid Layout Scaffolding stop -->
+</div> <!-- row-fluid -->
+</div> <!-- container-fluid -->
+
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
+
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
+
+<!-- Footer -->
+<div id="footer" role="contentinfo" style="display: none">
+	<!--#footer-->
+</div>
+
+</body>
+</html>

--- a/htdocs/themes/libretexts/simple.template
+++ b/htdocs/themes/libretexts/simple.template
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
+<head>
+<meta charset='utf-8'>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- This encourages IE to *not* use compatibility view, which breaks math4 -->
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+
+<link rel="icon" type="x-image/icon" href="<!--#url type="webwork" name="htdocs"-->/images/favicon.ico"/>
+
+<!-- CSS Loads -->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>
+<link href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/vendor/font-awesome/css/font-awesome.min.css"/>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts.css"/>
+<!--#if can="output_jquery_ui"-->
+	<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/jquery-ui-1.8.18.custom.css"/>
+<!--#endif-->
+<!--#if can="output_achievement_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/achievements.css"/>
+<!--#endif-->
+<!--#if can="output_tabber_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/tabber.css"/>
+<!--#endif-->
+<!--#if can="output_CSS"-->
+	<!--#output_CSS-->
+<!--#endif-->
+<!--#if exists="libretexts-coloring.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-coloring.css"/>
+<!--#endif-->
+<!--#if exists="libretexts-overrides.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-overrides.css"/>
+<!--#endif-->
+
+<!-- JS Loads -->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/jquery/jquery.js"></script>
+<script type="text/javascript" src="<!--#url type="webwork" name="MathJax"-->"></script>
+<!--#if can="output_jquery_ui"-->
+	<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/jquery-ui-1.9.0.js"></script>
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
+<!--#if can="output_tabber_CSS"-->
+<script type="text/javascript">
+var tabberOptions = {manualStartup:true};
+</script>
+<!--#endif-->
+<!--#if can="output_JS"-->
+	<!--#output_JS-->
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts.js"></script>	
+<!--#if exists="libretexts-overrides.js"-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts-overrides.js"></script>	
+<!--#endif-->
+
+<title><!--#path style="text" text=" : " textonly="1"--></title>
+
+<!--#head-->
+</head>
+
+<body>
+
+<!-- Bootstrap Fluid Layout Scaffolding start -->
+<div class="container-fluid">
+
+<div id="body-row" class="row-fluid">
+
+
+<!-- Main Content Area -->
+
+<div id="content" class="span10" >
+
+	<!-- Header Text for problem --> 
+	<!--#if can="post_header_text"-->
+		<!--#post_header_text-->
+	<!--#endif-->
+
+
+<!--	==============BEGIN BODY OF PROBLEM===============	-->
+
+	<!-- Indicate presence of perl warnings -->
+	<!--#if warnings="1"-->
+	<div class="row-fluid">
+		<div class="span12 alert alert-error">
+			<strong>Warning</strong> -- there may be something wrong with this question. Please inform your instructor including the warning messages below.
+		</div>
+	</div>
+	<!--#endif-->
+    <!--       
+	<!--#if can="output_tag_info"-->
+		<div class="row-fluid">
+		  <div class="span12">
+			<!--#output_tag_info-->
+		</div></div>
+		<!--#endif-->
+	-->
+	 <!--#if can="output_problem_body"--> 
+	    <!-- ==== in this case print body parts ELSE print entire body -->		<div class="row-fluid">
+		  <div class="Body span12">
+
+			<!--#if can="output_custom_edit_message"-->
+			<div class="row-fluid"><div class="span10">
+				<!--#output_custom_edit_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			<!--#if can="output_summary"-->
+			<div class="row-fluid"><div class="span10">
+					<!--#output_summary-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+
+			<!--#if can="output_achievement_message"-->
+			<div class="row-fluid"><div class="span10">
+					<!--#output_achievement_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			
+			<!--#if can="output_comments" "-->
+			<div class="row-fluid"><div class="span10">
+				  <!--#output_comments-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+				
+
+
+
+			<!--#if can="output_form_start"-->
+			<div class="row-fluid">
+			  <div class="span10">
+				<!--#output_form_start-->
+			    <!--#if can="output_hidden_info"-->
+				     <!--#output_hidden_info-->
+			    <!--#endif-->
+
+				<!--#if can="output_problem_body" can="output_message" can="output_editorLink"-->
+					<div class="problem">
+						<!--#if can="output_problem_body"-->
+						<div id="problem_body" class="problem-content" <!--#output_problem_lang_and_dir--> >
+							<!--#output_problem_body-->
+						</div>
+						<!--#endif-->
+						<!--#if can="output_message"-->
+							<!--#output_message-->
+						<!--#endif-->
+						<!--
+							<!--#if can="output_editorLink"-->
+								<!--#output_editorLink-->
+							<!--#endif-->
+						-->
+					</div>
+				<!--#endif-->
+
+				<!--#if can="output_checkboxes" can="output_submit_buttons"-->
+				 
+					<p> <!--
+								<!--#if can="output_checkboxes"-->
+									<!--#output_checkboxes-->
+								<!--#endif-->
+							-->
+						<!--#if can="output_submit_buttons"-->
+							<!--#output_submit_buttons-->
+						<!--#endif-->
+					</p>
+				
+				<!--#endif-->
+				<!--
+					<!--#if can="output_score_summary"-->
+						<div class="scoreSummary">
+							<!--#output_score_summary-->
+						</div>
+					<!--#endif-->
+					<!--#if can="output_misc"-->
+						<!--#output_misc-->
+					<!--#endif-->
+				-->
+				</form>
+			<!--#endif-->
+
+		<!-- inserted problem piece by piece -->
+
+		<!--#if can="info"-->
+			<p>Form2</p>
+			<!--  styles could be different for different pages so they are not set here -->
+			<div id="info-panel-right" >
+			<!--#info-->
+			</div>
+		<!--#endif-->
+
+		</div><div class="span2"></div></div>
+                </div></div>
+
+	<!-- ====  end printing body parts   -->
+	<!--#else-->
+	<!-- ==== couldn't print body parts so we'll print entire body -->	         <div class="row-fluid">
+	  <!--#if can="info"-->
+	  <div class="body span8">
+	  <!--#else-->
+	    <div class="body span12">
+	  <!--#endif-->
+	      <!--#body-->
+	</div>
+	<!-- inserted body as a whole -->
+	<!--#if can="info"-->
+	<div id="info-panel-right" class="span4 info-box">
+	  <!--  styles could be different for different pages so they are not set here -->
+	  <!--#info-->
+	</div>
+	<!--#endif-->
+	</div>
+	<!--#endif--> 
+<!--			      ==============END BODY OF PROBLEM===============      -->
+
+ 		
+</div><!--content-->
+<!-- Bootstrap Fluid Layout Scaffolding stop -->
+</div> <!-- row-fluid -->
+</div> <!-- container-fluid -->
+
+
+
+<!-- Footer -->
+<div id="footer" role="contentinfo" style="display: none">
+	<!--#footer-->
+</div>
+
+</body>
+</html>

--- a/htdocs/themes/libretexts/system.template
+++ b/htdocs/themes/libretexts/system.template
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html <!--#output_course_lang_and_dir-->>
+<!--  Note that the lang and dir attributes are now set during the
+      processing of the template and not hard-coded above.
+-->
+<head>
+<meta charset='utf-8'>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- This encourages IE to *not* use compatibility view, which breaks libretexts -->
+<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+
+<!--
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/conf/templates/math3/system.template,v 1.2 2008/06/26 19:46:02 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+-->
+
+<link rel="icon" type="x-image/icon" href="<!--#url type="webwork" name="htdocs"-->/images/favicon.ico"/>
+
+<!-- CSS Loads -->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap.css"/>
+<link href="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/css/bootstrap-responsive.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/vendor/font-awesome/css/font-awesome.min.css"/>
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts.css"/>
+<!--#if can="output_jquery_ui"-->
+	<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/jquery-ui-1.8.18.custom.css"/>
+<!--#endif-->
+<!--#if can="output_achievement_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/achievements.css"/>
+<!--#endif-->
+<!--#if can="output_tabber_CSS"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/css/tabber.css"/>
+<!--#endif-->
+<!--#if can="output_CSS"-->
+	<!--#output_CSS-->
+<!--#endif-->
+<!--#if exists="libretexts-coloring.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-coloring.css"/>
+<!--#endif-->
+<!--#if exists="libretexts-overrides.css"-->
+<link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="theme"-->/libretexts-overrides.css"/>
+<!--#endif-->
+
+<!-- JS Loads -->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/jquery/jquery.js"></script>
+<script type="text/javascript" src="<!--#url type="webwork" name="MathJax"-->"></script>
+<!--#if can="output_jquery_ui"-->
+	<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/jquery-ui-1.9.0.js"></script>
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
+<!--#if can="output_tabber_CSS"-->
+<script type="text/javascript">
+var tabberOptions = {manualStartup:true};
+</script>
+<!--#endif-->
+<!--#if can="output_JS"-->
+	<!--#output_JS-->
+<!--#endif-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts.js"></script>	
+<!--#if exists="libretexts-overrides.js"-->
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/libretexts-overrides.js"></script>	
+<!--#endif-->
+
+<title><!--#path style="text" text=" : " textonly="1"--></title>
+
+<!--#head-->
+</head>
+
+<body>
+<a href="#page-title" id="stmc-link" class="sr-only sr-only-focusable">Skip to main content</a>
+<!--#if can="output_wztooltip_JS"--> <!-- Please remind this -->
+	<!--#output_wztooltip_JS-->
+<!--#endif-->
+
+<!-- Bootstrap Fluid Layout Scaffolding start -->
+<div id="bs-container" class="container-fluid">
+<!-- Header -->
+<div id = "masthead" class="row-fluid" role="banner">
+	<div class="span2 webwork_logo">
+		<a href="<!--#url type="webwork" name="root"-->"><img src="<!--#url type="webwork" name="htdocs"-->/images/webwork_transparent_logo_small.png" alt="to courses page" />WeBWorK</a>
+	</div>
+	<div class="span4 maa_logo">
+		<a href="http://www.maa.org"><img src="<!--#url type="webwork" name="htdocs"-->/images/maa_logo_small.png" alt="to MAA (Mathematical Association of America) main web site" /></a>
+	</div>
+	<div id="loginstatus" class="offset3 span3">
+		<!--#loginstatus-->
+	</div>
+</div>
+
+<!-- Run masthead class js because it gets rendered early -->
+<script type="text/javascript">
+  // Changes links in masthead
+  $('#loginstatus a').addClass('btn btn-small');
+  $('#loginstatus a').append(' <span class="icon icon-signout" data-alt="signout"></span>'); 
+</script>
+
+<div id="body-row" class="row-fluid">
+
+<!-- Navigation -->
+<div id="site-navigation" class="span2 hidden" role="navigation" aria-label="main navigation">
+  <!--#if can="links"-->
+        <div id="site-links">
+	  <!--#links-->
+	  </div>
+	<!--#endif-->
+
+	<!--#if can="siblings"-->
+	<div id="siblings">
+	  <!--#siblings-->
+	  </div>
+	<!--#endif-->
+	<!--#if can="options"-->
+	<div id="options" class="info-box">
+	  <!--#options-->
+	  </div>
+	<!--#endif-->
+</div>
+
+<!-- Run site-navigation js because it gets loaded early -->
+<script type="text/javascript">
+  // Makes the fisheye stuff bootstrap nav
+  $('#site-navigation ul').addClass('nav nav-list');
+  $('#site-navigation li').each(function () { $(this).html($(this).html().replace(/<br>/g,"</li><li>")); });
+  $('#site-navigation a.active').parent().addClass('active');
+  $('#site-navigation strong.active').parent().addClass('active');
+  $('#site-navigation li').find('br').remove();
+  
+  $('img[src$="question_mark.png"]').replaceWith('<span class="icon icon-question-sign" data-alt="help" style="font-size:16px; margin-right:5px"></span>');
+
+  // Display options formatting
+  $('.facebookbox input:submit').addClass('btn-small');
+
+  $('#site-navigation').removeClass('hidden');
+  
+</script>
+
+
+<!-- Main Content Area -->
+<div id="content" class="span10" >
+	<!-- Breadcrumb -->
+	<div id="breadcrumb-row" class="row-fluid">
+	  <div class="span12">
+	    <a href="#" class="btn btn-primary btn" id="toggle-sidebar">
+	      <span id="toggle-sidebar-icon" class="icon icon-chevron-left" data-alt="close sidebar"></span></a>
+	    
+	    <div id="breadcrumb-navigation" role="navigation" aria-label="breadcrumb navigation">
+	      <ul class="breadcrumb">
+		<!--#path style="bootstrap" text="<li><span aria-hidden='true' class='divider'>/</span></li>"-->
+	      </ul>
+	    </div>
+	</div></div>
+	<!-- Run breadcrumb js since it gets loaded early -->
+	<script type="text/javascript"> 
+	  $('#toggle-sidebar').removeClass('btn-primary')
+	</script>
+	
+	<!-- Page Title -->
+	<!--#if can="title"-->
+	<div class="row-fluid"><div class="span12">
+		<h1 id='page-title' class='page-title'><!--#title --></h1>
+	</div></div>
+	<!--#endif-->
+
+	<!--#if can="nav" can="message"--> 
+	<div class="row-fluid">
+	  <div id="problem-nav" class="problem-nav span7" role="navigation" aria-label="problem navigation">
+	<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
+	<!--#if can="nav"-->
+		<!--#nav style="buttons" imageprefix="/webwork2_files/images/nav" imagesuffix=".gif" separator="  "-->
+	<!--#endif-->
+	  </div>
+	  
+	  <div id="Message" class="Message span4 offset1">
+	    <!-- Message for the user -->
+	    <!--#if can="message"-->
+	        <!--#message-->
+	<!--#endif-->
+	  </div>
+	</div>
+	<!--#endif-->
+
+	<!-- Header Text for problem --> 
+	<!--#if can="post_header_text"-->
+		<!--#post_header_text-->
+	<!--#endif-->
+
+<!--	==============BEGIN BODY OF PROBLEM===============	-->
+
+	<!-- Indicate presence of perl warnings -->
+	<!--#if warnings="1"-->
+	<div class="row-fluid">
+		<div id="alert-error" class="span12 alert alert-error">
+		    <!--#warningMessage-->
+		</div>
+	</div>
+	<!--#endif-->
+             
+	<!--#if can="output_tag_info"-->
+	<div class="row-fluid">
+	  <div id="tag_info" class="span12">
+		<!--#output_tag_info-->
+	</div></div>
+	<!--#endif-->
+	 <!--#if can="output_problem_body"--> 
+	    <!-- ==== in this case print body parts ELSE print entire body -->		<div class="row-fluid">
+		  <div id="problem_body" class="Body span12">
+
+			<!--#if can="output_custom_edit_message"-->
+			<div id="custom_edit_message" class="row-fluid"><div class="span10">
+				<!--#output_custom_edit_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			<!--#if can="output_summary"-->
+			<div class="row-fluid"><div id="output_summary" class="span10">
+					<!--#output_summary-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+
+			<!--#if can="output_achievement_message"-->
+			<div class="row-fluid"><div id="output_achievement_message" class="span10">
+					<!--#output_achievement_message-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+			
+			<!--#if can="output_comments" "-->
+			<div class="row-fluid"><div id="output_comments" class="span10">
+				  <!--#output_comments-->
+			</div><div class="span2"></div></div>
+			<!--#endif-->
+				
+
+
+
+			<!--#if can="output_form_start"-->
+			<div class="row-fluid">
+			  <div class="span10">
+				<!--#output_form_start-->
+			    <!--#if can="output_hidden_info"-->
+				     <!--#output_hidden_info-->
+			    <!--#endif-->
+
+				<!--#if can="output_problem_body" can="output_message" can="output_editorLink"-->
+					<div class="problem">
+						<!--#if can="output_problem_body"-->
+						<div id="problem_body" class="problem-content" <!--#output_problem_lang_and_dir--> >
+							<!--#output_problem_body-->
+						</div>
+						<!--#endif-->
+						<!--#if can="output_message"-->
+							<!--#output_message-->
+						<!--#endif-->
+						<!--#if can="output_editorLink"-->
+							<!--#output_editorLink-->
+						<!--#endif-->
+					</div>
+				<!--#endif-->
+
+				<!--#if can="output_checkboxes" can="output_submit_buttons"-->
+					<p>
+						<!--#if can="output_checkboxes"-->
+							<!--#output_checkboxes-->
+						<!--#endif-->
+						<!--#if can="output_submit_buttons"-->
+							<!--#output_submit_buttons-->
+						<!--#endif-->
+					</p>
+				<!--#endif-->
+				<!--#if can="output_score_summary"-->
+					<div id="score_summary" class="scoreSummary">
+						<!--#output_score_summary-->
+					</div>
+				<!--#endif-->
+
+				<!--#if can="output_misc"-->
+					<!--#output_misc-->
+				<!--#endif-->
+				</form>
+			<!--#endif-->
+
+		<!-- inserted problem piece by piece -->
+
+		<!--#if can="info"-->
+			<p>Form2</p>
+			<!--  styles could be different for different pages so they are not set here -->
+			<div id="info-panel-right" >
+			<!--#info-->
+			</div>
+		<!--#endif-->
+
+		</div><div class="span2"></div></div>
+                </div></div>
+
+	<!-- ====  end printing body parts   -->
+	<!--#else-->
+	<!-- ==== couldn't print body parts so we'll print entire body -->	         <div class="row-fluid">
+	  <!--#if can="info"-->
+	  <div class="body span8">
+	  <!--#else-->
+	    <div id="page_body" class="body span12">
+	  <!--#endif-->
+	      <!--#body-->
+	</div>
+	<!-- inserted body as a whole -->
+	<!--#if can="info"-->
+	<div id="info-panel-right" class="span4 info-box">
+	  <!--  styles could be different for different pages so they are not set here -->
+	  <!--#info-->
+	</div>
+	<!--#endif-->
+	</div>
+	<!--#endif-->  
+
+<!--			      ==============END BODY OF PROBLEM===============      -->
+	<!--#if can="output_past_answer_button" can="output_email_instructor"-->
+		<div id="problemFooter" class="problemFooter">
+			<!--#if can="output_past_answer_button"-->
+				<!--#output_past_answer_button-->
+			<!--#endif-->
+			<!--#if can="output_email_instructor"-->
+				<!--#output_email_instructor-->
+			<!--#endif-->
+		</div>
+	<!--#endif-->
+
+<!--#if warnings="1"-->
+<div id="warnings" class="Warnings alert alert-error">
+	<!--#warnings-->
+</div>
+<!--#endif-->
+<!--#if can="message"-->
+<div id="Message_bottom" class="Message">
+  <!--#message-->
+</div>
+<!--#endif-->
+		
+</div><!--content-->
+
+
+<!-- Bootstrap Fluid Layout Scaffolding stop -->
+</div> <!-- row-fluid -->
+</div> <!-- container-fluid -->
+
+
+<!-- Footer -->
+<div id="footer" role="contentinfo">
+	<!--#footer-->
+</div>
+
+</body>
+</html>

--- a/htdocs/themes/math4/libretexts.template
+++ b/htdocs/themes/math4/libretexts.template
@@ -232,11 +232,26 @@ var tabberOptions = {manualStartup:true};
 
  		
 </div><!--content-->
+
 <!-- Bootstrap Fluid Layout Scaffolding stop -->
 </div> <!-- row-fluid -->
 </div> <!-- container-fluid -->
 
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
 
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
 
 <!-- Footer -->
 <div id="footer" role="contentinfo" style="display: none">

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -227,8 +227,7 @@ var tabberOptions = {manualStartup:true};
 	</div>
 	<!--#endif-->
 	</div>
-	<!--#endif-->  
-
+	<!--#endif--> 
 <!--			      ==============END BODY OF PROBLEM===============      -->
 
  		
@@ -239,9 +238,23 @@ var tabberOptions = {manualStartup:true};
 </div> <!-- row-fluid -->
 </div> <!-- container-fluid -->
 
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
 
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
 <!-- Footer -->
-<div id="footer" role="contentinfo">
+<div id="footer" role="contentinfo" style="display: none">
 	<!--#footer-->
 </div>
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2252,6 +2252,11 @@ sub output_JS{
         print qq{
            <script type="text/javascript" src="$site_url/js/vendor/underscore/underscore.js"></script>
            <script type="text/javascript" src="$site_url/js/legacy/vendor/knowl.js"></script>};
+           
+    # This is for when the problem is embedded in an iframe
+    	print qq{
+    		<script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
+    	};
 
 	# This is for tagging menus (if allowed)
 	if ($r->authz->hasPermissions($r->param('user'), "modify_tags")) {

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -12,8 +12,9 @@ $libretexts_format = <<'ENDPROBLEMTEMPLATE';
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/libretexts/libretexts.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
+# contains overrides
+<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/libretexts/libretexts.css"/> 
 
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
@@ -34,7 +35,7 @@ $libretexts_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 
-<title>WeBWorK using host: $SITE_URL, format: sticky seed: $problemSeed</title>
+<title>WeBWorK using host: $SITE_URL, format: libretexts seed: $problemSeed</title>
 </head>
 <body>
 <div class="container-fluid">
@@ -68,7 +69,7 @@ $LTIGradeMessage
 <input type="hidden" name="course_password" value="$course_password">
 <input type="hidden" name="displayMode" value="$displayMode">
 <input type="hidden" name="session_key" value="$session_key">
-<input type="hidden" name="outputformat" value="sticky">
+<input type="hidden" name="outputformat" value="libretexts">
 <input type="hidden" name="language" value="$formLanguage">
 <input type="hidden" name="showSummary" value="$showSummary">
 <input type="hidden" name="forcePortNumber" value="$forcePortNumber">

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -1,4 +1,4 @@
-$sticky_format = <<'ENDPROBLEMTEMPLATE';
+$libretexts_format = <<'ENDPROBLEMTEMPLATE';
 
 <!DOCTYPE html>
 <html $COURSE_LANG_AND_DIR>
@@ -99,7 +99,7 @@ $LTIGradeMessage
 <img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
 </div>
 <div id="footer" style="display:none">
-WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky | theme: math4
+WeBWorK &copy; 1996-2020 | host: $SITE_URL | course: $courseID | format: libretexts | theme: math4
 </div>
 
 <!-- Activate local storage js -->
@@ -109,4 +109,4 @@ WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky 
 
 ENDPROBLEMTEMPLATE
 
-$sticky_format;
+$libretexts_format;

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -15,7 +15,7 @@ $libretexts_format = <<'ENDPROBLEMTEMPLATE';
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
 # contains overrides
 <link rel="stylesheet" type="text/css" href="/webwork2_files/themes/libretexts/libretexts.css"/> 
-
+<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/libretexts/libretexts-coloring.css"/>
 <!-- JS Loads -->
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/jquery.js"></script>
 <script type="text/javascript" src="/webwork2_files/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML-full"></script>
@@ -31,7 +31,7 @@ $libretexts_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/modules/jstorage.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/LocalStorage/localstorage.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
+<script type="text/javascript" src="/webwork2_files/themes/libretexts/libretexts.js"></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -39,11 +39,9 @@ $problemHeadText
 <body>
 <div class="container-fluid">
 <div class="row-fluid">
-<div class="span12 problem">	
-<hr/>		
+<div class="span12 problem">		
 $answerTemplate
-<hr/>
-<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
+<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post" style="margin-bottom:-20px">
 <div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 $problemText
 </div>
@@ -84,7 +82,23 @@ $LTIGradeMessage
 </div>
 </div>
 </div>
-<div id="footer">
+
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
+
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
+<div id="footer" style="display:none">
 WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky | theme: math4
 </div>
 

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -12,7 +12,7 @@ $libretexts_format = <<'ENDPROBLEMTEMPLATE';
 <link rel="stylesheet" type="text/css" href="/webwork2_files/js/vendor/bootstrap/css/bootstrap-responsive.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/jquery-ui-1.8.18.custom.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/vendor/font-awesome/css/font-awesome.min.css"/>
-<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css"/>
+<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/libretexts/libretexts.css"/>
 <link rel="stylesheet" type="text/css" href="/webwork2_files/css/knowlstyle.css"/>
 
 <!-- JS Loads -->

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -95,8 +95,8 @@ $LTIGradeMessage
 	   // jQuery methods go here...
 	});
 </script>
-<div class="clickme">
-<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+<div class="clickme" id="version">
+<img height="16px" width="16px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
 </div>
 <div id="footer" style="display:none">
 WeBWorK &copy; 1996-2020 | host: $SITE_URL | course: $courseID | format: libretexts | theme: math4

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -39,11 +39,9 @@ $problemHeadText
 <body>
 <div class="container-fluid">
 <div class="row-fluid">
-<div class="span12 problem">	
-<hr/>		
+<div class="span12 problem">		
 $answerTemplate
-<hr/>
-<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post">
+<form id="problemMainForm" class="problem-main-form" name="problemMainForm" action="$FORM_ACTION_URL" method="post" style="margin-bottom:-20px">
 <div id="problem_body" class="problem-content" $PROBLEM_LANG_AND_DIR>
 $problemText
 </div>
@@ -84,9 +82,26 @@ $LTIGradeMessage
 </div>
 </div>
 </div>
-<div id="footer">
+
+<!--  script for knowl-like object -->
+<script>
+	$(document).ready(function(){
+		$( ".clickme" ).click(function() {
+		  $( this).next().slideToggle( "slow", function() {
+			// Animation complete.
+		  });
+		});
+
+	   // jQuery methods go here...
+	});
+</script>
+<div class="clickme">
+<img height="8px" width="8px" src="https://demo.webwork.rochester.edu/webwork2_files/images/webwork_square.svg"/>
+</div>
+<div id="footer" style="display:none">
 WeBWorK &copy; 1996-2019 | host: $SITE_URL | course: $courseID | format: sticky | theme: math4
 </div>
+
 <!-- Activate local storage js -->
 <script type="text/javascript">WWLocalStorage();</script>
 </body>

--- a/t/test2_libretexts_format.html
+++ b/t/test2_libretexts_format.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>libretexts format</title>
+	<meta name="generator" content="BBEdit 13.0" />
+</head>
+<body>
+<iframe allowtransparency="true" 
+		frameborder="0" 
+		width = 80%
+		height= 600
+		src="https://webwork.libretexts.org/webwork2/html2xml?
+		&answersSubmitted=0&
+		&sourceFilePath=Library/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedTrigFunctions.pg&
+		&problemSeed=1234567&
+		&courseID=anonymous&
+		&userID=anonymous&
+		&course_password=anonymous&
+		&showSummary=1&
+		&displayMode=MathJax&
+		&problemIdentifierPrefix=102&
+		&language=en&
+		&outputformat=libretexts"  
+		></iframe>
+</body>
+</html>

--- a/t/test_libretexts_format.html
+++ b/t/test_libretexts_format.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>libretexts format</title>
+	<meta name="generator" content="BBEdit 13.0" />
+</head>
+<body>
+<iframe allowtransparency="true" 
+		frameborder="0" 
+		width = 80%
+		height= 600
+		src="http://127.0.0.1/webwork2/html2xml?
+		&answersSubmitted=0&
+		&sourceFilePath=Library/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedTrigFunctions.pg&
+		&problemSeed=1234567&
+		&courseID=daemon_course&
+		&userID=daemon&
+		&course_password=daemon&
+		&showSummary=1&
+		&displayMode=MathJax&
+		&problemIdentifierPrefix=102&
+		&language=en&
+		&outputformat=libretexts"  
+		></iframe>
+</body>
+</html>

--- a/t/ucdavis_libretexts_format.html
+++ b/t/ucdavis_libretexts_format.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>libretexts format</title>
+	<meta name="generator" content="BBEdit 13.0" />
+</head>
+<body>
+<iframe allowtransparency="true" 
+		frameborder="0" 
+		width = 80%
+		height= 600
+		src="https://webwork.libretexts.org/webwork2/html2xml?
+		&answersSubmitted=0&
+		&sourceFilePath=Library/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedTrigFunctions.pg&
+		&problemSeed=1234567&
+		&courseID=anonymous&
+		&userID=anonymous&
+		&course_password=anonymous&
+		&showSummary=1&
+		&displayMode=MathJax&
+		&problemIdentifierPrefix=102&
+		&language=en&
+		&outputformat=libretexts"  
+		></iframe>
+</body>
+</html>


### PR DESCRIPTION
CSS settings that match the use of webwork in Libretexts  (libretexts.org).

There is a potential for continual adjustments as the css for webwork and libretexts evolve so I have created a new theme libretexts (which initially was math4)  and an xmlhtml format
libretexts_format.pl which was initially sticky_format.

I would like to be able to override the css for knowles with entry in libretexts/libretexts.css,
specifically set the bottom-border to 0 width but I couldn't  make the entry in libretexts.css take precedence.  

This PR  replaces PR #1101