### PR TITLE
Allow UTF-8 in achievement export/import/score

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -54,6 +54,8 @@ use WeBWorK::Debug;
 use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive sortAchievements);
 use DateTime;
 use Text::CSV;
+use Encode;
+use open IO => ':encoding(UTF-8)';
 
 #constants for forms and the various handlers
 use constant BLANK_ACHIEVEMENT => "blankachievement.at";


### PR DESCRIPTION
Without this patch

- UTF-8 characters in the name or description of achievements produce error "Wide character in print at /usr/lib/x86_64-linux-gnu/perl/5.30/IO/Handle.pm line 418." The file is created fine, anyway.
- The UTF-8 characters in the names of students are broken when exporting score table for achievements
- The import of achievements with UTF-8 in name or description fails. Only the first non-UTF-8 lines are imported, the rest is silently ignored.

The patch solves these problems. Replaces previously submitted (and closed) pull request https://github.com/openwebwork/webwork2/pull/1196
