### PR TITLE
Fix a minor regression on the homework sets editor page introduced in #1250.

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -1125,6 +1125,7 @@ div.problem_sets_options {
     padding-left: 0px;
 }
 
+#psd_list li.ui-sortable-placeholder,
 #psd_list li.psd_list_row {
     list-style-type: none;
 }


### PR DESCRIPTION
When dragging a problem to reorder problems in homework sets editor page a number now appears to the left of where the problem currently being dragged was.  This is because a placeholder is inserted.  That placeholder is also an `<li>` element, but the current style does not prevent that from having the usual list-style-type.