### PR TITLE
Don't try to show the student nav in gateway quizzes when the set is invalid

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1166,7 +1166,7 @@ sub nav {
 	if ($r->authz->hasPermissions($user, "become_student") && $effectiveUser ne $user) {
 		my $setName = $self->{set}->set_id;
 
-		return "" if $setName eq "Undefined_Set";
+		return "" if $setName eq "Undefined_Set" || $self->{invalidSet};
 
 		my $setVersion = $self->{set}->version_id;
 		my $courseName = $self->{ce}{courseName};


### PR DESCRIPTION
Currently an error occurs if you attempt to open a new gateway quiz that is closed when acting as a student.  This fixes that and lets you see the page that says, "The selected problem set (Gateway_Past_Due) is not a valid set for tguy:  This set is closed. No new set versions may be taken."
 