### PR TITLE
Change the MathJax config to use its default color setup instead of colorv2

### DIFF
--- a/htdocs/js/apps/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/apps/MathJaxConfig/mathjax-config.js
@@ -1,7 +1,6 @@
 if (!window.MathJax) {
 	window.MathJax = {
 		tex: {
-			autoload: { color: [], colorV2: ['color'] },
 			packages: {'[+]': ['noerrors']}
 		},
 		loader: { load: ['input/asciimath', '[tex]/noerrors'] },

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -50,7 +50,7 @@
 <script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 <!-- [gateway] since the left-side menus are gone, don't indent the main content area -->
 

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -72,7 +72,7 @@ var tabberOptions = {manualStartup:true};
 <!--#endif-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 
 <title><!--#path style="text" text=" : " textonly="1"--></title>

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -72,7 +72,7 @@ var tabberOptions = {manualStartup:true};
 <!--#endif-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 
 <title><!--#path style="text" text=" : " textonly="1"--></title>


### PR DESCRIPTION
The current setup was compatible with how MathJax version 2 behaved by default, and that is how webwork has used it.  However, this changes to the MathJax 3 default.  The difference is in how the TeX `\color` command behaves.  With the MathJax 3 default it is the same as how LaTeX works (that is `\color{blue}This is text` makes all of "This is text" blue.  With the MathJax 2 default (and colorv2 in MathJax 3) only the first "T" would be blue.  The point of this change is that with this setting both HTML output and hardcopy output will be the same.  See the discussion in #1215.

This is up for discussion as to if this is the right way to go.  If this is incorrect, and we want to maintain the previous behavior then that needs to be fixed.  I had put in `colorV2` instead of `colorv2`.  I believe at the time I wrote that code (almost a year ago), that was correct.

This also adds the `defer` attribute to the loading of the `math4-overrides.js` file (if it exists) so that it loads after `math4.js` and can actually do overrides.