### PR TITLE
Adjust ADD_JS_FILE handling code to deal with new third parameter

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -155,14 +155,17 @@ sub formatRenderedProblem {
 	# Add JS files requested by problems via ADD_JS_FILE() in the PG file.
 	if (ref($rh_result->{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
-		$jsFiles{$_->{file}} = $_->{external} for @{$rh_result->{flags}{extra_js_files}};
-		for (keys(%jsFiles)) {
-			if ($jsFiles{$_}) {
-				$problemHeadText .= qq{<script src="$_"></script>}
-			} elsif (!$jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
-				$problemHeadText .= qq{<script src="$ce->{webworkURLs}{htdocs}/$_"></script>};
+		for my $jsFile (@{$rh_result->{flags}{extra_js_files}}) {
+			next if $jsFiles{$jsFile->{file}};
+			$jsFiles{$jsFile->{file}} = 1;
+			my $attributes = ref($jsFile->{attributes}) eq "HASH"
+				? join(" ", map { qq!$_="$jsFile->{attributes}{$_}"! } keys %{$jsFile->{attributes}}) : ();
+			if ($jsFile->{external}) {
+				$problemHeadText .= qq{<script src="$jsFile->{file}" $attributes></script>}
+			} elsif (!$jsFile->{external} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$jsFile->{file}") {
+				$problemHeadText .= qq{<script src="$ce->{webworkURLs}{htdocs}/$jsFile->{file}" $attributes></script>};
 			} else {
-				$problemHeadText .= qq{<!-- $_ is not available in htdocs/ on this server -->};
+				$problemHeadText .= qq{<!-- $jsFile->{file} is not available in htdocs/ on this server -->};
 			}
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2425,19 +2425,19 @@ sub output_JS{
 	for my $pg (@{$self->{ra_pg_results}}) {
 		next unless ref($pg);
 		if (ref($pg->{flags}{extra_js_files}) eq "ARRAY") {
-			# Avoid duplicates
-			$jsFiles{$_->{file}} = $_->{external} for @{$pg->{flags}{extra_js_files}};
-		}
-	}
-	for (keys(%jsFiles)) {
-		if ($jsFiles{$_}) {
-			print CGI::start_script({type => "text/javascript",
-					src => $_}), CGI::end_script();
-		} elsif (!$jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
-			print CGI::start_script({type => "text/javascript",
-					src => "$site_url/$_"}), CGI::end_script();
-		} else {
-			print "<!-- $_ is not available in htdocs/ on this server -->\n";
+			for (@{$pg->{flags}{extra_js_files}}) {
+				next if $jsFiles{$_->{file}};
+				$jsFiles{$_->{file}} = 1;
+
+				my %attributes = ref($_->{attributes}) eq "HASH" ? %{$_->{attributes}} : ();
+				if ($_->{external}) {
+					print CGI::script({ src => $_->{file}, %attributes }, "");
+				} elsif (!$_->{external} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_->{file}") {
+					print CGI::script({ src => "$site_url/$_->{file}", %attributes }, "");
+				} else {
+					print "<!-- $_ is not available in htdocs/ on this server -->\n";
+				}
+			}
 		}
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2361,15 +2361,14 @@ sub output_JS{
 	# Add JS files requested by problems via ADD_JS_FILE() in the PG file.
 	if (ref($self->{pg}{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
-		# Avoid duplicates
-		$jsFiles{$_->{file}} = $_->{external} for @{$self->{pg}{flags}{extra_js_files}};
-		for (keys(%jsFiles)) {
-			if ($jsFiles{$_}) {
-				print CGI::start_script({type => "text/javascript",
-						src => $_}), CGI::end_script();
-			} elsif (!$jsFiles{$_} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_") {
-				print CGI::start_script({type => "text/javascript",
-						src => "$site_url/$_"}), CGI::end_script();
+		for (@{$self->{pg}{flags}{extra_js_files}}) {
+			next if %jsFiles{$_->{file}};
+			$jsFiles{$_->{file}} = 1;
+			my %attributes = ref($_->{attributes}) eq "HASH" ? %{$_->{attributes}} : ();
+			if ($_->{external}) {
+				print CGI::script({ src => $_->{file} , %attributes }, "");
+			} elsif (!$_->{external} && -f "$WeBWorK::Constants::WEBWORK_DIRECTORY/htdocs/$_->{file}") {
+				print CGI::script({ src => "$site_url/$_->{file}", %attributes }, "");
 			} else {
 				print "<!-- $_ is not available in htdocs/ on this server -->\n";
 			}


### PR DESCRIPTION
Adjust the code for dealing with the files added by PG.pl's ADD_JS_FILE method to add attributes provided in the new optional third argument.

The code is also adjusted to ensure that scripts are loaded in the order that they are requested, instead of in the random order that perl gives with hash keys.  Should this be done with the ADD_CSS_FILE handling code also?  Order matters for css loading as well.

This is paired with https://github.com/openwebwork/pg/pull/576.