### PR TITLE
Allow the content div in the system template take up as much width as it can

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -866,7 +866,8 @@ table.attemptResults span.answer-preview {
 /*styles for the instructor comment box */
 
 .answerComments {
-    margin-left: 2em;
+    margin-left: auto;
+    margin-right: auto;
     max-width: 80%;
     border-style: outset;
     border-width: 1px;

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -14,13 +14,13 @@ if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
 	var hideSidebar = function () {
 		$('#site-navigation').remove();
 		$('#toggle-sidebar-icon i').removeClass('fa-chevron-left').addClass('fa-chevron-right');
-		$('#content').removeClass('span10').addClass('span11');
+		$('#content').removeClass('span10').addClass('span12').css('margin-left', '0');
 	};
 
 	var showSidebar = function () {
 		$('#body-row').prepend(navigation_element);
 		$('#toggle-sidebar-icon i').addClass('fa-chevron-left').removeClass('fa-chevron-right');
-		$('#content').addClass('span10').removeClass('span11');	
+		$('#content').addClass('span10').removeClass('span12').css('margin-left', '');
 	};
 
 	var toggleSidebar = function () {
@@ -34,7 +34,7 @@ if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
 	// if no fish eye then collapse site-navigation 
 	if($('#site-links').length > 0 && !$('#site-links').html().match(/[^\s]/)) {
 		$('#site-navigation').remove();
-		$('#content').removeClass('span10').addClass('span11');
+		$('#content').removeClass('span10').addClass('span12').css('margin-left', '0');
 		$('#toggle-sidebar').addClass('hidden');
 		$('#breadcrumb-navigation').width('100%');
 	} else {

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -194,37 +194,37 @@
 		  <div id="problem_body" class="Body span12">
 
 			<!--#if can="output_custom_edit_message"-->
-			<div id="custom_edit_message" class="row-fluid"><div class="span10">
+			<div id="custom_edit_message" class="row-fluid"><div class="span12">
 				<!--#output_custom_edit_message-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 			<!--#if can="output_summary"-->
-			<div class="row-fluid"><div id="output_summary" class="span10">
+			<div class="row-fluid"><div id="output_summary" class="span12">
 					<!--#output_summary-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_achievement_message"-->
-			<div class="row-fluid"><div id="output_achievement_message" class="span10">
+			<div class="row-fluid"><div id="output_achievement_message" class="span12">
 					<!--#output_achievement_message-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 			
 			<!--#if can="output_comments" "-->
-			<div class="row-fluid"><div id="output_comments" class="span10">
+			<div class="row-fluid"><div id="output_comments" class="span12">
 				  <!--#output_comments-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_grader"-->
-			<div class="row-fluid"><div id="output_grader" class="span10">
+			<div class="row-fluid"><div id="output_grader" class="span12">
 				<!--#output_grader-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_form_start"-->
 			<div class="row-fluid">
-			  <div class="span10">
+			  <div class="span12">
 				<!--#output_form_start-->
 			    <!--#if can="output_hidden_info"-->
 				     <!--#output_hidden_info-->
@@ -278,7 +278,7 @@
 			</div>
 		<!--#endif-->
 
-		</div><div class="span2"></div></div>
+		</div></div>
                 </div></div>
 
 	<!-- ====  end printing body parts   -->


### PR DESCRIPTION
Allow the content div in the system template take up as much width as it can instead of leaving empty space on the right.  This is done by removing the empty span2's, and using span12 instead of span11 when the side nav is hidden.

This makes homework problems more consistent with gateway quizzes, and generally looks better to me. This also uses space better on other content pages as well.

@Alex-Jordan and I disagree on this.  I like this consistency, and @Alex-Jordan doesn't like the long lines.  See our discussion at https://github.com/Alex-Jordan/webwork2/pull/9 and https://github.com/Alex-Jordan/webwork2/pull/10.