### PR TITLE
Problem Set Detail: view problem in versioned quiz, not undefined_set

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -2188,7 +2188,7 @@ sub body {
 				$viewProblemPage =
 					$urlpath->new(type =>'gateway_quiz',
 						      args => { courseID => $courseID,
-								setID => "Undefined_Set",
+								setID => ($editingSetVersion > 0) ? $fullSetID : "Undefined_Set",
 								problemID => "1" } );
 
 				my $seed = $problemToShow ? $problemToShow->problem_seed : "";

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -2390,7 +2390,7 @@ sub body {
 		    $viewProblemPage =
 			$urlpath->new(type =>'gateway_quiz',
 				      args => { courseID => $courseID,
-						setID => "Undefined_Set",
+						setID => ($editingSetVersion > 0) ? $fullSetID : "Undefined_Set",
 						problemID => "1" } );
 
 		    my $seed = $problemToShow ? $problemToShow->problem_seed : "";


### PR DESCRIPTION
Currently suppose a student has taken a quiz and has a quiz version. Make your way to the Set Detail page for that student, for that version: Classlist Editor, click the `#/#` for sets assigned to that student, and click the versioned quiz. Before this commit, if you click the eyeball icon, you will see the problem in an Undefined Set.

Since there is a version for this student, it seems better to use that. So now with this commit, you will be viewing the problem in the student's versioned quiz set.

This only affects the behavior of viewing the problem. If you click to _edit_ that problem, then view it from the editor, it is still usse an Undefined_Set. That sounds appropriate to me, but I haven't fully thought it through. Please comment if you feel that behavior should also change.

