### PR TITLE
fix ptx format answers

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -229,7 +229,7 @@ sub formatRenderedProblem {
 
 	# Answer hash in XML format used by the PTX format.
 	my $answerhashXML = XMLout($rh_result->{answers} // {}, RootName => 'answerhashes')
-	if $rh_result->{inputs_ref}{outputformat} // "" eq "ptx";
+	if $self->{inputs_ref}{outputformat} // "" eq "ptx";
 
 	# Sticky format local storage messages
 	my $localStorageMessages = CGI::start_div({ id => 'local-storage-messages' });


### PR DESCRIPTION
I think this was a mistake introduced in #1301. After making this change, what I do with ptx output on a 2.16 server is working again.