### PR TITLE
Fixing Night Owl, Last Minute and Crack o dawn achievements

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
+++ b/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
@@ -1,4 +1,14 @@
-# checks to see if a studen finished a set between 5AM and 7AM
+# checks to see if a student finished a set between 5AM and 7AM
+
+# Check that this is not a repeated submission of problem which has
+# been solved before.
+# Do not consider this achievement if this is a repeated submission
+# of previously solved problem.
+
+return 0 if $problem->status != 1 or $problem->num_correct != 1;
+
+# now check the time
+
     my @timeData = localtime(time);
 
     if ($timeData[2] < 5 || $timeData[2] > 6) {

--- a/courses.dist/modelCourse/templates/achievements/last_minute.at
+++ b/courses.dist/modelCourse/templates/achievements/last_minute.at
@@ -1,5 +1,12 @@
 # checks to see if a studen finished a set close to the due date
 
+# Check that this is not a repeated submission of problem which has
+# been solved before.
+# Do not consider this achievement if this is a repeated submission
+# of previously solved problem.
+
+return 0 if $problem->status != 1 or $problem->num_correct != 1;
+
     #test to see if it is within 30 min of the due date
     if (($set->due_date - time()) > 1800) {
 	return 0;

--- a/courses.dist/modelCourse/templates/achievements/night_owl.at
+++ b/courses.dist/modelCourse/templates/achievements/night_owl.at
@@ -1,4 +1,12 @@
 # checks to see if a studen finished a set between 12AM and 2AM
+
+# Check that this is not a repeated submission of problem which has
+# been solved before.
+# Do not consider this achievement if this is a repeated submission
+# of previously solved problem.
+
+return 0 if $problem->status != 1 or $problem->num_correct != 1;
+
     my @timeData = localtime(time);
 
     #test to see if it is between midnight and 2am


### PR DESCRIPTION
Without this fix the student gets achievement if he/she solves the set at any time, returns later after the midnight, submits another answer again, then returns in the morning, submits another answer again and finally returns 30 minutes before the due time and submits any answer again.
This adds the test that the submission is correct and the problem has one correct answer. I hope that this prevents the mentioned problem. I hope that it ensures, that this problem has been solved just now. The rest is usual - checking the time and checking the status of other questions.