### PR TITLE
Mathjax typeset on rerandomize in library browser

### DIFF
--- a/htdocs/js/apps/SetMaker/setmaker.js
+++ b/htdocs/js/apps/SetMaker/setmaker.js
@@ -412,7 +412,7 @@ function randomize(filepath, el) {
 	      // run typesetter depending on the displaymode
 	      if(displayMode=='MathJax')
               MathJax.startup.promise = MathJax.startup.promise.then(function() {
-				  return MathJax.typesetPromise([document.getElementById(el)]);
+				  return MathJax.typesetPromise(['#' + el]);
 			  });
 	      if(displayMode=='jsMath')
 		  jsMath.ProcessBeforeShowing(el);

--- a/htdocs/js/apps/SetMaker/setmaker.js
+++ b/htdocs/js/apps/SetMaker/setmaker.js
@@ -411,7 +411,9 @@ function randomize(filepath, el) {
 	      $('#'+el).html(data);
 	      // run typesetter depending on the displaymode
 	      if(displayMode=='MathJax')
-              MathJax.startup.promise = MathJax.startup.promise.then(function() { return MathJax.typesetPromise([el]); });
+              MathJax.startup.promise = MathJax.startup.promise.then(function() {
+				  return MathJax.typesetPromise([document.getElementById(el)]);
+			  });
 	      if(displayMode=='jsMath')
 		  jsMath.ProcessBeforeShowing(el);
 	      


### PR DESCRIPTION
In the library browser (setmaker) when the `Randomize` button is clicked on a problem, the TeX in the problem is not being typeset by MathJax.  The reason is that the html id of the element is passed and used and MathJax needs the element itself.

Without this pull request find some problems and click the randomize button.  The problem is reloaded and all TeX in the problem appears as `\(...\)`.

This was not introduced by the recent MathJax upgrade, but is also present in WeBWorK 2.15.
Edit:  Scratch that.  This was not present in WeBWorK 2.15.  My initial test was still on the develop branch.  I forgot my production server isn't on ww 2.15 anymore.