### PR TITLE
Add an option to disable MathQuill answer boxes per response 

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -32,7 +32,7 @@ span[id^=mq-answer]
     margin-left: 0
 }
 
-input[type=text].codeshard
+input[type=text].codeshard.mq-edit
 {
     display: none !important;
 }

--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -33,8 +33,8 @@ $("[id^=MaThQuIlL_]").each(function() {
 	};
 
 	// Merge options that are set by the problem.
-	if (this.id + '_Opts' in window)
-		$.extend(cfgOptions, cfgOptions, window[this.id + '_Opts']);
+	var optOverrides = answerQuill.latexInput.data("mq-opts");
+	if (typeof(optOverrides) == 'object') $.extend(cfgOptions, optOverrides);
 
 	// This is after the option merge to prevent handlers from being overridden.
 	cfgOptions.handlers = {

--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -1,18 +1,21 @@
+"use strict"
+
 // initialize MathQuill
 var MQ = MathQuill.getInterface(2);
-answerQuills = {};
+var answerQuills = {};
 
 // Avoid conflicts with bootstrap.
 $.widget.bridge('uitooltip', $.ui.tooltip);
 
-function createAnswerQuill() {
+$("[id^=MaThQuIlL_]").each(function() {
 	var answerLabel = this.id.replace(/^MaThQuIlL_/, "");
 	var input = $("#" + answerLabel);
 	var inputType = input.attr('type');
-	if (typeof(inputType) != 'string' || inputType.toLowerCase() !== "text") return;
+	if (typeof(inputType) != 'string' || inputType.toLowerCase() !== "text" || !input.hasClass('codeshard')) return;
 
 	var answerQuill = $("<span id='mq-answer-" + answerLabel + "'></span>");
 	answerQuill.input = input;
+	input.addClass('mq-edit');
 	answerQuill.latexInput = $(this);
 
 	input.after(answerQuill);
@@ -173,6 +176,4 @@ function createAnswerQuill() {
 	}
 
 	answerQuills[answerLabel] = answerQuill;
-}
-
-$(function() { $("[id^=MaThQuIlL_]").each(createAnswerQuill); });
+});

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2398,10 +2398,8 @@ sub output_JS{
 	if ($self->{will}->{useMathQuill}) {
 		print qq{<link href="$site_url/js/apps/MathQuill/mathquill.css" rel="stylesheet" />};
 		print qq{<link href="$site_url/js/apps/MathQuill/mqeditor.css" rel="stylesheet" />};
-		print CGI::start_script({type=>"text/javascript",
-				src=>"$site_url/js/apps/MathQuill/mathquill.min.js"}), CGI::end_script();
-		print CGI::start_script({type=>"text/javascript",
-				src=>"$site_url/js/apps/MathQuill/mqeditor.js"}), CGI::end_script();
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mathquill.min.js", defer => "" }, "");
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mqeditor.js", defer => "" }, "");
 	}
 
 	print CGI::start_script({type=>"text/javascript",

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1904,8 +1904,8 @@ sub output_JS{
 	if ($ce->{options}->{PGMathQuill}) {
 		print "<link rel=\"stylesheet\" type=\"text/css\" href=\"$site_url/js/vendor/mathquill/mathquill.css\"/>";
 		print "<link rel=\"stylesheet\" type=\"text/css\" href=\"$site_url/js/vendor/mathquill/mqeditor.css\"/>";
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/MathQuill/mathquill.min.js"}), CGI::end_script();
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/MathQuill/mqeditor.js"}), CGI::end_script();
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mathquill.min.js", defer => "" }, "");
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mqeditor.js", defer => ""}, "");
 	}
 
 	if ($ce->{options}->{PGCodeMirror}) {

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2366,8 +2366,8 @@ sub output_JS{
 
 	# MathQuill live rendering 
 	if ($self->{will}->{useMathQuill}) {
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/MathQuill/mathquill.min.js"}), CGI::end_script();
-		print CGI::start_script({type=>"text/javascript", src=>"$site_url/js/apps/MathQuill/mqeditor.js"}), CGI::end_script();
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mathquill.min.js", defer => "" }, "");
+		print CGI::script({ src=>"$site_url/js/apps/MathQuill/mqeditor.js", defer => "" }, "");
 	}
 	
 	# This is for knowls

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -365,6 +365,7 @@ sub insert_mathquill_responses {
 	my ($self, $pg) = @_;
 	for my $answerLabel (keys %{$pg->{pgcore}->{PG_ANSWERS_HASH}}) {
 		my $mq_opts = $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}->{ans_eval}{rh_ans}{mathQuillOpts};
+		next if ($mq_opts && $mq_opts =~ /\s*disabled\s*/);
 		my $response_obj = $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}->response_obj;
 		for my $response ($response_obj->response_labels) {
 			next if (ref($response_obj->{responses}{$response}));

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -364,7 +364,7 @@ sub create_ans_str_from_responses {
 sub insert_mathquill_responses {
 	my ($self, $pg) = @_;
 	for my $answerLabel (keys %{$pg->{pgcore}->{PG_ANSWERS_HASH}}) {
-		my $mq_opts = $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}->{ans_eval}{rh_ans}{mathQuillOpts};
+		my $mq_opts = $pg->{pgcore}{PG_ANSWERS_HASH}{$answerLabel}{ans_eval}{rh_ans}{mathQuillOpts} // "";
 		next if ($mq_opts && $mq_opts =~ /\s*disabled\s*/);
 		my $response_obj = $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}->response_obj;
 		for my $response ($response_obj->response_labels) {
@@ -373,8 +373,7 @@ sub insert_mathquill_responses {
 			push(@{$response_obj->{response_order}}, $name);
 			$response_obj->{responses}{$name} = '';
 			my $value = defined($self->{formFields}{$name}) ? $self->{formFields}{$name} : '';
-			$pg->{body_text} .= CGI::hidden({ -name => $name, -id => $name, -value => $value });
-			$pg->{body_text} .= "<script>var ${name}_Opts = {$mq_opts}</script>" if ($mq_opts);
+			$pg->{body_text} .= CGI::hidden({ -name => $name, -id => $name, -value => $value, data_mq_opts => "$mq_opts" });
 		}
 	}
 }


### PR DESCRIPTION
Add an option to disable MathQuill answer boxes per response (not quite per answer blank, but good enough for most cases).
    
To do so use `$ans->cmp(mathQuillOpts => "disabled")`.
    
This also changes the way the mathQuillOpts answer hash key works.  Previously to disable the spaceBehavesLikeTabs option (i.e. to enable typing of spaces) and the disable rootsAreExponents you would need to do
      `$ans->cmp(mathQuillOpts => "spaceBehavesLikeTab: false, rootsAreExponents: false")`
Now you will do
      `$ans->cmp(mathQuillOpts => { spaceBehavesLikeTab => 0, rootsAreExponents => 0 })`

This is paired with the pg pull request https://github.com/openwebwork/pg/pull/555.