### PR TITLE
Convert options

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1220,11 +1220,11 @@ $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 # This should be either 'pdf2svg' or 'dvipdfm'.
 $pg{specialPGEnvironmentVars}{tikzSVGMethod} = "pdf2svg";
 
-# When ImageMagick is used for image conversions, these are the default options
-# https://imagemagick.org/script/convert.php
-# will be used as:
-# convert $convertOptions[0] file.ext1 $convertOptions[1] file.ext2
-$pg{specialPGEnvironmentVars}{convertOptions} = [{density => 300}, {quality => 100}];
+# When ImageMagick is used for image conversions, this sets the default options.
+# See https://imagemagick.org/script/convert.php for a full list of options.
+# convert will be called as:
+# convert <input options> file.ext1 <output options> file.ext2
+$pg{specialPGEnvironmentVars}{tikzConvertOptions} = {input => {density => 300}, output => {quality => 100}};
 
    #  set the flags immediately above in the $pg{options} section above -- not here.
 

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1220,6 +1220,12 @@ $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 # This should be either 'pdf2svg' or 'dvipdfm'.
 $pg{specialPGEnvironmentVars}{tikzSVGMethod} = "pdf2svg";
 
+# When ImageMagick is used for image conversions, these are the default options
+# https://imagemagick.org/script/convert.php
+# will be used as:
+# convert $convertOptions[0] file.ext1 $convertOptions[1] file.ext2
+$pg{specialPGEnvironmentVars}{convertOptions} = [{density => 300}, {quality => 100}];
+
    #  set the flags immediately above in the $pg{options} section above -- not here.
 
 # Locations of CAPA resources. (Only necessary if you need to use converted CAPA

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -339,8 +339,11 @@ $mail{feedbackRecipients}    = [
 # images.
 #$pg{specialPGEnvironmentVars}{tikzSVGMethod} = "dvisvgm";
 
-# When ImageMagick is used for image conversions, default options
-#$pg{specialPGEnvironmentVars}{convertOptions} = [{density => 200}, {quality => 80}];
+# When ImageMagick is used for image conversions, this sets the default options.
+# See https://imagemagick.org/script/convert.php for a full list of options.
+# convert will be called as:
+# convert <input options> file.ext1 <output options> file.ext2
+#$pg{specialPGEnvironmentVars}{tikzConvertOptions} = {input => {density => 72}, output => {quality => 92}};
 
 ################################################################################
 #  Configuring the display of different versions of the editors

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -339,6 +339,9 @@ $mail{feedbackRecipients}    = [
 # images.
 #$pg{specialPGEnvironmentVars}{tikzSVGMethod} = "dvisvgm";
 
+# When ImageMagick is used for image conversions, default options
+#$pg{specialPGEnvironmentVars}{convertOptions} = [{density => 200}, {quality => 80}];
+
 ################################################################################
 #  Configuring the display of different versions of the editors
 ################################################################################


### PR DESCRIPTION
This branch follows #1320 and perhaps should be rebased once #1320 is merged.

This sets default options for using ImageMagick's convert. See here for a full list of options:
https://imagemagick.org/script/command-line-options.php

This pairs with a pull request to `pg`