### PR TITLE
Make it possible to override the default location of the common tex input files.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -294,6 +294,10 @@ $webworkDirs{tmp}           = "$webworkDirs{root}/tmp";
 #    $webworkDirs{valid_symlinks} = ["$webworkDirs{courses}/modelCourse/templates","/ww2/common/sets"];
 $webworkDirs{valid_symlinks}   = [];
 
+# Location of the common tex input files packages.tex, CAPA.tex, and PGML.tex
+# used for hardcopy generation.
+$webworkDirs{texinputs_common} = "$webworkDirs{root}/conf/snippets/hardcopyThemes/common";
+
 ################################################################################
 ##### The following locations are web-accessible.
 ################################################################################

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -558,6 +558,12 @@ $mail{feedbackRecipients}    = [
 # Be sure to choose one that is enabled!
 #$hardcopyTheme = "XeLaTeX-twoColumn";
 
+# Location of the common tex input files packages.tex, CAPA.tex, and PGML.tex
+# used for hardcopy generation.  Uncomment the following line and adjust the
+# path as needed to customize the TeX input files used for all themes in
+# hardcopy generation.  This location must contain the three files named above.
+#$webworkDirs{texinputs_common} = "$webworkDirs{root}/conf/snippets/hardcopyThemes/common";
+
 ################################################################################
 
 

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -94,6 +94,14 @@ eval "use lib '$pg_dir/lib'"; die $@ if $@;
 $WeBWorK::Constants::PG_DIRECTORY = $pg_dir;
 $ENV{PG_ROOT} = $pg_dir;
 
+# Location of common tex input files for hardcopy generation.  Uncomment the
+# following line and adjust the path between the two colons as needed to
+# customize the TeX input files used for all themes in hardcopy generation.
+# There are three required files that must be located in this path.  Those are
+# packages.tex, CAPA.tex, and PGML.tex.
+
+#$ENV{TEXINPUTS} = ".:$webwork_dir/conf/snippets/hardcopyThemes/common:";
+
 #################################################################
 # Modify the manner in which errors are reported.
 # Uncommenting $ENV{MIN_HTML_ERRORS} = 1; will minimize the data provided

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -869,7 +869,7 @@ sub generate_hardcopy_tex {
 
 	# Copy the common tex files into the bundle directory
 	my $ce = $self->r->ce;
-	my $commonTeXDir = "$ce->{webworkDirs}{conf}/snippets/hardcopyThemes/common";
+	my $commonTeXDir = $ENV{TEXINPUTS} =~ s/^\.:([^:]*):$/$1/r;
 	for (qw{packages.tex CAPA.tex PGML.tex}) {
 		my $cp_cmd = "2>&1 $ce->{externalPrograms}{cp} " . shell_quote("$commonTeXDir/$_", $bundle_path);
 		my $cp_out = readpipe $cp_cmd;

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -14,7 +14,10 @@
 # Artistic License for more details.
 ################################################################################
 
-BEGIN { $ENV{TEXINPUTS} = ".:$ENV{WEBWORK_ROOT}/conf/snippets/hardcopyThemes/common:"; }
+BEGIN {
+	$ENV{TEXINPUTS} = ".:$ENV{WEBWORK_ROOT}/conf/snippets/hardcopyThemes/common:"
+	unless defined($ENV{TEXINPUTS});
+}
 
 package WeBWorK::ContentGenerator::Hardcopy;
 use base qw(WeBWorK::ContentGenerator);


### PR DESCRIPTION
Make it possible to override the default location of the common tex input files so that it is possible for the hardcore tex enthusiasts to modify those files.

This was suggested by @Alex-Jordan in #1265.