### PR TITLE
Change LTIAdvanced.pm so that all new logins get logged + some other fixes - version 2

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -118,10 +118,11 @@ $preferred_source_of_username = "lis_person_contact_email_primary";
 # LTI Preferred source of Student Id
 ################################################################################
 
-# If preferred_source_of_student_id is not set, WeBWorK will look in the LTI
-# parameter 'custom_student_id.' If preferred_source_of_student_id is set, then
-# WeBWorK will look in the LTI parameter specified below. This parameter may be
-# dependendent on the LMS. E.G., In D2L, student_id is stored in OrgDefinedId and
+# If preferred_source_of_student_id is not set, WeBWorK will set student_id
+# to be an empty string. You should use debug_lti_parameters in order to determine
+# the value to use for your LMS.
+#
+# For example, in D2L, student_id is stored in OrgDefinedId and
 # the corresponding LTI parameter is called ext_d2l_orgdefinedid.
 
 #$preferred_source_of_student_id = "ext_d2l_orgdefinedid";

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -1,12 +1,12 @@
 ###############################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -96,7 +96,7 @@ sub  request_has_data_for_this_verification_module {
   debug("LTIAdvanced has been called for data verification");
   my $self = shift;
   my $r = $self->{r};
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     debug("LTIAdvanced returning 1 because it is an xmlrpc call");
@@ -120,14 +120,14 @@ sub get_credentials {
   my $self = shift;
   my $r = $self->{r};
   my $ce = $r->{ce};
-  
+
   debug("LTIAdvanced::get_credentials has been called\n");
 	
   ## Printing parameters to main page can help people set things up
   ## so we dont use the debug channel here
   if ( $ce->{debug_lti_parameters} ) {
     my $rh_headers = $r->headers_in;  #request headers
-    
+
     my @parameter_names = $r->param;       # form parameter names
     my $parameter_report = '';
     foreach my $key (@parameter_names) {
@@ -163,16 +163,16 @@ sub get_credentials {
   # when authenticating javascript web service requests (e.g., the
   # Library Browser).
   # Similar changes are needed in check_user() and verify_normal_user().
-  
+
   if ($r->{xmlrpc}) {
     debug("falling back to superclass get_credentials (xmlrpc call)");
     return $self->SUPER::get_credentials(@_);
   }
 
   # if at least the user ID is available in request parameters
-  if (defined $r->param("user_id")) 
+  if (defined $r->param("user_id"))
     {
-      map {$self->{$_->[0]} = $r->param($_->[1]);} 
+      map {$self->{$_->[0]} = $r->param($_->[1]);}
 	(
 	 ['role', 'roles'],
 	 ['last_name' , 'lis_person_name_family'],
@@ -189,13 +189,13 @@ sub get_credentials {
       # Some LMS's misspell the lis_person_sourcedid parameter name
       # so we try a number of variations here
       if (defined($r->param("lis_person_sourced_id"))) {
-	$self->{user_id} = $r->param("lis_person_sourced_id"); 
+	$self->{user_id} = $r->param("lis_person_sourced_id");
       } elsif (defined($r->param("lis_person_sourcedid"))) {
-	$self->{user_id} = $r->param("lis_person_sourcedid"); 
+	$self->{user_id} = $r->param("lis_person_sourcedid");
       } elsif (defined($r->param("lis_person_source_id"))) {
-	$self->{user_id} = $r->param("lis_person_source_id"); 
+	$self->{user_id} = $r->param("lis_person_source_id");
       } elsif (defined($r->param("lis_person_sourceid"))) {
-	$self->{user_id} = $r->param("lis_person_sourceid"); 
+	$self->{user_id} = $r->param("lis_person_sourceid");
       } else {
 	undef($self->{user_id});
       }
@@ -206,8 +206,8 @@ sub get_credentials {
       }
 
       # if preferred_source_of_username eq "lis_person_contact_email_primary"
-      # or if the user_id is still undefined at this point 
-      # then replace the user_id with the full email address. 
+      # or if the user_id is still undefined at this point
+      # then replace the user_id with the full email address.
       # if strip_address_from_email ==1  strip off the part of the address
       # after @
 
@@ -225,9 +225,9 @@ sub get_credentials {
       } else {
 	$self->{student_id} = ""; # fall back to avoid a warning when debug_lti_parameters enabled
       }
-      
+
       # For setting up its helpful to print out what the system think the
-      # User id and address is at this point 
+      # User id and address is at this point
       if ( $ce->{debug_lti_parameters} ) {
 	warn "=========== summary ============";
 	warn "User id is |$self->{user_id}|\n";
@@ -240,7 +240,7 @@ sub get_credentials {
       if (!defined($self->{user_id})) {
 	croak "LTIAdvanced was unable to create a username from the user_id or from the mail address. Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
       }
-      
+
       $self->{login_type} = "normal";
       $self->{credential_source} = "LTIAdvanced";
       debug("LTIAdvanced::get_credentials is returning a 1\n");
@@ -255,9 +255,9 @@ sub check_user {
   my $self = shift;
   my $r = $self->{r};
   my ($ce, $db, $authz) = map {$r->$_ ;} ('ce', 'db', 'authz');
-  
+
   my $user_id = $self->{user_id};
-  
+
   debug("LTIAdvanced::check_user has been called for user_id = |$user_id|");
 
   # See comment in get_credentials()
@@ -265,15 +265,15 @@ sub check_user {
     #debug("falling back to superclass check_user (xmlrpc call)");
     return $self->SUPER::check_user(@_);
   }
-  
+
   if (!defined($user_id) || (defined $user_id && $user_id eq "")) {
     $self->{log_error} .= "no user id specified";
     $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
     return 0;
   }
-  
+
   my $User = $db->getUser($user_id);
-  
+
   if (!$User) {
     if ( defined($r->param("lis_person_sourcedid"))
 	 || defined($r->param("lis_person_sourced_id"))
@@ -289,19 +289,19 @@ sub check_user {
       return 0;
     }
   }
-  
+
   unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {
     $self->{log_error} .= "LOGIN FAILED $user_id - course access denied";
     $self->{error} = $r->maketext("Authentication failed.  Please speak to your instructor.");
     return 0;
   }
-  
+
   unless ($authz->hasPermissions($user_id, "login")) {
     $self->{log_error} .= "LOGIN FAILED $user_id - no permission to login";
     $self->{error} = $r->maketext("Authentication failed.  Please speak to your instructor.");
     return 0;
   }
-  
+
   debug("LTIAdvanced::check_user is about to return a 1.");	
   return 1;
 }
@@ -311,29 +311,29 @@ sub verify_practice_user { return(0) ;}
 
 sub verify_normal_user {
   my $self = shift;
-  my ($r, $user_id, $session_key) 
+  my ($r, $user_id, $session_key)
     = map {$self->{$_};} ('r', 'user_id', 'session_key');
-  
+
   debug("LTIAdvanced::verify_normal_user called for user |$user_id|");
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     #debug("falling back to superclass verify_normal_user (xmlrpc call)");
     return $self->SUPER::verify_normal_user(@_);
   }
-  
+
   # Call check_session in order to destroy any existing session cookies and Key table sessions
   my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 0);
 
   debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-  
+
   my $auth_result = $self->authenticate;
-  
+
   debug("auth_result=|${auth_result}|");	
 
   # Parameters CANNOT be modified until after LTIAdvanced authentication
   # has been done, because the parameters passed with the request
-  # are used in computing the OAuth_signature.  If there  
+  # are used in computing the OAuth_signature.  If there
   # are any changes in $r->{paramcache} (see Request.pm)
   # before authentication occurs, then authentication will FAIL
   # even if the consumer_secret is correct.
@@ -348,19 +348,19 @@ sub verify_normal_user {
       $self->{error} = $auth_result;
       $self-> {log_error} .= "$user_id - authentication failed: ". $self->{error};
       return 0;
-    } 
+    }
 }
 
 sub authenticate {
   my $self = shift;
   my ($r, $user ) = map {$self->{$_};} ('r', 'user_id');
-  
+
   # See comment in get_credentials()
   if ($r->{xmlrpc}) {
     #debug("falling back to superclass authenticate (xmlrpc call)");
     return $self->SUPER::authenticate(@_);
   }
-  
+
   debug("LTIAdvanced::authenticate called for user |$user|");
   debug "ref(r) = |". ref($r) . "|";
   debug "ref of r->{paramcache} = |" . ref($r->{paramcache}) . "|";
@@ -368,10 +368,10 @@ sub authenticate {
   my $ce = $r->ce;
   my $db = $r->db;
   my $courseName = $r->ce->{'courseName'};
-  
+
   # Check nonce to see whether request is legitimate
   debug("Nonce = |" . $self-> {oauth_nonce} . "|");
-  my $nonce = WeBWorK::Authen::LTIAdvanced::Nonce->new($r, $self->{oauth_nonce}, $self->{oauth_timestamp}); 
+  my $nonce = WeBWorK::Authen::LTIAdvanced::Nonce->new($r, $self->{oauth_nonce}, $self->{oauth_timestamp});
   if (!($nonce->ok ) ) {
     $self->{error} .=  $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator if this recurs.");
     debug("Failed to verify nonce");
@@ -382,7 +382,7 @@ sub authenticate {
   my %request_hash;
   my @keys = keys %{$r-> {paramcache}};
   foreach my $key (@keys) {
-    $request_hash{$key} =  $r->param($key); 
+    $request_hash{$key} =  $r->param($key);
     debug("$key->|" . $request_hash{$key} . "|");
   }	
   my $requestHash = \%request_hash;
@@ -390,7 +390,7 @@ sub authenticate {
   # We need to provide the request URL when verifying the OAuth request.
   # We use the url request by default, but also allow it to be overriden
   my $path = $ce->{server_root_url}.$ce->{webwork_url};
-  $path = $ce->{LTIBasicToThisSiteURL} ? 
+  $path = $ce->{LTIBasicToThisSiteURL} ?
     $ce->{LTIBasicToThisSiteURL} : $path;
 
   # append the path the the server url
@@ -400,20 +400,20 @@ sub authenticate {
       warn("The following path was reconstructed by WeBWorK.  It should match the path in the LMS:");
       warn($path);
   }
-  
+
   # We also try a version without the trailing / in case that was not
-  # included when the LMS user created the LMS link 
+  # included when the LMS user created the LMS link
   my $altpath = $path;
   $altpath =~ s/\/$//;
-  
+
   my ($request, $altrequest);
-  eval { 
+  eval {
     $request = Net::OAuth->request("request token")->from_hash($requestHash,
 	       request_url => $path,
 	       request_method => "POST",
 	       consumer_secret => $ce->{LTIBasicConsumerSecret},
 							      );
-    
+
     $altrequest = Net::OAuth->request("request token")->from_hash($requestHash,
 		  request_url => $altpath,
 		  request_method => "POST",
@@ -433,7 +433,7 @@ sub authenticate {
   if (! $request->verify && ! $altrequest->verify) {
       debug("LTIAdvanced::authenticate request-> verify failed");
       debug("OAuth verification Failed ");
-      
+
       $self->{error} .= $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
       $self->{log_error} .= "OAuth verification failed.  Check the Consumer Secret and that the URL in the LMS exactly matches the WeBWorK URL.";
       if ( $ce->{debug_lti_parameters} ) {
@@ -442,7 +442,7 @@ sub authenticate {
       return 0;
   } else {
       debug("OAuth verification SUCCEEDED !!");
-      
+
       my $userID = $self->{user_id};
 
 	# Indentation of the internal blocks below was modified to follow
@@ -491,13 +491,13 @@ sub authenticate {
 
       return 1;
   }
-  
+
   debug("LTIAdvanced is returning a failed authentication");
   $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
   return(0);
 }
 
-# create a new user trying to log in 
+# create a new user trying to log in
 sub create_user {
   my $self = shift;
   my $r = $self->{r};
@@ -512,10 +512,10 @@ sub create_user {
   ############################################################
   my $LTIrolesString = $r->param("roles");
   my @LTIroles = split /,/, $LTIrolesString;
-  
+
   #remove the urn string if its present
   s/^urn:lti:.*:ims\/lis\/// for @LTIroles;
-  
+
   if ( $ce->{debug_lti_parameters} ) {
     warn "The adjusted LTI roles defined for this user are: \n--",
       join("\n--", @LTIroles), "\n",
@@ -523,14 +523,14 @@ sub create_user {
       "The user will be assigned the highest role defined for them\n",
       "========================\n"		
     }
-  
+
   my $nr = scalar(@LTIroles);
   if (! defined($ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}})) {
     croak("Cannot find a WeBWorK role that corresponds to the LMS role of "
 	  . $LTIroles[0] .".");
   }
-  
-  my $LTI_webwork_permissionLevel 
+
+  my $LTI_webwork_permissionLevel
     = $ce->{userRoles}->{$ce->{LMSrolesToWeBWorKroles}->{$LTIroles[0]}};
   if ($nr > 1) {
     for (my $j =1; $j < $nr; $j++) {
@@ -541,14 +541,14 @@ sub create_user {
       }	
     }
   }
-  
+
   ####### End defining roles and $LTI_webwork_permissionLevel#######
-  
-  
+
+
   warn "New user: $userID -- requested permission level is $LTI_webwork_permissionLevel." if ( $ce->{debug_lti_parameters} );
 
   # We dont create users with too high of a permission level
-  # for security reasons. 
+  # for security reasons.
   if ($LTI_webwork_permissionLevel > $ce->{userRoles}->{$ce->{LTIAccountCreationCutoff}}) {
     $self->{log_error}.= "userID: $userID -- Unknown instructor attempting to log in via LTI.  Instructor accounts must be created manually";
     croak $r->maketext("The instructor account with user id [_1] does not exist.  Please create the account manually via WeBWorK.",$userID);
@@ -583,11 +583,11 @@ sub create_user {
   $db->addPermissionLevel($newPermissionLevel);
   $r->authz->{PermissionLevel} = $newPermissionLevel;  #cache the Permission Level Record.
 
-  
+
   # Assign existing sets
   my $instructorTools = WeBWorK::ContentGenerator::Instructor->new($r);
   my @setsToAssign = ();
-  
+
   my @globalSetIDs = $db->listGlobalSets;
   my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
   foreach my $globalSet (@GlobalSets) {
@@ -599,12 +599,12 @@ sub create_user {
   }
   $self->{numberOfSetsAssigned} = scalar @setsToAssign;
 
-  # Give schools the chance to modify newly added sets 
+  # Give schools the chance to modify newly added sets
   if (defined($ce->{LTI_modify_user_set})) {
     foreach my $globalSet (@setsToAssign) {
       my $userSet = $db->getUserSet($userID,$globalSet->set_id);
       next unless $userSet;
-      
+
       $ce->{LTI_modify_user_set}($self,$globalSet,$userSet);
       $db->putUserSet($userSet);
     }
@@ -645,7 +645,7 @@ sub maybe_update_user {
     $tempUser->section($self->{section} // "");
     $tempUser->recitation($self->{recitation} // "");
     $tempUser->student_id($self->{student_id} // "");
-    
+
     # Allow sites to customize the temp user
     if (defined($ce->{LTI_modify_user})) {
       $ce->{LTI_modify_user}($self,$tempUser);

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -465,13 +465,17 @@ sub authenticate {
 		}
       }  elsif ($ce->{LMSManageUserData}) {
 		# Existing user.  Possibly modify demographic information and permission level.
-		unless ($self->maybe_update_user()) {
+		if ($self->maybe_update_user()) {
+			$self->{initial_login} = 1; # Set here so login gets logged, even for accounts which maybe_update_user() would not modify
+		} else {
 			$r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
 			  $self->{log_error} .= "Failed to update user $userID.";
 			if ( $ce->{debug_lti_parameters} ) {
 				warn("Failed to updateuser $userID.");
 			}
 		}
+      } else {
+	$self->{initial_login} = 1; # Set here so login gets logged when $ce->{LMSManageUserData} is false
       }
 
       # If we are using grade passback then make sure the data
@@ -664,8 +668,6 @@ sub maybe_update_user {
       warn "Existing user: $userID updated.\n"
 	if ( $ce->{debug_lti_parameters} );
     }
-      
-    $self->{initial_login} = 1;
   }
 
   return 1;


### PR DESCRIPTION
This replaces https://github.com/openwebwork/webwork2/pull/1388.
  - The first 2 commits are identical to those in https://github.com/openwebwork/webwork2/pull/1388.
  - The 4th commit here is just a cleanup of trailing whitespace.
  - The 3rd commit:
    1. Handles the "agreed" changes from the discussion there which in the last 3 commits of https://github.com/openwebwork/webwork2/pull/1388 
      - Avoid warning when email not provided by LMS.
      -  Replace `or` with `||` and `and` with `&&` where used just for logic in control flow.
      - Has a few minor code fixes.
    2. **New:** Make sure the WW `student_id` is only defined using `preferred_source_of_student_id` and fall back to an empty string to avoid warnings.
  - This PR does **not** modify the code to set `user_id` - which will be addressed in a different PR.

Given the reviews of  https://github.com/openwebwork/webwork2/pull/1388 the only **new** change to be carefully reviewed is the handling of `student_id` which is in accordance with a recent decision by the development team to make it `preferred_source_of_student_id` behave as the name means and avoid using any less-than-stable fall-back value (the form parameter `custom_student_id` was acting as a fall-back source for the value).

Once reviewed - I think a "squash" merge is recommended. The PR will provide the internal details.