### PR TITLE
Stop making symlinks to flash applets in the OPL when OPL-update is run.

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -610,11 +610,6 @@ sub pgfiles {
 	my @textproblems = (-1);
 #print "\n$name";
 
-	if ($name =~ /swf$/) { # Found a flash applet
-		my $applet_file = basename($name);
-		symlink($name,$ce->{webworkDirs}->{htdocs}."/applets/".$applet_file);
-	}
-
 	if ($name =~ /\.pg$/) {
 		$pgfile = basename($name);
 		$pgpath = dirname($name);


### PR DESCRIPTION
Just a little clean up.