### PR TITLE
show all sets that are successfully hidden

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -3138,11 +3138,7 @@ sub do_hide_inactive_course {
 	}	
 	
 	if ($succeeded_count) {
-		if ($succeeded_count < 6) {
-			$succeeded_message = $r->maketext("The following courses were successfully hidden: [_1]", @succeeded_courses);
-		} else {
-			$succeeded_message = $r->maketext("[quant_1, course was, courses were] successfully hidden.", $succeeded_count);
-		}
+		$succeeded_message = $r->maketext("The following courses were successfully hidden:" . CGI::br() . "[_1]", join(CGI::br(), @succeeded_courses));
 	}
 	if ($succeeded_count or $already_hidden_count) {
 			print CGI::div({class=>"ResultsWithoutError"},
@@ -3208,11 +3204,7 @@ sub do_unhide_inactive_course {
 	}	
 	
 	if ($succeeded_count) {
-		if ($succeeded_count < 6) {
-			$succeeded_message = $r->maketext("The following courses were successfully unhidden: [_1]", @succeeded_courses);
-		} else {
-			$succeeded_message = $r->maketext("[quant,_1,course was, courses were] successfully unhidden.", $succeeded_count);
-		}
+		$succeeded_message = $r->maketext("The following courses were successfully unhidden:" . CGI::br() . "[_1]", join(CGI::br(), @succeeded_courses));
 	}
 	if ($succeeded_count or $already_visible_count) {
 		print CGI::div({class=>"ResultsWithoutError"},


### PR DESCRIPTION
This is a very small thing that I ran into today which bothered me.

I went into the admin course to hide a handful of courses and the message I received was:

```
The following courses were successfully hidden: a-course-was-listed
```

Only one course was listed, even though I had hidden three. This change makes it list them all. Not that I need to see them all, but it's better than just listing one when you actually succeeded with all of them.