### PR TITLE
Fix a typo from the latest ADD_JS_FILES update that causes warnings

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2362,7 +2362,7 @@ sub output_JS{
 	if (ref($self->{pg}{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
 		for (@{$self->{pg}{flags}{extra_js_files}}) {
-			next if %jsFiles{$_->{file}};
+			next if $jsFiles{$_->{file}};
 			$jsFiles{$_->{file}} = 1;
 			my %attributes = ref($_->{attributes}) eq "HASH" ? %{$_->{attributes}} : ();
 			if ($_->{external}) {


### PR DESCRIPTION
Without this pull request run `apache2ctl -S` to see
`%jsFiles{...} in scalar context better written as $jsFiles{...} at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm line 2365.`

With this pull request run the same thing an enjoy not seeing that warning.

This typo did not happen in the other two places the ADD_JS_FILES handling occurs.