### PR TITLE
Revert "Cookie code refactor, Use CGI::Cookie and support samesite"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,6 @@ RUN git clone --single-branch --branch master --depth 1 https://github.com/mathj
 # we need to change FROM before setting the ENV variables
 
 FROM ubuntu:18.04
-# Once ubuntu 20.04 is used, CGI.pm and CGI::Cookie will be new enough to
-# drop the cpanm install of CGI::Cookie which is needed to upgrade it.
 
 ENV WEBWORK_URL=/webwork2 \
     WEBWORK_ROOT_URL=http://localhost \
@@ -279,9 +277,7 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 
 # Phase 6 - install additional Perl modules from CPAN (not packaged for Ubuntu or outdated in Ubuntu)
 
-# Ubuntu 18.04 has CGI.pm 4.38-1 which is too old to support the cookie samesite attribute added in CGI.pm 4.45 - so install CGI::Cookie here to get an upgraded version.
-
-RUN cpanm install Statistics::R::IO CGI::Cookie \
+RUN cpanm install Statistics::R::IO \
     && rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # Now installed from Ubuntu packages:

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -32,6 +32,7 @@ my @apache1ModulesList = qw(
 
 my @apache2ModulesList = qw(
 	Apache2::Request
+	Apache2::Cookie
 	Apache2::ServerRec
 	Apache2::ServerUtil
 );
@@ -43,7 +44,6 @@ my @modulesList = qw(
 	Benchmark
 	Carp
 	CGI
-	CGI::Cookie
 	Class::Accessor
 	Dancer
 	Dancer::Plugin::Database

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -901,31 +901,6 @@ $gatewayGracePeriod = 120;
 $session_management_via = "session_cookie";
 #$session_management_via = "key";
 
-################################################################################
-# Cookie control settings
-################################################################################
-
-# The following variables can be set to control cookie behavior.
-
-# Set the value of the samesite attribute of the WeBWorK cookie:
-#    See: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
-#         https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-#         https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
-
-$CookieSameSite = "Strict";
-
-# Set the value of the secure cookie attribute:
-$CookieSecure = 0; # Default is 0 here, as 1 will not work without https
-
-# Set cookie lifetime for when $session_management_via eq "session_cookie"
-$CookieLifeTime = "+7d";
-
-# Set cookie lifetime for when $session_management_via ne "session_cookie"
-$CookieLifeTime2 = "+30d";
-
-# NOTE: the cookie lifespan settings use the CGI.pm relative time settings.
-# Search for "30 seconds from now" at https://metacpan.org/pod/CGI to see the various options.
-
 
 ################################################################################
 # PG subsystem options

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -498,33 +498,6 @@ $showeditors{simplepgeditor}   = 0;
 #  $session_management_via = "key";
 
 ################################################################################
-# Cookie control settings
-################################################################################
-
-# The following variables can be set to control cookie behavior.
-
-# Set the value of the samesite attribute of the WeBWorK cookie:
-#    See: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
-#         https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-#         https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
-
-#$CookieSameSite = "None";
-#$CookieSameSite = "Strict";
-#$CookieSameSite = "Lax";
-
-# Set the value of the secure cookie attribute:
-#$CookieSecure = 1;
-
-# Set cookie lifetime for when $session_management_via eq "session_cookie"
-#$CookieLifeTime = "+7d";
-
-# Set cookie lifetime for when $session_management_via ne "session_cookie"
-#$CookieLifeTime2 = "+30d";
-
-# NOTE: the cookie lifespan settings use the CGI.pm relative time settings.
-# Search for "30 seconds from now" at https://metacpan.org/pod/CGI to see the various options.
-
-################################################################################
 # Searching for set.def files to import 
 ################################################################################
 ## Uncomment below so that when the homework sets editor searches for set def

--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -1,6 +1,7 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2020 The WeBWorK Project, https://openwebworkorg.wordpress.com/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Logout.pm,v 1.17 2012/06/08 22:50:50 wheeler Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -26,6 +27,7 @@ use strict;
 use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
+use WeBWorK::Cookie;
 use WeBWorK::Localize;
 
 
@@ -36,6 +38,20 @@ sub pre_header_initialize {
 	my $db = $r->db;
 	my $authen = $r->authen;
 	
+	# get rid of stored authentication info (this is kind of a hack. i have a better way
+	# in mind but it requires pretty much rewriting Authen/Login/Logout. :-( FIXME)
+#	$authen->forget_verification;
+#	
+#	my $cookie = WeBWorK::Cookie->new($r,
+#		-name => "WeBWorKAuthentication",
+#		-value => "",
+#		-expires => "-1D",
+#		-domain => $r->hostname,
+#		-path => $ce->{webworkURLRoot},
+#		-secure => 0,
+#	);
+#	$r->headers_out->set("Set-Cookie" => $cookie->as_string);
+#
 	my $userID = $r->param("user_id");
 	my $keyError = '';
 #	eval { $db->deleteKey($userID) };

--- a/lib/WeBWorK/Cookie.pm
+++ b/lib/WeBWorK/Cookie.pm
@@ -1,6 +1,7 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2020 The WeBWorK Project, https://openwebworkorg.wordpress.com/
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: webwork2/lib/WeBWorK/Cookie.pm,v 1.1 2006/06/29 21:10:52 sh002i Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -17,7 +18,7 @@ package WeBWorK::Cookie;
 
 =head1 NAME
 
-WeBWorK::Cookie - inherit from either Apache::Cookie or CGI::Cookie
+WeBWorK::Cookie - inherit from either Apache::Cookie or Apache2::Cookie
 depending on mod_perl version.
 
 =head1 SYNOPSIS
@@ -34,13 +35,13 @@ use warnings;
 
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
-# This class inherits from Apache::Cookie under mod_perl and CGI::Cookie under mod_perl2
+# This class inherits from Apache::Cookie under mod_perl and Apache2::Cookie under mod_perl2
 BEGIN {
 	if (MP2) {
-		#require APR::Request::Error;
-		require CGI::Cookie;
-		CGI::Cookie->import;
-		push @WeBWorK::Cookie::ISA, "CGI::Cookie";
+		require Apache2::Cookie;
+        require APR::Request::Error;
+		Apache2::Cookie->import;
+		push @WeBWorK::Cookie::ISA, "Apache2::Cookie";
 	} else {
 		require Apache::Cookie;
 		Apache::Cookie->import;


### PR DESCRIPTION
Reverts openwebwork/webwork2#1149

@taniwallach:   Please re-open this pull request and revise.  In think there might be other issues in addition to the issue with the CookieLifeTime not being numeric.  One thing I noticed is that there is no support for setting the cookie to expire with session in your implementation (which should probably be the default when using key management).  I guess I didn't give this pull request as careful a review as I thought I had.