### PR TITLE
LTI account creation patches + discussion about aborted connections being reported by the database

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -501,13 +501,16 @@ sub create_user {
     }
   
   my $nr = scalar(@LTIroles);
+
+  my $LTI_webwork_permissionLevel;
   if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
     croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
-	  . $LTIroles[0] .".");
+	  . $LTIroles[0] ." so will create a student level account.");
+    $LTI_webwork_permissionLevel = $ce->{userRoles}->{student};
+  } else {
+    $LTI_webwork_permissionLevel = $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}};
   }
-  
-  my $LTI_webwork_permissionLevel 
-    = $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}};
+
   if ($nr > 1) {
     for (my $j =1; $j < $nr; $j++) {
       my $wwRole = $ce->{LMSrolesToWeBWorKroles}->{$LTIroles[$j]};

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -503,8 +503,9 @@ sub create_user {
   my $nr = scalar(@LTIroles);
 
   my $LTI_webwork_permissionLevel;
-  if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
-    croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
+  if ( ! defined( $ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]} ) ||
+       ! defined( $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}} ) ) {
+    warn("Cannot find a WeBWorK role that corresponds to the LMS role of "
 	  . $LTIroles[0] ." so will create a student level account.");
     $LTI_webwork_permissionLevel = $ce->{userRoles}->{student};
   } else {

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -517,12 +517,16 @@ sub authenticate
 			}
 			
 			my $nr = scalar(@LTIroles);
-			if (! defined($ce -> {userRoles} -> {$ce -> {LMSrolesToWeBWorKroles} -> {$LTIroles[0]}})) {
+
+			my $LTI_webwork_permissionLevel;
+			if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
 				croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
-						. $LTIroles[0] .".");
+						. $LTIroles[0] ." so will create a student level account.");
+				$LTI_webwork_permissionLevel = $ce->{userRoles}->{student};
+			} else {
+				$LTI_webwork_permissionLevel = $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}};
 			}
-			my $LTI_webwork_permissionLevel 
-				= $ce -> {userRoles} -> {$ce -> {LMSrolesToWeBWorKroles} -> {$LTIroles[0]}};
+
 			if ($nr > 1) {
 				for (my $j =1; $j < $nr; $j++) {
 					my $wwRole = $ce -> {LMSrolesToWeBWorKroles} -> {$LTIroles[$j]};

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -519,8 +519,9 @@ sub authenticate
 			my $nr = scalar(@LTIroles);
 
 			my $LTI_webwork_permissionLevel;
-			if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
-				croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
+			if ( ! defined( $ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]} ) ||
+			     ! defined( $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}} ) ) {
+				warn("Cannot find a WeBWorK role that corresponds to the LMS role of "
 						. $LTIroles[0] ." so will create a student level account.");
 				$LTI_webwork_permissionLevel = $ce->{userRoles}->{student};
 			} else {


### PR DESCRIPTION
**Update:** The discussion thread gets into matters related to aborted connections being reported in the database logs.
See the forum post:  https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4958

---

I ran into an issue where a few LTI created accounts did not have a permission level set. Those accounts were reporting when login attempts were made a `WeBWorK error` something like below (pulled out of the Apache `error.log`):
```
Unable to retrieve your permissions, perhaps due to a collision between your request and that of another user (or possibly an unfinished request of yours). Please press the BACK button on your browser and try again. at
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm line 511.\n * in Carp::croak called at line 168 of
/opt/webwork/webwork2/lib/WeBWorK/Authz.pm\n * in WeBWorK::Authz::setCachedUser called at line 220 of
/opt/webwork/webwork2/lib/WeBWorK/Authz.pm\n * in WeBWorK::Authz::hasPermissions called at line 511 of
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm\n * in WeBWorK::Authen::check_user called at line 329 of
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm\n * in WeBWorK::Authen::do_verify called at line 216 of 
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm\n * in WeBWorK::Authen::verify called at line 160 of 
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm\n * in WeBWorK::Authen::call_next_authen_method called at line 213 of 
/opt/webwork/webwork2/lib/WeBWorK/Authen.pm\n * in WeBWorK::Authen::verify called at line 388 of 
/opt/webwork/webwork2/lib/WeBWorK.pm, referer: https://webwork.technion.ac.il/webwork2/104016_2021a
```

When I viewed the problematic accounts in the class list editor, the system automatically set a permission level, and reported `added missing permission level for user` (triggered in `lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm` and `lib/WeBWorK/ContentGenerator/Instructor/UserList.pm`). That resolved the problem.

---

It is not totally clear how an account was created in the few such cases without any permission level set.

I suspected that these students may have had a non-standard LMS role at the time they first accessed the LTI link. The most likely cause of such a problem would be missing LMS roles which are not defined in `%LMSrolesToWeBWorKroles` a conversion table defined as a hash in `conf/authen_LTI.conf` (and possibly modified elsewhere).

However, I tried to recreate such an error by modifying the conversion table for an old course, and got a different error when attempting to have LTI create an account, and no account was created (apparently due to the `croak`). Thus, it is not clear that a missing entry in the conversion table would lead to a missing permission level.

```
WeBWorK error
An error occured while processing your request. For help, please send mail to this site's webmaster (tREMOVED), including all of the following information as well as what what you were doing when the error occured.

Tue Oct 27 13:06:55 2020

Warning messages
Use of uninitialized value in hash element at /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm line 618.
Error messages
Cannot find a WeBWorK role that corresponds to the LMS role of Instructor. at /opt/webwork/webwork2/lib/WeBWorK.pm line 388.
Call stack
The information below can help locate the source of the problem.

in Carp::croak called at line 618 of /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm
in WeBWorK::Authen::LTIAdvanced::create_user called at line 547 of /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm
in WeBWorK::Authen::LTIAdvanced::authenticate called at line 343 of /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm
in WeBWorK::Authen::LTIAdvanced::verify_normal_user called at line 335 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::do_verify called at line 216 of /opt/webwork/webwork2/lib/WeBWorK/Authen.pm
in WeBWorK::Authen::verify called at line 388 of /opt/webwork/webwork2/lib/WeBWorK.pm
```

The `Use of uninitialized value in hash element at /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm line 618.` message is addressed in the second commit of the PR, by doing the `defined` test in 2 stages.

---

In any case, I am proposing to add a fallback setting for `$LTI_webwork_permissionLevel` as `student`  level so if the test
```
     defined( $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}} )
```
fails during the account creation process, the code will fall back to creating an account with `student` level access. To this end the `croak` is replaced by `warn`. With the patch and an intentionally damaged %LMSrolesToWeBWorKroles set in a course, account creation succeeded and a student account was created.

It is not clear if this fix will actually address the original problem of preventing an account from being created with an undefined permission level, which prevents logins from working, as I could not trigger that behavior (before applying the patch) but it will certainly reduce account creation issues in other cases.