### PR TITLE
Fix error in debug code in SubmitGrade.pm

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -336,7 +336,7 @@ my $response = eval {
     }
   } else {
     debug("Unable to update LMS grade $sourcedid. Error: ".($response->message) );
-    debug(local_escape_html($response->content)); 
+    debug($self->local_escape_html($response->content)); 
     return 0;
   }
    debug("Success submitting grade using sourcedid: $sourcedid and score: $score\n") ;


### PR DESCRIPTION
Fix local_escape_html() invocation, so that error message can be properly displayed, as sugegsted by Nathan Wallach in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4770.