### PR TITLE
Fix issues when viewing problems on another page from the library browser.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -576,7 +576,7 @@ sub pre_header_initialize {
 	# Check for a page refresh which causes a cached form resubmission.  In that case this is
 	# not a valid submission of answers.
 	$submitAnswers = 0, $self->{resubmitDetected} = 1
-	if ($submitAnswers && (!defined($formFields->{num_attempts}) ||
+	if ($set->set_id ne 'Undefined_Set' && $submitAnswers && (!defined($formFields->{num_attempts}) ||
 			(defined($formFields->{num_attempts}) &&
 				$formFields->{num_attempts} != $problem->num_correct + $problem->num_incorrect)));
 
@@ -1270,7 +1270,7 @@ sub title {
 	$out .= CGI::start_div({ class => "problem-sub-header" });
 
 	my $problemValue = $problem->value;
-	if (defined($problemValue)) {
+	if (defined($problemValue) && $problemValue ne "") {
 		my $points = $problemValue == 1 ? $r->maketext('point') : $r->maketext('points');
 		$out .= "($problemValue $points)";
 	}


### PR DESCRIPTION
Points are not defined for problems in the library browser, so don't try to show them.

The library browser does not record attempts, and so don't try to detect a browser refresh there.  This fixes issue openwebwork/pg#548.

These are both my fault.  I though I had checked the first, but didn't try the second.  I apparently don't use the library browser enough to catch these things.