### PR TITLE
Fix UTF-8 bug with JSON output from FormatRenderedProblem.pm (WW 2.16 RC1)

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -329,7 +329,7 @@ sub formatRenderedProblem {
 		}
 		$json_output->{score} = $json_score;
 
-		return JSON->new->utf8->encode($json_output);
+		return JSON->new->utf8(false)->canonical->pretty->encode($json_output);
 	}
 
 	# Raw format
@@ -350,7 +350,7 @@ sub formatRenderedProblem {
 		$output->{dir} = $PROBLEM_LANG_AND_DIR{dir};
 
 		# Convert to JSON
-		return JSON->new->utf8->canonical->pretty->encode($output);
+		return JSON->new->utf8(false)->canonical->pretty->encode($output);
 	}
 
 	# Find and execute the appropriate template in the WebworkClient folder.
@@ -361,7 +361,7 @@ sub formatRenderedProblem {
 	$template =~ s/(\$\w+)/$1/gee;
 
 	return $template unless $self->{inputs_ref}{send_pg_flags};
-	return JSON->new->utf8->encode({ html => $template, pg_flags => $rh_result->{flags} });
+	return JSON->new->utf8(false)->canonical->pretty->encode({ html => $template, pg_flags => $rh_result->{flags} });
 }
 
 sub saveGradeToLTI {

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -329,7 +329,7 @@ sub formatRenderedProblem {
 		}
 		$json_output->{score} = $json_score;
 
-		return JSON->new->utf8(false)->canonical->pretty->encode($json_output);
+		return JSON->new->utf8(0)->encode($json_output);
 	}
 
 	# Raw format
@@ -350,7 +350,7 @@ sub formatRenderedProblem {
 		$output->{dir} = $PROBLEM_LANG_AND_DIR{dir};
 
 		# Convert to JSON
-		return JSON->new->utf8(false)->canonical->pretty->encode($output);
+		return JSON->new->utf8(0)->encode($output);
 	}
 
 	# Find and execute the appropriate template in the WebworkClient folder.
@@ -361,7 +361,7 @@ sub formatRenderedProblem {
 	$template =~ s/(\$\w+)/$1/gee;
 
 	return $template unless $self->{inputs_ref}{send_pg_flags};
-	return JSON->new->utf8(false)->canonical->pretty->encode({ html => $template, pg_flags => $rh_result->{flags} });
+	return JSON->new->utf8(0)->encode({ html => $template, pg_flags => $rh_result->{flags} });
 }
 
 sub saveGradeToLTI {


### PR DESCRIPTION
The current json output formats (`json_format.pl`, "raw", and other formats when `send_pg_flags` is enabled) are resulting in UTF-8 text (inside the problem text, in the provided data structures in `raw` mode) being turned into mojibake.

The problem seems to be that the data being passed into the JSON encoder is already internally encoded as UTF-8 encoded strings, and then the `->utf8` in the definition of the `JSON` encoder was casing the strings to be encoding a second time causing the mojibake.

In earlier version of this code `json_format.pl` (from WW 2.15) worked properly using `JSON->new->utf8->encode` as apparently data was still internally in Perl strings which were not yet encoded into UTF-8.

The code in this PR is intended to fix the problem. For now it also applies both `canonical` and `pretty` to the JSON encoding process, and in the future removing  `canonical` might make the code a bit faster (by dropping the sorting). The `raw` format already had both settings enabled, and creates the largest JSON object to be encoded.

---

Attached is [SampleFiles.zip](https://github.com/openwebwork/webwork2/files/6597233/SampleFiles.zip) -  a ZIP file from the testing. It contains:
  - `z_squared2.pg` is a test file with a few Hebrew words, and one using MultiAnswer in a manner that the original rendering will set both an `ans_message` and `error_message` inside the `rh_ans` objects which also contain Hebrew characters.
  - It has several versions of the `FormatRenderedProblem.pm` used during the testing
  - It has text files with the `curl` commands used to collect the data provided by `html2xml` and collected data with and without the patch.
  - The results I collected and list below.

---

In order to test this nicely, I first slightly modified `FormatRenderedProblem.pm` using the file `FormatRenderedProblem.pm.WW216RC-pretty` from the attached ZIP file, in order to replace `JSON->new->utf8->encode` with `JSON->new->utf8->canonical->pretty->encode` in 2 places. These settings make comparing the output easier in most cases.

The files with names ending in `before-patch.json` were generated using the `curl` commands in `curl-commands-before-patch.txt` (except that the real password was used) when the `FormatRenderedProblem.pm.WW216RC-pretty` version of the file was in use.

The files with names ending in `after-patch.json` were generated using the `curl` commands in `curl-commands-before-after.txt` (except that the real password was used) when the `FormatRenderedProblem.pm.WW216RC-pretty-utf8-false` version of the file was in use. This is the file in the PR.

Results based on using `vimdiff` to compare pairs of files.
```

vimdiff debug-before-patch.json debug-after-patch.json
# No important differences. Was not using pgflags, so no JSON encoding

vimdiff simple-before-patch.json simple-after-patch.json 
# No important differences. Was not using pgflags, so no JSON encoding

vimdiff debug-pgflags1-before-patch.json debug-pgflags1-after-patch.json
# Hebrew characters OK in debug-pgflags1-after-patch.json
#     יהי
#     חשבו את
#     הנדרשים
# Mojibake in debug-pgflags1-before-patch.json

vimdiff json-before-patch.json json-after-patch.json 
# Hebrew characters OK in json-after-patch.json
#     יהי
#     חשבו את
# Mojibake in json-before-patch.json

vimdiff raw-before-patch.json raw-after-patch.json 
# Hebrew characters OK in raw-after-patch.json
#     אין להשאיר תיבות ריקות או להזין ביטויים לא חוקיים
#     יהי
#     חשבו את
# Mojibake in raw-before-patch.json

vimdiff simple-pgflags1-before-patch.json simple-pgflags1-after-patch.json 
# Hebrew characters OK in simple-pgflags1-before-patch.json
#     יהי
#     חשבו את 
# Mojibake in simple-pgflags1-before-patch.json
```

---

The order of `dir="rtl" lang="he-il"` was changed to `lang="he-il" dir="rtl"` in some pairs of files. I'm not sure why this minor and irrelevant change occurred.