### PR TITLE
Make sure that translations are not saved to simple.conf when editing the course configuration

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -190,6 +190,7 @@ $hardcopyTheme = "twoColumn";
 # Achievements
 ################################################################################
 $achievementsEnabled = 0;
+$achievementItemsEnabled = 0;
 $achievementPointsPerProblem = 5;
 $achievementPreambleFile = "preamble.at";
 


### PR DESCRIPTION
When an instructor makes changes to the course configuration the translated display values should not be used in any way in that process.  This completely separates the underlying values of the configuration objects from what is displayed by using labels and values for the html inputs.

This replaces #1351 and fixes https://github.com/openwebwork/webwork2/issues/1077.