### PR TITLE
Fix Caliper errors

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1619,7 +1619,7 @@ sub body {
 		}
 
 		my $caliper_sensor = Caliper::Sensor->new($self->{ce});
-		if ($caliper_sensor->caliperEnabled()) {
+		if ($caliper_sensor->caliperEnabled() && defined($answer_log)) {
 			my $events = [];
 
 			my $startTime = $r->param('startTime');

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -200,7 +200,7 @@ sub process_and_log_answer{
 					);
 
 				my $caliper_sensor = Caliper::Sensor->new($self->{ce});
-				if ($caliper_sensor->caliperEnabled()) {
+				if ($caliper_sensor->caliperEnabled() && defined($answer_log) && !$authz->hasPermissions($effectiveUser, "dont_log_past_answers")) {
 					my $startTime = $r->param('startTime');
 					my $endTime = time();
 


### PR DESCRIPTION
Errors are thrown if there is no past answer on homework or quiz submit.
In particular is instructors submit when `dont_log_past_answers` permissions are set to `professor`