### PR TITLE
Limit html2xml grade pass-back to when it is explicitly allowed.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -203,24 +203,27 @@ sub formatRenderedProblem {
 	my $showAnswerNumbers = $self->{inputs_ref}{showAnswerNumbers} // 1;
 
 	# Attempts table
-	my $tbl = WeBWorK::Utils::AttemptsTable->new(
-		$rh_result->{answers} // {},
-		answersSubmitted    => $self->{inputs_ref}{answersSubmitted} // 0,
-		answerOrder         => $rh_result->{flags}{ANSWER_ENTRY_ORDER} // [],
-		displayMode         => $displayMode,
-		showAnswerNumbers   => $showAnswerNumbers,
-		ce                  => $ce,
-		showAttemptPreviews => $previewMode || $submitMode || $showCorrectMode,
-		showAttemptResults  => $submitMode || $showCorrectMode,
-		showCorrectAnswers  => $showCorrectMode,
-		showMessages        => $previewMode || $submitMode || $showCorrectMode,
-		showSummary         => (($showSummary and ($submitMode or $showCorrectMode)) // 0) ? 1 : 0,
-		maketext            => WeBWorK::Localize::getLoc($formLanguage),
-		summary             => $problemResult->{summary} // '', # can be set by problem grader
-	);
-	my $answerTemplate = $tbl->answerTemplate;
-	my $color_input_blanks_script = (!$previewMode && ($checkMode || $submitMode)) ? $tbl->color_answer_blanks : "";
-	$tbl->imgGen->render(refresh => 1) if $tbl->displayMode eq 'images';
+
+	# Increase indent below - to make coming changes easier to track
+
+		my $tbl = WeBWorK::Utils::AttemptsTable->new(
+			$rh_result->{answers} // {},
+			answersSubmitted    => $self->{inputs_ref}{answersSubmitted} // 0,
+			answerOrder         => $rh_result->{flags}{ANSWER_ENTRY_ORDER} // [],
+			displayMode         => $displayMode,
+			showAnswerNumbers   => $showAnswerNumbers,
+			ce                  => $ce,
+			showAttemptPreviews => $previewMode || $submitMode || $showCorrectMode,
+			showAttemptResults  => $submitMode || $showCorrectMode,
+			showCorrectAnswers  => $showCorrectMode,
+			showMessages        => $previewMode || $submitMode || $showCorrectMode,
+			showSummary         => (($showSummary and ($submitMode or $showCorrectMode)) // 0) ? 1 : 0,
+			maketext            => WeBWorK::Localize::getLoc($formLanguage),
+			summary             => $problemResult->{summary} // '', # can be set by problem grader
+		);
+		my $answerTemplate = $tbl->answerTemplate;
+		my $color_input_blanks_script = (!$previewMode && ($checkMode || $submitMode)) ? $tbl->color_answer_blanks : "";
+		$tbl->imgGen->render(refresh => 1) if $tbl->displayMode eq 'images';
 
 	# Score summary
 	my $scoreSummary = '';
@@ -380,8 +383,11 @@ sub saveGradeToLTI {
 	my $consumer_secret = $ce->{'LISConsumerKeyHash'}{$consumer_key};
 	my $score = $rh_result->{problem_result} ? $rh_result->{problem_result}{score} : 0;
 
-	# This is boilerplate XML used to submit the $score for $sourcedid
-	my $replaceResultXML = <<EOS;
+
+		# Increase indent below - to make coming changes easier to track
+
+		# This is boilerplate XML used to submit the $score for $sourcedid
+		my $replaceResultXML = <<EOS;
 <?xml version = "1.0" encoding = "UTF-8"?>
 <imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
   <imsx_POXHeader>
@@ -408,56 +414,56 @@ sub saveGradeToLTI {
 </imsx_POXEnvelopeRequest>
 EOS
 
-	my $bodyhash = sha1_base64($replaceResultXML);
+		my $bodyhash = sha1_base64($replaceResultXML);
 
-	# since sha1_base64 doesn't pad we have to do so manually
-	while (length($bodyhash) % 4) {
-		$bodyhash .= '=';
-	}
-
-	my $requestGen = Net::OAuth->request("consumer");
-
-	$requestGen->add_required_message_params('body_hash');
-
-	my $gradeRequest = $requestGen->new(
-		request_url => $request_url,
-		request_method => "POST",
-		consumer_secret => $consumer_secret,
-		consumer_key => $consumer_key,
-		signature_method => $signature_method,
-		nonce => int(rand( 2**32)),
-		timestamp => time(),
-		body_hash => $bodyhash
-	);
-	$gradeRequest->sign();
-
-	my $HTTPRequest = HTTP::Request->new(
-		$gradeRequest->request_method,
-		$gradeRequest->request_url,
-		[
-			'Authorization' => $gradeRequest->to_authorization_header,
-			'Content-Type'  => 'application/xml',
-		],
-		$replaceResultXML,
-	);
-
-	my $response = LWP::UserAgent->new->request($HTTPRequest);
-
-
-	my $LTIGradeMessage = '';
-	if ($response->is_success) {
-		$response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
-		my $message = $1;
-		if ($message ne 'success') {
-			$LTIGradeMessage = CGI::p("Unable to update LMS grade. Error: ".$message);
-			$rh_result->{debug_messages} .= CGI::escapeHTML($response->content);
-		} else {
-			$LTIGradeMessage = CGI::p("Grade sucessfully saved.");
+		# since sha1_base64 doesn't pad we have to do so manually
+		while (length($bodyhash) % 4) {
+			$bodyhash .= '=';
 		}
-	} else {
-		$LTIGradeMessage = CGI::p("Unable to update LMS grade. Error: ".$response->message);
-		$rh_result->{debug_messages} .= CGI::escapeHTML($response->content);
-	}
+
+		my $requestGen = Net::OAuth->request("consumer");
+
+		$requestGen->add_required_message_params('body_hash');
+
+		my $gradeRequest = $requestGen->new(
+			request_url => $request_url,
+			request_method => "POST",
+			consumer_secret => $consumer_secret,
+			consumer_key => $consumer_key,
+			signature_method => $signature_method,
+			nonce => int(rand( 2**32)),
+			timestamp => time(),
+			body_hash => $bodyhash
+		);
+		$gradeRequest->sign();
+
+		my $HTTPRequest = HTTP::Request->new(
+			$gradeRequest->request_method,
+			$gradeRequest->request_url,
+			[
+				'Authorization' => $gradeRequest->to_authorization_header,
+				'Content-Type'  => 'application/xml',
+			],
+			$replaceResultXML,
+		);
+
+		my $response = LWP::UserAgent->new->request($HTTPRequest);
+
+
+		my $LTIGradeMessage = '';
+		if ($response->is_success) {
+			$response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
+			my $message = $1;
+			if ($message ne 'success') {
+				$LTIGradeMessage = CGI::p("Unable to update LMS grade. Error: ".$message);
+				$rh_result->{debug_messages} .= CGI::escapeHTML($response->content);
+			} else {
+				$LTIGradeMessage = CGI::p("Grade sucessfully saved.");
+			}
+		} else {
+			$LTIGradeMessage = CGI::p("Unable to update LMS grade. Error: ".$response->message);
+			$rh_result->{debug_messages} .= CGI::escapeHTML($response->content);
+		}
 
 	# save parameters for next time
 	$LTIGradeMessage .= CGI::input({type => 'hidden', name => 'lis_outcome_service_url', value => $request_url});

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -75,7 +75,7 @@ sub formatRenderedProblem {
 	my $rh_result   = $self->return_object() || {};  # wrap problem in formats
 	$problemText    = "No output from rendered Problem" unless $rh_result;
 
-	my $forbidGradePassback = 0; # 1 = feature blocked, 2 = due to rendering error
+	my $forbidGradePassback = 1; # 1 = feature blocked, 2 = due to rendering error
 
 	if (ref($rh_result) and $rh_result->{text}) {
 		$problemText = $rh_result->{text};
@@ -96,6 +96,13 @@ sub formatRenderedProblem {
 		});
 
 	my $mt = WeBWorK::Localize::getLangHandle($self->{inputs_ref}{language} // 'en');
+
+	if ( $forbidGradePassback == 1 &&
+	     defined( $ce->{html2xmlAllowGradePassback} ) &&
+	     $ce->{html2xmlAllowGradePassback} eq "This course intentionally enables the insecure LTI grade pass-back feature of html2xml." ) {
+		# It is strongly recommended that you clarify the security risks of enabling the current version of this feature before using it.
+		$forbidGradePassback = 0;
+	}
 
 	my $SITE_URL = $self->site_url // '';
 	my $FORM_ACTION_URL = $self->{form_action_url} // '';
@@ -382,7 +389,7 @@ sub formatRenderedProblem {
 sub saveGradeToLTI {
 	my ($self, $ce, $rh_result, $forbidGradePassback) = @_;
 	# When $forbidGradePassback is set, we will block the actual submission,
-	# but we still provide the data in the hidden fields.
+	# but we still provide the LTI data in the hidden fields.
 
 	return "" if !(defined($self->{inputs_ref}{lis_outcome_service_url}) &&
 		defined($self->{inputs_ref}{'oauth_consumer_key'}) &&

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -28,6 +28,7 @@ use WeBWorK::Utils qw(wwRound decode_utf8_base64);
 use XML::Simple qw(XMLout);
 use WeBWorK::Utils::LanguageAndDirection;
 use JSON;
+use Digest::SHA qw(sha1_base64);
 
 sub new {
     my $invocant = shift;
@@ -75,9 +76,9 @@ sub formatRenderedProblem {
 	my $rh_result   = $self->return_object() || {};  # wrap problem in formats
 	$problemText    = "No output from rendered Problem" unless $rh_result;
 
-	my $forbidGradePassback = 1; # 1 = feature blocked, 2 = due to rendering error
+	my $forbidGradePassback = 1; # 1 = feature blocked, 2 = due to rendering error, 3 = not in submit mode
 
-	if (ref($rh_result) and $rh_result->{text}) {
+	if (ref($rh_result) && $rh_result->{text}) {
 		$problemText = $rh_result->{text};
 	} else {
 		$problemText .= "Unable to decode problem text:<br>$self->{error_string}<br>" .
@@ -251,6 +252,9 @@ sub formatRenderedProblem {
 
 		$scoreSummary .= CGI::p($mt->maketext("Your score was not recorded.")) unless $hideWasNotRecordedMessage;
 		$scoreSummary .= CGI::hidden({id => 'problem-result-score', name => 'problem-result-score', value => $problemResult->{score}});
+	}
+	if ( !$forbidGradePassback && !$submitMode ) {
+		$forbidGradePassback = 3;
 	}
 	if ( $forbidGradePassback == 2 ) {
 		$scoreSummary  = '<!-- No scoreSummary on errors. -->';

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -215,6 +215,8 @@ sub formatRenderedProblem {
 	my $showSummary = $self->{inputs_ref}{showSummary} // 1;
 	my $showAnswerNumbers = $self->{inputs_ref}{showAnswerNumbers} // 1;
 
+	my $color_input_blanks_script = "";
+
 	# Attempts table
 	my $answerTemplate = "";
 
@@ -239,7 +241,7 @@ sub formatRenderedProblem {
 			summary             => $problemResult->{summary} // '', # can be set by problem grader
 		);
 		$answerTemplate = $tbl->answerTemplate;
-		my $color_input_blanks_script = (!$previewMode && ($checkMode || $submitMode)) ? $tbl->color_answer_blanks : "";
+		$color_input_blanks_script = (!$previewMode && ($checkMode || $submitMode)) ? $tbl->color_answer_blanks : "";
 		$tbl->imgGen->render(refresh => 1) if $tbl->displayMode eq 'images';
 	}
 	# Score summary
@@ -410,7 +412,7 @@ sub saveGradeToLTI {
 
 	my $LTIGradeMessage = '';
 
-        if ( ! $forbidGradePassback ) {
+	if ( ! $forbidGradePassback ) {
 
 		# This is boilerplate XML used to submit the $score for $sourcedid
 		my $replaceResultXML = <<EOS;


### PR DESCRIPTION
Prevent the `html2xml` subsystem from being able to make LTI grade pass-back submissions unless explicitly allowed via a course (or system) setting due to the potential security issues.

Fix some other issues along the way:
  1. Prevent LTI grade pass-back for occurring when not a "submit" or when render fails.
  2. Add a `hideWasNotRecordedMessage` setting to hide the message which refers to grades not being saved (in WeBWorK), so that message will not be displayed if not desired. Default is still to show it.

The first of the 4 commits is just white-space changes, mainly adding indentation - so the other commits are easier to follow.