### PR TITLE
Add code to automatically remove spurious "published" column

### DIFF
--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -332,6 +332,29 @@ sub _add_column_field_stmt {
 	my $sql_field_type = $self->field_data->{$field_name}{type};		
 	return "Alter table `$sql_table_name` add column `$sql_field_name` $sql_field_type";
 }
+
+####################################################
+# deleting Field column
+####################################################
+
+sub drop_column_field {
+	my $self = shift;
+	my $field_name = shift;
+	my $stmt = $self->_drop_column_field_stmt($field_name);
+	#warn "database command $stmt";
+	my $result = $self->dbh->do($stmt);
+	#warn "result of add column is $result";
+	#return  ($result eq "0E0") ? 0 : 1;    # failed result is 0E0
+	return 1;   #FIXME  how to determine if database update was successful???
+}
+
+sub _drop_column_field_stmt {
+	my $self = shift;	
+	my $field_name=shift;
+	my $sql_table_name = $self->sql_table_name;
+	my $sql_field_name = $self->sql_field_name($field_name);		
+	return "Alter table `$sql_table_name` drop column if exists `$sql_field_name` ";
+}
 ####################################################
 # checking Tables
 ####################################################


### PR DESCRIPTION
This automatically deletes the "published" column in several of the tables.  This column has not been used in a decade or more and is not created for recent courses. It does however hang around in tables that were created more than 10 years ago and produces annoying "Harmless:  published column is extra" messages. This deletes the columns and gets rid of the messages (after the deletion is reported).

The column "published" is not present no operation is performed.

To test unarchive an old course (more than 5 or 6 years old, perhaps more) from the admin course. 
Then upgrade that course. 
