### PR TITLE
Fix tab order hack for scaffolds

### DIFF
--- a/htdocs/js/apps/Scaffold/scaffold.js
+++ b/htdocs/js/apps/Scaffold/scaffold.js
@@ -1,6 +1,7 @@
 window.addEventListener('DOMContentLoaded', function() {
-	var sections = $('.section-div .collapse');
-	sections.on('show', function() {
+	var sections = $('.section-div > .accordion-body.collapse');
+	sections.on('show', function(e) {
+		if (e.target != this) return;
 		this.style.display = 'block';
 
 		// Reflow MathQuill answer boxes contained in the section so that their contents are rendered correctly.
@@ -13,5 +14,5 @@ window.addEventListener('DOMContentLoaded', function() {
 	});
 
 	// Hide the accordion content while collapsed to remove its contents from the tab order.
-	sections.on('hidden', function() { this.style.display = 'none'; });
+	sections.on('hidden', function(e) { if (e.target != this) return; this.style.display = 'none'; });
 });


### PR DESCRIPTION
This fixes a bug with the tab order hack in which a tooltip on an element within the scaffold causes the scaffold to also close.  This bug was seen in a problem with a graphTool element inside a scaffold.

Another way to fix this is to upgrade to bootstrap 4 or newer.  Those versions of bootstrap properly deal with the tab order, and remove the need for this hack.

Make the scaffold javascript more precise on the selector used to find the accordion body elements that belong to the scaffold.  Also make the event handlers only act if the target is actually the accordion body, and not an element within.  In other words, ignore events that bubble up from within.

