### PR TITLE
Add the javascript and css style for the scaffold.pl macro.

### DIFF
--- a/htdocs/js/apps/Scaffold/scaffold.css
+++ b/htdocs/js/apps/Scaffold/scaffold.css
@@ -1,0 +1,70 @@
+.section-div > .accordion-heading > a.accordion-toggle {
+	color: #212121;
+	padding: 2px 1.25rem;
+	border: 1px solid #AAAAAA;
+	border-top-left-radius: 3.3px;
+	border-top-right-radius: 3.3px;
+	display: flex;
+	transition: all 0.5s;
+}
+
+.section-div > .accordion-heading > .accordion-toggle span.section-title {
+	padding-top: 2px;
+}
+
+.section-div > .accordion-heading > a.accordion-toggle.collapsed {
+	border-bottom-left-radius: 3.3px;
+	border-bottom-right-radius: 3.3px;
+}
+
+.section-div .accordion-heading.canopen a.accordion-toggle::after {
+	width: 1.25rem;
+	height: 1.25rem;
+	margin-left: auto;
+	content: "";
+	background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+	background-repeat: no-repeat;
+	background-size: 1.25rem;
+	transition: transform 0.2s ease-in-out;
+}
+
+.section-div .accordion-heading.canopen a.accordion-toggle:not(.collapsed)::after {
+	transform: rotate(-180deg);
+}
+
+.section-div > .accordion-heading > a.accordion-toggle:focus,
+.section-div > .accordion-heading > a.accordion-toggle:hover {
+	text-decoration: none;
+}
+
+.section-div .accordion-heading.canopen a.accordion-toggle:focus {
+	outline: none;
+	box-shadow: inset 0 0 3px 2px #aaaa00;
+}
+
+.section-div > .accordion-heading.canopen > a.accordion-toggle {
+	background: yellow;
+}
+
+.section-div > .accordion-heading.iscorrect > a.accordion-toggle {
+	background: lightgreen;
+}
+
+.section-div > .accordion-heading.cannotopen > a.accordion-toggle {
+	background: #EEEEEE;
+}
+
+.section-div > .accordion-heading.cannotopen > a.accordion-toggle:focus {
+	outline: none;
+}
+
+.section-div > .accordion-heading.cannotopen > a.accordion-toggle:hover {
+	cursor: default;
+}
+
+.section-div > .accordion-body div.accordion-inner {
+	background: #FAFAFA;
+	padding: 1rem 1.25rem;
+	border-bottom-left-radius: 3.3px;
+	border-bottom-right-radius: 3.3px;
+}

--- a/htdocs/js/apps/Scaffold/scaffold.js
+++ b/htdocs/js/apps/Scaffold/scaffold.js
@@ -1,0 +1,17 @@
+window.addEventListener('DOMContentLoaded', function() {
+	var sections = $('.section-div .collapse');
+	sections.on('show', function() {
+		this.style.display = 'block';
+
+		// Reflow MathQuill answer boxes contained in the section so that their contents are rendered correctly.
+		var section = this;
+		if (window.answerQuills) {
+			Object.keys(answerQuills).forEach(
+				function(quill) { if (section.querySelector('#' + quill)) answerQuills[quill].mathField.reflow(); }
+			);
+		}
+	});
+
+	// Hide the accordion content while collapsed to remove its contents from the tab order.
+	sections.on('hidden', function() { this.style.display = 'none'; });
+});


### PR DESCRIPTION
This is moved out of the macro and loaded via ADD_JS_FILE and ADD_CSS_FILE.
The main difference though is that this switches from a jquery-ui accordion to a bootstrap accordion.

See the paired pg pull request openwebwork/pg#573.