### PR TITLE
style the tabs in course configuration page

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1745,7 +1745,7 @@ $ConfigValues = [
 		  type => 'permission'
 		},
 	],
-	['PG - Problem Display/Answer Checking',
+	['Problem Display/Answer Checking',
 		{ var => 'pg{displayModes}',
 		  doc => 'List of display modes made available to students',
 		  doc2 => '<p>When viewing a problem, users may choose different methods of rendering formulas via an options box in the left panel. Here, you can adjust what display modes are listed.</p><p>Some display modes require other software to be installed on the server. Be sure to check that all display modes selected here work from your server.</p><p>The display modes are <ul><li> plainText: shows the raw LaTeX srings for formulas.<li> images: produces images using the external programs LaTeX and dvipng.<li> MathJax: a successor to jsMath, uses javascript to place render mathematics.</ul></p></p>You must use at least one display mode. If you select only one, then the options box will not give a choice of modes (since there will only be one active).</p>',

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -1289,6 +1289,38 @@ table#grades_table pre{
     font-size:105%;
 }
 
+.config-tabs {
+	text-align: center;
+	margin-bottom: 40pt;
+}
+
+.config-tabs span {
+	padding: 10px;
+	font-weight: bold;
+}
+
+.config-tabs span.current {
+	background-color: #003388;
+	color: white;
+}
+
+.config-tabs span.other {
+	background-color: #f6f6f6;
+
+}
+
+.config-tabs span.other:hover {
+	background-color: #e1e1e1;
+}
+
+.config-tabs > span > a {
+	padding: 10px;
+	margin: -10px;
+	color: inherit;
+	text-decoration: none;
+
+}
+
 #config-form input[type="checkbox"] {
     margin-right:1.5ex;
 }

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -499,13 +499,15 @@ sub print_navigation_tabs {
 	my $str = '';
 	for my $tab (0..(scalar(@tab_names)-1)) {
 		if($current_tab eq "tab$tab") {
-			$tab_names[$tab] = $r->maketext($tab_names[$tab]);
+			$tab_names[$tab] = CGI::span({class => 'current'}, $r->maketext($tab_names[$tab]));
 		} else {
-			$tab_names[$tab] = CGI::a({href=>$self->systemLink($r->urlpath, params=>{section_tab=>"tab$tab"})}, $r->maketext($tab_names[$tab]));
+			$tab_names[$tab] = CGI::span({class => 'other'},
+				CGI::a({href => $self->systemLink($r->urlpath, params=>{section_tab=>"tab$tab"})}, $r->maketext($tab_names[$tab]))
+			);
 		}
 	}
 	print CGI::p() .
-		'<div align="center">' . join('&nbsp;|&nbsp;', @tab_names) .'</div>'.
+		CGI::div({class=>'config-tabs'}, join('', @tab_names)) .
 		CGI::p();
 }
 
@@ -675,7 +677,6 @@ sub body {
 	$tabnumber =~ s/tab//;
 	my @configSectionArray = @{$ConfigValues->[$tabnumber]};
 	my $configTitle = shift @configSectionArray;
-	print CGI::p(CGI::div({-align=>'center'}, CGI::b($r->maketext($configTitle))));
 
 	print CGI::start_table({-border=>"1"});
 	print '<tr>'.CGI::th($r->maketext('Setting')). CGI::th($r->maketext('Default')) .CGI::th($r->maketext('Current'));

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -677,6 +677,7 @@ sub body {
 	$tabnumber =~ s/tab//;
 	my @configSectionArray = @{$ConfigValues->[$tabnumber]};
 	my $configTitle = shift @configSectionArray;
+	print CGI::h2(CGI::b($r->maketext($configTitle)));
 
 	print CGI::start_table({-border=>"1"});
 	print '<tr>'.CGI::th($r->maketext('Setting')). CGI::th($r->maketext('Default')) .CGI::th($r->maketext('Current'));

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -356,7 +356,7 @@ my $ConfigStrings = [
 		  type => 'permission'
 		},
 	],
-	[x('PG - Problem Display/Answer Checking'),
+	[x('Problem Display/Answer Checking'),
 		{ var => 'pg{displayModes}',
 		  doc => x('List of display modes made available to students'),
 		  doc2 => x('<p>When viewing a problem, users may choose different methods of rendering formulas via an options box in the left panel. Here, you can adjust what display modes are listed.</p><p>Some display modes require other software to be installed on the server. Be sure to check that all display modes selected here work from your server.</p><p>The display modes are <ul><li> plainText: shows the raw LaTeX srings for formulas.<li> images: produces images using the external programs LaTeX and dvipng.<li> MathJax: a successor to jsMath, uses javascript to place render mathematics.</ul></p></p>You must use at least one display mode. If you select only one, then the options box will not give a choice of modes (since there will only be one active).</p>'),


### PR DESCRIPTION
This styles the tabs in the Course Config page.

Really, these should be buttons with the form for all the areas fully present, and there are no links to other pages to get to a different subsection of the config options. That is a heavier project.

Here is what I styled it to be like, going for minimalism. If you hover over one of the other tabs, that tab turns a darker gray.

<img width="1135" alt="Screen Shot 2021-05-14 at 5 48 57 PM" src="https://user-images.githubusercontent.com/4732672/118343263-b9ec2d80-b4dc-11eb-8ab2-aee39e46c84e.png">
