### PR TITLE
Modifications to support use of the DBD::MariaDB driver instead of DBD::mysql

### DIFF
--- a/bin/load-OPL-global-statistics.pl
+++ b/bin/load-OPL-global-statistics.pl
@@ -53,6 +53,18 @@ my $global_sql_file = $ce->{problemLibrary}{root}.'/OPL_global_statistics.sql';
 if (-e $global_sql_file) {
 
   my ($dbi,$dbtype,$db,$host,$port) = split(':',$ce->{database_dsn});
+
+  # The MariaDB driver use a different DSN format
+  # Ex: DBI:MariaDB:database=webwork;host=db;port=3306
+
+  if ( $dbtype =~ /MariaDB/i ) {
+    ($db,$host,$port) = split(';',$db);
+    $db   =~ s/database=//;
+    $host =~ s/host=//;
+    $port =~ s/port=//;
+  }
+
+
   
   $host = 'localhost' unless $host;
 

--- a/bin/restore-OPL-tables.pl
+++ b/bin/restore-OPL-tables.pl
@@ -66,6 +66,16 @@ my $prepared_OPL_tables_file = "$prepared_OPL_tables_dir/OPL-tables.sql";
 
 my ($dbi,$dbtype,$db,$host,$port) = split(':',$ce->{database_dsn});
 
+# The MariaDB driver use a different DSN format
+# Ex: DBI:MariaDB:database=webwork;host=db;port=3306
+
+if ( $dbtype =~ /MariaDB/i ) {
+  ($db,$host,$port) = split(';',$db);
+  $db   =~ s/database=//;
+  $host =~ s/host=//;
+  $port =~ s/port=//;
+}
+
 $host = 'localhost' unless $host;
 
 $port = 3306 unless $port;

--- a/bin/upload-OPL-statistics.pl
+++ b/bin/upload-OPL-statistics.pl
@@ -32,6 +32,16 @@ my $ce = new WeBWorK::CourseEnvironment({
 
 my ($dbi,$dbtype,$db,$host,$port) = split(':',$ce->{database_dsn});
 
+# The MariaDB driver use a different DSN format
+# Ex: DBI:MariaDB:database=webwork;host=db;port=3306
+
+if ( $dbtype =~ /MariaDB/i ) {
+  ($db,$host,$port) = split(';',$db);
+  $db   =~ s/database=//;
+  $host =~ s/host=//;
+  $port =~ s/port=//;
+}
+
 $host = 'localhost' unless $host;
 
 $port = 3306 unless $port;
@@ -53,7 +63,17 @@ $ENV{'MYSQL_PWD'}=$dbpass;
 
 my $mysqldump_command = $ce->{externalPrograms}->{mysqldump};  
 
-`$mysqldump_command --host=$host --port=$port --user=$dbuser $db OPL_local_statistics > $output_file`;
+# Conditionally add --column-statistics=0 as MariaDB databases do not support it
+# see: https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
+#      https://github.com/drush-ops/drush/issues/4410
+
+my $column_statistics_off = "";
+my $test_for_column_statistics = `$mysqldump_command --help | grep 'column-statistics'`;
+if ( $test_for_column_statistics ) {
+  $column_statistics_off = " --column-statistics=0 ";
+}
+
+`$mysqldump_command --host=$host --port=$port --user=$dbuser $column_statistics_off $db OPL_local_statistics > $output_file`;
 
 print "Database File Created\n";
 

--- a/lib/WeBWorK/DB/Driver/SQL.pm
+++ b/lib/WeBWorK/DB/Driver/SQL.pm
@@ -61,6 +61,15 @@ sub new($$$) {
 	
 	my $self = $proto->SUPER::new($source, $params);
 	
+	# The DBD::MariaDB driver should not get the
+	#    mysql_enable_utf8mb4 or mysql_enable_utf8 settings,
+	# but DBD::mysql should.
+	my %utf8_parameters = ();
+	if ( $source =~ /DBI:mysql/ ) {
+	  $utf8_parameters{mysql_enable_utf8mb4} = 1;
+	  $utf8_parameters{mysql_enable_utf8} = 1;
+	}
+
 	# add handle
 	$self->{handle} = DBI->connect_cached(
 		$source,
@@ -70,8 +79,7 @@ sub new($$$) {
 			PrintError => 0,
 			RaiseError => 1,
 
-			mysql_enable_utf8mb4 => 1,
-			mysql_enable_utf8 => 1,  # for older versions of DBD-mysql Perl modules
+			%utf8_parameters,
 		},
 	);
 	die $DBI::errstr unless defined $self->{handle};

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -269,28 +269,52 @@ sub _get_db_info {
 	my $dsn = $self->{driver}{source};
 	my $username = $self->{params}{username};
 	my $password = $self->{params}{password};
-	
-	die "Can't call dump_table or restore_table on a table with a non-MySQL source"
-		unless $dsn =~ s/^dbi:mysql://i;
-	
-	# this is an internal function which we probably shouldn't be using here
-	# but it's quick and gets us what we want (FIXME what about sockets, etc?)
+
 	my %dsn;
-	DBD::mysql->_OdbcParse($dsn, \%dsn, ['database', 'host', 'port']);
-	die "no database specified in DSN!" unless defined $dsn{database};
+	if (      $dsn =~ m/^dbi:mariadb:/i ) {
+		# Expect DBI:MariaDB:database=webwork;host=db;port=3306
+		my ($dbi,$dbtype,$temp1) = split(':',$dsn);
+		( $dsn{database}, $dsn{host}, $dsn{port} ) = split(';',$temp1);
+		$dsn{database} =~ s/database=//;
+		$dsn{host} =~ s/host=// if ( defined $dsn{host} );
+		$dsn{port} =~ s/port=// if ( defined $dsn{port} );
+	} elsif ( $dsn =~ m/^dbi:mysql:/i ) {
+		# This code works for DBD::mysql
+		# this is an internal function which we probably shouldn't be using here
+		# but it's quick and gets us what we want (FIXME what about sockets, etc?)
+		DBD::mysql->_OdbcParse($dsn, \%dsn, ['database', 'host', 'port']);
+	} else {
+		die "Can't call dump_table or restore_table on a table with a non-MySQL/MariaDB source";
+	}
 	
+	die "no database specified in DSN!" unless defined $dsn{database};
+
+	my $mysqldump = $self->{params}{mysqldump_path};
+	# Conditionally add column-statistics=0 as MariaDB databases do not support it
+	# see: https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
+	#      https://github.com/drush-ops/drush/issues/4410
+
+	my $column_statistics_off = "";
+	my $test_for_column_statistics = `$mysqldump --help | grep 'column-statistics'`;
+	if ( $test_for_column_statistics ) {
+		$column_statistics_off = "[mysqldump]\ncolumn-statistics=0\n";
+		#warn "Setting in the temporary mysql config file for table dump/restore:\n$column_statistics_off\n\n";
+	}
+
 	# doing this securely is kind of a hassle...
 	my $my_cnf = new File::Temp;
 	$my_cnf->unlink_on_destroy(1);
 	chmod 0600, $my_cnf or die "failed to chmod 0600 $my_cnf: $!"; # File::Temp objects stringify with ->filename
 	print $my_cnf "[client]\n";
-	print $my_cnf "user=\"$username\"\n" if defined $username and length($username) > 0;
-	print $my_cnf "password=\"$password\"\n" if defined $password and length($password) > 0;
-	print $my_cnf "host=\"$dsn{host}\"\n" if defined $dsn{host} and length($dsn{host}) > 0;
-	print $my_cnf "port=\"$dsn{port}\"\n" if defined $dsn{port} and length($dsn{port}) > 0;
-	
+	print $my_cnf "user=$username\n" if defined $username and length($username) > 0;
+	print $my_cnf "password=$password\n" if defined $password and length($password) > 0;
+	print $my_cnf "host=$dsn{host}\n" if defined $dsn{host} and length($dsn{host}) > 0;
+	print $my_cnf "port=$dsn{port}\n" if defined $dsn{port} and length($dsn{port}) > 0;
+	print $my_cnf "$column_statistics_off" if $test_for_column_statistics;
+
 	return ($my_cnf, $dsn{database});
 }
+
 ####################################################
 # checking Fields
 ####################################################

--- a/lib/WeBWorK/Utils/CourseManagement/sql_single.pm
+++ b/lib/WeBWorK/Utils/CourseManagement/sql_single.pm
@@ -195,17 +195,38 @@ sub _get_db_info {
 	my $dsn = $ce->{database_dsn};
 	my $username = $ce->{database_username};
 	my $password = $ce->{database_password};
-	
-	die "Can't call dump_table or restore_table on a table with a non-MySQL source"
-		unless $dsn =~ s/^dbi:mysql://i;
-	
-	# this is an internal function which we probably shouldn't be using here
-	# but it's quick and gets us what we want (FIXME what about sockets, etc?)
+
 	my %dsn;
-	runtime_use "DBD::mysql";
-	DBD::mysql->_OdbcParse($dsn, \%dsn, ['database', 'host', 'port']);
-	die "no database specified in DSN!" unless defined $dsn{database};
+	if (      $dsn =~ s/^dbi:mariadb://i ) {
+		my ($dbi,$dbtype,$temp1) = split(':',$dsn);
+		( $dsn{database}, $dsn{host}, $dsn{port} ) = split(';',$db);
+		$dsn{database} =~ s/database=//;
+		$dsn{host} =~ s/host=// if ( defined $dsn{host} );
+		$dsn{port} =~ s/port=// if ( defined $dsn{port} );
+	} elsif ( $dsn =~ s/^dbi:mysql://i ) {
+		# This code works for DBD::mysql
+		# this is an internal function which we probably shouldn't be using here
+		# but it's quick and gets us what we want (FIXME what about sockets, etc?)
+		runtime_use "DBD::mysql";
+		DBD::mysql->_OdbcParse($dsn, \%dsn, ['database', 'host', 'port']);
+	} else {
+		die "Can't call dump_table or restore_table on a table with a non-MySQL/MariaDB source";
+	}
 	
+	die "no database specified in DSN!" unless defined $dsn{database};
+
+	my $mysqldump = $self->{params}{mysqldump_path};
+	# Conditionally add column-statistics=0 as MariaDB databases do not support it
+	# see: https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
+	#      https://github.com/drush-ops/drush/issues/4410
+
+	my $column_statistics_off = "";
+	my $test_for_column_statistics = `$mysqldump_command --help | grep 'column-statistics'`;
+	if ( $test_for_column_statistics ) {
+		$column_statistics_off = "[mysqldump]\ncolumn-statistics=0\n";
+warn "Setting in the temporary mysql config file for table dump/restore:\n$column_statistics_off\n\n";
+	}
+
 	# doing this securely is kind of a hassle...
 	my $my_cnf = new File::Temp;
 	$my_cnf->unlink_on_destroy(1);
@@ -215,7 +236,8 @@ sub _get_db_info {
 	print $my_cnf "password=$password\n" if defined $password and length($password) > 0;
 	print $my_cnf "host=$dsn{host}\n" if defined $dsn{host} and length($dsn{host}) > 0;
 	print $my_cnf "port=$dsn{port}\n" if defined $dsn{port} and length($dsn{port}) > 0;
-	
+	print $my_cnf "$column_statistics_off" if $test_for_column_statistics;
+
 	return ($my_cnf, $dsn{database});
 }
 


### PR DESCRIPTION
Modifications to allow use of the `DBD::MariaDB` driver instead of `DBD::mysql`.

The `DBD::MariaDB` driver handles UTF-8 by default, and does not need `mysql_enable_utf8mb4` or `mysql_enable_utf8` and would fail if they were given.

These changes are far beyond the initial one mentioned in https://github.com/openwebwork/webwork2/pull/1150#issuecomment-724196085 which was needed to allow using the new driver.

See:
  - https://github.com/openwebwork/webwork2/pull/1150
  - https://github.com/openwebwork/webwork2/issues/1157

---

Also included modifications to prevent `mysqldump` of mysql 8+ for reporting errors about `column-statistics` being missing from MariaDB databases by disabling column_statistic when the installed `mysqldump` command would support it.

See:
  - https://serverfault.com/questions/912162/mysqldump-throws-unknown-table-column-statistics-in-information-schema-1109
  - https://github.com/drush-ops/drush/issues/4410