### PR TITLE
Consider individual deadlines when evaluating achievements.

### DIFF
--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -44,7 +44,7 @@ sub checkForAchievements {
     my $cheevoMessage = '';
     my $user_id = $problem->user_id;
     my $set_id = $problem->set_id;
-    our $set = $db->getGlobalSet($problem->set_id);
+    our $set = $db->getMergedSet($user_id,$problem->set_id);
     my @allAchievementIDs = $db->listAchievements; 
     my @achievements = $db->getAchievements(@allAchievementIDs);
     @achievements = sortAchievements(@achievements);


### PR DESCRIPTION
I believe that the achievements "the early bird", "the really early bird" and "last minute math" should take into account the open_time and due_time for the individual student. The current state takes into account the global setting. 

Consequently, the member of the group with shifted due_time may get the message "finished in last 30 minutes" even if there could be still days to his/her due_time.