### PR TITLE
Create xmlrpc server variable

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -48,6 +48,11 @@ $webwork_url       = '/webwork2';
 $server_root_url   = '';   # e.g.  'https://webwork.yourschool.edu' or 'http://localhost'
                            # Note, if running a secure (ssl) server, you probably need 'https://...'
 
+# if the XMLRPC runs on a different server or uses http internally, uncomment the following
+# line and set the proper URL.  For example, 'http://192.168.1.1'
+
+# $xmlrpc_root_url = ''; 
+
 # The following two variables must match the user ID and group ID respectively
 # under which apache is running.
 # In the apache configuration file (often called httpd.conf) you will find

--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -100,6 +100,11 @@ unless ($server_root_url) {
 	die "unable to determine apache server url using course environment |$seed_ce|.".
 	    "check that the variable \$server_root_url has been properly set in conf/site.conf\n";
 }
+my $xmlrpc_root_url = $seed_ce->{xmlrpc_root_url} || $server_root_url;
+unless ($xmlrpc_root_url) {
+        die "unable to determine xmlrpc server url using course environment |$seed_ce|.".
+            "check that the variable \$xmlrpc_root_url has been properly set in conf/site.conf\n";
+}
 
 ############################
 # These variables are set when the child process is started
@@ -114,8 +119,8 @@ our ($SITE_URL, $FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
 
 
 
-	$SITE_URL            =  "$server_root_url" ; 
-	$FORM_ACTION_URL     =  "$server_root_url/webwork2/instructorXMLHandler";
+	$SITE_URL            =  "$xmlrpc_root_url" ; 
+	$FORM_ACTION_URL     =  "$xmlrpc_root_url/webwork2/instructorXMLHandler";
 
 use constant DISPLAYMODE   => 'images'; #  Mathjax  is another possibilities.
 

--- a/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
@@ -101,8 +101,15 @@ my $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
 my $server_root_url = $seed_ce->{server_root_url};
 unless ($server_root_url) {
 	die "unable to determine apache server url using course environment |$seed_ce|.".
-	    "check that the variable \$server_root_url has been properly set in conf/site.conf\n";
+			"check that the variable \$server_root_url has been properly set in conf/site.conf\n";
 }
+
+my $xmlrpc_root_url = $seed_ce->{xmlrpc_root_url} || $server_root_url;
+unless ($xmlrpc_root_url) {
+	die "unable to determine xmlrpc server url using course environment |$seed_ce|.".
+			"check that the variable \$xmlrpc_root_url has been properly set in conf/site.conf\n";
+}
+
 
 ############################
 # These variables are set when the child process is started
@@ -117,8 +124,8 @@ our ($SITE_URL,$FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
 
 
 
-	$SITE_URL             =  "$server_root_url"; 
-	$FORM_ACTION_URL     =  "$server_root_url/webwork2/html2xml";
+	$SITE_URL             =  "$xmlrpc_root_url"; 
+	$FORM_ACTION_URL     =  "$xmlrpc_root_url/webwork2/html2xml";
 
 
 our @COMMANDS = qw( listLibraries    renderProblem  ); #listLib  readFile tex2pdf 
@@ -157,19 +164,19 @@ sub pre_header_initialize {
 	# rather than trying to set defaults such as displaymode
 	unless ( $user_id && $courseName && $displayMode && $problemSeed) {
 		print CGI::ul( 
-		      CGI::h1("Missing essential data in web dataform:"),
-			  CGI::li(CGI::escapeHTML([
-		      	"userID: |$user_id|", 
-		      	"courseID: |$courseName|",	
-		        "displayMode: |$displayMode|", 
-		        "problemSeed: |$problemSeed|"
-		      ])));
+					CGI::h1("Missing essential data in web dataform:"),
+				CGI::li(CGI::escapeHTML([
+						"userID: |$user_id|", 
+						"courseID: |$courseName|",	
+						"displayMode: |$displayMode|", 
+						"problemSeed: |$problemSeed|"
+					])));
 		return;
 	}
-    #######################
-    #  setup xmlrpc client
-    #######################
-    my $xmlrpc_client = new WebworkClient;
+		#######################
+		#  setup xmlrpc client
+		#######################
+		my $xmlrpc_client = new WebworkClient;
 
 	$xmlrpc_client ->encoded_source($r->param('problemSource')) ; # this source has already been encoded
 	$xmlrpc_client-> site_url($SITE_URL);
@@ -203,9 +210,9 @@ sub pre_header_initialize {
  }
 
 sub content {
-   ###########################
-   # Return content of rendered problem to the browser that requested it
-   ###########################
+	 ###########################
+	 # Return content of rendered problem to the browser that requested it
+	 ###########################
 	my $self = shift;
 	$self->{r}->content_type("application/json; charset=utf-8") if $self->{wantsjson};
 	print $self->{output};


### PR DESCRIPTION
This creates a `$xmlrpc_root_url` variable to allow xmlprc to run on a separate server or in my case under http://  since the https:// is taken care of on a proxy level.  

If no variable is set, it should use `$server_root_url` as the url.  