### PR TITLE
Remove the text "WeBWorK" from the gateway template webwork logo

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -64,7 +64,7 @@
 <!-- Header -->
 <div id = "masthead" class="row-fluid">
 	<div class="span2 webwork_logo">
-		<a href="<!--#url type="webwork" name="root"-->"><img src="<!--#url type="webwork" name="htdocs"-->/images/webwork_logo.svg" alt="to courses page" />WeBWorK</a>
+		<a href="<!--#url type="webwork" name="root"-->"><img src="<!--#url type="webwork" name="htdocs"-->/images/webwork_logo.svg" alt="to courses page" /></a>
 	</div>
 	<div class="span6 maa_logo">
 		<a href="http://www.maa.org"><img src="<!--#url type="webwork" name="htdocs"-->/images/maa_logo_small.png" alt="image link to MAA (Mathematical Association of America) main web site" /></a>


### PR DESCRIPTION
The text is now shown below the logo as well as in the logo.  This is another thing missed when the svg logo was added to the masthead.