### PR TITLE
LTI (Advanced) modify user_id selection

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -77,32 +77,45 @@ $authen{user_module} = [
 # LTI preferred and fallback source of WW user_id
 ################################################################################
 
-# If both lis_person_sourcedid (or one of its variants)
-# and lis_person_contact_email_primary are present,
-# then one needs to state which one is preferred
-# as the WeBWorK username.
-# The considerations are (1) ensuring that usernames
-# are unique and (2) being as compatible as possible with the practices
-# of the institutions that are being served in a site.
-# If a site is only being used be students from a single
-# institution and the value  lis_person_sourcedid  is
-# unique across the population and matches the  logon username
-# at that institution, then lis_person_sourcedid is
-# probably the better choice.
-# On the other hand, if a site is serving a population
-# from several institutions and  lis_person_sourcedid  is not
-# necessarily unique across the population, then
-# lis_person_contact_email_primary is the better choice.
-# Because the WeBWorK username must be unique across
-# the population served by a site, the default if
-# neither line is uncommented will be the value of
-# lis_person_contact_email_primary.
+# You MUST set what LTI field is used to set the WeBWorK user_id.
+#
+# The lis_person_sourcedid (or one of its variants) is formally an OPTIONAL field
+#    https://www.imsglobal.org/specs/ltiv1p1/implementation-guide
+# but is relatively consistently available.
+# However, some LMS systems, Blackboard in particular, do not send lis_person_sourcedid.
+#
+# The email address lis_person_contact_email_primary is often a more understandable
+# value but may not exist.
+#
+# The LTI standard recommends providing a "user_id" value, which needs to be a unique
+# indentifier for each student in the LMS. The value is not expected to be people
+# friendly by may be available when neither of the others are.
+#
+# You need to make sure to use a setting such that
+#    (1) usernames are unique and
+#    (2) the setting is as compatible as possible with the practices
+#        of the institutions that are being served in a site.
+#
+# If each course is only being used be students from a single institution
+# and the value  lis_person_sourcedid is unique across that population
+# and matches the logon username at that institution, then lis_person_sourcedid
+# is probably the better choice.
+#
+# On the other hand, if a site is serving a population from several institutions
+# or if the lis_person_sourcedid is not necessarily unique across the population,
+# then lis_person_contact_email_primary is the better choice.
+#
+# NOTE: As of WeBWorK 2.16 some setting MUST be made.
+#
+#       If no setting is made, all LTI logins will fail and an error will be reported.
+#
+#       See the comment further down on how to get WeBWorK 2.16 to behave similarly to
+#       the prior behavior.
 
-# NOTE: Even if a course management system sends 
-# one of the common misspellings of "lis_person_sourcedid", i.e.,
-# lis_person_sourced_id, lis_person_source_id, and
-# lis_person_sourceid, one must nevertheless use
-# the correct spelling here, i.e. "lis_person_sourcedid".
+# NOTE: Even if a course management system sends one of the common misspellings of
+# "lis_person_sourcedid", i.e.,
+# lis_person_sourced_id, lis_person_source_id, and lis_person_sourceid,
+# one must nevertheless use the correct spelling "lis_person_sourcedid" here.
 
 #$preferred_source_of_username = "lis_person_sourcedid";
 $preferred_source_of_username = "lis_person_contact_email_primary";
@@ -114,16 +127,41 @@ $preferred_source_of_username = "lis_person_contact_email_primary";
 # You can also optionally provide a $fallback_source_of_username
 # which will only be used if WW is unable to determine a user_id
 # using $preferred_source_of_username.
+
+# Warning: This can be dangerous, as if it the fallback was used
+# for some student, and then on a later connection by that student
+# the LMS provided a value for the $preferred_source_of_username
+# field, then the student will get a new WeBWorK account and lose
+# access to their prior account and the prior scores will not be
+# associated with their account any longer.
+#
+# Thus, this feature should be used carefully!
+#
 # Ex:
 #$fallback_source_of_username = "lis_person_sourcedid";
 
-# Some LMS systems, Blackboard in particular, do not send lis_person_sourcedid
-# if you enable this flag and have $preferred_source_of_username or
-# $fallback_source_of_username set to lis_person_contact_email_primary,
-# and the email is being used as the WW user_id, then WW will strip off
-# the domain portion of the email (after the '@') and just use the username.
+# Stripping the domain when creating user_id from an email address:
+#
+#   If you set either $preferred_source_of_username or $fallback_source_of_username
+#   to lis_person_contact_email_primary, and the email is being used as the WeBWorK
+#   user_id, then if the following setting is enabled, then WeBWorK will strip off
+#   the domain portion of the email (after the '@') and just use the username.
 
 #$strip_address_from_email = 1;
+
+# This feature should not be used if emails could collide after the domain is removed.
+
+# To get WeBWorK 2.16 to handle LTI authentication using an approach
+# roughly the same as was used until WeBWorK 2.15, you can set one of the 2 pairs of
+# settings:
+#
+# Option 1: Primary choice is lis_person_contact_email_primary, fallback to lis_person_sourcedid:
+#$preferred_source_of_username = "lis_person_contact_email_primary";
+#$fallback_source_of_username = "lis_person_sourcedid";
+#
+# Option 2: Primary choice is lis_person_sourcedid, fallback to lis_person_contact_email_primary:
+#$preferred_source_of_username = "lis_person_sourcedid";
+#$fallback_source_of_username = "lis_person_contact_email_primary";
 
 ################################################################################
 # LTI Preferred source of Student Id

--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -74,7 +74,7 @@ $authen{user_module} = [
 ################################################################################
 
 ################################################################################
-# LTI Preferred Source of Username
+# LTI preferred and fallback source of WW user_id
 ################################################################################
 
 # If both lis_person_sourcedid (or one of its variants)
@@ -107,10 +107,21 @@ $authen{user_module} = [
 #$preferred_source_of_username = "lis_person_sourcedid";
 $preferred_source_of_username = "lis_person_contact_email_primary";
 
+# You can use any parameter the LMS will provide for the
+# $preferred_source_of_username, ex:
+#$preferred_source_of_username = "user_id";
+
+# You can also optionally provide a $fallback_source_of_username
+# which will only be used if WW is unable to determine a user_id
+# using $preferred_source_of_username.
+# Ex:
+#$fallback_source_of_username = "lis_person_sourcedid";
+
 # Some LMS systems, Blackboard in particular, do not send lis_person_sourcedid
-# if you enable this flag and have $preferred_source_of_username set to
-# lis_person_contact_email_primary, then webwork will strip off the address 
-# portion of the email and just use the username.  
+# if you enable this flag and have $preferred_source_of_username or
+# $fallback_source_of_username set to lis_person_contact_email_primary,
+# and the email is being used as the WW user_id, then WW will strip off
+# the domain portion of the email (after the '@') and just use the username.
 
 #$strip_address_from_email = 1;
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -273,6 +273,7 @@ sub get_credentials {
 	warn "=========== summary ============";
 	warn "User id is |$self->{user_id}| (obtained from $user_id_source which was $type_of_source)\n";
 	warn "User mail address is |$self->{email}|\n";
+	warn "strip_address_from_email is |", $ce->{strip_address_from_email}//0,"|\n";
 	warn "Student id is |$self->{student_id}|\n";
 	warn "preferred_source_of_username is |$ce->{preferred_source_of_username}|\n";
 	warn "fallback_source_of_username is |", $ce->{fallback_source_of_username}//'undefined',"|\n";
@@ -280,7 +281,7 @@ sub get_credentials {
 	warn "================================\n";
       }
       if (!defined($self->{user_id})) {
-	croak "LTIAdvanced was unable to create a username from the user_id or from the mail address. Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
+	croak "LTIAdvanced was unable to create a username from the data provided with the current settings. Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
       }
 
       $self->{login_type} = "normal";

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -181,7 +181,7 @@ sub get_credentials {
   # Determine the WW user_id to use, if possible
 
   if ( ! $ce->{preferred_source_of_username} ) {
-    warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+    warn "LTI is not properly configured (no preferred_source_of_username). Please contact your instructor or system administrator.";
     $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
     debug("No preferred_source_of_username in " . $r->ce->{'courseName'} . " so LTIAdvanced::get_credentials is returning a 0\n");
     return 0;
@@ -244,7 +244,7 @@ sub get_credentials {
 	}
   }
 
-  # if at least the user ID is available in request parameters
+  # if we were able to set a user_id
   if ( defined($self->{user_id}) && $self->{user_id} ne "" ) {
       map {$self->{$_->[0]} = $r->param($_->[1]);}
 	(
@@ -289,7 +289,7 @@ sub get_credentials {
       debug("LTIAdvanced::get_credentials is returning a 1\n");
       return 1;
     }
-  warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+  warn "LTI is not properly configured (failed to set user_id from preferred_source_of_username or fallback_source_of_username). Please contact your instructor or system administrator.";
   $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
   debug("LTIAdvanced::get_credentials is returning a 0\n");
   return 0;

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -92,6 +92,15 @@ sub new {
 #	  $Key->key = "nonce"
 #	  $Key->timestamp = the nonce's timestamp
 
+# Some LMS's misspell the lis_person_sourcedid parameter name
+# so we use a list of variations when needed.
+our @lis_person_sourcedid_options = (
+	"lis_person_sourcedid", # from spec at https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-3
+	"lis_person_sourced_id",
+	"lis_person_source_id",
+	"lis_person_sourceid"
+);
+
 sub  request_has_data_for_this_verification_module {
   debug("LTIAdvanced has been called for data verification");
   my $self = shift;
@@ -122,7 +131,7 @@ sub get_credentials {
   my $ce = $r->{ce};
 
   debug("LTIAdvanced::get_credentials has been called\n");
-	
+
   ## Printing parameters to main page can help people set things up
   ## so we dont use the debug channel here
   if ( $ce->{debug_lti_parameters} ) {
@@ -169,9 +178,74 @@ sub get_credentials {
     return $self->SUPER::get_credentials(@_);
   }
 
+  # Determine the WW user_id to use, if possible
+
+  if ( ! $ce->{preferred_source_of_username} ) {
+    warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+    $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
+    debug("No preferred_source_of_username in " . $r->ce->{'courseName'} . " so LTIAdvanced::get_credentials is returning a 0\n");
+    return 0;
+  }
+
+  my $user_id_source = "";
+  my $type_of_source = "";
+
+  $self->{email} = ""; # set an initial value to avoid warnings when not provided
+  if ( defined( $r->param("lis_person_contact_email_primary") ) ) {
+	$self->{email} = uri_unescape($r->param("lis_person_contact_email_primary")) // "";
+  }
+
+  if ( $ce->{preferred_source_of_username} eq "lis_person_sourcedid" ) {
+	foreach my $key ( @lis_person_sourcedid_options ) {
+		if ( $r->param($key) ) {
+			$user_id_source = $key;
+			$type_of_source = "preferred_source_of_username";
+			$self->{user_id} = $r->param($key);
+			last;
+		}
+	}
+  } elsif ( $ce->{preferred_source_of_username} eq "lis_person_contact_email_primary"
+	&& $self->{email} ne "" ) {
+	$user_id_source = "lis_person_contact_email_primary";
+	$type_of_source = "preferred_source_of_username";
+	$self->{user_id} = $self->{email};
+
+	# Strip off the part of the address after @ if requested to do so:
+	$self->{user_id} =~ s/@.*$// if $ce->{strip_address_from_email};
+  } elsif ( $r->param($ce->{preferred_source_of_username}) ) {
+	$user_id_source = $ce->{preferred_source_of_username};
+	$type_of_source = "preferred_source_of_username";
+	$self->{user_id} = $r->param($ce->{preferred_source_of_username});
+  }
+
+  # Fallback if necessary
+  if ( !defined( $self->{user_id} ) && $ce->{fallback_source_of_username} ) {
+	if ( $ce->{fallback_source_of_username} eq "lis_person_sourcedid" ) {
+		foreach my $key ( @lis_person_sourcedid_options ) {
+			if ( $r->param($key) ) {
+				$user_id_source = $key;
+				$type_of_source = "fallback_source_of_username";
+				$self->{user_id} = $r->param($key);
+				last;
+			}
+		}
+	} elsif ( $ce->{fallback_source_of_username} eq "lis_person_contact_email_primary"
+		&& $self->{email} ne "" ) {
+		$user_id_source = "lis_person_contact_email_primary";
+		$type_of_source = "fallback_source_of_username";
+		$self->{user_id} = $self->{email};
+
+		# Strip off the part of the address after @ if requested to do so:
+		$self->{user_id} =~ s/@.*$// if $ce->{strip_address_from_email};
+	} elsif ( $r->param($ce->{fallback_source_of_username}) ) {
+		$user_id_source = $ce->{fallback_source_of_username};
+		$type_of_source = "fallback_source_of_username";
+		$self->{user_id} = $r->param($ce->{fallback_source_of_username});
+	}
+  }
+
   # if at least the user ID is available in request parameters
-  if (defined $r->param("user_id"))
-    {
+  if ( defined($self->{user_id}) && $self->{user_id} ne "" ) {
       map {$self->{$_->[0]} = $r->param($_->[1]);}
 	(
 	 ['role', 'roles'],
@@ -186,39 +260,6 @@ sub get_credentials {
 	 ['recitation', 'custom_recitation'],
 	);
 
-      # Some LMS's misspell the lis_person_sourcedid parameter name
-      # so we try a number of variations here
-      if (defined($r->param("lis_person_sourced_id"))) {
-	$self->{user_id} = $r->param("lis_person_sourced_id");
-      } elsif (defined($r->param("lis_person_sourcedid"))) {
-	$self->{user_id} = $r->param("lis_person_sourcedid");
-      } elsif (defined($r->param("lis_person_source_id"))) {
-	$self->{user_id} = $r->param("lis_person_source_id");
-      } elsif (defined($r->param("lis_person_sourceid"))) {
-	$self->{user_id} = $r->param("lis_person_sourceid");
-      } else {
-	undef($self->{user_id});
-      }
-
-      $self->{email} = ""; # set an initial value to avoid warnings when not provided
-      if ( defined( $r->param("lis_person_contact_email_primary") ) ) {
-        $self->{email} = uri_unescape($r->param("lis_person_contact_email_primary")) // "";
-      }
-
-      # if preferred_source_of_username eq "lis_person_contact_email_primary"
-      # or if the user_id is still undefined at this point
-      # then replace the user_id with the full email address.
-      # if strip_address_from_email ==1  strip off the part of the address
-      # after @
-
-      if (!defined($self->{user_id})
-	  || ($self->{email} ne ""
-	      && defined($ce->{preferred_source_of_username})
-	      && $ce->{preferred_source_of_username} eq "lis_person_contact_email_primary")) {
-	$self->{user_id} = $self->{email};
-	$self->{user_id} =~ s/@.*$// if $ce->{strip_address_from_email};
-      }
-
       if (defined($ce->{preferred_source_of_student_id})
 	&& defined($r->param($ce->{preferred_source_of_student_id}))) {
 	$self->{student_id} = $r->param($ce->{preferred_source_of_student_id});
@@ -230,10 +271,11 @@ sub get_credentials {
       # User id and address is at this point
       if ( $ce->{debug_lti_parameters} ) {
 	warn "=========== summary ============";
-	warn "User id is |$self->{user_id}|\n";
+	warn "User id is |$self->{user_id}| (obtained from $user_id_source which was $type_of_source)\n";
 	warn "User mail address is |$self->{email}|\n";
 	warn "Student id is |$self->{student_id}|\n";
-	warn "preferred_source_of_username is |", $ce->{preferred_source_of_username}//'undefined',"|\n";
+	warn "preferred_source_of_username is |$ce->{preferred_source_of_username}|\n";
+	warn "fallback_source_of_username is |", $ce->{fallback_source_of_username}//'undefined',"|\n";
 	warn "preferred_source_of_student_id is |", $ce->{preferred_source_of_student_id}//'undefined',"|\n";
 	warn "================================\n";
       }
@@ -246,6 +288,8 @@ sub get_credentials {
       debug("LTIAdvanced::get_credentials is returning a 1\n");
       return 1;
     }
+  warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+  $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
   debug("LTIAdvanced::get_credentials is returning a 0\n");
   return 0;
 }
@@ -275,19 +319,30 @@ sub check_user {
   my $User = $db->getUser($user_id);
 
   if (!$User) {
-    if ( defined($r->param("lis_person_sourcedid"))
-	 || defined($r->param("lis_person_sourced_id"))
-	 || defined($r->param("lis_person_source_id"))
-	 || defined($r->param("lis_person_sourceid"))
-	 || defined($r->param("lis_person_contact_email_primary"))
-       ) {
-      debug("User |$user_id| is unknown but may be an new user from an LSM via LTI. About to return a 1");
-      return 1;  #This may be a new user coming in from a LMS via LTI.
-    } else {
-      $self->{log_error} .= " $user_id - user unknown";
-      $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
-      return 0;
+    my %options;
+    $options{$ce->{preferred_source_of_username}} = 1 if ($ce->{preferred_source_of_username});
+    $options{$ce->{fallback_source_of_username}}  = 1 if ($ce->{fallback_source_of_username});
+
+    # May need to add alternate "spellings" for lis_person_sourcedid
+    my $use_lis_person_sourcedid_options = 0;
+    if ( defined($ce->{preferred_source_of_username})
+	&& $ce->{preferred_source_of_username} eq "lis_person_sourcedid" ) {
+	$use_lis_person_sourcedid_options = 1;
+    } elsif ( defined($ce->{fallback_source_of_username})
+	&& $ce->{fallback_source_of_username} eq "lis_person_sourcedid" ) {
+	$use_lis_person_sourcedid_options = 1;
     }
+
+    foreach my $key ( keys( %options ), ( $use_lis_person_sourcedid_options ? @lis_person_sourcedid_options : () ) ) {
+	if ( defined($r->param($key)) ) {
+		debug("User |$user_id| is unknown but may be an new user from an LSM via LTI. Saw a value for $key About to return a 1");
+		return 1;  #This may be a new user coming in from a LMS via LTI.
+	}
+    }
+
+    $self->{log_error} .= " $user_id - user unknown";
+    $self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
+    return 0;
   }
 
   unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {
@@ -302,7 +357,7 @@ sub check_user {
     return 0;
   }
 
-  debug("LTIAdvanced::check_user is about to return a 1.");	
+  debug("LTIAdvanced::check_user is about to return a 1.");
   return 1;
 }
 
@@ -329,7 +384,7 @@ sub verify_normal_user {
 
   my $auth_result = $self->authenticate;
 
-  debug("auth_result=|${auth_result}|");	
+  debug("auth_result=|${auth_result}|");
 
   # Parameters CANNOT be modified until after LTIAdvanced authentication
   # has been done, because the parameters passed with the request
@@ -384,7 +439,7 @@ sub authenticate {
   foreach my $key (@keys) {
     $request_hash{$key} =  $r->param($key);
     debug("$key->|" . $request_hash{$key} . "|");
-  }	
+  }
   my $requestHash = \%request_hash;
 
   # We need to provide the request URL when verifying the OAuth request.
@@ -521,7 +576,7 @@ sub create_user {
       join("\n--", @LTIroles), "\n",
       "Any initial ^urn:lti:.*:ims/lis/ segments have been stripped off.\n",
       "The user will be assigned the highest role defined for them\n",
-      "========================\n"		
+      "========================\n"
     }
 
   my $nr = scalar(@LTIroles);
@@ -538,7 +593,7 @@ sub create_user {
       next unless defined $wwRole;
       if ($LTI_webwork_permissionLevel < $ce->{userRoles}->{$wwRole}) {
 	$LTI_webwork_permissionLevel = $ce->{userRoles}->{$wwRole};
-      }	
+      }
     }
   }
 

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -224,7 +224,7 @@ sub get_credentials {
 	# Determine the WW user_id to use, if possible
 
 	if ( ! $ce->{preferred_source_of_username} ) {
-		warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+		warn "LTI is not properly configured (no preferred_source_of_username). Please contact your instructor or system administrator.";
 		$self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
 		debug("No preferred_source_of_username in " . $r->ce->{'courseName'} . " so LTIBasic::get_credentials is returning a 0\n");
 		return 0;
@@ -287,7 +287,7 @@ sub get_credentials {
 		}
 	}
 
-	# if at least the user ID is available in request parameters
+	# if we were able to set a user_id
 	if ( defined($self->{user_id}) && $self->{user_id} ne "" ) {
 		map {$self -> {$_ -> [0]} = $r -> param($_ -> [1]);}
 						(
@@ -341,7 +341,7 @@ sub get_credentials {
 		return 1;
 	}
 	#debug("LTIBasic::get_credentials is returning a 0\n");
-	warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+	warn "LTI is not properly configured (failed to obtain user_id from preferred_source_of_username or fallback_source_of_username). Please contact your instructor or system administrator.";
 	$self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
 	return 0;
 }

--- a/lib/WeBWorK/Authen/LTIBasic.pm
+++ b/lib/WeBWorK/Authen/LTIBasic.pm
@@ -153,6 +153,15 @@ sub new {
 #custom_semster=?
 #custom_section=?
 
+# Some LMS's misspell the lis_person_sourcedid parameter name
+# so we use a list of variations when needed.
+our @lis_person_sourcedid_options = (
+	"lis_person_sourcedid", # from spec at https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-3
+	"lis_person_sourced_id",
+	"lis_person_source_id",
+	"lis_person_sourceid"
+);
+
 sub  request_has_data_for_this_verification_module {
 	#debug("LTIBasic has been called for data verification");
 	my $self = shift;
@@ -194,10 +203,7 @@ sub get_credentials {
 		warn ("===== parameters received =======\n", $parameter_report);
 	}
 	###
-	
-	
-	
-	
+
 	#disable password login
 	$self->{external_auth} = 1;
 
@@ -215,10 +221,75 @@ sub get_credentials {
 		return $self->SUPER::get_credentials(@_);
 	}
 
+	# Determine the WW user_id to use, if possible
+
+	if ( ! $ce->{preferred_source_of_username} ) {
+		warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+		$self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
+		debug("No preferred_source_of_username in " . $r->ce->{'courseName'} . " so LTIBasic::get_credentials is returning a 0\n");
+		return 0;
+	}
+
+	my $user_id_source = "";
+	my $type_of_source = "";
+
+	$self->{email} = ""; # set an initial value to avoid warnings when not provided
+	if ( defined( $r->param("lis_person_contact_email_primary") ) ) {
+		$self->{email} = uri_unescape($r->param("lis_person_contact_email_primary")) // "";
+	}
+
+	if ( $ce->{preferred_source_of_username} eq "lis_person_sourcedid" ) {
+		foreach my $key ( @lis_person_sourcedid_options ) {
+			if ( $r->param($key) ) {
+				$user_id_source = $key;
+				$type_of_source = "preferred_source_of_username";
+				$self->{user_id} = $r->param($key);
+				last;
+			}
+		}
+	} elsif ( $ce->{preferred_source_of_username} eq "lis_person_contact_email_primary"
+		    && $self->{email} ne "" ) {
+		$user_id_source = "lis_person_contact_email_primary";
+		$type_of_source = "preferred_source_of_username";
+		$self->{user_id} = $self->{email};
+
+		# Strip off the part of the address after @ if requested to do so:
+		$self->{user_id} =~ s/@.*$// if $ce->{strip_address_from_email};
+	} elsif ( $r->param($ce->{preferred_source_of_username}) ) {
+		$user_id_source = $ce->{preferred_source_of_username};
+		$type_of_source = "preferred_source_of_username";
+		$self->{user_id} = $r->param($ce->{preferred_source_of_username});
+	}
+
+	# Fallback if necessary
+	if ( !defined( $self->{user_id} ) && $ce->{fallback_source_of_username} ) {
+		if ( $ce->{fallback_source_of_username} eq "lis_person_sourcedid" ) {
+			foreach my $key ( @lis_person_sourcedid_options ) {
+				if ( $r->param($key) ) {
+					$user_id_source = $key;
+					$type_of_source = "fallback_source_of_username";
+					$self->{user_id} = $r->param($key);
+					last;
+				}
+			}
+		} elsif ( $ce->{fallback_source_of_username} eq "lis_person_contact_email_primary"
+			    && $self->{email} ne "" ) {
+			$user_id_source = "lis_person_contact_email_primary";
+			$type_of_source = "fallback_source_of_username";
+			$self->{user_id} = $self->{email};
+
+			# Strip off the part of the address after @ if requested to do so:
+			$self->{user_id} =~ s/@.*$// if $ce->{strip_address_from_email};
+		} elsif ( $r->param($ce->{fallback_source_of_username}) ) {
+			$user_id_source = $ce->{fallback_source_of_username};
+			$type_of_source = "fallback_source_of_username";
+			$self->{user_id} = $r->param($ce->{fallback_source_of_username});
+		}
+	}
+
 	# if at least the user ID is available in request parameters
-	if (defined $r->param("user_id")) 
-		{
-		map {$self -> {$_ -> [0]} = $r -> param($_ -> [1]);} 
+	if ( defined($self->{user_id}) && $self->{user_id} ne "" ) {
+		map {$self -> {$_ -> [0]} = $r -> param($_ -> [1]);}
 						(
 						#['user_id', 'lis_person_sourcedid'],
 						['role', 'roles'],
@@ -234,58 +305,29 @@ sub get_credentials {
 						['recitation', 'custom_recitation'],
 						);
 
-		# The following lines were substituted for the commented out line above
-		# because some LMS's misspell the lis_person_sourcedid parameter name
-		if (defined($r -> param("lis_person_sourced_id"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourced_id"); 
-		} elsif (defined($r -> param("lis_person_sourcedid"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourcedid"); 
-		} elsif (defined($r -> param("lis_person_source_id"))) {
-			$self -> {user_id} = $r -> param("lis_person_source_id"); 
-		} elsif (defined($r -> param("lis_person_sourceid"))) {
-			$self -> {user_id} = $r -> param("lis_person_sourceid"); 
+		if (defined($ce->{preferred_source_of_student_id})
+		      && defined($r->param($ce->{preferred_source_of_student_id}))) {
+			$self->{student_id} = $r->param($ce->{preferred_source_of_student_id});
 		} else {
-			undef($self ->{user_id});
+			$self->{student_id} = ""; # fall back to avoid a warning when debug_lti_parameters enabled
 		}
-		###############
-		# if get_username_from_email == 1 then replace user_id with the full email address if possible 
-		# or if the user_id is still undefined try to set the user_id to full the email address
-		
-		$self -> {email} = uri_unescape($r -> param("lis_person_contact_email_primary"));
-# 		if (!defined($self->{user_id})
-# 		    or defined($self -> {email}) and $ce -> {get_username_from_email} )  {
-# 		    $self->{user_id} = $self -> {email};
-# 
-# 		}
-		
-		#############
-		# if preferred_source_of_username eq "lis_person_contact_email_primary"
-		# then replace the user_id with the full email address. 
-		
-		# or if the user_id is still undefined try to set the user_id to full the email address
-		
-		# if strip_address_from_email ==1  strip off the part of the address after @
-		#############
-		if (!defined($self->{user_id})
-			or (defined($self -> {email})  
-				and defined($ce -> {preferred_source_of_username})
-				and $ce -> {preferred_source_of_username} eq "lis_person_contact_email_primary")) {
-			$self->{user_id} = $self -> {email};
-			$self->{user_id} =~ s/@.*$// if
-			    $ce->{strip_address_from_email};
-		}
-		# MEG debug code
+
+		# For setting up its helpful to print out what the system think the
+		# User id and address is at this point
 		if ( $ce->{debug_lti_parameters} ) {
 			warn "=========== summary ============";
-			warn "User id is |$self->{user_id}|\n";
+			warn "User id is |$self->{user_id}| (obtained from $user_id_source which was $type_of_source)\n";
 			warn "User mail address is |$self->{email}|\n";
 			warn "strip_address_from_email is |", $ce->{strip_address_from_email}//0,"|\n";
-			warn "preferred_source_of_username is |", $ce -> {preferred_source_of_username}//'undefined',"|\n";
+			warn "Student id is |$self->{student_id}|\n";
+			warn "preferred_source_of_username is |$ce->{preferred_source_of_username}|\n";
+			warn "fallback_source_of_username is |", $ce->{fallback_source_of_username}//'undefined',"|\n";
+			warn "preferred_source_of_student_id is |", $ce->{preferred_source_of_student_id}//'undefined',"|\n";
 			warn "================================\n";
-		 }
+		}
+
 		if (!defined($self->{user_id})) {
-			croak "LTIBasic was unable to create a username from the user_id or from the mail address.
-			       Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
+			croak "LTIBasic was unable to create a username from the data provided with the current settings. Set \$debug_lti_parameters=1 in authen_LTI.conf to debug";
 		}
 		if (defined $ce -> {analyze_context_id}) {
 			$ce -> {analyze_context_id} ($self) ;
@@ -297,8 +339,10 @@ sub get_credentials {
 		$self -> {credential_source} = "LTIBasic";
 		#debug("LTIBasic::get_credentials is returning a 1\n");
 		return 1;
-		}
+	}
 	#debug("LTIBasic::get_credentials is returning a 0\n");
+	warn "LTI is not properly configured. Please contact your instructor or system administrator.";
+	$self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
 	return 0;
 }
 
@@ -307,7 +351,7 @@ sub check_user {
 	my $self = shift;
 	my $r = $self->{r};
 	my ($ce, $db, $authz) = map {$r -> $_ ;} ('ce', 'db', 'authz');
-	
+
 	my $user_id = $self->{user_id};
 
 	#debug("LTIBasic::check_user has been called for user_id = |$user_id|");
@@ -324,22 +368,34 @@ sub check_user {
 		$self->{error} = $r->maketext($GENERIC_MISSING_USER_ID_ERROR_MESSAGE, $LMS);
 		return 0;
 	}
-	
+
 	my $User = $db->getUser($user_id);
-	
+
 	if (!$User) {
-		if ( defined($r -> param("lis_person_sourcedid"))
-			or defined($r -> param("lis_person_sourced_id"))
-			or defined($r -> param("lis_person_source_id"))
-			or defined($r -> param("lis_person_sourceid")) 
-			or defined($r -> param("lis_person_contact_email_primary")) ) {
-			#debug("User |$user_id| is unknown but may be an new user from an LSM via LTI.  About to return a 1");
-			return 1;  #This may be a new user coming in from a LMS via LTI.
-		} else {
-		$self->{log_error} .= " $user_id - user unknown";
-		$self->{error} = $r->maketext("Username presented:  [_1]",$user_id)."<br/>". $r->maketext($GENERIC_UNKNOWN_USER_ERROR_MESSAGE);
-		return 0;
+		my %options;
+		$options{$ce->{preferred_source_of_username}} = 1 if ($ce->{preferred_source_of_username});
+		$options{$ce->{fallback_source_of_username}}  = 1 if ($ce->{fallback_source_of_username});
+
+		# May need to add alternate "spellings" for lis_person_sourcedid
+		my $use_lis_person_sourcedid_options = 0;
+		if ( defined($ce->{preferred_source_of_username})
+		       && $ce->{preferred_source_of_username} eq "lis_person_sourcedid" ) {
+			$use_lis_person_sourcedid_options = 1;
+		} elsif ( defined($ce->{fallback_source_of_username})
+			    && $ce->{fallback_source_of_username} eq "lis_person_sourcedid" ) {
+			$use_lis_person_sourcedid_options = 1;
 		}
+
+		foreach my $key ( keys( %options ), ( $use_lis_person_sourcedid_options ? @lis_person_sourcedid_options : () ) ) {
+			if ( defined($r->param($key)) ) {
+				debug("User |$user_id| is unknown but may be an new user from an LSM via LTI. Saw a value for $key About to return a 1");
+				return 1;  #This may be a new user coming in from a LMS via LTI.
+			}
+		}
+
+		$self->{log_error} .= " $user_id - user unknown";
+		$self->{error} = $r->maketext("There was an error during the login process.  Please speak to your instructor or system administrator.");
+		return 0;
 	}
 
 	unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {


### PR DESCRIPTION
This is a totally reworked approach to setting the WW `user_id` for `LTIAdvanced.pm`.

It is based off the code in https://github.com/openwebwork/webwork2/pull/1402, and was rebased off `WeBWorK-2.16`after that PR was squash-merged. 

Two settings are used:
  - `preferred_source_of_username` (**required**) names the LTI parameter to use as the first choice for WW's `user_id`.
  - `fallback_source_of_username` (**optional**) provides a single fallback option.

As in the past when a setting has the value `lis_person_sourcedid`, several options are checked due to LMS "spelling" issues.

As in the past when `lis_person_contact_email_primary` is selected as the option to use, the setting `strip_address_from_email` can be used to remove the part after the `@`.