### PR TITLE
ResurrectHW and reduced credit date

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -114,11 +114,16 @@ sub print_form {
     my @openSetCount;
     my $maxProblems=0;
 
-    #Find all of the closed sets and put them in form
+    #Find all of the closed sets or sets that are past their reduced scoring date and put them in form
 
     for (my $i=0; $i<=$#$sets; $i++) {
 	if (after($$sets[$i]->due_date()) & $$sets[$i]->assignment_type eq "default") {
 	    push(@openSets,$$sets[$i]->set_id);
+	}
+	elsif (defined($$sets[$i]->reduced_scoring_date())) {
+		if (after($$sets[$i]->reduced_scoring_date()) & $$sets[$i]->assignment_type eq "default") {
+			push(@openSets,$$sets[$i]->set_id);
+		}
 	}
     }
 


### PR DESCRIPTION
ResurrectHW is an achievement item. If you have earned it, you may select a problem set that is past the close date, and then it changes the close date and reduced credit date to 24 hours from now, and randomizes all seeds.

Before this commit, if you are past the reduced credit date but not past the close date, you may not use ResurrectHW on that set. But you could wait out the reduced credit period, and then use it. And get 24 hours of access to exercises for full credit.

It's silly to make the student wait out the reduced credit period if they just want to use this item to get that 24 hour access for 100% credit. This commit allows them to use it after the reduced credit period begins, but before the reduced credit period ends.