### PR TITLE
Use student id for password

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -49,7 +49,7 @@ sub initialize {
 		warn "Internal error -- the number of students to be added has not been included" unless defined $numberOfStudents;
 		foreach my $i (1..$numberOfStudents) {
 		    my $new_user_id  = trim_spaces($r->param("new_user_id_$i"));
-		    my $new_password = cryptPassword($new_user_id);
+		    my $new_password = cryptPassword($r->param("student_id_$i"));
 		    next unless defined($new_user_id) and $new_user_id;
 			push @userIDs, $new_user_id;
 		    


### PR DESCRIPTION
The student id should be used for the password by default when adding a user from the classlist editor. This was unintentionally changed in #1290.

This fixes #1356.