### PR TITLE
Attempted fix to bug in XML handling of Value::Matrix when Context()->texStrings was active at ANS() level

### DIFF
--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -530,6 +530,17 @@ sub xml_filter {
 		return;
 	}
 	my $type = ref($input);
+
+	# The string value of a Value::Matrix object will often get mishandled below
+	# as the string form can contain HTML code including things like
+	#    class="ans_array", class="ans_array_open", class="ans_array_table"
+	#    class="ans_array_cell", class="ans_array_sep", class="ans_array_close"
+	# which get picked up and detected as an ARRAY reference when it is not.
+	# So bypass if necessary.
+	if ( ( "$type" eq "Value::Matrix" ) && ( "$input"=~/ARRAY/i ) ) {
+		#warn "Special processing of Value::Matrix" . $input;
+		return( "Value::Matrix object with string value: $input" );
+	}
 	
 	# Hack to filter out CODE references??
 	if (!defined($type) or !$type ) {


### PR DESCRIPTION
See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4933

The OPL problem `Library/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_30.pg` currently does not render "inline" inside the assignment editor.

Adding just after the `END_TEXT` line the following
``` 
Context()->normalStrings;
```
solves the problem for that file. so essentially the problem is caused by a relatively minor issue in how the PG code of the problem was written. However, there may be other problems with similar issues, and it seems to be possible to bypass the problem with the code in this PR.

---

The root problem is that when `Context()->texStrings` is still active, the value of `correct_ans` in the answer hash being sent to `xml_filter` for conversion to XML contains a string with HTML class settings which contain the string `ans_array` which causes `xml_filter` in `lib/WebworkWebservice/RenderProblem.pm` to try to treat it as an array reference, which it is not. Apparently when the `normalStrings` is turned back on, this does not occur.

The XML handling can apparently be fixed by the code in the PR.The code detects when a `Value::Matrix` is about to be processed by and incorrectly detected as an array reference, and heads off the incorrect handling and substitutes a string value into the XML being produced before the processing reaches the stage where problems occurred. It could be that a similar workaround may be needed for some other cases of a similar nature which make use of `array` (case insensitive) as substring of the value set for `correct_ans`.

---

Value seen in `correct_ans` when the problem occurred
```
correct_ans	=>	 <span class="ans_array" style="display:inline-block;vertical-align:.5ex"><span class="ans_array_open" style="display:inline-block; vertical-align:middle; margin-right:4px"><DIV STYLE="font-family: symbol; line-height:90%; margin: 0px 2px">⎡<BR>⎢<BR>⎢<BR>⎣</DIV></span><span class="ans_array_table" style="display:inline-table; vertical-align:middle"><span style="display:table-row"><span class="ans_array_cell" style="display:table-cell;vertical-align:middle;padding:4px 0;">0</span><span class="ans_array_sep" style="display:table-cell;vertical-align:middle;width:8px"></span><span class="ans_array_cell" style="display:table-cell;vertical-align:middle;padding:4px 0;">-1</span></span><span style="display:table-row"><span class="ans_array_cell" style="display:table-cell;vertical-align:middle;padding:4px 0;">1</span><span class="ans_array_sep" style="display:table-cell;vertical-align:middle;width:8px"></span><span class="ans_array_cell" style="display:table-cell;vertical-align:middle;padding:4px 0;">0</span></span></span><span class="ans_array_close" style="display:inline-block; vertical-align:middle; margin-left:4px"><DIV STYLE="font-family: symbol; line-height:90%; margin: 0px 2px">⎤<BR>⎥<BR>⎥<BR>⎦</DIV></span></span>
```