### PR TITLE
Add an option for setting the application (dvisvgm or pdf2svg) used by the PGtikz.pl macro to generate svg images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN apt-get update \
 	apache2 \
 	curl \
 	dvipng \
+	dvisvgm \
 	gcc \
 	libapache2-request-perl \
 	libarchive-zip-perl \
@@ -183,6 +184,7 @@ RUN apt-get update \
 	make \
 	netpbm \
 	patch \
+	pdf2svg \
 	preview-latex-style \
 	texlive \
 	texlive-latex-extra \

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -15,6 +15,7 @@ my @applicationsList = qw(
 	git
 	gzip
 	latex
+	pdf2svg
 	pdflatex
 	dvipng
 	giftopnm

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1216,8 +1216,9 @@ $pg{specialPGEnvironmentVars}{use_knowls_for_solutions} = $pg{options}{use_knowl
 # whether to use javascript for rendering Live3D graphs
 $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 
-# Default image extension used by the PGtikz.pl macro.
-$pg{specialPGEnvironmentVars}{tikzImageExtension} = "png";
+# Binary that the PGtikz.pl macro will use to create svg images.
+# This should be either 'pdf2svg' or 'dvipdfm'.
+$pg{specialPGEnvironmentVars}{tikzSVGMethod} = "pdf2svg";
 
    #  set the flags immediately above in the $pg{options} section above -- not here.
 

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1216,6 +1216,9 @@ $pg{specialPGEnvironmentVars}{use_knowls_for_solutions} = $pg{options}{use_knowl
 # whether to use javascript for rendering Live3D graphs
 $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 
+# Default image extension used by the PGtikz.pl macro.
+$pg{specialPGEnvironmentVars}{tikzImageExtension} = "png";
+
    #  set the flags immediately above in the $pg{options} section above -- not here.
 
 # Locations of CAPA resources. (Only necessary if you need to use converted CAPA

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -331,11 +331,13 @@ $mail{feedbackRecipients}    = [
 # (U+FF01 to U+FF5E) to their corresponding ASCII characters (U+0021 to U+007E) automatically.
 # $pg{specialPGEnvironmentVars}{convertFullWidthCharacters} = 1;
 
-# Default image extension used by the PGtikz.pl macro.  If the system version of latex
-# is 3.14159265-2.6-1.40.20 (TeX Live 2019) or newer and the system version of dvisvgm
-# is 2.8.1 or newer, then change this to 'svg' by uncommenting the line below.
-# The versions on Ubuntu 18.04 are not new enough, but the versions on Ubuntu 20.04 are.
-#$pg{specialPGEnvironmentVars}{tikzImageExtension} = 'svg';
+# Application that the PGtikz.pl macro will use to create svg images.
+# This should be either 'pdf2svg' or 'dvisvgm'.  The default is 'pdf2svg'.
+# If the system version of latex is 3.14159265-2.6-1.40.20 (TeX Live 2019) or newer
+# and the system version of dvisvgm is 2.8.1 or newer, then change this to 'dvisvgm'
+# by uncommenting the line below.  'dvisvgm' will generally create better 'svg'
+# images.
+#$pg{specialPGEnvironmentVars}{tikzSVGMethod} = "dvisvgm";
 
 ################################################################################
 #  Configuring the display of different versions of the editors

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -331,6 +331,12 @@ $mail{feedbackRecipients}    = [
 # (U+FF01 to U+FF5E) to their corresponding ASCII characters (U+0021 to U+007E) automatically.
 # $pg{specialPGEnvironmentVars}{convertFullWidthCharacters} = 1;
 
+# Default image extension used by the PGtikz.pl macro.  If the system version of latex
+# is 3.14159265-2.6-1.40.20 (TeX Live 2019) or newer and the system version of dvisvgm
+# is 2.8.1 or newer, then change this to 'svg' by uncommenting the line below.
+# The versions on Ubuntu 18.04 are not new enough, but the versions on Ubuntu 20.04 are.
+#$pg{specialPGEnvironmentVars}{tikzImageExtension} = 'svg';
+
 ################################################################################
 #  Configuring the display of different versions of the editors
 ################################################################################

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -118,6 +118,7 @@ $externalPrograms{dvipng}   = "/usr/bin/dvipng";
 $externalPrograms{convert}  = "/usr/bin/convert";
 
 $externalPrograms{dvisvgm}  = "/usr/bin/dvisvgm";
+$externalPrograms{pdf2svg}  = "/usr/bin/pdf2svg";
 
 ####################################################
 # NetPBM - basic image manipulation utilities


### PR DESCRIPTION
Unfortunately the versions of latex and dvisvgm on Ubuntu 18.04 do not work well for generating svg images with the PGtikz.pl macro.  However, the versions on 20.04 do.  The pdf2svg application works okay in any case.  So this adds a configuration option used by the macro to set the application used by PGtikz.pl to be either dvisvgm or pdf2svg.  The default (set in defaults.config) is pdf2svg.  If your system is running Ubuntu 20.04 you can change this in localOverrides.conf to dvisvgm.