### PR TITLE
Fix variable used to configure old answer macros

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1731,7 +1731,7 @@ $ConfigValues = [
 		  type => 'boolean'
 		},
 
-		{ var => 'pg{ansEvalDefaults}{useOldAnswerMacros}',
+		{ var => 'pg{specialPGEnvironmentVars}{useOldAnswerMacros}',
 		  doc => 'Use older answer checkers',
 		  doc2 => 'During summer 2005, a newer version of the answer checkers was implemented for answers which are functions and numbers.  The newer checkers allow more functions in student answers, and behave better in certain cases.  Some problems are specifically coded to use new (or old) answer checkers.  However, for the bulk of the problems, you can choose what the default will be here.  <p>Choosing <i>false</i> here means that the newer answer checkers will be used by default, and choosing <i>true</i> means that the old answer checkers will be used by default.',
 		  type => 'boolean'

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -384,7 +384,7 @@ my $ConfigStrings = [
 		  type => 'boolean'
 		},
 
-		{ var => 'pg{ansEvalDefaults}{useOldAnswerMacros}',
+		{ var => 'pg{specialPGEnvironmentVars}{useOldAnswerMacros}',
 		  doc => x('Use older answer checkers'),
 		  doc2 => x('During summer 2005, a newer version of the answer checkers was implemented for answers which are functions and numbers.  The newer checkers allow more functions in student answers, and behave better in certain cases.  Some problems are specifically coded to use new (or old) answer checkers.  However, for the bulk of the problems, you can choose what the default will be here.  <p>Choosing <i>false</i> here means that the newer answer checkers will be used by default, and choosing <i>true</i> means that the old answer checkers will be used by default.'),
 		  type => 'boolean'


### PR DESCRIPTION
The variable associated with the use-old-answer-checkers configuration was incorrect (it is in `specialPGEnvironmentVariables`, not `ansEvalDefaults`).  Not that anyone is using old answer checkers at this point, I expect.  Perhaps the option should be removed?  The new ones have been in place for over a decade.