### PR TITLE
Page Load speed tweak

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -48,7 +48,7 @@
 <script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
 <link rel="stylesheet" type="text/css" href="<!--#url type="webwork" name="htdocs"-->/node_modules/jquery-ui-dist/jquery-ui.min.css"/>
 <script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/node_modules/jquery-ui-dist/jquery-ui.min.js"></script>
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
 <!--#endif-->

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -5,8 +5,8 @@ if ($.widget) {
 }
 if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
 
-// Object for toggling the sidebar
-var ToggleNavigation = function () {
+(function() {
+	// Initialize navigation menu toggling
 	var threshold = 768
 	var windowwidth = $(window).width();
 	var navigation_element = $('#site-navigation');
@@ -15,13 +15,13 @@ var ToggleNavigation = function () {
 		$('#site-navigation').remove();
 		$('#toggle-sidebar-icon').removeClass('icon-chevron-left').addClass('icon-chevron-right');	
 		$('#content').removeClass('span10').addClass('span11');
-	}
+	};
 
 	var showSidebar = function () {
 		$('#body-row').prepend(navigation_element);
 		$('#toggle-sidebar-icon').addClass('icon-chevron-left').removeClass('icon-chevron-right');
 		$('#content').addClass('span10').removeClass('span11');	
-	}
+	};
 
 	var toggleSidebar = function () {
 		if ($('#toggle-sidebar-icon').hasClass('icon-chevron-left')) {
@@ -29,7 +29,7 @@ var ToggleNavigation = function () {
 		} else {
 			showSidebar();
 		}
-	}
+	};
 
 	// if no fish eye then collapse site-navigation 
 	if($('#site-links').length > 0 && !$('#site-links').html().match(/[^\s]/)) {
@@ -60,11 +60,6 @@ var ToggleNavigation = function () {
 			}
 		}); 
 	}
-}
-
-$(function(){
-	// Initialize navigation menu toggling
-	ToggleNavigation();
 
 	// Focus on a  results with error if one is around and focussable. 
 	$('.ResultsWithError').first().focus();
@@ -129,7 +124,7 @@ $(function(){
 	$('.problem_set_options a').addClass('btn btn-info');
 
 	// Problem formatting
-    $('#problemMainForm, form[name=gwquiz]').addClass('problem-main-form form-inline');
+	$('#problemMainForm, form[name=gwquiz]').addClass('problem-main-form form-inline');
 	$('.attemptResults').addClass('table table-condensed table-bordered');
 	$('.problem .problem-content').addClass('well well-small');
 	$('.answerComments').addClass('well');
@@ -318,5 +313,4 @@ $(function(){
 		}
 	});
 
-});    
-
+})();

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -70,7 +70,7 @@ var tabberOptions = {manualStartup:true};
 <!--#if can="output_JS"-->
 	<!--#output_JS-->
 <!--#endif-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
 <!--#endif-->

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -70,7 +70,7 @@ var tabberOptions = {manualStartup:true};
 <!--#if can="output_JS"-->
 	<!--#output_JS-->
 <!--#endif-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
 <!--#endif-->

--- a/lib/WebworkClient/json_format.pl
+++ b/lib/WebworkClient/json_format.pl
@@ -47,7 +47,7 @@ $nextBlock = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>
+<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js" defer></script>
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 ENDPROBLEMTEMPLATE
 

--- a/lib/WebworkClient/simple2_format.pl
+++ b/lib/WebworkClient/simple2_format.pl
@@ -28,7 +28,7 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
+<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js" defer></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -28,7 +28,7 @@ $simple_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
+<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js" defer></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -25,7 +25,7 @@ $standard_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/underscore/underscore.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/legacy/vendor/knowl.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
+<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js" defer></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 

--- a/lib/WebworkClient/sticky_format.pl
+++ b/lib/WebworkClient/sticky_format.pl
@@ -31,7 +31,7 @@ $sticky_format = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="/webwork2_files/js/vendor/jquery/modules/jstorage.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/LocalStorage/localstorage.js"></script>
 <script type="text/javascript" src="/webwork2_files/js/apps/Problem/problem.js"></script>
-<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js"></script>	
+<script type="text/javascript" src="/webwork2_files/themes/math4/math4.js" defer></script>	
 <script type="text/javascript" src="/webwork2_files/js/vendor/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
 $problemHeadText
 


### PR DESCRIPTION
Defer loading of the the math4.js script and remove the jQuery ready
function.  Just execute it as soon as it is loaded.

In newer version of jQuery, jQuery's ready function is supposed the execute when the DOMContentLoaded event occurs, but it seems to actually occur a bit later.  Even the DOMContentLoaded event seems to run to late to prevent flickering.

This seems to be the best option without really fixing things the right way.  That will probably need to be deferred until after the ww-2.16 release though.