### PR TITLE
Wrap answer previews in `<script type="math/tex"></script>` tags in the attempts table

### DIFF
--- a/htdocs/js/apps/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/apps/MathJaxConfig/mathjax-config.js
@@ -14,6 +14,22 @@ if (!window.MathJax) {
 				}
 				return MathJax.startup.defaultReady()
 			}
+		},
+		options: {
+			renderActions: {
+				findScript: [10, function (doc) {
+					document.querySelectorAll('script[type^="math/tex"]').forEach(function(node) {
+						var display = !!node.type.match(/; *mode=display/);
+						var math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+						var text = document.createTextNode('');
+						node.parentNode.replaceChild(text, node);
+						math.start = {node: text, delim: '', n: 0};
+						math.end = {node: text, delim: '', n: 0};
+						doc.math.push(math);
+					});
+				}, '']
+			}
 		}
+
 	};
 }

--- a/htdocs/js/apps/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/apps/MathJaxConfig/mathjax-config.js
@@ -28,7 +28,8 @@ if (!window.MathJax) {
 						doc.math.push(math);
 					});
 				}, '']
-			}
+			},
+			ignoreHtmlClass: 'tex2jax_ignore'
 		}
 
 	};

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -362,7 +362,7 @@ sub previewAnswer {
 	} elsif ($displayMode eq "images") {
 		$imgGen->add($tex);
 	} elsif ($displayMode eq "MathJax") {
-		return '\['.$tex.'\]';
+		return '<script type="math/tex; mode=display">' . $tex . '</script>';
 	}
 }
 
@@ -384,7 +384,7 @@ sub previewCorrectAnswer {
 		$imgGen->add($tex);
 		# warn "adding $tex";
 	} elsif ($displayMode eq "MathJax") {
-		return '\['.$tex.'\]';
+		return '<script type="math/tex; mode=display">' . $tex . '</script>';
 	}
 }
 


### PR DESCRIPTION
This also adds the appropriate MathJax configuration to handle this to the mathjax-config.js file.

This is paired with openwebwork/pg#564.

This fixes #1315.