### PR TITLE
Fix some OPL script issues

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -985,7 +985,7 @@ $dbh->disconnect;
 if ($ce->{problemLibrary}{showLibraryLocalStats} ||
     $ce->{problemLibrary}{showLibraryGlobalStats}) {
   print "\nUpdating Library Statistics.\n";
-  do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics';
+  do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics.pl';
 
   print "\nLoading global statistics (if possible).\n";
   do $ENV{WEBWORK_ROOT}.'/bin/load-OPL-global-statistics.pl';

--- a/bin/dump-OPL-tables.pl
+++ b/bin/dump-OPL-tables.pl
@@ -74,7 +74,6 @@ my $dbuser = $ce->{database_username};
 my $dbpass = $ce->{database_password};
 
 $dbuser = shell_quote($dbuser);
-$dbpass = shell_quote($dbpass);
 $db = shell_quote($db);
 
 $ENV{'MYSQL_PWD'}=$dbpass;

--- a/bin/load-OPL-global-statistics.pl
+++ b/bin/load-OPL-global-statistics.pl
@@ -68,7 +68,6 @@ EOS
   $dbh->commit();
 
   $dbuser = shell_quote($dbuser);
-  $dbpass = shell_quote($dbpass);
   $db = shell_quote($db);
 
   $ENV{'MYSQL_PWD'}=$dbpass;

--- a/bin/restore-OPL-tables.pl
+++ b/bin/restore-OPL-tables.pl
@@ -74,7 +74,6 @@ my $dbuser = $ce->{database_username};
 my $dbpass = $ce->{database_password};
 
 $dbuser = shell_quote($dbuser);
-$dbpass = shell_quote($dbpass);
 $db = shell_quote($db);
 
 $ENV{'MYSQL_PWD'}=$dbpass;

--- a/bin/upload-OPL-statistics.pl
+++ b/bin/upload-OPL-statistics.pl
@@ -46,7 +46,6 @@ my $output_file = "$domainname-$time-opl.sql";
 print "Dumping local OPL statistics\n";
 
 $dbuser = shell_quote($dbuser);
-$dbpass = shell_quote($dbpass);
 $db = shell_quote($db);
 
 $ENV{'MYSQL_PWD'}=$dbpass;


### PR DESCRIPTION
The $dbpass variable in the OPL scripts should not be shell quoted anymore.  It is not used in the shell command anymore.  This fixes an issue discovered in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=5018 when the database password contains characters like "*".

Also fix a long standing typo in OPL-update that causes the update-OPL-statistics.pl script not to be run as advertised.

I also have a question regarding the logic of in the OPL-update and when the two scripts update-OPL-statistics.pl and load-OPL-global-statistics.pl are run.  Shouldn't the first script only be run if $ce->{problemLibrary}{showLibraryLocalStats} is true, and the second script only be run if $ce->{problemLibrary}{showLibraryGlobalStats} is true, instead of both scripts being run if either is true?