### PR TITLE
Increment number of items in achievements rather than setting to 1.

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/level_eight.at
+++ b/courses.dist/modelCourse/templates/achievements/level_eight.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 1200;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{DoubleSet} = 1;
+    $globalData->{DoubleSet}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_five.at
+++ b/courses.dist/modelCourse/templates/achievements/level_five.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 750;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{DuplicateProb} = 1;
+    $globalData->{DuplicateProb}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_four.at
+++ b/courses.dist/modelCourse/templates/achievements/level_four.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 600;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{DoubleProb} = 1;
+    $globalData->{DoubleProb}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_nine.at
+++ b/courses.dist/modelCourse/templates/achievements/level_nine.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 1350;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{ResurrectHW} = 1;
+    $globalData->{ResurrectHW}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_one.at
+++ b/courses.dist/modelCourse/templates/achievements/level_one.at
@@ -12,7 +12,7 @@
 #Threshold for level 2
 my $newLevelThreshold = 150;
 
-$globalData->{HalfCreditProb} = 1;
+$globalData->{HalfCreditProb}++;
 
 #Code
 

--- a/courses.dist/modelCourse/templates/achievements/level_seven.at
+++ b/courses.dist/modelCourse/templates/achievements/level_seven.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 1050;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1
-    $globalData->{SuperExtendDueDate} = 1; 
+    $globalData->{SuperExtendDueDate}++; 
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_six.at
+++ b/courses.dist/modelCourse/templates/achievements/level_six.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 900;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{FullCreditProb} = 1;
+    $globalData->{FullCreditProb}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_ten.at
+++ b/courses.dist/modelCourse/templates/achievements/level_ten.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = '';
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{FullCreditSet} = 1;
+    $globalData->{FullCreditSet}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_three.at
+++ b/courses.dist/modelCourse/templates/achievements/level_three.at
@@ -16,7 +16,7 @@ my $newLevelThreshold = 450;
 
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
-    $globalData->{ExtendDueDate} = 1;
+    $globalData->{ExtendDueDate}++;
     $nextLevelPoints = $newLevelThreshold;
     return 1;
 } else {

--- a/courses.dist/modelCourse/templates/achievements/level_two.at
+++ b/courses.dist/modelCourse/templates/achievements/level_two.at
@@ -17,7 +17,7 @@ my $newLevelThreshold = 300;
 if ($achievementPoints >= $nextLevelPoints) {
     #set new threshold and return 1 
     $nextLevelPoints = $newLevelThreshold;
-    $globalData->{ResetIncorrectAttempts} = 1;
+    $globalData->{ResetIncorrectAttempts}++;
     return 1;
 } else {
     return 0;


### PR DESCRIPTION
The items earned by achievements can be used more than once (see https://github.com/openwebwork/webwork2/commit/e78c63b004ac3d3a5e07b2fe02c41395fa94b60f ). For this reason we should increment number of items earned on each level rather than set to 1. 