### PR TITLE
Tweak gateway header

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2085,10 +2085,10 @@ sub body {
 				}
 
 				print CGI::start_div({class=>"gwProblem"});
-				print CGI::div({-id=>"prob$i"},"");
+				print CGI::div({-id=>"prob$i"}, $recordMessage);
 
 				# Output the problem header.
-				print CGI::h2($r->maketext("Problem [_1].", $problemNumber)), $recordMessage;
+				print CGI::h2($r->maketext("Problem [_1].", $problemNumber));
 
 				print CGI::start_span({ class => "problem-sub-header" });
 


### PR DESCRIPTION
Move the problem status message (about whether or not the answers were checked and recorded) up above the problem header in gateway quizzes.  Now that the problem points (and possibly source file path) are shown on the same line, this looks better.