### PR TITLE
Install Mathjax via npm

### DIFF
--- a/htdocs/mathjax
+++ b/htdocs/mathjax
@@ -1,1 +1,1 @@
-../../MathJax/
+node_modules/mathjax

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -28,6 +28,11 @@
             "resolved": "https://registry.npmjs.org/jquery-ui-themes/-/jquery-ui-themes-1.12.0.tgz",
             "integrity": "sha1-pXugrZaADYRSL+dok//L3mcIHVE="
         },
+        "mathjax": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.1.2.tgz",
+            "integrity": "sha512-BojKspBv4nNWzO1wC6VEI+g9gHDOhkaGHGgLxXkasdU4pwjdO5AXD5M/wcLPkXYPjZ/N+6sU8rjQTlyvN2cWiQ=="
+        },
         "nestedSortable": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/nestedSortable/-/nestedSortable-1.3.4.tgz",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -12,6 +12,7 @@
         "jquery": "3.5.1",
         "jquery-ui-dist": "1.12.1",
         "jquery-ui-themes": "1.12.0",
+        "mathjax": "^3.1.2",
         "nestedSortable": "^1.3.4"
     }
 }


### PR DESCRIPTION
This is a simple change that simplifies the webwork install process a bit.