### PR TITLE
avoid a comparison with an undefined variable

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -2004,12 +2004,14 @@ sub readSetDef {
 			}
 		}
 
-		if ($reducedScoringDate && ($reducedScoringDate < $time1 || $reducedScoringDate > $time2)) {
-		    warn $r->maketext("The reduced credit date should be between the open date [_1] and close date [_2]", $openDate, $dueDate);
-		} elsif ( $reducedScoringDate == 0 && $enableReducedScoring ne 'Y' ) {
-			# In this case - the date in the file was Unix epoch 0 (or treated as such),
-			# and unless $enableReducedScoring eq 'Y' we will leave it as 0.
-		} elsif (!$reducedScoringDate) {
+		if ($reducedScoringDate) {
+			if ($reducedScoringDate < $time1 || $reducedScoringDate > $time2) {
+				warn $r->maketext("The reduced credit date should be between the open date [_1] and close date [_2]", $openDate, $dueDate);
+			} elsif ( $reducedScoringDate == 0 && $enableReducedScoring ne 'Y' ) {
+				# In this case - the date in the file was Unix epoch 0 (or treated as such),
+				# and unless $enableReducedScoring eq 'Y' we will leave it as 0.
+			}
+		} else {
 		    $reducedScoringDate = $time2 - 60*$r->{ce}->{pg}{ansEvalDefaults}{reducedScoringPeriod};
 		}
 


### PR DESCRIPTION
If you have a set definition file that does not declare a reduce scoring date, then when you try to import it, there will be a comparison of that undefined date against 0, which gives an error/warning message. This edit simply pulls that little block of code up inside another conditional that was already present, that first checks if the reduced scoring date is defined.

To test, take a set definition file and manually edit it so that there is no reduced scoring date. Then import the problem set on`develop` and you should see the error. Then delete the problem set.

After merging this commit, import the problem set again and there will be no error.