### PR TITLE
Give output formats a consistent display order on the hardcopy generation page

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -64,7 +64,7 @@ our %HC_FORMATS = (
 	tex => { name => x("TeX Source"), subr => "generate_hardcopy_tex" },
 	pdf => { name => x("Adobe PDF"),  subr => "generate_hardcopy_pdf" },
 );
-our @HC_FORMAT_TYPES = ('tex', 'pdf');
+our @HC_FORMAT_DISPLAY_ORDER = ('tex', 'pdf');
 
 # custom fields used in $self hash
 # FOR HEAVEN'S SAKE, PLEASE KEEP THIS UP-TO-DATE!
@@ -378,7 +378,7 @@ sub display_form {
 	
 	# get formats
 	my @formats;
-	foreach my $format (@HC_FORMAT_TYPES) {
+	foreach my $format (@HC_FORMAT_DISPLAY_ORDER) {
 		push @formats, $format if $authz->hasPermissions($userID, "download_hardcopy_format_$format");
 	}
 	

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -63,9 +63,8 @@ our $HC_DEFAULT_FORMAT = "pdf"; # problems if this is not an allowed format for 
 our %HC_FORMATS = (
 	tex => { name => x("TeX Source"), subr => "generate_hardcopy_tex" },
 	pdf => { name => x("Adobe PDF"),  subr => "generate_hardcopy_pdf" },
-# Not ready for prime time
-#	tikz =>{ name => "TikZ PDF file", subr => "generate_hardcopy_tigz"},
 );
+our @HC_FORMAT_TYPES = ('tex', 'pdf');
 
 # custom fields used in $self hash
 # FOR HEAVEN'S SAKE, PLEASE KEEP THIS UP-TO-DATE!
@@ -379,7 +378,7 @@ sub display_form {
 	
 	# get formats
 	my @formats;
-	foreach my $format (keys %HC_FORMATS) {
+	foreach my $format (@HC_FORMAT_TYPES) {
 		push @formats, $format if $authz->hasPermissions($userID, "download_hardcopy_format_$format");
 	}
 	


### PR DESCRIPTION
This ensures that the "Adoby PDF" and "TeX Source" hardcopy format radio buttons appear in the same order everytime when they are both present on the hardcopy generator page.

I find it rather annoying when trying to debug a problem that these radio buttons keep switching order, and I end up checking the wrong one.  I am sure I am not the only one that has found this annoying.
