### PR TITLE
Navigation restrictions for LMS

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -818,6 +818,9 @@ $authen{xmlrpc_module}  = "WeBWorK::Authen::XMLRPC";
 	download_hardcopy_format_pdf => "guest",
 	download_hardcopy_format_tex => "ta",
 	download_hardcopy_change_theme=> "ta", 
+
+    ##### UI modifications for LMS ######
+	navigation_allowed => "guest",  # default everyone is allowed
 );
 
 # This is the default permission level given to new students and students with

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -112,6 +112,34 @@ our %HC_FORMATS = (
 # UI subroutines
 ################################################################################
 
+sub path {
+	my ($self, $args) = @_;
+	my $r = $self->r;
+	my $authz = $r->authz;
+	
+	my @path;
+	
+	my $urlpath = $r->urlpath;
+	my $courseID = $urlpath->arg("courseID");
+	my $userID = $r->param('user');
+  
+  $self->SUPER::path($args);
+
+	# If regular navigation is restricted, we'll need a "go back" button in case students are using an iframe window within their LMS.
+  # Using browser navigation will only navigate away from the entire webwork iframe in that case.
+	if (defined $courseID) {
+		unless ($authz->hasPermissions($userID, "navigation_allowed")){
+			print CGI::button(
+        -name=>'goBackButton',
+        -class=>"nav_button",
+        -value=>'Go Back',
+        -onClick=>'window.history.back();');
+		}
+	}
+	
+	return "";
+}
+
 sub pre_header_initialize {
 	my ($self) = @_;
 	my $r = $self->r;

--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -30,7 +30,33 @@ use WeBWorK::CGI;
 use WeBWorK::Utils qw(cryptPassword dequote);
 use WeBWorK::Localize;
 
+sub path {
+	my ($self, $args) = @_;
+	my $r = $self->r;
+	my $authz = $r->authz;
+	
+	my @path;
+	
+	my $urlpath = $r->urlpath;
+	my $courseID = $urlpath->arg("courseID");
+	my $userID = $r->param('user');
+  
+	$self->SUPER::path($args);
 
+	# If regular navigation is restricted, we'll need a "go back" button in case students are using an iframe window within their LMS.
+	# Using browser navigation will only navigate away from the entire webwork iframe in that case.
+	if (defined $courseID) {
+		unless ($authz->hasPermissions($userID, "navigation_allowed")){
+			print CGI::button(
+        -name=>'goBackButton',
+        -class=>"nav_button",
+        -value=>'Go Back',
+        -onClick=>'window.history.back();');
+		}
+	}
+	
+	return "";
+}
 
 sub body {
 	my ($self) = @_;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1127,6 +1127,8 @@ sub path {
 	my $setName       = $urlpath->arg("setID") || '';
 	my $problemNumber = $urlpath->arg("problemID") || '';
 	my $prettyProblemNumber = $problemNumber;
+    my $authz = $r->authz;
+    my $userID = $r->param('user');
 
 	if ($setName) {
 	    my $set = $r->db->getGlobalSet($setName);
@@ -1140,6 +1142,15 @@ sub path {
 	          "$setName",    $r->location."/$courseName/$setName",
 	          "$prettyProblemNumber", $r->location."/$courseName/$setName/$problemNumber",
 	);
+
+    unless ($authz->hasPermissions($userID, "navigation_allowed")){
+        print CGI::button(
+            -name=>'goBackButton',
+            -class=>"nav_button",
+            -value=>'Go Back',
+            -onClick=>'window.history.back();');
+        return "";
+    }
 
 	print $self->pathMacro($args, @path);
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -109,10 +109,17 @@ sub nav {
 	my ($self, $args) = @_;
 	my $r = $self->r;
 	my $urlpath = $r->urlpath;
+    my $authz = $r->authz;
+	my $userID = $r->param('user');
 
 	my $courseID = $urlpath->arg("courseID");
 	#my $problemSetsPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::ProblemSets",  $r, courseID => $courseID);
 	my $problemSetsPage = $urlpath->parent;
+
+    # If navigation is restricted, we don't want to allow a student to navigate to a different problem set.
+	unless ($authz->hasPermissions($userID, "navigation_allowed")) {
+	    return "";
+    }
 	
 	my @links = ($r->maketext("Homework Sets") , $r->location . $problemSetsPage->path, $r->maketext("Homework Sets"));
 	return $self->navMacro($args, '', @links);
@@ -190,6 +197,12 @@ sub siblings {
 				     && !$LTIRestricted;
 				           }   @setIDs;
 	}
+
+    # restrict navigation to other problem sets if not allowed
+	unless ($authz->hasPermissions($user, "navigation_allowed")){
+		return "";
+	}
+
 
 	print CGI::start_div({class=>"info-box", id=>"fisheye"});
 	print CGI::h2($r->maketext("Sets"));


### PR DESCRIPTION
With excellent direction from Alex Jordan, I have added some modifications that give the ability to restrict navigation within WeBWorK.  

### Problem
WeBWorK can be used within an LMS where the problem sets are graded separately within the LMS.  However, this only works properly if the specific problem set that the LMS expects a grade for is navigated to directly from the LMS.  If the student then decides to do another problem set by navigating within WeBWorK, the grade for the second problem set is NOT sent back to the LMS.  It will only transfer if the link from the LMS is clicked.  This creates annoying sync issues.

If we restrict navigation by turning off all links within WeBWorK other than 
1. The User Settings link
2. Individual problems
3. Email TA
4. Hardcopy
then we can force the student to exit WeBWorK and navigate to the next problem set using the LMS.

### Solution
I created a new permission in `defaults.conf` called "navigation_allowed".  This is set to "guest" by default meaning that the default for everyone is allowed.

However, if you set `$permissionLevels{navigation_allowed} = "login_proctor";` or higher, then the students will no longer be able to see the sidebar links (except for "User Settings") nor the breadcrumb links.  Where the sibling window is supposed to show other problem sets, nothing is shown instead.  (The sibling window for the problem itself, where it shows other problems within a set, still shows.)  

Finally, when the student navigates to "User Settings" or "Hardcopy", they need to be able to navigate backwards.  If used within an LMS, they are most likely seeing an IFRAME and the back button on the browser won't work.  So I have rendered a "Go Back" button that simply runs a simple javascript command: "window.history.back()".

![image](https://user-images.githubusercontent.com/7821384/109908500-3f3fa000-7c59-11eb-9ebe-d4407a2551ea.png)

![image](https://user-images.githubusercontent.com/7821384/109908540-541c3380-7c59-11eb-941b-605053075b50.png)
