### PR TITLE
Add css files requested by problems to gateway quizzes

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2393,14 +2393,14 @@ sub output_JS{
 	if (ref($self->{pg}{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
 		# Avoid duplicates
-		$jsFiles{$_->{file}} = $_->{local} for @{$self->{pg}{flags}{extra_js_files}};
+		$jsFiles{$_->{file}} = $_->{external} for @{$self->{pg}{flags}{extra_js_files}};
 		for (keys(%jsFiles)) {
-			if ($jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
-				print CGI::start_script({type => "text/javascript",
-						src => "$site_url/$_"}), CGI::end_script();
-			} elsif (!$jsFiles{$_}) {
+			if ($jsFiles{$_}) {
 				print CGI::start_script({type => "text/javascript",
 						src => $_}), CGI::end_script();
+			} elsif (!$jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
+				print CGI::start_script({type => "text/javascript",
+						src => "$site_url/$_"}), CGI::end_script();
 			} else {
 				print "<!-- $_ is not available in htdocs/ on this server -->\n";
 			}
@@ -2440,13 +2440,15 @@ sub output_CSS {
 	my %cssFiles;
 	# Avoid duplicates
 	if (ref($ce->{pg}{specialPGEnvironmentVars}{extra_css_files}) eq "ARRAY") {
-		$cssFiles{$_} = 1 for @{$ce->{pg}{specialPGEnvironmentVars}{extra_css_files}};
+		$cssFiles{$_} = 0 for @{$ce->{pg}{specialPGEnvironmentVars}{extra_css_files}};
 	}
 	if (ref($self->{pg}{flags}{extra_css_files}) eq "ARRAY") {
-		$cssFiles{$_} = 1 for @{$self->{pg}{flags}{extra_css_files}};
+		$cssFiles{$_->{file}} = $_->{external} for @{$self->{pg}{flags}{extra_css_files}};
 	}
 	for (keys(%cssFiles)) {
-		if (-f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
+		if ($cssFiles{$_}) {
+			print "<link rel=\"stylesheet\" type=\"text/css\" href=\"$_\" />\n";
+		} elsif (!$cssFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
 			print "<link rel=\"stylesheet\" type=\"text/css\" href=\"${site_url}/$_\" />\n";
 		} else {
 			print "<!-- $_ is not available in htdocs/ on this server -->\n";

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2390,21 +2390,19 @@ sub output_JS{
 	print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/ImageView/imageview.js"}), CGI::end_script();
 
 	# Add JS files requested by problems via ADD_JS_FILE() in the PG file.
-	if (defined($self->{pg}{flags}{extra_js_files})) {
+	if (ref($self->{pg}{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
 		# Avoid duplicates
-		for (@{$self->{pg}{flags}{extra_js_files}}) {
-			$jsFiles{$_->{file}} = $_->{local};
-		}
+		$jsFiles{$_->{file}} = $_->{local} for @{$self->{pg}{flags}{extra_js_files}};
 		for (keys(%jsFiles)) {
-			if ($jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/js/$_") {
+			if ($jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
 				print CGI::start_script({type => "text/javascript",
-						src => "$site_url/js/$_"}), CGI::end_script();
+						src => "$site_url/$_"}), CGI::end_script();
 			} elsif (!$jsFiles{$_}) {
 				print CGI::start_script({type => "text/javascript",
-						src => "$_"}), CGI::end_script();
+						src => $_}), CGI::end_script();
 			} else {
-				print "<!-- $_ is not available in htdocs/js/ on this server -->\n";
+				print "<!-- $_ is not available in htdocs/ on this server -->\n";
 			}
 		}
 	}
@@ -2437,32 +2435,21 @@ sub output_CSS {
 	print "<link href=\"$site_url/js/apps/ImageView/imageview.css\" rel=\"stylesheet\" />\n";
 
 	# Add CSS files requested by problems via ADD_CSS_FILE() in the PG file
-	# or via a setting of $ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}
-	# which can be set in course.conf (the value should be an anon array).
-	my $pg = $self->{pg};
-	if ( defined( $pg->{flags}{extra_css_files} ) ||
-	     ( defined(  $ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}  ) &&
-	       scalar( @{$ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}} ) > 0   )
-	   ) {
-		my $baseDir = $ce->{webwork_htdocs_url};
-		my $webwork_dir  = $WeBWorK::Constants::WEBWORK_DIRECTORY;
-		my $cssFile;
-		my %cssFiles;
-		# Avoid duplicates
-		my @courseCssRequests = ();
-		if ( defined($ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files} ) ) {
-			@courseCssRequests = ( @{$ce->{pg}->{specialPGEnvironmentVars}->{extra_css_files}
-} );
-		}
-		foreach $cssFile ( @courseCssRequests, @{$pg->{flags}{extra_css_files}} ) {
-			$cssFiles{$cssFile} = 1;
-		}
-		foreach $cssFile ( keys( %cssFiles ) ) {
-			if ( -f "$webwork_dir/htdocs/css/$cssFile" ) { # FIXME - test for existence
-				print "<link rel=\"stylesheet\" type=\"text/css\" href=\"${baseDir}/css/$cssFile\" />\n";
-			} else {
-				print "<!-- $cssFile is not available in htdocs/css/ on this server -->\n";
-			}
+	# or via a setting of $ce->{pg}{specialPGEnvironmentVars}{extra_css_files}
+	# which can be set in course.conf (the value should be an anonomous array).
+	my %cssFiles;
+	# Avoid duplicates
+	if (ref($ce->{pg}{specialPGEnvironmentVars}{extra_css_files}) eq "ARRAY") {
+		$cssFiles{$_} = 1 for @{$ce->{pg}{specialPGEnvironmentVars}{extra_css_files}};
+	}
+	if (ref($self->{pg}{flags}{extra_css_files}) eq "ARRAY") {
+		$cssFiles{$_} = 1 for @{$self->{pg}{flags}{extra_css_files}};
+	}
+	for (keys(%cssFiles)) {
+		if (-f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
+			print "<link rel=\"stylesheet\" type=\"text/css\" href=\"${site_url}/$_\" />\n";
+		} else {
+			print "<!-- $_ is not available in htdocs/ on this server -->\n";
 		}
 	}
 


### PR DESCRIPTION
Add the method for adding css files passed from PG problems via ADD_CSS_FILE or via the extra_css_files key of the specialPGEnvironmentVars hash to gateway quizzes.

Also make it so that js and css files can be added that are not in the css or js sub-directories, but any subdirectory of htdocs on the server.

Generally clean up the coding of those methods.