### PR TITLE
don't hide list labels on lists in problem set detail problems

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -1125,7 +1125,7 @@ div.problem_sets_options {
     padding-left: 0px;
 }
 
-#psd_list > li {
+#psd_list li.psd_list_row {
     list-style-type: none;
 }
 

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -1125,7 +1125,7 @@ div.problem_sets_options {
     padding-left: 0px;
 }
 
-#psd_list li {
+#psd_list > li {
     list-style-type: none;
 }
 


### PR DESCRIPTION
This is just a quick fix for an issue that bugged me as I am setting up courses for the next term.

Find a problem that has a list in it. For example, Library/PCC/BasicAlgebra/LinearInequalities/CompoundInequalityOr10.pg has an unordered list with some instructions for entering answers. Put this problem in a set, and then go to the Problem Set Detail page. Render all problems. The bullets for the ul will be missing.

This is because there is CSS that removes list labels, but the intent is just to remove the list labels on the problems themselves in the context of the problem set detail page, not on deeper lists within the problems. So the change to the CSS does that.

Perhaps it would be better to put a class on the problem set detail list and style that. This is a quick fix.

