### PR TITLE
Fix the capaLibrary link in the modelCourse

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1183,7 +1183,7 @@ $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
  $pg{specialPGEnvironmentVars}{DragMath} = 0;
  $pg{specialPGEnvironmentVars}{CAPA_Tools}             = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Tools/",
  $pg{specialPGEnvironmentVars}{CAPA_MCTools}           = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_MCTools/",
- $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/macros/CAPA_Graphics/",
+ $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory} = "$courseDirs{templates}/Contrib/CAPA/CAPA_Graphics/",
  $pg{specialPGEnvironmentVars}{CAPA_Graphics_URL}      = "$webworkURLs{htdocs}/CAPA_Graphics/",
 
  push @{$pg{directories}{macrosPath}},  

--- a/courses.dist/modelCourse/templates/capaLibrary
+++ b/courses.dist/modelCourse/templates/capaLibrary
@@ -1,1 +1,1 @@
-Contrib/CAPA
+../../../libraries/webwork-open-problem-library/Contrib/CAPA


### PR DESCRIPTION
The capaLibrary link created in #1058 should point directly to the
location in Contrib, and not point to the Contrib link to the actual
Contrib location.  The isSymLink method of FileManager.pm does not fully
resolve link paths, and resolves this link to a path inside the course
directory.  As such it allows users to browse into the CAPA library path
in the File Manager, and edit files there.

This also corrects the $pg{specialPGEnvironmentVars}{CAPA_GraphicsDirectory}
variable value in defaults.config.  That should be the same as in
localOverrides.dist, and both of those should be the actual location of
the CAPA_Graphics directory in Contrib/CAPA.