### PR TITLE
Mathjax configuration color fix (alternate to #1294)

### DIFF
--- a/htdocs/js/apps/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/apps/MathJaxConfig/mathjax-config.js
@@ -1,7 +1,7 @@
 if (!window.MathJax) {
 	window.MathJax = {
 		tex: {
-			autoload: { color: [], colorV2: ['color'] },
+			autoload: { color: [], colorv2: ['color'] },
 			packages: {'[+]': ['noerrors']}
 		},
 		loader: { load: ['input/asciimath', '[tex]/noerrors'] },

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -50,7 +50,7 @@
 <script type="text/javascript" src="<!--#url type="webwork" name="htdocs"-->/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 <!-- [gateway] since the left-side menus are gone, don't indent the main content area -->
 

--- a/htdocs/themes/math4/simple.template
+++ b/htdocs/themes/math4/simple.template
@@ -72,7 +72,7 @@ var tabberOptions = {manualStartup:true};
 <!--#endif-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 
 <title><!--#path style="text" text=" : " textonly="1"--></title>

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -72,7 +72,7 @@ var tabberOptions = {manualStartup:true};
 <!--#endif-->
 <script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4.js" defer></script>	
 <!--#if exists="math4-overrides.js"-->
-<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js"></script>	
+<script type="text/javascript" src="<!--#url type="webwork" name="theme"-->/math4-overrides.js" defer></script>	
 <!--#endif-->
 
 <title><!--#path style="text" text=" : " textonly="1"--></title>


### PR DESCRIPTION
This fixes the current setup for compatability with MathJax version 2.

Either this pull request of #1294 needs to be chosen and merged.  Currently the `\color` TeX command does not work.

This also adds the defer attribute to the loading of the math4-overrides.js file (if it exists) so that it loads after math4.js and can actually do overrides (same as #1294).