### PR TITLE
SameSite cookie default to Lax

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -918,7 +918,13 @@ $caliper{enabled} = 0;
 #         https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 #         https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 
-$CookieSameSite = "Strict";
+
+# Notes about the $CookieSameSite options:
+#   The "None" setting should only be used with HTTPS and when $CookieSecure = 1; is set below. The "None" setting is also less secure and can allow certain types of cross-site attacks.
+#   The "Strict" setting can break the links in the system generated feedback emails when read in a web mail client.
+#   Due to those factors, the "Lax" setting is probably the optimal choice for typical WeBWorK servers.
+
+$CookieSameSite = "Lax";
 
 # Set the value of the secure cookie attribute:
 $CookieSecure = 0; # Default is 0 here, as 1 will not work without https

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -503,6 +503,11 @@ $mail{feedbackRecipients}    = [
 #         https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 #         https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
 
+# Notes about the $CookieSameSite options:
+#   The "None" setting should only be used with HTTPS and when $CookieSecure = 1; is set below. The "None" setting is also less secure and can allow certain types of cross-site attacks.
+#   The "Strict" setting can break the links in the system generated feedback emails when read in a web mail client.
+#   Due to those factors, the "Lax" setting is probably the optimal choice for typical WeBWorK servers.
+
 #$CookieSameSite = "None";
 #$CookieSameSite = "Strict";
 #$CookieSameSite = "Lax";


### PR DESCRIPTION
Change SameSite cookie setting to Lax as default, and add some explanations about the options and why Lax was selected as the default value.