### PR TITLE
turn GW 'test' into 'version'

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1219,7 +1219,7 @@ sub nav {
 								currentPage => $self->{pageNumber},
 								showProblemGrader => $self->{will}{showProblemGrader} }), $prevTest->{setVersion}),
 					data_toggle => "tooltip", data_placement => "top",
-					title => "$prevTest->{displayName} (test $prevTest->{setVersion})",
+					title => "$prevTest->{displayName} (version $prevTest->{setVersion})",
 					class => "nav_button student-nav-button"
 				}, $r->maketext("Previous Test"))
 			: CGI::span({ class => "gray_button" }, $r->maketext("Previous Test")),
@@ -1227,7 +1227,7 @@ sub nav {
 			CGI::start_span({ class => "btn-group student-nav-selector" }),
 			CGI::a({ class => "btn btn-primary dropdown-toggle", role => "button", data_toggle => "dropdown" },
 				$userRecords[$currentTestIndex]{displayName} .
-				" (test $userRecords[$currentTestIndex]{setVersion}) " .
+				" (version $userRecords[$currentTestIndex]{setVersion}) " .
 				CGI::span({ class => "caret" }, "")),
 			CGI::start_ul({ class => "dropdown-menu", role => "menu", aria_labelledby => "studentSelector" }),
 			(
@@ -1237,7 +1237,7 @@ sub nav {
 						href => sprintf($self->systemLink($setPage, params => { effectiveUser => $_->user_id,
 									currentPage => $self->{pageNumber},
 									showProblemGrader => $self->{will}{showProblemGrader} }), $_->{setVersion}) },
-					"$_->{displayName} (test $_->{setVersion})" )
+					"$_->{displayName} (version $_->{setVersion})" )
 					)
 				}
 				@userRecords[$minTestIndex ..  $maxTestIndex]
@@ -1251,7 +1251,7 @@ sub nav {
 								currentPage => $self->{pageNumber},
 								showProblemGrader => $self->{will}{showProblemGrader} }), $nextTest->{setVersion}),
 					data_toggle => "tooltip", data_placement => "top",
-					title => "$nextTest->{displayName} (test $nextTest->{setVersion})",
+					title => "$nextTest->{displayName} (version $nextTest->{setVersion})",
 					class => "nav_button student-nav-button"
 				}, $r->maketext("Next Test"))
 			: CGI::span({ class => "gray_button" }, $r->maketext("Next Test")),
@@ -1780,7 +1780,7 @@ sub body {
 	# a handy noun for when referring to a test
 	my $testNoun = (($set->attempts_per_version || 0) > 1) ? $r->maketext("submission") : $r->maketext("test");
 	my $testNounNum = (($set->attempts_per_version ||0) > 1)
-		? $r->maketext("submission (test [_1])",$versionNumber) : $r->maketext("test ([_1])",$versionNumber);
+		? $r->maketext("submission (version [_1])",$versionNumber) : $r->maketext("version ([_1])",$versionNumber);
 
 	##### start output of test headers:
 	##### display information about recorded and checked scores
@@ -1837,7 +1837,7 @@ sub body {
 			$recordedScore != $attemptScore && $can{showScore}) {
 			print CGI::start_div({class=>'gwMessage'});
 			my $recScore = wwRound(2,$recordedScore);
-			print $r->maketext("The recorded score for this test is  [_1]/[_2].",$recScore,$totPossible);
+			print $r->maketext("The recorded score for this version is  [_1]/[_2].",$recScore,$totPossible);
 			print CGI::end_div();
 		}
 
@@ -1847,7 +1847,7 @@ sub body {
 			print CGI::strong($r->maketext("Your score on this (checked, not recorded) submission is [_1]/[_2].",
 					$attemptScore,$totPossible)), CGI::br();
 			my $recScore = wwRound(2,$recordedScore);
-			print $r->maketext("The recorded score for this test is [_1]/[_2].",$recScore, $totPossible);
+			print $r->maketext("The recorded score for this version is [_1]/[_2].",$recScore, $totPossible);
 			print CGI::end_div();
 		}
 	}
@@ -1904,7 +1904,7 @@ sub body {
 			if ($can{showScore}) {
 				print CGI::start_div({class=>'gwMessage'});
 
-				my $scMsg = $r->maketext("Your recorded score on this test (number [_1]) is [_2]/[_3].",
+				my $scMsg = $r->maketext("Your recorded score on this test (version [_1]) is [_2]/[_3].",
 					$versionNumber, wwRound(2,$recordedScore), $totPossible);
 				if ($exceededAllowedTime && $recordedScore == 0) {
 					$scMsg .= $r->maketext("You exceeded the allowed time.");
@@ -1927,7 +1927,7 @@ sub body {
 		}
 
 		if ($canShowWork && $set->set_id ne "Undefined_Set") {
-			print $r->maketext("The test (which is number [_1]) may  no longer be submitted for a grade.",$versionNumber);
+			print $r->maketext("The test (which is version [_1]) may  no longer be submitted for a grade.",$versionNumber);
 			print "" . (($can{showScore}) ? $r->maketext("You may still check your answers.") : ".") ;
 
 			# print a "printme" link if we're allowed to see our

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -311,7 +311,7 @@ sub displayStudentStats {
 		     ( ! $authz->hasPermissions($r->param("user"), "view_hidden_work") &&
 		       ( $set->hide_score eq 'Y' || 
 			 ($set->hide_score eq 'BeforeAnswerDate' && time < $set->answer_date) ) ) ) {
-			push( @rows, CGI::Tr({}, CGI::td(WeBWorK::ContentGenerator::underscore2sp("${setID}_(test_" . $set->version_id . ")")), 
+			push( @rows, CGI::Tr({}, CGI::td(WeBWorK::ContentGenerator::underscore2sp("${setID}_(version_" . $set->version_id . ")")),
 					     CGI::td({colspan=>($max_problems+2)}, CGI::em($r->maketext("Display of scores for this set is not allowed.")))) );
 			next;
 		}
@@ -407,7 +407,7 @@ sub displayStudentStats {
 		# Otherwise we just add the set to the running course total
 		if ($setIsVersioned) {
 		  # prettify versioned set display
-		  $setName =~ s/(.+),v(\d+)$/${1}_(test_$2)/;
+		  $setName =~ s/(.+),v(\d+)$/${1}_(version_$2)/;
 		  my $gatewayName = $1;
 		  my $currentVersion = $2;
 

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -560,7 +560,7 @@ sub display_form {
  			(defined($mergedSet) && after($mergedSet->answer_date));
  		}
 	        # make display for versioned sets a bit nicer
-		$selected_set_id =~ s/,v(\d+)$/ (test $1)/;
+		$selected_set_id =~ s/,v(\d+)$/ (version $1)/;
 	
 		# FIXME!	
 		print CGI::p($r->maketext("Download hardcopy of set [_1] for [_2]?", $selected_set_id, $Users[0]->first_name." ".$Users[0]->last_name));

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -345,7 +345,7 @@ sub body {
 		                                editForUser   => $editForUserID,
 		});
 
-		my $setName = ( $setVersion ) ? "$setID (test $setVersion)" : $setID;
+		my $setName = ( $setVersion ) ? "$setID (version $setVersion)" : $setID;
 
 		print CGI::Tr(
 			CGI::td({ -align => "center" }, [

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -456,7 +456,7 @@ sub setListRow {
 	    # reset the link to give the test number
 	    my $vnum = $set->version_id;
 	    $interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(), href=>$interactiveURL},
-				  $r->maketext("[_1] (test [_2])", $display_name, $vnum));
+				  $r->maketext("[_1] (version [_2])", $display_name, $vnum));
 	  } else {
 	    my $t = time();
 	    if ( $t < $set->open_date() ) {
@@ -468,9 +468,9 @@ sub setListRow {
 	      }  
 	      if ( $preOpenSets ) {
 		# reset the link
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
 	      } else {
-		$interactive = $r->maketext("Take [_1] test", $display_name);
+		$interactive = $r->maketext("Start a version of [_1]", $display_name);
 	      }
 	      $control = "";
 	      
@@ -496,20 +496,20 @@ sub setListRow {
 	      if ($setIsOpen ||  $preOpenSets ) {
 		# reset the link
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL},
-				      $r->maketext("Take [_1] test.", $display_name));
+				      $r->maketext("Start a version of [_1].", $display_name));
 		$control = "";
 	      } else {
 		$control = "";
-		$interactive = $r->maketext("Take [_1] test.", $display_name);
+		$interactive = $r->maketext("Start a version of [_1].", $display_name);
 	      }
 	    } else {
 	      $status = $r->maketext("Closed.");
 	    
 	      if ( $authz->hasPermissions( $user, "record_answers_after_due_date" ) ) {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
 	      
 	      } else {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Take [_1] test", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
 	      }
 	    }
 	  } 


### PR DESCRIPTION
Instructors use Gateway for more than things that are "test"s. For example, quizzes.

Also, instructors have actual tests where they put "Test" in the set name. This has led to a student seeing confusing things like "Test 1 (test 2)" where "Test" is in the set name, and "test" is really the version. Or "Take Test 1 test".

So this commit tries to change the language so that "version" is used in all the appropriate places. 