### PR TITLE
Sticky student nav

### DIFF
--- a/htdocs/themes/math4/gateway.css
+++ b/htdocs/themes/math4/gateway.css
@@ -4,7 +4,7 @@
 
 /* update margins to reflect missing left column */
 #content {
-	margin: 1em 1em 1em 0; 
+	margin: 0 1em 1em 0;
 }
 
 div.gwMessage { 

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -93,13 +93,11 @@
 	<!--#endif-->
 	
 	<!--#if can="nav"-->
-	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
-		<!--#nav separator="  "-->
-	</div>
+	<!--#nav separator="  "-->
 	<!--#endif-->
 	
 	<!--#if can="title"-->
-	<h1 id="content"><!--#title--></h1>
+	<h1><!--#title--></h1>
 	<!--#endif-->
 	
 	<!--#if can="message"-->

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -93,7 +93,9 @@
 	<!--#endif-->
 	
 	<!--#if can="nav"-->
+	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
 		<!--#nav separator="  "-->
+	</div>
 	<!--#endif-->
 	
 	<!--#if can="title"-->

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -294,7 +294,13 @@ h2.page-title {
 .problem-nav {
 	margin-bottom:1ex;
 	display: inline-block;
+}
 	
+.row-fluid.sticky, .user-nav {
+	z-index: 1;
+	position: sticky;
+	top: 0;
+	background-color: white;
 }
 
 .problem-nav .user-nav {

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -157,6 +157,10 @@ legend {
     border:0px;
 }
 
+ul.nav {
+	margin-top: 0;
+}
+
 ul.nav li a:hover {
 	background: #e1e1e1;	
 }
@@ -235,6 +239,7 @@ div.unattempted-progress {
     height:20px;
     padding-top:8px;
     padding-bottom:8px;
+    margin-right: 5px;
 }
 
 #breadcrumb-navigation {
@@ -284,6 +289,7 @@ h2.page-title {
 
 .breadcrumb {
 	border: 1px solid #e6e6e6;
+	margin-bottom: 10px;
 }
 
 .Warnings {
@@ -304,14 +310,18 @@ h2.page-title {
 	background-color: white;
 	margin-bottom: 1rem;
 	padding: 0.25rem;
-	border-radius: 4px;
-	box-shadow: 0 0 0.25rem 1px gray;
+	border-radius: 0 0 4px 4px;
+	box-shadow: 0 0.1rem 0.2rem 1px gray;
 	box-sizing: border-box;
 }
 
 .sticky-nav > a,
 .sticky-nav > div {
-	margin: 0.25rem auto 0.25rem 0.25rem;
+	margin: 0.25rem;
+}
+
+.sticky-nav > div:first-child {
+	margin-right: auto;
 }
 
 .user-nav .student-nav-selector .dropdown-menu {

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -245,6 +245,10 @@ div.unattempted-progress {
 }
 
 /* Main Content */
+body {
+	padding: 0;
+}
+
 .body {
 	display: inline-block;
 	float: left;
@@ -291,20 +295,23 @@ h2.page-title {
 }
 
 /* Question nav section */
-.problem-nav {
-	margin-bottom:1ex;
-	display: inline-block;
-}
-	
-.row-fluid.sticky, .user-nav {
+.sticky-nav {
+	display: flex;
+	flex-wrap: wrap;
 	z-index: 1;
 	position: sticky;
 	top: 0;
 	background-color: white;
+	margin-bottom: 1rem;
+	padding: 0.25rem;
+	border-radius: 4px;
+	box-shadow: 0 0 0.25rem 1px gray;
+	box-sizing: border-box;
 }
 
-.problem-nav .user-nav {
-	margin-bottom: 5px;
+.sticky-nav > a,
+.sticky-nav > div {
+	margin: 0.25rem auto 0.25rem 0.25rem;
 }
 
 .user-nav .student-nav-selector .dropdown-menu {

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -90,6 +90,27 @@
 	</div>
 </div>
 
+<!-- Breadcrumb -->
+<div id="breadcrumb-row" class="row-fluid">
+	<div class="span12">
+		<a href="#" class="btn btn-primary btn" id="toggle-sidebar">
+			<span id="toggle-sidebar-icon">
+				<i class="icon fas fa-chevron-left" aria-hidden="true" data-alt="close sidebar"></i>
+			</span>
+		</a>
+		<div id="breadcrumb-navigation" role="navigation" aria-label="breadcrumb navigation">
+			<ul class="breadcrumb">
+				<!--#path style="bootstrap" text="<li><span aria-hidden='true' class='divider'>/</span></li>"-->
+			</ul>
+		</div>
+	</div>
+</div>
+
+<!-- Run breadcrumb js since it gets loaded early -->
+<script type="text/javascript">
+	$('#toggle-sidebar').removeClass('btn-primary')
+</script>
+
 <div id="body-row" class="row-fluid">
 
 <!-- Navigation -->
@@ -131,25 +152,13 @@
 
 <!-- Main Content Area -->
 <div id="content" class="span10" >
-	<!-- Breadcrumb -->
-	<div id="breadcrumb-row" class="row-fluid">
-	  <div class="span12">
-	    <a href="#" class="btn btn-primary btn" id="toggle-sidebar">
-			<span id="toggle-sidebar-icon">
-				<i class="icon fas fa-chevron-left" aria-hidden="true" data-alt="close sidebar"></i>
-			</span>
-	    </a>
-	    <div id="breadcrumb-navigation" role="navigation" aria-label="breadcrumb navigation">
-	      <ul class="breadcrumb">
-			<!--#path style="bootstrap" text="<li><span aria-hidden='true' class='divider'>/</span></li>"-->
-	      </ul>
-	    </div>
-	</div></div>
-	<!-- Run breadcrumb js since it gets loaded early -->
-	<script type="text/javascript"> 
-	  $('#toggle-sidebar').removeClass('btn-primary')
-	</script>
-	
+	<!--#if can="nav"-->
+	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
+		<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
+		<!--#nav style="buttons" imageprefix="/webwork2_files/images/nav" imagesuffix=".gif" separator="  "-->
+	</div>
+	<!--#endif-->
+
 	<!-- Page Title -->
 	<!--#if can="title"-->
 	<div class="row-fluid"><div class="span12">
@@ -161,13 +170,6 @@
 	<div id="Message" class="Message row-fluid">
 		<!-- Message for the user -->
 		<!--#message-->
-	</div>
-	<!--#endif-->
-
-	<!--#if can="nav"--> 
-	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
-		<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
-		<!--#nav style="buttons" imageprefix="/webwork2_files/images/nav" imagesuffix=".gif" separator="  "-->
 	</div>
 	<!--#endif-->
 

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -93,7 +93,7 @@
 <!-- Breadcrumb -->
 <div id="breadcrumb-row" class="row-fluid">
 	<div class="span12">
-		<a href="#" class="btn btn-primary btn" id="toggle-sidebar">
+		<a href="#" class="btn" id="toggle-sidebar">
 			<span id="toggle-sidebar-icon">
 				<i class="icon fas fa-chevron-left" aria-hidden="true" data-alt="close sidebar"></i>
 			</span>
@@ -105,11 +105,6 @@
 		</div>
 	</div>
 </div>
-
-<!-- Run breadcrumb js since it gets loaded early -->
-<script type="text/javascript">
-	$('#toggle-sidebar').removeClass('btn-primary')
-</script>
 
 <div id="body-row" class="row-fluid">
 

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -158,7 +158,7 @@
 	<!--#endif-->
 
 	<!--#if can="nav" can="message"--> 
-	<div class="row-fluid">
+	<div class="row-fluid sticky">
 	  <div id="problem-nav" class="problem-nav span7" role="navigation" aria-label="problem navigation">
 	<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
 	<!--#if can="nav"-->

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -157,21 +157,17 @@
 	</div></div>
 	<!--#endif-->
 
-	<!--#if can="nav" can="message"--> 
-	<div class="row-fluid sticky">
-	  <div id="problem-nav" class="problem-nav span7" role="navigation" aria-label="problem navigation">
-	<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
-	<!--#if can="nav"-->
+	<!--#if can="message"--> 
+	<div id="Message" class="Message row-fluid">
+		<!-- Message for the user -->
+		<!--#message-->
+	</div>
+	<!--#endif-->
+
+	<!--#if can="nav"--> 
+	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
+		<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
 		<!--#nav style="buttons" imageprefix="/webwork2_files/images/nav" imagesuffix=".gif" separator="  "-->
-	<!--#endif-->
-	  </div>
-	  
-	  <div id="Message" class="Message span4 offset1">
-	    <!-- Message for the user -->
-	    <!--#if can="message"-->
-	        <!--#message-->
-	<!--#endif-->
-	  </div>
 	</div>
 	<!--#endif-->
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1214,6 +1214,7 @@ sub nav {
 
 		# Set up the student nav.
 		print join("",
+			CGI::start_div({ class => "row-fluid sticky-nav", role => "navigation", aria_label => "user navigation"}),
 			CGI::start_div({ class => 'user-nav' }),
 			$prevTest
 			? CGI::a({
@@ -1257,6 +1258,7 @@ sub nav {
 					class => "nav_button student-nav-button"
 				}, $r->maketext("Next Test"))
 			: CGI::span({ class => "gray_button" }, $r->maketext("Next Test")),
+			CGI::end_div(),
 			CGI::end_div()
 		);
 	}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1208,7 +1208,7 @@ sub nav {
 		if defined $self->{will}->{showOldAnswers};
 	$tail .= "&showProblemGrader=" . $self->{will}{showProblemGrader}
 		if defined $self->{will}{showProblemGrader};
-	return $userNav . $self->navMacro($args, $tail, @links);
+	return $userNav . CGI::div($self->navMacro($args, $tail, @links));
 }
 
 sub path {


### PR DESCRIPTION
This makes the problem and user navigation buttons sticky to the top of the screen. So for example if you have scrolled down to the bottom of a problem or quiz, you can move to the next student or problem without scrolling back up.