### PR TITLE
LMS url in LTI config

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -11,6 +11,11 @@
 $LMS_name = 'e.g., Blackboard, Canvas, Moodle, etc.';
 #$LMS_name = 'Desire2Learn';
 
+# This is a URL that should take users to a place they can log in to their LMS.
+# It will use the text from $LMS_name, but use $LMS_url as the href.
+# If $LMS_url is empty or undefined, the text from $LMS_name is used with no link.
+#$LMS_url = 'https://myschool.edu/lms/';
+
 # Set debug_lti_parameters  to 1 to have LTI calling parameters printed to HTML page for
 # debugging.  This is useful when setting things up for the first time because
 # different LMS systems have different parameters

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -320,7 +320,8 @@ sub check_user {
 
 	if (!defined($user_id) or (defined $user_id and $user_id eq "")) {
 		$self->{log_error} .= "no user id specified";
-		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE, $ce->{LMS_name});
+		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
+		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE, $LMS);
 		return 0;
 	}
 	
@@ -433,13 +434,13 @@ sub authenticate
 	# Check nonce to see whether request is legitimate
 	#debug("Nonce = |" . $self-> {oauth_nonce} . "|");
 	my $nonce = WeBWorK::Authen::LTIBasic::Nonce -> new($r, $self -> {oauth_nonce}, $self -> {oauth_timestamp}); 
-	if (!($nonce -> ok ) )
-		{
+	if (!($nonce -> ok ) ) {
+		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
 		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r);); 
 		$self -> {error} .= $r->maketext($GENERIC_ERROR_MESSAGE
-				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor", $ce->{LMS_name});
+				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor", $LMS);
 		return 0;
-		}
+	}
 	#debug( "r->param(oauth_signature) = |" . $r -> param("oauth_signature") . "|");
 	my %request_hash;
 	my @keys = keys %{$r-> {paramcache}};

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -485,7 +485,8 @@ sub checkSet {
 	my $LTIGradeMode = $ce->{LTIGradeMode} // '';
 
 	if ($LTIGradeMode eq 'homework' && !$self->hasPermissions($userName, "view_unopened_sets")) {
-	  return $r->maketext("You must use your Learning Managment System ([_1]) to access this set.  Try logging in to the Learning Managment System and visiting the set from there.",$ce->{LMS_name})
+		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
+		return $r->maketext("You must use your Learning Managment System ([_1]) to access this set.  Try logging in to the Learning Managment System and visiting the set from there.",$LMS)
 	    unless $set->lis_source_did;
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -206,15 +206,11 @@ sub body {
 
 	if ($externalAuth ) {
 		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
-		if ($authen_error) {
-			if ($r -> authen() eq "WeBWorK::Authen::LTIBasic") {
-				print CGI::p($r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $LMS));
-			} else {
-				print CGI::p($r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course), $LMS));
-			}
+		if (!$authen_error || $r->authen() eq "WeBWorK::Authen::LTIBasic") {
+			print CGI::p($r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $LMS));
 		} else {
-			print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $LMS));
-		} 
+			print CGI::p($r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course), $LMS));
+		}
 	} else {
 		print CGI::p($r->maketext("Please enter your username and password for [_1] below:", CGI::b($course)));
 		if ($ce -> {session_management_via} ne "session_cookie") {

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -205,14 +205,15 @@ sub body {
 	}
 
 	if ($externalAuth ) {
+		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
 		if ($authen_error) {
 			if ($r -> authen() eq "WeBWorK::Authen::LTIBasic") {
-				print CGI::p($r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
+				print CGI::p($r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $LMS));
 			} else {
-				print CGI::p($r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course), $ce->{LMS_name}));
+				print CGI::p($r->maketext("_EXTERNAL_AUTH_MESSAGE", CGI::strong($course), $LMS));
 			}
 		} else {
-			print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $ce->{LMS_name}));
+			print CGI::p({}, $r->maketext('The course [_1] uses an external authentication system ([_2]). Please return to that system to access this course.', CGI::strong($course), $LMS));
 		} 
 	} else {
 		print CGI::p($r->maketext("Please enter your username and password for [_1] below:", CGI::b($course)));

--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -142,8 +142,9 @@ sub body {
 	print CGI::p($r->maketext("You have been logged out of WeBWorK."));
 
 	if ( $externalAuth ) {
+		my $LMS = ($ce->{LMS_url}) ? CGI::a({href => $ce->{LMS_url}},$ce->{LMS_name}) : $ce->{LMS_name};
 	   	print 
-		CGI::p($r->maketext("The course [_1] uses an external authentication system ([_2]). Please go there to login again.", CGI::b($courseID), $ce->{LMS_name}));
+		CGI::p($r->maketext("The course [_1] uses an external authentication system ([_2]). Please go there to log in again.", CGI::b($courseID), $LMS));
 	} else {
 		print CGI::start_form(-method=>"POST", -action=>$loginURL);
 	#	print CGI::hidden("user", $userID);  ### Line Commented out to suppress error message when this button is used.  WHW


### PR DESCRIPTION
This formalizes a clever hack that @drgrice1 posted in #1280. Separate from `$LMS_name`, you have `$LMS_url`. If the latter exists and is not empty, things that previously used plain `$LMS_name` will make a link with `$LMS_name` as the text, and `$LMS_url` as the href.

I made this change at all places where `$LMS_name` was used except in ProblemSets.pl. In that location, the LMS is referenced in a problem set's status field to say "you will need to go in through the LMS to get to this set". In practice in my own courses, the LMS may have release conditions that do not yet allow the student to get to the ELT link for that assignment. So it doesn't feel right to encourage the student to actually follow a link at that time.