### PR TITLE
Add support for a 2 stage Docker build process + support graceful Apache restart

### DIFF
--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -1,0 +1,146 @@
+# This is the Stage 1 Dockerfile, which builds a base OS image (webwork-base)
+# on top of which the WeBWorK parts will be installed by the Stage 2 Dockerfile.
+
+FROM ubuntu:20.04
+
+# ==================================================================
+
+# Phase 1 - set base OS image install stage ENV variables
+#
+# We only need install time ENV variables, not those needed by the WeBWorK system
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true
+
+# ==================================================================
+
+# Phase 2 - Ubuntu 20.04 base image + required packages
+
+# Packages changes/added for ubuntu 20.04:
+#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl
+
+# Do NOT include "apt-get -y upgrade"
+# see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+	apache2 \
+	curl \
+	dvipng \
+	dvisvgm \
+	gcc \
+	libapache2-request-perl \
+	libarchive-zip-perl \
+	libcgi-pm-perl \
+	libcrypt-ssleay-perl \
+	libdatetime-perl \
+	libdbd-mysql-perl \
+	libdbd-mariadb-perl \
+	libemail-address-xs-perl \
+	libexception-class-perl \
+	libextutils-xsbuilder-perl \
+	libfile-find-rule-perl-perl \
+	libgd-perl \
+	libhtml-scrubber-perl \
+	libjson-perl \
+	liblocale-maketext-lexicon-perl \
+	libmail-sender-perl \
+	libmime-tools-perl \
+	libnet-ip-perl \
+	libnet-ldap-perl \
+	libnet-oauth-perl \
+	libossp-uuid-perl \
+	libpadwalker-perl \
+	libpath-class-perl \
+	libphp-serialization-perl \
+	libxml-simple-perl \
+	libnet-https-nb-perl \
+	libhttp-async-perl \
+	libsoap-lite-perl \
+	libsql-abstract-perl \
+	libstring-shellquote-perl \
+	libtemplate-perl \
+	libtext-csv-perl \
+	libtimedate-perl \
+	libuuid-tiny-perl \
+	libxml-parser-perl \
+	libxml-writer-perl \
+	libxmlrpc-lite-perl \
+	libapache2-reload-perl \
+	cpanminus \
+	libxml-parser-easytree-perl \
+	libiterator-perl \
+	libiterator-util-perl \
+	libpod-wsdl-perl \
+	libtest-xml-perl \
+	libmodule-build-perl \
+	libxml-semanticdiff-perl \
+	libxml-xpath-perl \
+	libpath-tiny-perl \
+	libarray-utils-perl \
+	libhtml-template-perl \
+	libtest-pod-perl \
+	libemail-sender-perl \
+	libmail-sender-perl \
+	libmodule-pluggable-perl \
+	libemail-date-format-perl \
+	libcapture-tiny-perl \
+	libthrowable-perl \
+	libdata-dump-perl \
+	libfile-sharedir-install-perl \
+	libclass-tiny-perl \
+	libtest-requires-perl \
+	libtest-mockobject-perl \
+	libtest-warn-perl \
+	libsub-uplevel-perl \
+	libtest-exception-perl \
+	libuniversal-can-perl \
+	libuniversal-isa-perl \
+	libtest-fatal-perl \
+	libjson-xs-perl \
+	libjson-maybexs-perl \
+	libcpanel-json-xs-perl \
+	make \
+	netpbm \
+	patch \
+	pdf2svg \
+	preview-latex-style \
+	texlive \
+	texlive-latex-extra \
+	texlive-plain-generic \
+	texlive-xetex \
+	texlive-latex-recommended \
+	texlive-lang-other \
+	texlive-lang-arabic \
+	libc6-dev \
+	git \
+	mysql-client \
+	tzdata \
+	apt-utils \
+	locales \
+	debconf-utils \
+	ssl-cert \
+	ca-certificates \
+	culmus \
+	fonts-linuxlibertine \
+	lmodern \
+	zip \
+	iputils-ping \
+	imagemagick \
+	jq \
+	npm \
+    && apt-get clean \
+    && rm -fr /var/lib/apt/lists/* /tmp/*
+
+# Developers may want to add additional packages inside the image
+# such as: telnet vim mc file
+
+# ==================================================================
+
+# Phase 3 - install additional Perl modules from CPAN (not packaged for Ubuntu or outdated in Ubuntu)
+
+RUN cpanm install Statistics::R::IO \
+    && rm -fr ./cpanm /root/.cpanm /tmp/*
+
+# ==================================================================
+

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -1,4 +1,8 @@
-
+# This is the Stage 2 Dockerfile, which handles the WeBWorK part, building
+# on top of the base OS image (webwork-base) created by the Stage 1 Dockerfile.
+#
+# ==================================================================
+#
 # Optional things to change/configure below:
 #
 # 1. Which branch of webwork2/ and pg/ to install.
@@ -67,7 +71,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # we need to change FROM before setting the ENV variables
 
-FROM ubuntu:20.04
+FROM webwork-base:forWW216
 
 ENV WEBWORK_URL=/webwork2 \
     WEBWORK_ROOT_URL=http://localhost \
@@ -95,130 +99,7 @@ ENV WEBWORK_ROOT=$APP_ROOT/webwork2 \
 
 # ==================================================================
 
-# Phase 3 - Ubuntu 20.04 base image + required packages
-
-# Packages changes/added for ubuntu 20.04:
-#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl
-
-# Do NOT include "apt-get -y upgrade"
-# see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
-	apache2 \
-	curl \
-	dvipng \
-	dvisvgm \
-	gcc \
-	libapache2-request-perl \
-	libarchive-zip-perl \
-	libcgi-pm-perl \
-	libcrypt-ssleay-perl \
-	libdatetime-perl \
-	libdbd-mysql-perl \
-	libdbd-mariadb-perl \
-	libemail-address-xs-perl \
-	libexception-class-perl \
-	libextutils-xsbuilder-perl \
-	libfile-find-rule-perl-perl \
-	libgd-perl \
-	libhtml-scrubber-perl \
-	libjson-perl \
-	liblocale-maketext-lexicon-perl \
-	libmail-sender-perl \
-	libmime-tools-perl \
-	libnet-ip-perl \
-	libnet-ldap-perl \
-	libnet-oauth-perl \
-	libossp-uuid-perl \
-	libpadwalker-perl \
-	libpath-class-perl \
-	libphp-serialization-perl \
-	libxml-simple-perl \
-	libnet-https-nb-perl \
-	libhttp-async-perl \
-	libsoap-lite-perl \
-	libsql-abstract-perl \
-	libstring-shellquote-perl \
-	libtemplate-perl \
-	libtext-csv-perl \
-	libtimedate-perl \
-	libuuid-tiny-perl \
-	libxml-parser-perl \
-	libxml-writer-perl \
-	libxmlrpc-lite-perl \
-	libapache2-reload-perl \
-	cpanminus \
-	libxml-parser-easytree-perl \
-	libiterator-perl \
-	libiterator-util-perl \
-	libpod-wsdl-perl \
-	libtest-xml-perl \
-	libmodule-build-perl \
-	libxml-semanticdiff-perl \
-	libxml-xpath-perl \
-	libpath-tiny-perl \
-	libarray-utils-perl \
-	libhtml-template-perl \
-	libtest-pod-perl \
-	libemail-sender-perl \
-	libmail-sender-perl \
-	libmodule-pluggable-perl \
-	libemail-date-format-perl \
-	libcapture-tiny-perl \
-	libthrowable-perl \
-	libdata-dump-perl \
-	libfile-sharedir-install-perl \
-	libclass-tiny-perl \
-	libtest-requires-perl \
-	libtest-mockobject-perl \
-	libtest-warn-perl \
-	libsub-uplevel-perl \
-	libtest-exception-perl \
-	libuniversal-can-perl \
-	libuniversal-isa-perl \
-	libtest-fatal-perl \
-	libjson-xs-perl \
-	libjson-maybexs-perl \
-	libcpanel-json-xs-perl \
-	make \
-	netpbm \
-	patch \
-	pdf2svg \
-	preview-latex-style \
-	texlive \
-	texlive-latex-extra \
-	texlive-plain-generic \
-	texlive-xetex \
-	texlive-latex-recommended \
-	texlive-lang-other \
-	texlive-lang-arabic \
-	libc6-dev \
-	git \
-	mysql-client \
-	tzdata \
-	apt-utils \
-	locales \
-	debconf-utils \
-	ssl-cert \
-	ca-certificates \
-	culmus \
-	fonts-linuxlibertine \
-	lmodern \
-	zip \
-	iputils-ping \
-	imagemagick \
-	jq \
-	npm \
-    && apt-get clean \
-    && rm -fr /var/lib/apt/lists/* /tmp/*
-
-# Developers may want to add additional packages inside the image
-# such as: telnet vim mc file
-
-# ==================================================================
-
-# Phase 4 - Install webwork2 and pg which were downloaded to /opt/base/ in phase 1
+# Phase 3 - Install webwork2 and pg which were downloaded to /opt/base/ in phase 1
 #   Option: Install the OPL in the image also (about 850 MB)
 
 RUN mkdir -p $APP_ROOT/courses $APP_ROOT/libraries $APP_ROOT/libraries/webwork-open-problem-library $APP_ROOT/webwork2 /www/www/html
@@ -232,7 +113,7 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 
 # ==================================================================
 
-# Phase 5 - some configuration work
+# Phase 4 - some configuration work
 
 # 1. Setup PATH.
 # 2. Compiles color.c in the copy INSIDE the image, will also be done in docker-entrypoint.sh for externally mounted locations.
@@ -262,14 +143,7 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 
 # ==================================================================
 
-# Phase 6 - install additional Perl modules from CPAN (not packaged for Ubuntu or outdated in Ubuntu)
-
-RUN cpanm install Statistics::R::IO \
-    && rm -fr ./cpanm /root/.cpanm /tmp/*
-
-# ==================================================================
-
-# Phase 7 - setup apache
+# Phase 5 - setup apache
 
 # Note we always create the /etc/ssl/local directory in case it will be needed, as
 # the SSL config can also be done via a modified docker-entrypoint.sh script.
@@ -325,7 +199,7 @@ WORKDIR $APP_ROOT
 
 # ==================================================================
 
-# Phase 8 - prepare docker-entrypoint.sh
+# Phase 6 - prepare docker-entrypoint.sh
 # Done near the end, so that an update to docker-entrypoint.sh can be
 # done without rebuilding the earlier layers of the Docker image.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,13 @@ services:
             - PG_GIT_URL=https://github.com/openwebwork/pg.git
             - PG_BRANCH=PG-2.16
 
+        # If you are using the 2 stage build process uncomment the next line
+        #dockerfile: DockerfileStage2
+        # and first run
+        #     docker build --tag webwork-base:forWW216 -f DockerfileStage1 .
+        # and then
+        #     docker-compose build
+
     depends_on:
       - db
       - r
@@ -177,6 +184,8 @@ services:
 
     # For a production machine
     #restart: always
+    stop_signal: SIGWINCH
+    stop_grace_period: 30s
 
     environment:
 
@@ -213,7 +222,7 @@ services:
       #PAPERSIZE: a4
 
       # Use to build additional locales in the running container at startup. Ex:
-      #ADD_LOCALES: he_IL ISO-8859-8,he_IL.UTF-8 UTF-8
+      #ADD_LOCALES: "he_IL ISO-8859-8\nhe_IL.UTF-8 UTF-8\n"
 
       # Extra Ubuntu packages to install during startup
       #ADD_APT_PACKAGES: vim telnet


### PR DESCRIPTION
Docker improvements:

1. Add files for a 2 stage Docker build process.
2. Set things up so Apache gets stopped "gracefully" (current requests get completed).
  - https://httpd.apache.org/docs/2.4/programs/apachectl.html
  - Also, it is now possible to do `docker container exec -it webwork2_app_1 /usr/sbin/apachectl graceful`:
    - This is a faster restart if code is mounted from outside the container.
    - It should also help with log rotation.
3.   Also some minor fixes.

---

### 2 stage build process

```
# cd into webwork2 directory (as usual)
docker build --tag webwork-base:forWW216 -f DockerfileStage1 .
vim docker-compose.yml
# uncomment the line
#    dockerfile: DockerfileStage2
docker-compose build
```

The first stage does all the OS level work, and involves installing several hundred ubuntu packages (and some CPAN Perl packages), so takes quite some time.
The second stage installs WeBWorK, and is relatively fast.

---

### Force rebuild of OS later
```
# cd into webwork2 directory (as usual)
docker build --no-cache --tag webwork-base:forWW216 -f DockerfileStage1 .
```

