### PR TITLE
Add 'raw' format to FormatRenderedProblem.pm

### DIFF
--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -229,6 +229,10 @@ PerlModule WebworkWebservice
         Require all granted
 </Location>
 
+########### For "raw" json format ###########
+<Location /webwork2/html2xml>
+    Header set Access-Control-Allow-Origin "*"
+</Location>
 
 
 ########## WebworkWebservice SOAP handler ##########

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -230,9 +230,24 @@ PerlModule WebworkWebservice
 </Location>
 
 ########### For "raw" json format ###########
-<Location /webwork2/html2xml>
-    Header set Access-Control-Allow-Origin "*"
-</Location>
+# If a remote site is using this WW server to process WW problems
+# and embed them into web pages, the web browser might not permit
+# the WW problems to be displayed, as it violates security policy
+# to mix content from different originis without an explicit
+# directive from the WW server that it is safe.
+# Uncomment the following to set the header to enable Cross-Origin
+# Resource Sharing (CORS).
+# You will also need to enable headers via something like:
+# sudo a2enmod headers
+# to use this. 
+# This is not actually needed to use the client formats unless
+# they are accessed from a *remote* server. 
+
+#<IfModule mod_headers.c>
+#    <Location /webwork2/html2xml>
+#        Header set Access-Control-Allow-Origin "*"
+#    </Location>
+#</IfModule>
 
 
 ########## WebworkWebservice SOAP handler ##########

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -444,7 +444,7 @@ EOS
 
 	my $format_name = $self->{inputs_ref}->{outputformat}//'standard';
 
-        # The json output format is special and cannot be handled by the
+        # The json and raw output formats are special and cannot be handled by the
 	# the standard code
 	if ( $format_name eq "json" ) {
 	  my %output_data_hash;
@@ -477,6 +477,22 @@ EOS
 	  return $json_output_data;
 	}
 
+	# This format returns javascript object notation corresponding to the perl hash
+	# with everything that a client-side application could use to work with the problem.
+	# There is no wrapping HTML "_format" template.
+	if ( $format_name eq "raw") {
+	  $output = {};
+	  # Everything that ships out with other formats can be constructed from these
+	  $output->{rh_result} = {%{$rh_result}};
+	  $output->{inputs_ref} = {%{$self->{inputs_ref}}};
+	  $output->{input} = {%{$self->{input}}};
+	  # The following could be constructed from the above, but this is a convenience
+	  $output->{answerTemplate} = $answerTemplate if ($answerTemplate);
+	  $output->{lang} = $PROBLEM_LANG_AND_DIR[2];
+	  $output->{dir} = $PROBLEM_LANG_AND_DIR[6];
+	  # Convert to JSON
+	  return to_json( $output ,{pretty=>1, canonical=>1});
+	}
 
 	# find the appropriate template in WebworkClient folder
 	my $template = do("WebworkClient/${format_name}_format.pl");

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -472,7 +472,7 @@ EOS
 	  }
 	  $output_data_hash{score} = $json_score;
 
-	  my $json_output_data = to_json( \%output_data_hash ,{pretty=>1, canonical=>1});
+	  my $json_output_data = encode_json( \%output_data_hash ,{pretty=>1, canonical=>1});
 	  # FIXME: Should set header of response to content_type("text/json; charset=utf-8");
 	  return $json_output_data;
 	}
@@ -491,7 +491,7 @@ EOS
 	  $output->{lang} = $PROBLEM_LANG_AND_DIR[2];
 	  $output->{dir} = $PROBLEM_LANG_AND_DIR[6];
 	  # Convert to JSON
-	  return to_json( $output ,{pretty=>1, canonical=>1});
+	  return encode_json( $output ,{pretty=>1, canonical=>1});
 	}
 
 	# find the appropriate template in WebworkClient folder


### PR DESCRIPTION
This adds a "format" named "raw" to FormatRenderedProblem.pm. Using this format, client-side javascript can easily access what it would need to build its own front end for the problem.

Here is an [example](https://webwork-dev.aimath.org/webwork2/html2xml?&problemSeed=1&answersSubmitted=1&AnSwEr0001=23&sourceFilePath=Library/Union/setLimitContinuity/ur_lr_5_4.pg&displayMode=MathJax&courseID=anonymous&userID=anonymous&course_password=anonymous&outputformat=raw) of an OPL problem being handled this way. Be sure to view course or your browser will try to process the JSON as HTML.

