### PR TITLE
Fix issue #1077

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -33,6 +33,11 @@ package configobject;
 
 use strict;
 use warnings;
+use utf8;
+
+binmode(STDIN, ':encoding(utf8)');
+binmode(STDOUT, ':encoding(utf8)');
+binmode(STDERR, ':encoding(utf8)');
 
 sub new {
 	my $class = shift;

--- a/lib/WebworkWebservice/CourseActions.pm
+++ b/lib/WebworkWebservice/CourseActions.pm
@@ -16,6 +16,11 @@ use WeBWorK::Utils::CourseManagement qw(addCourse);
 use WeBWorK::Debug;
 use WeBWorK::ContentGenerator::Instructor::SendMail;
 use JSON;
+use utf8;
+
+binmode(STDIN, ':encoding(utf8)');
+binmode(STDOUT, ':encoding(utf8)');
+binmode(STDERR, ':encoding(utf8)');
 
 use Time::HiRes qw/gettimeofday/; # for log timestamp
 use Date::Format; # for log timestamp
@@ -611,7 +616,7 @@ sub updateSetting {
 
 	# read in the file 
 
-	open(DAT, $filename) || die("Could not open file!");
+	open(DAT, "<:utf8", $filename) || die("Could not open file!");
 	my @raw_data=<DAT>;
 	close(DAT);
 


### PR DESCRIPTION
This is an attempt to fix the issue #1077 by forcing UTF-8 encoding to read and write configuration files.

Note: Because of the Windows text file saving mechanism, some unexpected situations can occur on Windows Server 2012/Windows 8.1 and earlier versions. Most commonly, in such circumstances languages other than English may experience garbled characters.  But this problem does not appear after Windows 10 Build 19041. To better support multilingual features maybe we should suggest users to upgrade to Windows Server 2018 or later.