### PR TITLE
Change LTIAdvanced.pm so that all new logins get logged + some other fixes

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -248,7 +248,7 @@ sub get_credentials {
       # User id and address is at this point
       if ( $ce->{debug_lti_parameters} ) {
 	warn "=========== summary ============";
-	my $tmpIDmsg = ( $used_LMS_user_id == 1 ) ? " was the remote LMS LTI provided user_id\n" : "\n" ;
+	my $tmpIDmsg = ( $used_LMS_user_id == 1 ) ? " (the remote LMS LTI provided user_id)\n" : "\n" ;
 	warn "User id is |$self->{user_id}| $tmpIDmsg";
 	warn "User mail address is |$self->{email}|\n";
 	warn "Student id is |", $self->{student_id}//'undefined',"|\n";
@@ -287,7 +287,7 @@ sub check_user {
     return $self->SUPER::check_user(@_);
   }
 
-  if (!defined($user_id) || (defined $user_id and $user_id eq "")) {
+  if (!defined($user_id) || (defined $user_id && $user_id eq "")) {
     $self->{log_error} .= "no user id specified";
     $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
     return 0;
@@ -453,13 +453,9 @@ sub authenticate {
       $self->{error} .= $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
       $self->{log_error} .= "Construction of OAuth request record failed";
       return 0;
-  } # was an elsif here, but we would have returned in the case that the if condition held
+  }
 
-  $verifyOK = $request->verify || $altrequest->verify;
-
-  # Space for future LTI verification options
-
-  if ( ! $verifyOK ) {
+  if ( ! $request->verify && ! $altrequest->verify) {
       debug("LTIAdvanced::authenticate request-> verify failed");
       debug("OAuth verification Failed ");
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -105,9 +105,9 @@ sub  request_has_data_for_this_verification_module {
 
   # We need at least these things to verify an oauth request
   if (!(defined $r->param("oauth_consumer_key"))
-      or !(defined $r->param("oauth_signature"))
-      or !(defined $r->param("oauth_nonce"))
-      or !(defined $r->param("oauth_timestamp")) ) {
+      || !(defined $r->param("oauth_signature"))
+      || !(defined $r->param("oauth_nonce"))
+      || !(defined $r->param("oauth_timestamp")) ) {
     debug("LTIAdvanced returning that it has insufficent data");
     return(0);
   } else {
@@ -213,7 +213,7 @@ sub get_credentials {
       # after @
 
       if (!defined($self->{user_id})
-	  || ( $self->{email} ne "" # modified to ne "" as fallback value defined above
+	  || ( $self->{email} ne ""
 	       && defined($ce->{preferred_source_of_username})
 	       && $ce->{preferred_source_of_username} eq "lis_person_contact_email_primary")) {
 	$self->{user_id} = $self->{email};
@@ -287,7 +287,7 @@ sub check_user {
     return $self->SUPER::check_user(@_);
   }
 
-  if (!defined($user_id) or (defined $user_id and $user_id eq "")) {
+  if (!defined($user_id) || (defined $user_id and $user_id eq "")) {
     $self->{log_error} .= "no user id specified";
     $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
     return 0;
@@ -297,11 +297,12 @@ sub check_user {
 
   if (!$User) {
     if (    defined($r->param("lis_person_sourcedid"))
-	 or defined($r->param("lis_person_sourced_id"))
-	 or defined($r->param("lis_person_source_id"))
-	 or defined($r->param("lis_person_sourceid"))
-	 or defined($r->param("lis_person_contact_email_primary"))
-         or $ce->{allow_lti_to_use_provided_user_id}
+	 || defined($r->param("lis_person_sourced_id"))
+	 || defined($r->param("lis_person_source_id"))
+	 || defined($r->param("lis_person_sourceid"))
+	 || defined($r->param("lis_person_contact_email_primary"))
+	 || $ce->{allow_lti_to_use_provided_user_id}
+	 || $ce->{force_lti_to_use_provided_user_id}
        ) {
       debug("User |$user_id| is unknown but may be an new user from an LSM via LTI. About to return a 1");
       return 1;  #This may be a new user coming in from a LMS via LTI.
@@ -498,7 +499,6 @@ sub authenticate {
 		}
       }  elsif ($ce->{LMSManageUserData}) {
 		$self->{initial_login} = 1; # Set here so login gets logged, even for accounts which maybe_update_user() would not modify or when it fails to update
-		$self->{was_LTI} = 1;
 		# Existing user. Possibly modify demographic information and permission level.
 		unless ( $self->maybe_update_user() ) {
 			# Do not fail the login if data update failed
@@ -507,7 +507,6 @@ sub authenticate {
 		}
       } else {
 	$self->{initial_login} = 1; # Set here so login gets logged when $ce->{LMSManageUserData} is false
-	$self->{was_LTI} = 1;
       }
 
       # If we are using grade passback then make sure the data
@@ -641,7 +640,6 @@ sub create_user {
   }
 
   $self->{initial_login} = 1;
-  $self->{was_LTI} = 1;
 
   return 1;
 }

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -465,13 +465,17 @@ sub authenticate {
 		}
       }  elsif ($ce->{LMSManageUserData}) {
 		# Existing user.  Possibly modify demographic information and permission level.
-		unless ($self->maybe_update_user()) {
+		if ($self->maybe_update_user()) {
+			$self->{initial_login} = 1; # Set here so login gets logged, even for accounts which maybe_update_user() would not modify
+		} else {
 			$r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
 			  $self->{log_error} .= "Failed to update user $userID.";
 			if ( $ce->{debug_lti_parameters} ) {
 				warn("Failed to updateuser $userID.");
 			}
 		}
+      } else {
+	$self->{initial_login} = 1; # Set here so login gets logged when $ce->{LMSManageUserData} is false
       }
 
       # If we are using grade passback then make sure the data
@@ -664,8 +668,6 @@ sub maybe_update_user {
       warn "Existing user: $userID updated.\n"
 	if ( $ce->{debug_lti_parameters} );
     }
-      
-    $self->{initial_login} = 1;
   }
 
   return 1;


### PR DESCRIPTION
This is intended to solve the same problem as https://github.com/openwebwork/webwork2/pull/1348, but by forcing the regular logging code to trigger by setting `$self->{initial_login} = 1;` on all logins.

The change was only made to `LTIAdvanced.pm`.

Now all new logins get logged,even when
  1. `$ce->{LMSManageUserData}` is false, and when
  2. `maybe_update_user()` would not modify the user due to the user's permission level being > `$ce->{userRoles}->{$ce->{LTIAccountCreationCutoff}}`.
Both of those cases failed to be logged in the past.