### PR TITLE
Trim leading and trailing space when passwords are set.

### DIFF
--- a/bin/change_user_id
+++ b/bin/change_user_id
@@ -27,7 +27,7 @@ BEGIN {
 use lib "$ENV{WEBWORK_ROOT}/lib";
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
-use WeBWorK::Utils qw(runtime_use readFile cryptPassword);
+use WeBWorK::Utils qw(runtime_use readFile);
 use Data::Dumper;
 
 if((scalar(@ARGV) != 3)) {

--- a/bin/delcourse
+++ b/bin/delcourse
@@ -96,7 +96,7 @@ use lib "$ENV{PG_ROOT}/lib";
 
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
-use WeBWorK::Utils qw(runtime_use readFile cryptPassword);
+use WeBWorK::Utils qw(runtime_use readFile);
 use WeBWorK::Utils::CourseManagement qw(addCourse deleteCourse listCourses);
 
 sub usage {

--- a/bin/importClassList.pl
+++ b/bin/importClassList.pl
@@ -111,7 +111,7 @@ sub importUsersFromCSV {
 		
 		# set password from student ID if password field is "empty"
 		if (not defined $record{password} or $record{password} eq "") {
-			if (defined $record{student_id} and $record{student_id} ne "") {
+			if (defined $record{student_id} and $record{student_id} =~ /\S/) {
 				# crypt the student ID and use that
 				$record{password} = cryptPassword($record{student_id});
 			} else {

--- a/bin/newpassword
+++ b/bin/newpassword
@@ -83,7 +83,7 @@ sub dopasswd {
   my ($db, $user, $newpass) = @_;
   my $passwordRecord = eval {$db->getPassword($user)};
   die "Can't get password for user |$user| $@" if $@ or not defined($passwordRecord);
-  my $cryptedPassword = cryptPassword($newP);
+  my $cryptedPassword = cryptPassword($newpass);
   $passwordRecord->password($cryptedPassword);
   eval {$db->putPassword($passwordRecord) };
   if ($@) {

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -743,7 +743,7 @@ sub do_add_course {
 	}
 	
 	# add initial instructor if desired
-	if ($add_initial_userID ne "") {
+	if ($add_initial_userID =~ /\S/) {
 		my $User = $db->newUser(
 			user_id       => $add_initial_userID,
 			first_name    => $add_initial_firstName,
@@ -818,7 +818,7 @@ sub do_add_course {
 	    ));
 	    # add contact to admin course as student?
 	    # FIXME -- should we do this?
-	    if ($add_initial_userID ne "") {
+	    if ($add_initial_userID =~ /\S/) {
 	        my $composite_id = "${add_initial_userID}_${add_courseID}"; # student id includes school name and contact
 			my $User = $db->newUser(
 			user_id       => $composite_id,          # student id includes school name and contact

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -51,7 +51,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive cryptPassword sortAchievements);
+use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive sortAchievements);
 use DateTime;
 use Text::CSV;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -49,7 +49,7 @@ sub initialize {
 		warn "Internal error -- the number of students to be added has not been included" unless defined $numberOfStudents;
 		foreach my $i (1..$numberOfStudents) {
 		    my $new_user_id  = trim_spaces($r->param("new_user_id_$i"));
-		    my $new_password = cryptPassword($r->param("student_id_$i"));
+		    my $new_password = cryptPassword($new_user_id);
 		    next unless defined($new_user_id) and $new_user_id;
 			push @userIDs, $new_user_id;
 		    

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -83,7 +83,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive cryptPassword sortByName);
+use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive sortByName);
 
 use constant HIDE_SETS_THRESHOLD => 500;
 use constant DEFAULT_VISIBILITY_STATE => 1;

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -84,7 +84,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive cryptPassword sortByName jitar_id_to_seq seq_to_jitar_id x);
+use WeBWorK::Utils qw(timeToSec readFile listFilesRecursive sortByName jitar_id_to_seq seq_to_jitar_id x);
 
 use WeBWorK::Utils::DatePickerScripts;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList2.pm
@@ -1303,18 +1303,20 @@ sub savePassword_handler {
 		my $User = $db->getUser($userID); # checked
 		die $r->maketext("record for visible user [_1] not found", $userID) unless $User;
 		my $param = "user.${userID}.new_password";
-			if ((defined $tableParams->{$param}->[0]) and ($tableParams->{$param}->[0])) {
-			  my $newP = $tableParams->{$param}->[0];
-			  my $Password = eval {$db->getPassword($User->user_id)}; # checked
-			  my 	$cryptPassword = cryptPassword($newP);											 				if (!defined($Password)) {
-			    $Password = $db->newPassword();
-			    $Password->user_id($userID);
-			    $Password->password(cryptPassword($newP));
-			    eval { $db->addPassword($Password) };		             		} else { 
-			      
-			      $Password->password(cryptPassword($newP));
-			      eval { $db->putPassword($Password) };		             		}
+		if ((defined $tableParams->{$param}->[0]) and ($tableParams->{$param}->[0])) {
+			my $newP = $tableParams->{$param}->[0];
+			my $Password = eval {$db->getPassword($User->user_id)}; # checked
+			my $cryptPassword = cryptPassword($newP);
+			if (!defined($Password)) {
+				$Password = $db->newPassword();
+				$Password->user_id($userID);
+				$Password->password(cryptPassword($newP));
+				eval { $db->addPassword($Password) };
+			} else {
+				$Password->password(cryptPassword($newP));
+				eval { $db->putPassword($Password) };
 			}
+		}
 	}
 	
 	if (defined $r->param("prev_visible_users")) {

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -846,7 +846,7 @@ sub writeTimingLogEntry($$$$) {
 sub trim_spaces {
 	my $in = shift;
 	return '' unless $in;  # skip blank spaces
-	$in =~ s/^\s*(.*?)\s*$/$1/;
+	$in =~ s/^\s*|\s*$//g;
 	return($in);
 }
 sub list2hash(@) {
@@ -1023,7 +1023,7 @@ sub cryptPassword($) {
 	    $salt .= ('.','/','0'..'9','A'..'Z','a'..'z')[rand 64];
 	}
 
-	my $cryptPassword = crypt($clearPassword, $salt);
+	my $cryptPassword = crypt(trim_spaces($clearPassword), $salt);
 	return $cryptPassword;
 }
 


### PR DESCRIPTION
There is some code clean up that I did while initially thinking I would trim passwords where they were set.  Then I found the quick and simple solution.  Passwords are trimmed when cryptPassword is called.

Do we also want to trim passwords when they are entered to sign in?  That is also not hard to accomplish.