### PR TITLE
display problem sets by urgency, with GW versions under their GW temp…

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -413,11 +413,6 @@ table.classlist-table .tbody {
 	padding-left:40px;
 }
 
-/* 80px chosen so "Start a version of" never has to wrap at default zoom */
-.problem_set_table tr.gw-version td.gw-version {
-	min-width:80px;
-}
-
 /* these are for indenting problems on jitar sets */
 .problem_set_table .nested-problem-1 {
     margin-left: 10px;

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -413,6 +413,10 @@ table.classlist-table .tbody {
 	padding-left:40px;
 }
 
+.problem_set_table a.gw-parenthetical {
+	font-weight:normal;
+}
+
 /* these are for indenting problems on jitar sets */
 .problem_set_table .nested-problem-1 {
     margin-left: 10px;

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -413,6 +413,11 @@ table.classlist-table .tbody {
 	padding-left:40px;
 }
 
+/* 80px chosen so "Start a version of" never has to wrap at default zoom */
+.problem_set_table tr.gw-version td.gw-version {
+	min-width:80px;
+}
+
 /* these are for indenting problems on jitar sets */
 .problem_set_table .nested-problem-1 {
     margin-left: 10px;

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -409,6 +409,9 @@ table.classlist-table .tbody {
     white-space: nowrap;
 }
 
+.problem_set_table tr.gw-version td.gw-version {
+	padding-left:40px;
+}
 
 /* these are for indenting problems on jitar sets */
 .problem_set_table .nested-problem-1 {

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -478,9 +478,9 @@ sub setListRow {
 	      }  
 	      if ( $preOpenSets ) {
 		# reset the link
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
 	      } else {
-		$interactive = $r->maketext("Start a version of [_1]", $display_name);
+		$interactive = $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name);
 	      }
 	      $control = "";
 	      
@@ -506,20 +506,20 @@ sub setListRow {
 	      if ($setIsOpen ||  $preOpenSets ) {
 		# reset the link
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL},
-				      $r->maketext("Start a version of [_1].", $display_name));
+				      $r->maketext("Start a version of[_1][_2].", CGI::br(), $display_name));
 		$control = "";
 	      } else {
 		$control = "";
-		$interactive = $r->maketext("Start a version of [_1].", $display_name);
+		$interactive = $r->maketext("Start a version of[_1][_2].", CGI::br(), $display_name);
 	      }
 	    } else {
 	      $status = $r->maketext("Closed.");
 	    
 	      if ( $authz->hasPermissions( $user, "record_answers_after_due_date" ) ) {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
 	      
 	      } else {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of [_1]", $display_name));
+		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
 	      }
 	    }
 	  } 
@@ -639,7 +639,7 @@ sub setListRow {
 	  
 	  return CGI::Tr(($gwtype == 1) ? {class => 'gw-version'} : {},
 		  CGI::td($control).
-		  CGI::td(($gwtype == 1) ? {class => 'gw-version'} : {},$interactive).
+		  CGI::td(($gwtype == 1) ? {class => 'gw-version'} : ($gwtype == 2) ? {class => 'gw-template'} : {},$interactive).
 		  CGI::td([$status,$score,$startTime]));
 	}
       }

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -506,11 +506,11 @@ sub setListRow {
 	      if ($setIsOpen ||  $preOpenSets ) {
 		# reset the link
 		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL},
-				      $r->maketext("Start a version of[_1][_2].", CGI::br(), $display_name));
+				      $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
 		$control = "";
 	      } else {
 		$control = "";
-		$interactive = $r->maketext("Start a version of[_1][_2].", CGI::br(), $display_name);
+		$interactive = $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name);
 	      }
 	    } else {
 	      $status = $r->maketext("Closed.");

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -471,7 +471,7 @@ sub setListRow {
 		} else {
 			my $t = time();
 			if ($set->{version_time_limit} > 0 && $t < $set->due_date()) {
-				$display_name = CGI::i({class=>"far fa-clock", title=>$r->maketext("This is a quiz with a time limit")}, '') . ' ' . $display_name;
+				$display_name = CGI::i({class=>"icon far fa-clock", title=>$r->maketext("Quiz with time limit"), data_alt => $r->maketext("Quiz with time limit.")}, '') . ' ' . $display_name;
 			}
 			if ( $t < $set->open_date() ) {
 				$status = $r->maketext("Will open on [_1].", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -505,7 +505,7 @@ sub setListRow {
 					$setIsOpen = 0;
 					$status .= restricted_progression_msg($r,0,$restriction,@restricted);
 				} elsif ($LTIRestricted) {
-					$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System (e.g. Blackboard, Moodle, etc...).");
+					$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System ([_1]).", $ce->{LMS_name});
 					$control = "" unless $preOpenSets;
 					$interactive = $display_name unless $preOpenSets;
 					$setIsOpen = 0;

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -463,7 +463,7 @@ sub setListRow {
 	    # reset the link to give the test number
 	    my $vnum = $set->version_id;
 	    $interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(), href=>$interactiveURL},
-				  $r->maketext("(version\xA0[_2])", $display_name, $vnum));
+				  $r->maketext("(version\xA0[_1])",, $vnum));
 	  } else {
 	    my $t = time();
 	    if ( $t < $set->open_date() ) {
@@ -690,7 +690,7 @@ sub set_due_msg {
   if ($enable_reduced_scoring &&
       $t < $reduced_scoring_date) {
     
-    $status .= $r->maketext("Open, due [_1], afterward reduced credit can be earned until [_2].", $beginReducedScoringPeriod, $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
+    $status .= $r->maketext("Open, due [_1].",$beginReducedScoringPeriod) . CGI::br() . $r->maketext("Afterward reduced credit can be earned until [_1].", $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
   } else {
     if ($gwversion) {
       $status = $r->maketext("Open, complete by [_1].",  $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
@@ -700,7 +700,7 @@ sub set_due_msg {
 
     if ($enable_reduced_scoring && $reduced_scoring_date &&
 	$t > $reduced_scoring_date) {
-      $status = $r->maketext("Due date [_1] has passed, reduced credit can still be earned until [_2].", $beginReducedScoringPeriod, $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
+      $status = $r->maketext("Due date [_1] has passed.",$beginReducedScoringPeriod) . CGI::br() . $r->maketext("Reduced credit can still be earned until [_1].", $self->formatDateTime($set->due_date(),undef,$ce->{studentDateDisplayFormat}));
     }
   }
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -444,85 +444,124 @@ sub setListRow {
 	my $setIsOpen = 0;
 	my $status = '';
 	if ( $gwtype ) {
-	  if ( $gwtype == 1 ) {
-	    unless (ref($problemRecords[0]) ) {warn "Error: problem not defined in set $display_name"; return()}
-	    if ( $set->attempts_per_version() &&
-		 $problemRecords[0]->num_correct() + 
-		 $problemRecords[0]->num_incorrect() >= 
-		 $set->attempts_per_version()) {
-	      $status = $r->maketext("Completed.");
-	    } elsif ( time() > $set->due_date() + 
-		      $self->r->ce->{gatewayGracePeriod} ) {
-	      $status = $r->maketext("Over time, closed.");
-	    } else {
-	      $status = $self->set_due_msg($set,1);
-	    }
-	    # we let people go back to old tests
-	    $setIsOpen = 1;
-	    
-	    # reset the link to give the test number
-	    my $vnum = $set->version_id;
-	    $interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(), href=>$interactiveURL},
-				  $r->maketext("(version\xA0[_1])",, $vnum));
-	  } else {
-	    my $t = time();
-	    if ( $t < $set->open_date() ) {
-	      $status = $r->maketext("Will open on [_1].", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));
-	      
-	      if (@restricted) {
-		my $restriction = ($set->restricted_status)*100;
-		$status .= restricted_progression_msg($r,1, $restriction, @restricted);
-	      }  
-	      if ( $preOpenSets ) {
-		# reset the link
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
-	      } else {
-		$interactive = $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name);
-	      }
-	      $control = "";
-	      
-	    } elsif ( $t < $set->due_date() ) {
-	      
-	      $status = $self->set_due_msg($set,0);
-	      
-	      if (@restricted) {
-		my $restriction = ($set->restricted_status)*100;
-		$control = "" unless $preOpenSets;
-		$interactive = $display_name unless $preOpenSets;
-		$setIsOpen = 0;
-		$status .= restricted_progression_msg($r,0,$restriction,@restricted);
-	      } elsif ($LTIRestricted) {
-		$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System (e.g. Blackboard, Moodle, etc...).");   
-		$control = "" unless $preOpenSets;
-		$interactive = $display_name unless $preOpenSets;
-		$setIsOpen = 0;
-	      } else {
-	      	$setIsOpen = 1;
-	      }
-	      
-	      if ($setIsOpen ||  $preOpenSets ) {
-		# reset the link
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL},
-				      $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
-		$control = "";
-	      } else {
-		$control = "";
-		$interactive = $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name);
-	      }
-	    } else {
-	      $status = $r->maketext("Closed.");
-	    
-	      if ( $authz->hasPermissions( $user, "record_answers_after_due_date" ) ) {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
-	      
-	      } else {
-		$interactive = CGI::a({class=>"set-id-tooltip", "data-toggle"=>"tooltip", "data-placement"=>"right", title=>"", "data-original-title"=>$globalSet->description(),href=>$interactiveURL}, $r->maketext("Start a version of[_1][_2]", CGI::br(), $display_name));
-	      }
-	    }
-	  } 
-	  # old conditional
+		if ( $gwtype == 1 ) {
+			unless (ref($problemRecords[0]) ) {warn "Error: problem not defined in set $display_name"; return()}
+			if ($set->attempts_per_version() && $problemRecords[0]->num_correct() + $problemRecords[0]->num_incorrect() >= $set->attempts_per_version()) {
+				$status = $r->maketext("Completed.");
+			} elsif ( time() > $set->due_date() + $self->r->ce->{gatewayGracePeriod} ) {
+				$status = $r->maketext("Over time, closed.");
+			} else {
+				$status = $self->set_due_msg($set,1);
+			}
+			# we let people go back to old tests
+			$setIsOpen = 1;
+			# reset the link to give the test number
+			my $vnum = $set->version_id;
+			$interactive = CGI::a(
+				{
+					class=>"set-id-tooltip gw-parenthetical",
+					"data-toggle"=>"tooltip",
+					"data-placement"=>"right",
+					title=>"",
+					"data-original-title"=>$globalSet->description(),
+					href=>$interactiveURL
+				},
+				$r->maketext("(version\xA0[_1])", $vnum)
+			);
+		} else {
+			my $t = time();
+			if ($set->{version_time_limit} > 0 && $t < $set->due_date()) {
+				$display_name = CGI::i({class=>"far fa-clock", title=>$r->maketext("This is a quiz with a time limit")}, '') . ' ' . $display_name;
+			}
+			if ( $t < $set->open_date() ) {
+				$status = $r->maketext("Will open on [_1].", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));
+				if (@restricted) {
+					my $restriction = ($set->restricted_status)*100;
+					$status .= restricted_progression_msg($r,1, $restriction, @restricted);
+				}
+				if ( $preOpenSets ) {
+					# reset the link
+					$interactive = CGI::a(
+						{
+							class=>"set-id-tooltip",
+							"data-toggle"=>"tooltip",
+							"data-placement"=>"right",
+							title=>"",
+							"data-original-title"=>$globalSet->description(),
+							href=>$interactiveURL
+						},
+						$display_name
+					);
+				} else {
+					$interactive = $display_name;
+				}
+				$control = "";
+			} elsif ( $t < $set->due_date() ) {
+				$status = $self->set_due_msg($set,0);
+				if (@restricted) {
+					my $restriction = ($set->restricted_status)*100;
+					$control = "" unless $preOpenSets;
+					$interactive = $display_name unless $preOpenSets;
+					$setIsOpen = 0;
+					$status .= restricted_progression_msg($r,0,$restriction,@restricted);
+				} elsif ($LTIRestricted) {
+					$status .= CGI::br().$r->maketext("You must log into this set via your Learning Management System (e.g. Blackboard, Moodle, etc...).");
+					$control = "" unless $preOpenSets;
+					$interactive = $display_name unless $preOpenSets;
+					$setIsOpen = 0;
+				} else {
+					$setIsOpen = 1;
+				}
+				if ($setIsOpen ||  $preOpenSets ) {
+					# reset the link
+					$interactive = CGI::a(
+						{
+							class=>"set-id-tooltip",
+							"data-toggle"=>"tooltip",
+							"data-placement"=>"right",
+							title=>"",
+							"data-original-title"=>$globalSet->description(),
+							href=>$interactiveURL
+						},
+						$display_name
+					);
+					$control = "";
+				} else {
+					$control = "";
+					$interactive = $display_name;
+				}
+			} else {
+				$status = $r->maketext("Closed.");
+				if ( $authz->hasPermissions( $user, "record_answers_after_due_date" ) ) {
+					$interactive = CGI::a(
+						{
+							class=>"set-id-tooltip",
+							"data-toggle"=>"tooltip",
+							"data-placement"=>"right",
+							title=>"",
+							"data-original-title"=>$globalSet->description(),
+							href=>$interactiveURL
+						},
+						$display_name
+					);
+				} else {
+					$interactive = CGI::a(
+						{
+							class=>"set-id-tooltip",
+							"data-toggle"=>"tooltip",
+							"data-placement"=>"right",
+							title=>"",
+							"data-original-title"=>$globalSet->description(),
+							href=>$interactiveURL
+						},
+						$display_name
+					);
+				}
+			}
+		}
+	# old conditional
 	} elsif (time < $set->open_date) {
-	  $status = $r->maketext("Will open on [_1].", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));
+		$status = $r->maketext("Will open on [_1].", $self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat}));
 	  
 	  if (@restricted) {
 	    my $restriction = ($set->restricted_status)*100;

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -290,7 +290,7 @@ sub body {
 	@vSets = sortByName(["set_id", "version_id"], @vSets);
 
 # put together a complete list of sorted sets to consider
-	@sets = (@nonGWsets, @gwSets );
+	@sets = sort byUrgency (@nonGWsets, @gwSets );
 	
 	debug("End preparing merged sets");
 
@@ -303,12 +303,14 @@ sub body {
 		if ($set->visible || $authz->hasPermissions($user, "view_hidden_sets")) {
 			print $self->setListRow($set, $authz->hasPermissions($user, "view_multiple_sets"), $authz->hasPermissions($user, "view_unopened_sets"),$existVersions,$db);
 		}
-	}
-	foreach my $set (@vSets) {
-		die "set $set not defined" unless $set;
-		
-		if ($set->visible || $authz->hasPermissions($user, "view_hidden_sets")) {
-			print $self->setListRow($set, $authz->hasPermissions($user, "view_multiple_sets"), $authz->hasPermissions($user, "view_unopened_sets"),$existVersions,$db,1, $gwSetsBySetID{$set->{set_id}}, "ethet" );  # 1 = gateway, versioned set
+		if (defined($gwSetNames{$set->set_id})) {
+			foreach my $vset (@vSets) {
+				die "set $vset not defined" unless $vset;
+				if (($set->set_id eq $vset->set_id) && ($vset->visible || $authz->hasPermissions($user, "view_hidden_sets"))) {
+					print $self->setListRow($vset, $authz->hasPermissions($user, "view_multiple_sets"), $authz->hasPermissions($user, "view_unopened_sets"),$existVersions,$db,1, $gwSetsBySetID{$vset->{set_id}});  # 1 = gateway, versioned set
+				}
+			}
+
 		}
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -284,8 +284,8 @@ sub body {
 	} elsif ( $sort eq 'status' ) {
 		@sets = sort byUrgency (@nonGWsets, @gwSets );
 	}
-# build a tree for set versions
-# first sort set versions by parent set name, then by version
+	# build a tree for set versions
+	# first sort set versions by parent set name, then by version
 	@vSets = sortByName(["set_id", "version_id"], @vSets);
 	my %vSetTree = ();
 	# initialize keys as the parent GW set ids
@@ -299,12 +299,9 @@ sub body {
 
 	debug("End preparing merged sets");
 
-# Regular sets and gateway template sets are merged, but sorted either by name or urgency.
-# Immediately following a gateway template set comes its set versions.
-# Note: this assumes that the set_id of a versioned GW set cannot differ from all of the corresponding GW versions.
-# In a future version of WeBWorK where instructors can change names of sets, that may not be a safe assumption.
-# Similarly, properties like visibility of a set version are directly interpreted from that property of the template set.
-# If that changes in the future, then this needs to be revisited.
+	# Regular sets and gateway template sets are merged, but sorted either by name or urgency.
+	# Immediately following a gateway template set comes its set versions.
+	# Note: this assumes that the set_id of a versioned GW set cannot differ from all of the corresponding GW versions.
 	foreach my $set (@sets) {
 		die "set $set not defined" unless $set;
 		


### PR DESCRIPTION
…late

Before this commit, the problem sets on the main course page are displayed:
* all non-GW sets first
* then GW templates
* then GW versioned sets

This can mean an urgent quiz is not visible until scrolling down off screen, if there are many non-GW sets.

The commit changes it so that non-GW and GW templates are mixed, sorted by urgency. Then, immediately following each GW template set, its versions come in their natural order.

(It would be nice if the versioned GW sets could be indented under their GW template set. But this whole thing is built as a table, and I'm not sure the right way to do that.)