### PR TITLE
Fix for empty reduced_scoring_date when using certaing items.

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -250,7 +250,7 @@ sub use_item {
     my $userSet = $db->getUserSet($userName,$setID);
     
     #add time to the reduced scoring date, due date, and answer date; remove item from inventory
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
 
@@ -334,7 +334,7 @@ sub use_item {
     my $userSet = $db->getUserSet($userName,$setID);
     
     #add time to the reduced scoring date, due date, and answer date; remove item from inventory
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+172800) if defined($set->reduced_scoring_date());
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+172800) if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
     $userSet->due_date($set->due_date()+172800);
     $userSet->answer_date($set->answer_date()+172800);
 
@@ -1521,7 +1521,7 @@ sub use_item {
     my $userSet = $db->getUserSet($userName,$setID);
     
     #add time to the reduced scoring date, due date, and answer date
-    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
+    $userSet->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
     $userSet->due_date($set->due_date()+86400);
     $userSet->answer_date($set->answer_date()+86400);
 
@@ -1533,7 +1533,7 @@ sub use_item {
     foreach my $version (@versions) {
 
 	$set = $db->getSetVersion($userName,$setID,$version);
-	$set->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date());
+	$set->reduced_scoring_date($set->reduced_scoring_date()+86400) if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
 	$set->due_date($set->due_date()+86400);
 	$set->answer_date($set->answer_date()+86400);
 	$db->putSetVersion($set);
@@ -1623,7 +1623,7 @@ sub use_item {
 	($set);
     
     #add time to the reduced scoring date, due date, and answer date; remove item from inventory
-    $set->reduced_scoring_date(time()+86400) if defined($set->reduced_scoring_date());
+    $set->reduced_scoring_date(time()+86400) if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
     $set->due_date(time()+86400);
     $set->answer_date(time()+86400);
 


### PR DESCRIPTION
If the course does not use reduced scoring the following message is produced when the user wants to use items which extend the due date.

```Warning -- There may be something wrong with this question. Please inform your instructor including the warning messages below.
```
and
```
    Argument "" isn't numeric in addition (+) at /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm line 253.
    Argument "" isn't numeric in numeric gt (>) at /opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 775.
    Argument "" isn't numeric in numeric gt (>) at /opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 775.
    Argument "" isn't numeric in numeric gt (>) at /opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 775.
    Argument "" isn't numeric in numeric gt (>) at /opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 775.
    Argument "" isn't numeric in numeric gt (>) at /opt/webwork/webwork2/lib/WeBWorK/Utils.pm line 775.
```

I believe that this patch solves the problem and does not introduce another issue.