### PR TITLE
Keep simple.conf file in English

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -193,8 +193,8 @@ package configboolean;
 sub display_value {
   my ($self, $val) = @_;
   my $r = $self->{Module}->r;
-  return $r->maketext('True') if $val;
-  return $r->maketext('False');
+  return 'True' if $val;
+  return 'False';
 }
 
 sub save_string {
@@ -204,14 +204,14 @@ sub save_string {
 	my $newval = $self->convert_newval_source($newvalsource);
 	my $displayoldval = $self->comparison_value($oldval);
 	return '' if($displayoldval eq $newval);
-	return('$'. $varname . " = " . ($newval eq $r->maketext("True") ? 1 : 0) .";\n");
+	return('$'. $varname . " = " . ($newval eq "True" ? 1 : 0) .";\n");
 }
 
 sub entry_widget {
 	my ($self, $name, $default) = @_;
 	my $r = $self->{Module}->r;
-	my $true = $r->maketext('True');
-	my $false = $r->maketext('False');
+	my $true = 'True';
+	my $false = 'False';
 	return CGI::popup_menu(
 		-name => $name,
 		-default => ($default ? $true: $false),
@@ -229,11 +229,11 @@ package configpermission;
 sub display_value {
   my ($self, $val) = @_;
   my $r = $self->{Module}->r;
-  return $r->maketext('nobody') if not defined($val);
+  return 'nobody' if not defined($val);
   my %userRoles = %{$self->{Module}->{r}->{ce}->{userRoles}};
   my %reverseUserRoles = reverse %userRoles;
-  return $r->maketext($reverseUserRoles{$val}) if defined($reverseUserRoles{$val});
-  return $r->maketext($val);
+  return $reverseUserRoles{$val} if defined($reverseUserRoles{$val});
+  return $val;
 }
 
 sub save_string {
@@ -244,7 +244,7 @@ sub save_string {
 	my $r = $self->{Module}->r;
 	return '' if($displayoldval eq $newval);
 	my $str = '$'. $varname . " = '$newval';\n";
-	$str = '$'. $varname . " = undef;\n" if $newval eq $r->maketext('nobody');
+	$str = '$'. $varname . " = undef;\n" if $newval eq 'nobody';
 	return($str);
 }
 
@@ -265,7 +265,7 @@ sub entry_widget {
 
 	my @values = sort { $userRoles{$a} <=> $userRoles{$b} } keys %userRoles;
 
-	my %labels = map {$_ => $r->maketext($_)} @values;
+	my %labels = map {$_ => $_} @values;
 	return CGI::popup_menu(-name=>$name, -values => \@values,
 		-default=>$default, -labels => \%labels);
 }
@@ -401,7 +401,7 @@ sub display_value {
 	$val = 'ur' if not defined($val);
 
 	if ($self->{labels}->{$val}) {
-	    return join(CGI::br(), $r->maketext($self->{labels}->{$val}));
+	    return join(CGI::br(), $self->{labels}->{$val});
 	}
 
 	return join(CGI::br(), $val);
@@ -437,7 +437,7 @@ sub save_string {
 sub entry_widget {
 	my ($self, $name, $default) = @_;
 	my $r = $self->{Module}->r;
-	my %labels = map {$_ => $r->maketext($self->{labels}->{$_} // $_)} @{$self->{values}};
+	my %labels = map {$_ => $self->{labels}->{$_} // $_} @{$self->{values}};
 	
 	return CGI::popup_menu(
 		-name => $name,


### PR DESCRIPTION
This PR solves issue https://github.com/openwebwork/webwork2/issues/1077
The problem is that localized phrases for professor, student, true, false can be written to simple.conf file when saving configuration. However, WeBWorK is not capable to read localized strings and the file is messed.

The problems is in pull down menus. If they are on the current tab of configuration editor, the user sees translated phrase in pull down menu. The value field is in English and the corresponding part of the simple.conf file is correct. 
However, if the pull down menu is NOT on the active tab, the translated phrase is written int simple.conf file and remains there even if the language is changed. 

I believe that the correct approach is not to write translated strings to the conf file. I also believe, that the value in the pull down menu should be the same as the value written in the config file.  Therefore it is sufficient to remove `maketext` commands.

I was not able to rebase commit https://github.com/robert-marik/webwork2/commit/939fe2b1d86c54011c3dd28b709efb7ae4040ce4 and therefore made another one.

Only few languages (Hebrew, French, Hungarian) translated these strings and only these languages are affected.
This issue is somewhat related to https://github.com/openwebwork/webwork2/pull/1333 where similar situation appears for date/time string: WeBWorK is not capable to parse nonEnglish text which may appear if locales is not en_US.