### PR TITLE
Remove Dancer and Dancer::Plugin::Database from bin/check_modules.pl and Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,8 +131,6 @@ RUN apt-get update \
 	libarchive-zip-perl \
 	libcrypt-ssleay-perl \
 	libdatetime-perl \
-	libdancer-perl \
-	libdancer-plugin-database-perl \
 	libdbd-mysql-perl \
 	libemail-address-xs-perl \
 	libexception-class-perl \

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -46,8 +46,6 @@ my @modulesList = qw(
 	Carp
 	CGI
 	Class::Accessor
-	Dancer
-	Dancer::Plugin::Database
 	Data::Dump
 	Data::Dumper
 	Data::UUID


### PR DESCRIPTION
Those perl modules are not used by webwork2 (and will not be used by ww3 either).

The fact that these are here has bugged me for a while now.