### PR TITLE
Fix a bug which prevented setting $server_apache_version in site.conf from functioning as intended and documented

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -997,7 +997,7 @@ sub write_log_entry {
 	    }
 
 	    if ($version) {
-		$APACHE24 = version->parse($version) >= version->parse('2.4');
+		$APACHE24 = version->parse($version) >= version->parse('2.4.0');
 	    }
 	}
 	# If its apache 2.4 then the API has changed

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -202,7 +202,7 @@ sub body {
 		    }
 
 		    if ($version) {
-			$APACHE24 = version->parse($version) >= version->parse('2.4');
+			$APACHE24 = version->parse($version) >= version->parse('2.4.0');
 		    }
 		}
 		# If its apache 2.4 then the API has changed

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -312,7 +312,7 @@ sub initialize {
 	    }
 
 	    if ($version) {
-		$APACHE24 = version->parse($version) >= version->parse('2.4');
+		$APACHE24 = version->parse($version) >= version->parse('2.4.0');
 	    }
 	}
 	# If its apache 2.4 then the API has changed


### PR DESCRIPTION
Fix a bug which prevented setting `$server_apache_version` in `site.conf` to something like '2.4.29' from helping to get WW to see the Apache version and handle the login info properly for Apache 2.4 servers with `ServerTokens Prod` or `ServerTokens Major` set in the Apache config. Providing such a setting was the documented approach to avoiding the issue which still occurs with such a setting.

After discovering the documentation I added a not about this to both the 2.15 install notes and to two forum threads where older workarounds for the problem were discussed. Then, I noticed that the setting was not really fixing the bug as claimed, and debugging why it failed to work lead to the patch proposed.

For initial review and testing - this is a patch to develop. Later a hotfix to WW 2.15 should be considered.

Without the patch error messages about
```
	Can't locate object method "remote_addr" via package "Apache2::Connection"
```
would be triggered when a password was submitted to the login page, or when trying to send a feedback email. Similar code in `Instructor/SendMail.pm` had the same correction made.

---

  - Security recommendations may recommend setting Apache to hide the version information in the banner it provides.
  - That is often done by setting `ServerTokens Prod` or `ServerTokens Major` set in the Apache config.
  - In Ubuntu 18.04 (and Docker versions of WW using Ubuntu 18.04) this is set is `/etc/apache2/conf-available/security.conf`.
  - [The WW 2.11 release notes](https://webwork.maa.org/wiki/Release_notes_for_WeBWorK_2.11) explain that a new setting was added to `site.conf.dist` to allow WW to behave properly with Apache 2.4 servers with these settings.
    - That setting is `$server_apache_version` and its use is explained in recent versions of `site.conf` and in those release notes, and the instructions are to use a value with 3 numeric parts like `2.22.1`.
    - However, with WW 2.15 this setting fails to work with such a setting and to overcome the issue, and the patch is intended to fix the problem.
     - Note: using a setting of `$server_apache_version = '2.4';` (without the 3rd number of the version code) does seem to work with the current code. That patched code will work with both forms of the setting.
    - See: https://github.com/openwebwork/webwork2/commit/7f21afa034d01417f42a9070810008a3770a9d44#diff-d7212ed759de7d3a30aa6dadc29f25f7 in which the code to handle this setting was added.
    - Note that the older code tested `$APACHE24 = version->parse($1) >= version->parse('2.4.00');` while the newer code has 
`$APACHE24 = version->parse($version) >= version->parse('2.4');`
    - Using only `2.4` and not `2.4.0` or `2.4.00` is what causes the trouble when the  `$server_apache_version` setting is used with a setting like `2.4.29` with 3 numeric parts.

---

People testing the patch may wish to add
```
warn "SAW in parse " . version->parse($version) ;
warn "GOT APACHE24 as $APACHE24\n";
```
just below the patched line, which helps show what is happening.

---
The patch is only needed on Apache 2.4 (not for Apache 2.2), so can only be tested with sufficiently recent versions of Apache.

Testing - before installing the patch:
  1. Configure Apache to use `ServerTokens Prod` or `ServerTokens Major` and make sure `$server_apache_version` is **not** set in `site.conf`.
  2. Restart WW.
  3. Attempt to login using a regular login page. It is expected that you will get an error page reporting the error message shown above about `remote_addr`.
  4. Now set `$server_apache_version = '2.4.29'` or something similar in `site.conf`.
  5. Restart WW.
  6. Attempt to login using a regular login page. It is expected that you will **still** get an error page reporting the error message shown above about `remote_addr`.
  7. Leave `$server_apache_version` set in `site.conf` but change Apache to use `ServerTokens Minor`.
  8. Restart WW.
  9. Attempt to login using a regular login page. It is expected that you will **still** get an error page reporting the error message shown above about `remote_addr`. (This is because the value of `$server_apache_version` takes priority over the server banner.)
  10. Comment out the `$server_apache_version` setting in `site.conf` and leave Apache using `ServerTokens Minor`.
  11. Restart WW.
  12. Attempt to login using a regular login page. It should work properly. (This is the behavior we are used to, and since use of the other settings was rare - the bug has hung around for a while.)

---

Testing - after installing the patch: Run through the 4 cases of the settings. The login page should work when either ServerTokens Minor` or when `ServerTokens Major` **and** `$server_apache_version` is set suitable (ex. to `2.4.29'). 
When `ServerTokens Major` is set and no value of `$server_apache_version` is provided - the issue will still occur.

---

Note: The patch fixes similar code used in sending emails. Without the patch to `Feedback.pm` the same sorts of errors would occur in the 3 problematic cases, while after the patch it should work properly in all cases.

---

Sample error from login page (the line numbers in the code may differ as I have some local modifications to various files, which are unrelated to the code being fixed here):

```
WeBWorK error
An error occured while processing your request. For help, please send mail to this site's webmaster (techdesk@mathnet.technion.ac.il), including all of the following information as well as what what you were doing when the error occured.

Mon Oct 05 11:05:48 2020

Warning messages
Error messages
Can't locate object method "remote_addr" via package "Apache2::Connection" at /opt/webwork/webwork2/lib/WeBWorK/Authen.pm line 1084.
Call stack
The information below can help locate the source of the problem.

in WeBWorK::Authen::write_log_entry called at line 705 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::checkPassword called at line 609 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::authenticate called at line 578 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::verify_normal_user called at line 335 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::do_verify called at line 216 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::verify called at line 160 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::call_next_authen_method called at line 213 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::verify called at line 388 of /opt/webwork/webwork2/lib/WeBWorK.pm

```

---

Sample error from after attempting to send a Feedback message using the form opened via "Email WeBWorK TA".

```
WeBWorK error
An error occured while processing your request. For help, please send mail to this site's webmaster (techdesk@mathnet.technion.ac.il), including all of the following information as well as what what you were doing when the error occured.

Mon Oct 05 10:57:14 2020

Warning messages
Error messages
Can't locate object method "remote_addr" via package "Apache2::Connection" at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm line 250.
Call stack
The information below can help locate the source of the problem.

in WeBWorK::ContentGenerator::Feedback::body called at line 155 of /opt/webwork/webwork2/lib/WeBWorK/Template.pm
in WeBWorK::Template::template called at line 611 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::content called at line 233 of /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm
in WeBWorK::ContentGenerator::go called at line 478 of /opt/webwork/webwork2/lib/WeBWorK.pm

```