### PR TITLE
tweak message for when a roster file is uploaded as csv instead of lst

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -1174,7 +1174,10 @@ sub checkFileLocation {
 	return if $dir =~ m/^$location$/;
 	$location =~ s!/\.\*!!;
 	return if $dir =~ m/^$location$/;
-	$self->addbadmessage($r->maketext("Files with extension '.[_1]' usually belong in '[_2]'",$extension,$location));
+	$self->addbadmessage(
+		$r->maketext("Files with extension '.[_1]' usually belong in '[_2]'",$extension,$location)
+		. (($extension eq 'csv') ? $r->maketext(". If this is a class roster, rename it to have extension '.lst'") : '')
+	);
 }
 
 ##################################################


### PR DESCRIPTION
This is just a tiny improvement in messaging. At least where I am, it is common to upload a roster file as .csv. If you use Excel to create it, that's what you get, not .lst. You need to change the extension, either before or after upload. If you upload it as csv, the warning message is not helpful. And more importantly, some newbie faculty don't realize there is a need to make it lst.