### PR TITLE
Pass information on the course timezone to the achievements

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
+++ b/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
@@ -1,7 +1,15 @@
-# checks to see if a studen finished a set between 5AM and 7AM
-    my @timeData = localtime(time);
+# checks to see if a student finished a set between 5AM and 7AM
 
-    if ($timeData[2] < 5 || $timeData[2] > 6) {
+# Check that this is not a repeated submission of problem which has
+# been solved before.
+# Do not consider this achievement if this is a repeated submission
+# of previously solved problem.
+
+return 0 unless ($problem->status == 1 && $problem->num_correct == 1);
+
+# now check the time
+
+    if ($courseDateTime[2] < 5 || $courseDateTime[2] > 6) {
 	return 0;
     }
 
@@ -81,3 +89,6 @@
 #         $globalData you need to either write your code so it doesnt matter which
 #         order the evaluators are run in, or you need to pay very close attention
 #         to which evaluators are run and when. 
+#   - @courseDateTime - array of time information in course timezone
+#         (sec,min,hour,day,month,year,day_of_week) as produced by
+#         https://metacpan.org/pod/DateTime

--- a/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
+++ b/courses.dist/modelCourse/templates/achievements/crack_o_dawn.at
@@ -89,6 +89,7 @@ return 0 unless ($problem->status == 1 && $problem->num_correct == 1);
 #         $globalData you need to either write your code so it doesnt matter which
 #         order the evaluators are run in, or you need to pay very close attention
 #         to which evaluators are run and when. 
+#
 #   - @courseDateTime - array of time information in course timezone
 #         (sec,min,hour,day,month,year,day_of_week) as produced by
 #         https://metacpan.org/pod/DateTime

--- a/courses.dist/modelCourse/templates/achievements/night_owl.at
+++ b/courses.dist/modelCourse/templates/achievements/night_owl.at
@@ -1,8 +1,14 @@
-# checks to see if a studen finished a set between 12AM and 2AM
-    my @timeData = localtime(time);
+# checks to see if a student finished a set between 12AM and 2AM
+
+# Check that this is not a repeated submission of problem which has
+# been solved before.
+# Do not consider this achievement if this is a repeated submission
+# of previously solved problem.
+
+return 0 unless ($problem->status == 1 && $problem->num_correct == 1);
 
     #test to see if it is between midnight and 2am
-    if ($timeData[2] > 1) {
+    if ($courseDateTime[2] > 1) {
 	return 0;
     }
 
@@ -82,3 +88,6 @@
 #         $globalData you need to either write your code so it doesnt matter which
 #         order the evaluators are run in, or you need to pay very close attention
 #         to which evaluators are run and when. 
+#   - @courseDateTime - array of time information in course timezone
+#         (sec,min,hour,day,month,year,day_of_week) as produced by
+#         https://metacpan.org/pod/DateTime

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -28,6 +28,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Utils qw(before after readFile sortAchievements nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::Tags;
+use DateTime;
 
 use WWSafe;
 
@@ -39,6 +40,15 @@ sub checkForAchievements {
     my %options = @_;
     my $db = $r->db;
     my $ce = $r->ce;
+
+    my $course_display_tz = $ce->{siteDefaults}{timezone};
+    # the following line from Utils.pm
+    $course_display_tz ||= "local";    # do our best to provide default vaules
+
+    # Date and time for course timezone (may differ from the server timezone)
+    # Saved into separate array
+    # https://metacpan.org/pod/DateTime
+    my $dtCourseTime = DateTime->from_epoch( epoch => time(), time_zone  => $course_display_tz);
 
     #set up variables and get achievements
     my $cheevoMessage = '';
@@ -106,6 +116,7 @@ sub checkForAchievements {
     our $globalData = {};
     our $tags;
     our @setProblems = ();
+    our @courseDateTime = ($dtCourseTime->sec,$dtCourseTime->min,$dtCourseTime->hour,$dtCourseTime->day,$dtCourseTime->month,$dtCourseTime->year,$dtCourseTime->day_of_week);
 
     my $compartment = new WWSafe;
 
@@ -192,9 +203,10 @@ sub checkForAchievements {
     # $set - the set data
     # $achievementPoints - the number of achievmeent points
     # $tags -this is the tag data associated to the problem from the problem library
+    # @courseDateTime - array of time information in course timezone (sec,min,hour,day,month,year,day_of_week)
 
     $compartment->share(qw( $problem @setProblems $localData $maxCounter 
-             $globalData $counter $nextLevelPoints $set $achievementPoints $tags));
+             $globalData $counter $nextLevelPoints $set $achievementPoints $tags @courseDateTime));
 
     #load any preamble code
     # this line causes the whole file to be read into one string


### PR DESCRIPTION
This tries to solve the problem mentioned by @Alex-Jordan in https://github.com/openwebwork/webwork2/pull/1325
The patch allows to pass information on the current time to the achievement. This allows to properly handle achievements with courses in different time zones on the same server.

Tested as follows:
1. create new course, new users, new short homeworks with few simple questions, assign achievements to the users.
2. solve the hw
3. change the timezone in confiuguration of the course to the timezone with time just after the midnight.
4. solve with another user or solve another set. You should get "Night owl"
5. change timezone to the land where the current time is between 5 and 7 in the morning
6. solve another hw or solve another set. You should get the "Crack of dawn"

When you merge, the code here contains changes did in https://github.com/openwebwork/webwork2/pull/1325 again. Not sure if it will merge automatically.

Hope it will work. When I played and tested, I observed some problems. But these problems were probably caused by the fact that I repeatedly deleted and added homeworks and users with names 1,2,3, ... and this does not remove the rows in the past_answers table. When I manually deleted old answers and did the tests again, everything  behaved as expected.