### PR TITLE
Revised "WeBWorK errors" page code + error.log records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -314,6 +314,8 @@ RUN cd $APP_ROOT/webwork2/conf \
 	PerlPassEnv WEBWORK_SMTP_SERVER\n\
 	PerlPassEnv WEBWORK_SMTP_SENDER\n\
 	PerlPassEnv WEBWORK_TIMEZONE\n\
+	PerlPassEnv MIN_HTML_ERRORS\n\
+	PerlPassEnv JSON_ERROR_LOG\n\
 	\n<Perl>/' /etc/apache2/conf-enabled/webwork.conf
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,8 @@ RUN apt-get update \
 	libuniversal-isa-perl \
 	libtest-fatal-perl \
 	libjson-xs-perl \
+	libjson-maybexs-perl \
+	libcpanel-json-xs-perl \
 	libmoox-options-perl \
 	make \
 	netpbm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -314,8 +314,6 @@ RUN cd $APP_ROOT/webwork2/conf \
 	PerlPassEnv WEBWORK_SMTP_SERVER\n\
 	PerlPassEnv WEBWORK_SMTP_SENDER\n\
 	PerlPassEnv WEBWORK_TIMEZONE\n\
-	PerlPassEnv MIN_HTML_ERRORS\n\
-	PerlPassEnv JSON_ERROR_LOG\n\
 	\n<Perl>/' /etc/apache2/conf-enabled/webwork.conf
 
 EXPOSE 80

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -82,6 +82,7 @@ my @modulesList = qw(
 	Iterator
 	Iterator::Util
 	JSON
+	JSON::MaybeXS
 	Locale::Maketext::Lexicon
 	Locale::Maketext::Simple
 	LWP::Protocol::https

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -41,6 +41,9 @@ PerlChildInitHandler "sub { srand }"
 
 PerlModule mod_perl2
 
+PerlPassEnv MIN_HTML_ERRORS
+PerlPassEnv JSON_ERROR_LOG
+
 <Perl>
 
 #################################################################
@@ -90,6 +93,28 @@ $ENV{WEBWORK_SERVER_ADMIN} = $webwork_server_admin_email;
 eval "use lib '$pg_dir/lib'"; die $@ if $@;
 $WeBWorK::Constants::PG_DIRECTORY = $pg_dir;
 $ENV{PG_ROOT} = $pg_dir;
+
+#################################################################
+# Modify the manner in which errors are reported.
+# Uncommenting $ENV{MIN_HTML_ERRORS} = 1; will minimize the data provided
+#    on HTML error pages, which some security reviews request, as in particular
+#    the older output provided backtrace information which could help idenfify
+#    the code and version of the code being used on the server.
+#    The useful information will be in the Apache error.log file, with a UID
+#    displayed also in the HTML error page to help match up records.
+# Warning: The Apache error.log is available to system adminstrators but not to
+#    users with staff level accounts in the courses, so using the more secure
+#    settings requires more cooperation from the system administrators when
+#    debugging data is needed.
+# Uncommenting $ENV{JSON_ERROR_LOG} = 1; will change the output format in the
+#    Apache error.log file to be JSON based, which will make programmatic
+#    processing of the error reports easier, but can break the functionality
+#    of existing scripts which parse error.log.
+#################################################################
+
+#$ENV{MIN_HTML_ERRORS} = 1;
+#$ENV{JSON_ERROR_LOG} = 1;
+
 #################################################################
 # report server setup when child process starts up -- for example when restarting the server
 #################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,11 @@ services:
       # To turn on SSL in the running container
       #SSL: 1
 
+      # Control settings for error message handling by webwork2/lib/WeBWorK.pm
+      # The standard behavior is with both of these set to 0
+      MIN_HTML_ERRORS: 0
+      JSON_ERROR_LOG: 0
+
       # Change to A4 paper
       #PAPERSIZE: a4
 

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -37,7 +37,7 @@ use Date::Format;
 use WeBWorK;
 use Encode;
 use utf8;
-use JSON::MaybeXS;
+use JSON;
 use UUID::Tiny  ':std';
 
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
@@ -415,6 +415,7 @@ associated warnings.
 sub jsonMessage($$$@) {
 	my ($r, $warnings, $exception, $uuid, $time, @backtrace) = @_;
 
+	chomp $exception;
 	my @warnings = defined $warnings ? split m/\n+/, $warnings : ();
 
 	my %headers = MP2 ? %{$r->headers_in} : $r->headers_in;
@@ -438,7 +439,7 @@ sub jsonMessage($$$@) {
 		    encode_json( {%headers} ), ", ",
 		    encode_json("Warnings"), ": ", jsonWarningsList(@warnings), ", ",
 		    encode_json("Exception"), ": ",
-		    encode_json(chomp $exception), ", ",
+		    encode_json($exception), ", ",
 		    encode_json("Backtrace"), ": ", jsonBacktrace(@backtrace),
 		    " }" # End object
 		   );

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -92,23 +92,23 @@ sub handler($) {
 			#$warnings .= "$backtrace\n\n";
 			$warnings = Encode::encode_utf8($warnings);
 			$r->notes->set(warnings => $warnings);
-			
+
 			$log->warn("[$uri] $warning");
 		};
 	} else {
 		$warning_handler = sub {
 			my ($warning) = @_;
 			chomp $warning;
-			
+
 			my $warnings = $r->notes("warnings");
 			$warnings .= "$warning\n";
 			#my $backtrace = join("\n",backtrace());
 			#$warnings .= "$backtrace\n\n";
 			$r->notes("warnings" => $warnings);
-			
+
 			$log->warn("[$uri] $warning");
 		};
-		
+
 		# the exception handler generates a backtrace when catching an exception
 		my @backtrace;
 		my $exception_handler = sub {
@@ -116,24 +116,24 @@ sub handler($) {
 			die @_;
 		};
 	}
-	
+
 	# the exception handler generates a backtrace when catching an exception
 	my @backtrace;
 	my $exception_handler = sub {
 		@backtrace = backtrace();
 		die @_;
 	};
-	
+
 	my $result = do {
 		local $SIG{__WARN__} = $warning_handler;
 		local $SIG{__DIE__} = $exception_handler;
-		
+
 		eval { WeBWorK::dispatch($r) };
 	};
-	
+
 	if ($@) {
 		my $exception = $@;
-		
+
 		my $warnings = MP2 ? $r->notes->get("warnings") : $r->notes("warnings");
 		my $htmlMessage;
 		my $uuid = create_uuid_as_string(UUID_SHA1, UUID_NS_URL, $r->uri )
@@ -150,7 +150,7 @@ sub handler($) {
 			$r->send_http_header unless MP2; # not needed for Apache2
 			$htmlMessage = "<html lang=\"en-US\"><head><title>WeBWorK error</title></head><body>$htmlMessage</body></html>";
 		}
-		
+
 		# log the error to the apache error log
 		my $logMessage;
 		if ( JSON_ERROR_LOG ) {
@@ -164,7 +164,7 @@ sub handler($) {
 
 		$result = FORBIDDEN;
 	}
-	
+
 	return $result;
 }
 
@@ -188,12 +188,12 @@ Apache::WeBWorK.
 sub backtrace {
 	my $frame = 2;
 	my @trace;
-	
+
 	while (my ($pkg, $file, $line, $subname) = caller($frame++)) {
 		last if $pkg eq "Apache::WeBWorK";
 		push @trace, "in $subname called at line $line of $file";
 	}
-	
+
 	return @trace;
 }
 
@@ -217,7 +217,7 @@ associated warnings.
 sub htmlMessage($$$@) {
 	my ($r, $warnings, $exception, $uuid, $time, @backtrace) = @_;
 
-	# Warnings have html and look better scrubbed. 
+	# Warnings have html and look better scrubbed.
 
 	my $scrubber = HTML::Scrubber->new(
 	    default => 1,
@@ -243,7 +243,7 @@ sub htmlMessage($$$@) {
 	# if an explicit email address has not been set.
 
 	$ENV{WEBWORK_SERVER_ADMIN} = ($ENV{WEBWORK_SERVER_ADMIN}) ?$ENV{WEBWORK_SERVER_ADMIN}:$ENV{SERVER_ADMIN};
-	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined. 
+	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined.
 
 	my $admin = ($ENV{WEBWORK_SERVER_ADMIN}
 		? " (<a href=\"mailto:$ENV{WEBWORK_SERVER_ADMIN}\">$ENV{WEBWORK_SERVER_ADMIN}</a>)"
@@ -355,13 +355,13 @@ associated warnings.
 
 sub textMessage($$$@) {
 	my ($r, $warnings, $exception, $uuid, $time, @backtrace) = @_;
-	
+
 	#my @warnings = defined $warnings ? split m/\n+/, $warnings : ();
 	#$warnings = textWarningsList(@warnings);
 	chomp $exception;
 	my $backtrace = textBacktrace(@backtrace);
 	my $uri = $r->uri;
-	
+
 	return "[$uuid] [$uri] $exception\n$backtrace";
 }
 

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -242,8 +242,7 @@ sub htmlMessage($$$@) {
 	# and $ENV{SERVER_ADMIN} which is set by ServerAdmin in httpd.conf is used as a backup
 	# if an explicit email address has not been set.
 
-	$ENV{WEBWORK_SERVER_ADMIN} = ($ENV{WEBWORK_SERVER_ADMIN}) ?$ENV{WEBWORK_SERVER_ADMIN}:$ENV{SERVER_ADMIN};
-	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined.
+	$ENV{WEBWORK_SERVER_ADMIN} = $ENV{WEBWORK_SERVER_ADMIN} || $ENV{SERVER_ADMIN} // ''; #guarantee this variable is defined.
 
 	my $admin = ($ENV{WEBWORK_SERVER_ADMIN}
 		? " (<a href=\"mailto:$ENV{WEBWORK_SERVER_ADMIN}\">$ENV{WEBWORK_SERVER_ADMIN}</a>)"
@@ -258,21 +257,21 @@ sub htmlMessage($$$@) {
 
 	return <<EOF;
 <div style="text-align:left">
- <h1>WeBWorK error</h2>
+ <h1>WeBWorK error</h1>
  <p>An error occured while processing your request. For help, please send mail
  to this site's webmaster $admin, including all of the following information as
  well as what what you were doing when the error occured.</p>
  <p>$time</p>
- <h2>Error record identifier</h3>
+ <h2>Error record identifier</h2>
  <p style="color: #dc2a2a"><code>$uuid</code></blockquote>
- <h2>Warning messages</h3>
+ <h2>Warning messages</h2>
  <ul>$warnings</ul>
- <h2>Error messages</h3>
+ <h2>Error messages</h2>
  <blockquote style="color: #dc2a2a"><code>$exception</code></blockquote>
- <h2>Call stack</h3>
+ <h2>Call stack</h2>
    <p>The information below can help locate the source of the problem.</p>
    <ul>$backtrace</ul>
- <h2>Request information</h3>
+ <h2>Request information</h2>
  <table border="1">
   <tr><td>Method</td><td>$method</td></tr>
   <tr><td>URI</td><td>$uri</td></tr>
@@ -321,8 +320,7 @@ sub htmlMinMessage($$$@) {
 	# and $ENV{SERVER_ADMIN} which is set by ServerAdmin in httpd.conf is used as a backup
 	# if an explicit email address has not been set.
 
-	$ENV{WEBWORK_SERVER_ADMIN} = ($ENV{WEBWORK_SERVER_ADMIN}) ?$ENV{WEBWORK_SERVER_ADMIN}:$ENV{SERVER_ADMIN};
-	$ENV{WEBWORK_SERVER_ADMIN}= $ENV{WEBWORK_SERVER_ADMIN}//''; #guarantee this variable is defined.
+	$ENV{WEBWORK_SERVER_ADMIN} = $ENV{WEBWORK_SERVER_ADMIN} || $ENV{SERVER_ADMIN} // ''; #guarantee this variable is defined.
 
 	my $admin = ($ENV{WEBWORK_SERVER_ADMIN}
 		? " (<a href=\"mailto:$ENV{WEBWORK_SERVER_ADMIN}\">$ENV{WEBWORK_SERVER_ADMIN}</a>)"
@@ -330,14 +328,14 @@ sub htmlMinMessage($$$@) {
 
 	return <<EOF;
 <div style="text-align:left">
- <h1>WeBWorK error</h2>
+ <h1>WeBWorK error</h1>
  <p>An error occured while processing your request. For help, please send mail
  to this site's webmaster $admin, including all of the following information as
  well as what what you were doing when the error occured.</p>
  <p>$time</p>
- <h2>Error record identifier</h3>
+ <h2>Error record identifier</h2>
  <p style="color: #dc2a2a"><code>$uuid</code></blockquote>
- <h2>Error messages</h3>
+ <h2>Error messages</h2>
  <blockquote style="color: #dc2a2a"><code>$exception</code></blockquote>
 
 </div>


### PR DESCRIPTION
Various WW sites (including mine) have been subjected to security review using commercial scanning tools, which have reported various "security flaws" due to the information provided by "WeBWorK error" pages.

This PR is intended to allow a site to optionally:
  1. Minimize what is provided by the HTML"WeBWorK error" pages.
    - Controlled by the new `MIN_HTML_ERRORS` environment variable, set to true (`1`)to enable the new behavior.
  2. Store the data in the Apache `error.log` file in a JSON structure.
    - Controlled by the new `JSON_ERROR_LOG` environment variable, set to true (`1`)to enable the new behavior.

In all cases, the revised code assigns a UUID to each error record to allow matching up between the HTML error output (which students may get) and the data recorded in the Apache `error.log` file. This is particularly important when the `MIN_HTML_ERRORS` setting is turned on.

Setting the environment variables (and having the passed into the Apache mod_perl process) is necessary to enable the new options. I do not believe that this can be controlled via the `course.conf` file or similar configuration files, as errors may potentially occur when no course environment will be available, and none seems to be available to the code in `lib/Apache/WeBWorK.pm` where the main changes are.

Using the `MIN_HTML_ERRORS` should hopefully suffice for WeBWorK to no longer trigger significant warnings from the "WeBWorK error" pages.

Pay attention to the need to add `PerlPassEnv` lines for the new environment variables to the `/etc/apache2/conf-enabled/webwork.conf` file.

---

  * The first commit message has some details.
  * The second commit is just some white-space cleanup.