### PR TITLE
log LTI authentication to course's login.log

### DIFF
--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -399,12 +399,14 @@ sub verify_normal_user
 		#debug("About to call create_session.");
 		$self->{session_key} = $self->create_session($user_id);
 		#debug("session_key=|" . $self -> {session_key} . "|.");
+		$self->write_log_entry("LOGIN OK");
 		return 1;
 		}
 	else  
 		{
 		$self->{error} = $r->maketext($auth_result);
 		$self-> {log_error} .= "$user_id - authentication failed: ". $self->{error};
+		$self->write_log_entry("LOGIN FAILED");
 		return 0;
 		} 
 }
@@ -439,6 +441,7 @@ sub authenticate
 		#debug( "eval failed: ", $@, "<br /><br />"; print_keys($r);); 
 		$self -> {error} .= $r->maketext($GENERIC_ERROR_MESSAGE
 				. ":  Something was wrong with your Nonce LTI parameters.  If this recurs, please speak with your instructor", $LMS);
+		$self->write_log_entry("AUTH LTI: Nonce error");
 		return 0;
 	}
 	#debug( "r->param(oauth_signature) = |" . $r -> param("oauth_signature") . "|");
@@ -481,6 +484,7 @@ sub authenticate
 		$self -> {error} .= $r->maketext("Your authentication failed.  Please return to Oncourse and login again.");
 		$self -> {error} .= $r->maketext("Something was wrong with your LTI parameters.  If this recurs, please speak with your instructor");
 		$self -> {log_error} .= "Construction of OAuth request record failed";
+		$self->write_log_entry("AUTH LTI: LTI parameters error");
 		return 0;
 		}
 	else
@@ -492,6 +496,7 @@ sub authenticate
 			$self -> {error} .= $r->maketext("Your authentication failed.  Please return to Oncourse and login again.");
 			$self -> {error} .= $r->maketext("Your LTI OAuth verification failed.  If this recurs, please speak with your instructor");
 			$self -> {log_error} .= "OAuth verification failed.  Check the Consumer Secret.";
+			$self->write_log_entry("AUTH LTI: OAuth verification error");
 			return 0;
 			}
 		else
@@ -761,11 +766,13 @@ sub authenticate
 			}
 			$self -> {initial_login} = 1;
 			}
+			$self->write_log_entry("AUTH LTI: user authenticated");
 			return 1;
 		}
 	}
 	#debug("LTIBasic is returning a failed authentication");
 	$self -> {error} = $r->maketext($GENERIC_ERROR_MESSAGE, $ce->{LMS_name});
+	$self->write_log_entry("AUTH LTI: failed to authenticate");
 	return(0);
 }
 


### PR DESCRIPTION
This replaces #1297.

When a user comes in through an LMS, if it is a new WW user, there is a record in the course's login.log. But if they authenticate and enter WW, there is currently no record in the login.log. Instructors cannot verify a student was in the course when they report that they were. This commit changes that.

All I really wanted was for LTIAdvanced, to log a "LOGIN OK" message. To mirror what happens with basic password logins, I put a message "AUTH LTI: user authenticated" message as a counterpart to "AUTH WWDB: password accepted". I really don't know what the "AUTH WWDB" is supposed to convey, so I really don't know if "AUTH LTI" is a good counterpart.

And then there are all these points where authentication could fail, so I felt I should put log messages there too. I'm not confident I made these messages say the right thing. And each one is preceded by `$self->{log_error} .= ...`, so I suspect it is redundant to add what I added. However I am not sure where the messages in `$self->{log_error}` end up...

And then even though I only cared about LTIAdvanced, it seemed appropriate to do the same things in LTIBasic.

I've only tested this for a student user that enters through the LMS, using LTIAdvanced, and successfully enters. Testing the fail points seems unnecessary, at least compared with the effort it would take to engineer each fail.