### PR TITLE
Use current submission result in achievement calculations

### DIFF
--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -88,9 +88,10 @@ sub checkForAchievements {
     # updated $problem with the new results from $pg.  So we cheat and update the 
     # important bits here.  The only thing that gets left behind is last_answer, which is
     # still the previous last answer. 
-    # 
     
-    $problem->status($pg->{state}->{recorded_score});
+    # $pg->{result} reflects the current submission, $pg->{state} holds the best result 
+    # close the unlimited achievement points loophole by only using the current result!
+    $problem->status($pg->{result}->{score});
     $problem->sub_status($pg->{state}->{sub_recorded_score});
     $problem->attempted(1);
     $problem->num_correct($pg->{state}->{num_of_correct_ans});


### PR DESCRIPTION
Thanks to @robert-marik for pointing out that there is an exploitable loophole in the achievement evaluator. I believe this should be considered a priority fix for v2.16.

The oversight here is based on the differences between the `$pg->{state}` and `$pg->{result}` hashes. Essentially, we only want to consider the 'result' of the current submission, rather than the overall 'state' of the problem. By considering the 'state' of a problem, we can **repeatedly** end up with `state->{recorded_score} == 1 && num_correct == 1`. However, we can only achieve `result->{score} == 1 AND num_correct == 1` **once**.