### PR TITLE
Make output_JS in ProblemSets.pm return the empty string.  Oops.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -774,6 +774,8 @@ sub output_JS {
 	my $site_url = $self->r->ce->{webworkURLs}{htdocs};
 
 	print CGI::script({ src => "$site_url/js/apps/ProblemSets/problemsets.js", defer => '' }, "");
+
+	return "";
 }
 
 1;


### PR DESCRIPTION
When I added the output_JS method to ProblemSets.pm I forgot to have it return the empty string.  So now you get 1's where they shouldn't be.