### PR TITLE
send explicit courseId in feedbackMacro

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -519,6 +519,7 @@ sub output_footer{
 
 	print $self->feedbackMacro(
 		module             => __PACKAGE__,
+		courseId           => $courseName,	
 		set                => $self->{set}->set_id,
 		problem            => $problem->problem_id,
 		problemPath        => $problem->source_file,


### PR DESCRIPTION
This is one more minor update to the feedback_form data that WeBWorK sends when the 'email instructor/ta' button is overridden. Previously, our plugin had parsed the `courseId` from the URL of the request, but that is fragile (in the sense of expanding the use of this plugin to other WeBWorK providers / other applications that might want to make use of plugin.

This PR adds the `courseId` as a parameter to be sent explicitly with the rest of the POST'ed form data.

API documentation for the Q&A plugin is available [here](https://github.com/openlab-at-city-tech/webworkqa/), and we are aiming to release this plugin to the official WordPress Plugins directory alongside the release of WW 2.16. 

This plugin has been in use at CityTech for several years - see a preview of the functionality [here](https://openlab.citytech.cuny.edu/ol-webwork/). 

issue link: openlab-at-city-tech/webworkqa#195