### PR TITLE
Move the definition of the TEXINPUTS environment variable

### DIFF
--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -94,9 +94,6 @@ eval "use lib '$pg_dir/lib'"; die $@ if $@;
 $WeBWorK::Constants::PG_DIRECTORY = $pg_dir;
 $ENV{PG_ROOT} = $pg_dir;
 
-# Location of common tex input files for hardcopy generation
-$ENV{TEXINPUTS} = ".:$webwork_dir/conf/snippets/hardcopyThemes/common:";
-
 #################################################################
 # Modify the manner in which errors are reported.
 # Uncommenting $ENV{MIN_HTML_ERRORS} = 1; will minimize the data provided

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -14,6 +14,8 @@
 # Artistic License for more details.
 ################################################################################
 
+BEGIN { $ENV{TEXINPUTS} = ".:$ENV{WEBWORK_ROOT}/conf/snippets/hardcopyThemes/common:"; }
+
 package WeBWorK::ContentGenerator::Hardcopy;
 use base qw(WeBWorK::ContentGenerator);
 


### PR DESCRIPTION
Move the definition of the TEXINPUTS environment variable out of webwork.apache2.4-config.dist and just define it directly in
Hardcopy.pm.

The previous method works, but this makes it so that things don't break if a sysadmin does not update the webwork.apache2.4-config file.

On the other hand, if one had a desire to override the default location then one would now have to edit Hardcopy.pm.

So the decision as to whether or not this is the way to go comes down to whether or not this should be configurable.