### PR TITLE
fix CAPA_Graphics symlink location

### DIFF
--- a/htdocs/CAPA_Graphics
+++ b/htdocs/CAPA_Graphics
@@ -1,1 +1,1 @@
-../../libraries/webwork-open-problem-library/Contrib/CAPA/graphics/CAPA_Graphics
+../../libraries/webwork-open-problem-library/Contrib/CAPA/CAPA_Graphics


### PR DESCRIPTION
Just noticed this symlink was incorrect. Not sure if the OPL changed where it keeps CAPA_graphics, but right now, it is here: https://github.com/openwebwork/webwork-open-problem-library/tree/master/Contrib/CAPA/CAPA_Graphics