### PR TITLE
Exclude files from evaluating achivements and incrementing counters.

### DIFF
--- a/courses.dist/modelCourse/course.conf
+++ b/courses.dist/modelCourse/course.conf
@@ -89,4 +89,14 @@ $dbLayoutName = 'sql_single';
 # $LTIBasicConsumerSecret = "xxxxxxxxx";
 # $LTIGradeMode = "homework";
 
+# For achievements you may set the preamble.at file as described at
+# https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4209 to exclude
+# certain sets or questions from achievement system.  However, these
+# questions still count to the score used to determine the level.  The
+# variable $achievementExcludeSet allows to exclude certain set completely
+# from the achievement system and these questions do not count to the level.
+# Remember that the names of the sets do not contain spaces.
+#
+# $achievementExcludeSet = ["00_Introduction","99_Summary","Sample_exam"];
+
 1;

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -44,6 +44,10 @@ sub checkForAchievements {
     my $cheevoMessage = '';
     my $user_id = $problem->user_id;
     my $set_id = $problem->set_id;
+    # exit early if the set is to be ignored by achievements
+    foreach my $excludedSet (@{ $ce->{achievementExcludeSet} }) {
+	return '' if $set_id eq $excludedSet;
+    }
     our $set = $db->getMergedSet($user_id,$problem->set_id);
     my @allAchievementIDs = $db->listAchievements; 
     my @achievements = $db->getAchievements(@allAchievementIDs);


### PR DESCRIPTION
There is a file `preamble.at` which excludes certain set or problem from assigning achievements. However, points counting to the next level are still assigned since the code which increments `$globalData->{'completeProblems'}` and  `$achievementPoints` preceeds the lines where `preamble.at` takes effect. The patch solves this problem.