### PR TITLE
Make LMS name configurable

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -6,6 +6,11 @@
 # To enable this file, uncomment the appropriate lines in localOverrides.conf
 #############################################################################
 
+# This is a string that is used to name the LMS for end users,
+# for example in a message telling users to sign in through their LMS.
+$LMS_name = 'e.g., Blackboard, Canvas, Moodle, etc.';
+#$LMS_name = 'Desire2Learn';
+
 # Set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
 # debugging.  This is useful when setting things up for the first time because
 # different LMS systems have different parameters

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -53,12 +53,10 @@ BEGIN {
 
 our $GENERIC_ERROR_MESSAGE = 
 	"Your authentication failed.  Please return to "
-	. "your Course Management System (e.g., Oncourse, Moodle, "
-	. "Blackboard, Canvas, Sakai, etc.)  and login again.";
+	. "your Course Management System ([_1]) and login again.";
 our $GENERIC_MISSING_USER_ID_ERROR_MESSAGE = 
 	"Your authentication failed.  Please return to "
-	. "your Course Management System (e.g., Oncourse, Moodle, "
-	. "Blackboard, Canvas, Sakai, etc.)  and login again.";
+	. "your Course Management System ([_1]) and login again.";
 our $GENERIC_DENIED_LOGIN_ERROR_MESSAGE = 
 	"You are not permitted to login into this site at this time. "
 	. "Please speak with your instructor.";
@@ -322,7 +320,7 @@ sub check_user {
 
 	if (!defined($user_id) or (defined $user_id and $user_id eq "")) {
 		$self->{log_error} .= "no user id specified";
-		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE);
+		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE, $ce->{LMS_name});
 		return 0;
 	}
 	
@@ -439,7 +437,7 @@ sub authenticate
 		{
 		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r);); 
 		$self -> {error} .= $r->maketext($GENERIC_ERROR_MESSAGE
-				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor");
+				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor", $ce->{LMS_name});
 		return 0;
 		}
 	#debug( "r->param(oauth_signature) = |" . $r -> param("oauth_signature") . "|");
@@ -766,7 +764,7 @@ sub authenticate
 		}
 	}
 	#debug("LTIBasic is returning a failed authentication");
-	$self -> {error} = $r->maketext($GENERIC_ERROR_MESSAGE);
+	$self -> {error} = $r->maketext($GENERIC_ERROR_MESSAGE, $ce->{LMS_name});
 	return(0);
 }
 

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -485,7 +485,7 @@ sub checkSet {
 	my $LTIGradeMode = $ce->{LTIGradeMode} // '';
 
 	if ($LTIGradeMode eq 'homework' && !$self->hasPermissions($userName, "view_unopened_sets")) {
-	  return $r->maketext("You must use your Learning Managment System (E.G. Blackboard, Moodle, Canvas, etc...) to access this set.  Try logging in to the Learning Managment System and visiting the set from there.")
+	  return $r->maketext("You must use your Learning Managment System ([_1]) to access this set.  Try logging in to the Learning Managment System and visiting the set from there.",$ce->{LMS_name})
 	    unless $set->lis_source_did;
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -207,9 +207,9 @@ sub body {
 	if ($externalAuth ) {
 		if ($authen_error) {
 			if ($r -> authen() eq "WeBWorK::Authen::LTIBasic") {
-				print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
+				print CGI::p($r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
 			} else {
-				print CGI::p({}, $r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course)));
+				print CGI::p($r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course), $ce->{LMS_name}));
 			}
 		} else {
 			print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -207,12 +207,12 @@ sub body {
 	if ($externalAuth ) {
 		if ($authen_error) {
 			if ($r -> authen() eq "WeBWorK::Authen::LTIBasic") {
-				print CGI::p({}, $r->maketext('[_1] uses an external authentication system (e.g., Oncourse,  CAS,  Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try again.', CGI::strong($course)));
+				print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
 			} else {
 				print CGI::p({}, $r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course)));
 			}
 		} else {
-		    print CGI::p({}, $r->maketext('[_1] uses an external authentication system (e.g., Oncourse,  CAS,  Blackboard, Moodle, Canvas, etc.).  Please return to system you used and try again.', CGI::strong($course)));
+			print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
 		} 
 	} else {
 		print CGI::p($r->maketext("Please enter your username and password for [_1] below:", CGI::b($course)));

--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -143,8 +143,7 @@ sub body {
 
 	if ( $externalAuth ) {
 	   	print 
-		CGI::p({}, CGI::b($courseID), "uses an external", 
-		"authentication system.  Please go there to login again.");
+		CGI::p($r->maketext("The course [_1] uses an external authentication system ([_2]). Please go there to login again.", CGI::b($courseID), $ce->{LMS_name}));
 	} else {
 		print CGI::start_form(-method=>"POST", -action=>$loginURL);
 	#	print CGI::hidden("user", $userID);  ### Line Commented out to suppress error message when this button is used.  WHW

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -485,7 +485,7 @@ sub setListRow {
 		$setIsOpen = 0;
 		$status .= restricted_progression_msg($r,0,$restriction,@restricted);
 	      } elsif ($LTIRestricted) {
-		$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System (e.g. Blackboard, Moodle, etc...).");   
+		$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System ([_1]).", $ce->{LMS_name});
 		$control = "" unless $preOpenSets;
 		$interactive = $display_name unless $preOpenSets;
 		$setIsOpen = 0;
@@ -538,7 +538,7 @@ sub setListRow {
 	    
 	    $setIsOpen = 0;
 	  } elsif ($LTIRestricted) {
-	    $status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System (e.g. Blackboard, Moodle, etc...).");   
+	    $status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System ([_1]).", $ce->{LMS_name});
 	    $control = "" unless $preOpenSets;
 	    $interactive = $display_name unless $preOpenSets;
 	    $setIsOpen = 0;

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -100,7 +100,7 @@ sub negquant {
 	    
 	    "_GUEST_LOGIN_MESSAGE"   => x(q{This course supports guest logins. Click [_1] to log into this course as a guest.}),
 
-	    "_EXTERNAL_AUTH_MESSAGE" => x(q{[_1] uses an external authentication system.  You've authenticated through that system, but aren't allowed to log in to this course.}),
+	    "_EXTERNAL_AUTH_MESSAGE" => x(q{The course [_1] uses an external authentication system ([_2]). You've authenticated through that system, but aren't allowed to log in to this course.}),
 	    
 	    "_PROBLEM_SET_SUMMARY"   => x(q{This is a table showing the current Homework sets for this class.  The fields from left to right are: Edit Set Data, Edit Problems, Edit Assigned Users, Visibility to students, Reduced Credit Enabled, Date it was opened, Date it is due, and the Date during which the answers are posted.  The Edit Set Data field contains checkboxes for selection and a link to the set data editing page.  The cells in the Edit Problems fields contain links which take you to a page where you can edit the containing problems, and the cells in the edit assigned users field contains links which take you to a page where you can edit what students the set is assigned to.}),
 	    


### PR DESCRIPTION
Set a string in a config file to give end users the name of the LMS. (Students at my school don't know what Blackboard, etc even is, so the reference is confusing.) 