### PR TITLE
Disable the quiz begin confirmation dialog for a gateway quiz if a quiz is in progress

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -304,19 +304,27 @@ sub body {
 	# Note: this assumes that the set_id of a versioned GW set cannot differ from all of the corresponding GW versions.
 	foreach my $set (@sets) {
 		die "set $set not defined" unless $set;
-		
-		if ($set->visible || $authz->hasPermissions($user, "view_hidden_sets")) {
-			print $self->setListRow($set, $authz->hasPermissions($user, "view_multiple_sets"), $authz->hasPermissions($user, "view_unopened_sets"),$existVersions,$db);
-		}
+
+		# Generate the versioned quiz rows, but delay printing them until after the template is printed.  On this pass
+		# the gw_quiz_version_in_progress flag will be set if a quiz is currently in progress, in which case the quiz
+		# begin dialog is disabled for the template.
+		my @versions;
 		if (defined($gwSetNames{$set->set_id})) {
 			foreach my $vset (@{$vSetTree{$set->set_id}}) {
 				die "set $vset not defined" unless $vset;
 				if (($set->set_id eq $vset->set_id) && ($vset->visible || $authz->hasPermissions($user, "view_hidden_sets"))) {
-					print $self->setListRow($vset, $authz->hasPermissions($user, "view_multiple_sets"), $authz->hasPermissions($user, "view_unopened_sets"),$existVersions,$db,1, $gwSetsBySetID{$vset->{set_id}});  # 1 = gateway, versioned set
+					push(@versions, $self->setListRow($vset, $authz->hasPermissions($user, "view_multiple_sets"),
+							$authz->hasPermissions($user, "view_unopened_sets"), $existVersions, $db, 1,
+							$gwSetsBySetID{$vset->{set_id}})); # 1 = gateway, versioned set
 				}
 			}
-
 		}
+		if ($set->visible || $authz->hasPermissions($user, "view_hidden_sets")) {
+			print $self->setListRow($set, $authz->hasPermissions($user, "view_multiple_sets"),
+				$authz->hasPermissions($user, "view_unopened_sets"), $existVersions, $db);
+		}
+		print $_ for @versions;
+		delete $self->{gw_quiz_version_in_progress};
 	}
 	
 	print CGI::end_table();
@@ -451,6 +459,7 @@ sub setListRow {
 			} elsif ( time() > $set->due_date() + $self->r->ce->{gatewayGracePeriod} ) {
 				$status = $r->maketext("Over time, closed.");
 			} else {
+				$self->{gw_quiz_version_in_progress} = 1;
 				$status = $self->set_due_msg($set,1);
 			}
 			# we let people go back to old tests
@@ -523,7 +532,7 @@ sub setListRow {
 							class=>"set-id-tooltip",
 							"data-toggle"=>"tooltip",
 							"data-placement"=>"right",
-							data_open => $setIsOpen && $effectiveUser eq $user,
+							data_open => $setIsOpen && $effectiveUser eq $user && !$self->{gw_quiz_version_in_progress},
 							title=>"",
 							"data-original-title"=>$globalSet->description(),
 							href=>$interactiveURL


### PR DESCRIPTION
This fixes an issue with the new gateway quiz confirmation dialog that was pointed out by @Alex-Jordan.  See https://github.com/openwebwork/webwork2/pull/1355#issuecomment-860138358.

The issue is that if a quiz is in progress and the student returns to the problem sets list page, then the confirmation dialog is displayed again.  This pull request disables the dialog in that case.