### PR TITLE
Gateway navigation table

### DIFF
--- a/htdocs/themes/math4/gateway.css
+++ b/htdocs/themes/math4/gateway.css
@@ -98,12 +98,28 @@ div.gwProblem
 }
 
 .gwNavigation {
-    margin-top: 1em;	
-    margin-bottom: 1em;
+	margin-top: 1em;
+	margin-bottom: 1em;
+	text-align: center;
+}
+
+.gwNavigation th, td {
+	padding: 0 0.5rem;
 }
 
 .gwNavigation th {
     text-align:right;
+    font-weight: bold;
+    padding-right: 1rem;
+}
+
+.gwNavigation colgroup.page {
+	border-left: solid 1pt black;
+	border-right: solid 1pt black;
+}
+
+.gwNavigation .page.active {
+	background-color: #ffeeaa;
 }
 
 div.gwDivider {

--- a/htdocs/themes/math4/gateway.css
+++ b/htdocs/themes/math4/gateway.css
@@ -103,7 +103,7 @@ div.gwProblem
 	text-align: center;
 }
 
-.gwNavigation th, td {
+.gwNavigation th, .gwNavigation td {
 	padding: 0 0.5rem;
 }
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1978,7 +1978,7 @@ sub body {
 		# subsequent pages of a multipage test
 		print CGI::hidden({-name=>'pageChangeHack', -value=>''}),
 			CGI::br();
-        print CGI::hidden({-name=>'startTime', -value=>$startTime});
+		print CGI::hidden({-name=>'startTime', -value=>$startTime});
 		if ($numProbPerPage && $numPages > 1) { 
 			print CGI::hidden({-name=>'newPage', -value=>''});
 			print CGI::hidden({-name=>'currentPage', -value=>$pageNumber});
@@ -1993,50 +1993,42 @@ sub body {
 		# set up links between problems and, for multi-page tests, pages
 		my $jumpLinks = '';
 		my $probRow = [ ];
+		my $scoreRow = [ ];
 		for my $i (0 .. $#pg_results) {
-
 			my $pn = $i + 1;
 			if ($i >= $startProb && $i <= $endProb) {
-				push(@$probRow, CGI::b(" [ ")) if ($i == $startProb);
-				push(@$probRow, " &nbsp;" .
-					CGI::a({-href=>"#",
-							-onclick=>"jumpTo($pn);return false;"},
-						"$pn") . "&nbsp; ");
-				push(@$probRow, CGI::b(" ] ")) if ($i == $endProb);
-			} elsif (!($i % $numProbPerPage)) {
-				push(@$probRow, " &nbsp;&nbsp; ",
-					" &nbsp;&nbsp; ", " &nbsp;&nbsp; ");
+				push(@$probRow, CGI::a({-href=>"#", -onclick => "jumpTo($pn);return false;"}, "$pn"));
+			} else {
+				push(@$probRow, "$pn");
 			}
+			my $score = $probStatus[$probOrder[$i]];
+			$score = ($score == 1) ? "\x{1F4AF}" : wwRound(0,100*$score);
+			push(@$scoreRow, $score);
 		}
+		my @tableRows;
+		my @cols = (CGI::colgroup(CGI::col({class => 'header'})));
 		if ($numProbPerPage && $numPages > 1) {
-			my $pageRow = [ CGI::th( {scope=>"row"}, CGI::b($r->maketext('Jump to Page:'))),
-					CGI::td(CGI::b(' [ ' )) ];
+			push (@cols, (CGI::colgroup({class => 'page'},CGI::col({class => 'problem'}) x $numProbPerPage) x $numPages));
+			my @pages;
 			for my $i (1 .. $numPages) {
 				my $pn = ($i == $pageNumber) ? $i : 
 					CGI::a({-href=>'javascript:document.gwquiz.pageChangeHack.value=1;' .
 							"document.gwquiz.newPage.value=\"$i\";" .
 							'document.gwquiz.previewAnswers.click();'}, "&nbsp;$i&nbsp;");
-
-				my $colspan =  0;
-				if ($i == $pageNumber) {
-					$colspan = ($#pg_results - ($i-1)*$numProbPerPage > $numProbPerPage)
-						? $numProbPerPage : $#pg_results - ($i-1)*$numProbPerPage + 1;
-				} else {
-					$colspan = 1;
-				}
-				push(@$pageRow, CGI::td({-colspan=>$colspan, -align=>'center'}, $pn));
-				push(@$pageRow, CGI::td([CGI::b(' ] '), CGI::b(' [ ')]))
-				if ($i != $numPages);
+				my $class = ($i == $pageNumber) ? 'page active' : 'page';
+				push(@pages, CGI::td({-colspan => $numProbPerPage, -class => $class}, $pn));
 			}
-			push(@$pageRow, CGI::td(CGI::b(' ] ')));
-			$jumpLinks = CGI::table({class=>"gwNavigation", role=>"navigation", 'aria-label'=>"problem navigation"},
-				CGI::Tr(@$pageRow),
-				CGI::Tr(CGI::th(CGI::b($r->maketext("Jump to Problem:"))), CGI::td($probRow)));
+			if ($numProbPerPage == 1) {
+				@tableRows = (CGI::Tr(CGI::th( {scope=>"row"}, $r->maketext('Move to Problem:')), @pages));
+			} else {
+				@tableRows = (CGI::Tr(CGI::th( {scope=>"row"}, $r->maketext('Move to Page:')), @pages), CGI::Tr(CGI::th($r->maketext("Jump to Problem:")), CGI::td({class => "problem"}, $probRow)));
+			}
 		} else {
-			$jumpLinks = CGI::table({class=>"gwNavigation", role=>"navigation", 'aria-label'=>"problem navigation"},
-				CGI::Tr(CGI::th(CGI::b($r->maketext("Jump to Problem:"))), CGI::td($probRow)));
+			push (@cols, (CGI::colgroup({class => 'page'}, CGI::col({class => 'problem'}) x ($#pg_results + 1))));
+			@tableRows = (CGI::Tr(CGI::th($r->maketext("Jump to Problem:")), CGI::td({class => "problem"}, $probRow)));
 		}
-
+		push (@tableRows, CGI::Tr(CGI::th($r->maketext("% Score:")), CGI::td({class => "score"}, $scoreRow))) if $canShowProblemScores;
+		$jumpLinks = CGI::table({class=>"gwNavigation", role=>"navigation", 'aria-label'=>"problem navigation"}, @cols, @tableRows);
 		print $jumpLinks,"\n";
 
 		# print out problems and attempt results, as appropriate

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1909,9 +1909,7 @@ sub body {
 				my $scMsg = $r->maketext("Your recorded score on this test (version [_1]) is [_2]/[_3].",
 					$versionNumber, wwRound(2,$recordedScore), $totPossible);
 				if ($exceededAllowedTime && $recordedScore == 0) {
-					$scMsg .= $r->maketext("You exceeded the allowed time.");
-				} else {
-					$scMsg .= ".  ";
+					$scMsg .= " " . $r->maketext("You exceeded the allowed time.");
 				}
 				print CGI::strong($scMsg), CGI::br();
 				print CGI::end_div();
@@ -1930,7 +1928,7 @@ sub body {
 
 		if ($canShowWork && $set->set_id ne "Undefined_Set") {
 			print $r->maketext("The test (which is version [_1]) may  no longer be submitted for a grade.",$versionNumber);
-			print "" . (($can{showScore}) ? $r->maketext("You may still check your answers.") : ".") ;
+			print " " . $r->maketext("You may still check your answers.") if $can{showScore};
 
 			# print a "printme" link if we're allowed to see our
 			#    work

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1997,9 +1997,9 @@ sub body {
 		for my $i (0 .. $#pg_results) {
 			my $pn = $i + 1;
 			if ($i >= $startProb && $i <= $endProb) {
-				push(@$probRow, CGI::a({-href=>"#", -onclick => "jumpTo($pn);return false;"}, "$pn"));
+				push(@$probRow, CGI::a({-href=>"#", -onclick => "jumpTo($pn);return false;"}, $pn));
 			} else {
-				push(@$probRow, "$pn");
+				push(@$probRow, $pn);
 			}
 			my $score = $probStatus[$probOrder[$i]];
 			$score = ($score == 1) ? "\x{1F4AF}" : wwRound(0,100*$score);
@@ -2014,7 +2014,7 @@ sub body {
 				my $pn = ($i == $pageNumber) ? $i : 
 					CGI::a({-href=>'javascript:document.gwquiz.pageChangeHack.value=1;' .
 							"document.gwquiz.newPage.value=\"$i\";" .
-							'document.gwquiz.previewAnswers.click();'}, "&nbsp;$i&nbsp;");
+							'document.gwquiz.previewAnswers.click();'}, $i);
 				my $class = ($i == $pageNumber) ? 'page active' : 'page';
 				push(@pages, CGI::td({-colspan => $numProbPerPage, -class => $class}, $pn));
 			}

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2027,7 +2027,7 @@ sub body {
 			push (@cols, (CGI::colgroup({class => 'page'}, CGI::col({class => 'problem'}) x ($#pg_results + 1))));
 			@tableRows = (CGI::Tr(CGI::th($r->maketext("Jump to Problem:")), CGI::td({class => "problem"}, $probRow)));
 		}
-		push (@tableRows, CGI::Tr(CGI::th($r->maketext("% Score:")), CGI::td({class => "score"}, $scoreRow))) if $canShowProblemScores;
+		push (@tableRows, CGI::Tr(CGI::th($r->maketext("% Score:")), CGI::td({class => "score"}, $scoreRow))) if ($canShowProblemScores && $set->version_last_attempt_time);
 		$jumpLinks = CGI::table({class=>"gwNavigation", role=>"navigation", 'aria-label'=>"problem navigation"}, @cols, @tableRows);
 		print $jumpLinks,"\n";
 


### PR DESCRIPTION
There are two commits here. The first is more or less trivial, inserting some space characters in between Gateway status messages so they don't come out like:

Your recorded score on this test (version 1) is 0/5.You exceeded the allowed time.

The second commit rebuilds the page/problem navigation table. There was a lot of excess things in the navigation table like nbsp characters for spacing and entire cells using `[` and `]` for delimiting pages. With this, all the excess stuff is cleared away and a table cell with a colspan is used for a page with multiple problems in it.

Then I also added a third row to the navigation table with problem scores. As an instructor with a 20-question quiz with 4 questions on each page, it can help to know that the student's only incorrect answer is on page 3, or something like that. Also if you are permitting students to see scores on previously graded submissions, this is good. I've had students complain that they graded a test and it told them a few were wrong. They went to preview some answer and that cleared the display of what was right/wrong and they didn't know how to get that info back. I was only allowing one additional graded submission, so they had a fair complaint.

Once scores are printed, it makes sense to list all of the problem numbers, even for problems on other pages. But I did not make them into links.

I put classes, colgroup elements, and col elements into the table to do better styling. Also I put an "active" class on the cell for the current page. All I did for now with styling was to put left/right borders on the colgroups, give everything some padding, highlight the active page cell, and style the row headers with CSS instead of how they had been styled with a `b` tag. I think more attention to styling would be great, but I don't know what direction to take it in.

More broadly, this could be improved upon. But it is an improvement from what is there now.