### PR TITLE
Use en_US format whenever date and time are intended to be in form fields

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -608,9 +608,9 @@ sub FieldHTML {
 	$userValue = (defined($userValue)) ? ($labels{$userValue // ""} || $userValue) : $blankfield; # this allows for a label if value is 0
 
 	if ($field =~ /_date/) {
-		$globalValue = $self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P') if defined $globalValue && $globalValue ne $labels{""};
+		$globalValue = $self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P', 'en_US') if defined $globalValue && $globalValue ne $labels{""};
 		# this is still fragile, but the check for blank (as opposed to 0) $userValue seems to prevent errors when no user has been assigned.
-		$userValue = $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') if defined $userValue && $userValue =~/\S/ && $userValue ne $labels{""};
+		$userValue = $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P', 'en_US') if defined $userValue && $userValue =~/\S/ && $userValue ne $labels{""};
 	}
 
 	if ( defined($properties{convertby}) && $properties{convertby} ) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail2.pm
@@ -650,9 +650,9 @@ sub FieldHTML {
 	$userValue = (defined($userValue)) ? ($labels{$userValue // ""} || $userValue) : $blankfield; # this allows for a label if value is 0
 
 	if ($field =~ /_date/) {
-		$globalValue = $self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P') if defined $globalValue && $globalValue ne "";
+		$globalValue = $self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P', 'en_US') if defined $globalValue && $globalValue ne "";
 		# this is still fragile, but the check for blank (as opposed to 0) $userValue seems to prevent errors when no user has been assigned.
-		$userValue = $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') if defined $userValue && $userValue =~/\S/ && $userValue ne "";
+		$userValue = $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P', 'en_US') if defined $userValue && $userValue =~/\S/ && $userValue ne "";
 	}
 
 	if ( defined($properties{convertby}) && $properties{convertby} ) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList2.pm
@@ -1133,7 +1133,7 @@ sub create_handler {
 
 	my $dueDate = time+2*ONE_WEEK();
 	my $display_tz = $ce->{siteDefaults}{timezone};
-	my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P");
+	my $fDueDate = $self->formatDateTime($dueDate, $display_tz, "%m/%d/%Y at %I:%M%P",'en_US');
 	my $dueTime = $ce->{pg}{timeAssignDue};
 
 	# We replace the due time by the one from the config variable
@@ -2675,7 +2675,7 @@ sub recordEditHTML {
 		my %properties = %{ FIELD_PROPERTIES()->{$field} };
 		$properties{access} = "readonly" unless $editMode;
 		
-		$fieldValue = $self->formatDateTime($fieldValue,'','%m/%d/%Y at %I:%M%P') if $field =~ /_date/;
+		$fieldValue = $self->formatDateTime($fieldValue,'','%m/%d/%Y at %I:%M%P','en_US') if $field =~ /_date/;
 		
 		$fieldValue =~ s/ /&nbsp;/g unless $editMode;
 		$fieldValue = ($fieldValue) ? $r->maketext("Yes") : $r->maketext("No") if $field =~ /visible/ and not $editMode;

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -496,7 +496,7 @@ sub DBFieldTable {
 					(CGI::input({ -name=>"$recordType.$recordID.$field",
 							-id =>"$recordType.$recordID.${field}_id",
 							-type=> "text",
-							-value => $userValue ? $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P') : "",
+							-value => $userValue ? $self->formatDateTime($userValue,'','%m/%d/%Y at %I:%M%P','en_US') : "",
 							-onchange => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked', this.value != '')",
 							-onkeyup => "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked', this.value != '')",
 							-placeholder => x("None Specified"),
@@ -504,7 +504,7 @@ sub DBFieldTable {
 								. "\$('input[id=\"$recordType.$recordID.$field.override_id\"]').prop('checked',false);",
 							-size => 25})
 					) : "",
-				$self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P'),
+				$self->formatDateTime($globalValue,'','%m/%d/%Y at %I:%M%P','en_US'),
 			]
 
 	}


### PR DESCRIPTION
This solves #1164

Explanation: WeBWorK assumes on some places the date and time in the format "%m/%d/%Y at %I:%M%P" and the parser expects the date and the time in this format. However, if the course uses non-english locales, the %P string gets its local value (for example "odp." stands for "pm" in cs_CZ) and the parser fails. **In this case WeBWorK is not able to parse his own string back.**

As a consequence: If I open the editor for HW with due_time at 5:00pm, the value in the form field is in cs_CZ 5:00odp. which is parsed back as 5:00am. (see #1164 for the corresponding code pieces). If I change something (say give different point values to problems) and save without fixing the time, the due_time is shifted from 5pm to 5am. This is annoying if the lecturer intends to open HW for 90 minutes in the afternoon as an exam. I think that two possible solutions are either to improve the parser or to force date and time to be in en_US whenewer required. I followed the second possibility, since this seems to be easier and there is lower risk that something gets broken. This is also compatible with date picker which is used to enter dates and times. Finally, it is compatible with the fact that WeBWorK supposes to separate the day and time by English "at" clause.