### PR TITLE
Fix an unitialized usage in join or string issue in WeBWorK.pm.

### DIFF
--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -251,9 +251,11 @@ sub htmlMessage($$$@) {
 	my $uri = htmlEscape(  $r->uri );
 	my $headers = do {
 		my %headers = MP2 ? %{$r->headers_in} : $r->headers_in;
-		# Was getting warnings about the value of "sec-ch-ua" in my testing...
-		$headers{"sec-ch-ua"} = join("",$headers{"sec-ch-ua"});
-		$headers{"sec-ch-ua"} =~ s/\"//g;
+		if (defined($headers{"sec-ch-ua"})) {
+			# Was getting warnings about the value of "sec-ch-ua" in my testing...
+			$headers{"sec-ch-ua"} = join("",$headers{"sec-ch-ua"});
+			$headers{"sec-ch-ua"} =~ s/\"//g;
+		}
 
 		join("",
 			"<tr><th id=\"header_key\"><small>Key</small></th><th id=\"header_value\"><small>Value</small></th></tr>\n",


### PR DESCRIPTION
This shows up when errors happen and the sec-ch-ua parameter is not defined.  This happens anytime that errors occur through the WebworkWebservice as that parameter is not set there.