### PR TITLE
Allow instructors to use spaces in set names (that get converted to u…

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -657,6 +657,12 @@ sub read_dir {  # read a directory
 	return sort @files;
 }
 
+sub format_set_name {
+	my $string = shift;
+	$string =~ s/ /_/g;
+	return $string;
+}
+
 =back
 
 =cut

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -238,19 +238,20 @@ sub pre_header_initialize {
 	};
 	
 	defined param $r "create_set" and do {
-	  my $setname = $r->param("new_set_name");
-	  if ($setname && $setname ne 'Name for new set here') {
-		if ($setname =~ /^[\w.-]*$/) {
-		$module = "${ipfx}::SetMaker";
-		$params{new_local_set} = "Create a New Set in this Course";
-		$params{new_set_name} = $setname;
-		$params{selfassign} = 1;
-		  } else {
-		push @error, E_BAD_NAME;
-		  }
-	  } else {
-		push @error, E_SET_NAME;
-	  }
+		my $setname = $r->param("new_set_name");
+		if ($setname && $setname ne 'Name for new set here') {
+			if ($setname =~ /^[\w .-]*$/) {
+				$setname = WeBWorK::ContentGenerator::Instructor::format_set_name($setname);
+				$module = "${ipfx}::SetMaker";
+				$params{new_local_set} = "Create a New Set in this Course";
+				$params{new_set_name} = $setname;
+				$params{selfassign} = 1;
+			} else {
+				push @error, E_BAD_NAME;
+			}
+		} else {
+			push @error, E_SET_NAME;
+		}
 	};
 
 	defined param $r "add_users" and do {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1320,7 +1320,10 @@ sub initialize {
 				    $param = $self->parseDateTime($param) unless (defined $unlabel || !$param);
 				}
 				if ($field =~ /restricted_release/) {
-				    $self->check_sets($db,$param) if $param;
+					if ($param) {
+						$param = WeBWorK::ContentGenerator::Instructor::format_set_name($param);
+						$self->check_sets($db,$param) if $param;
+					}
 				}
 				if (defined($properties{$field}->{convertby}) && $properties{$field}->{convertby} && $param) {
 					$param = $param*$properties{$field}->{convertby};

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -728,8 +728,9 @@ sub filter_handler {
 		$self->{visibleSetIDs} = $genericParams->{selected_sets}; # an arrayref
 	} elsif ($scope eq "match_ids") {
                 $result = $r->maketext("showing matching sets");
-		#my @setIDs = split /\s*,\s*/, $actionParams->{"action.filter.set_ids"}->[0];
-		my @setIDs = split /\s*,\s*/, $actionParams->{"action.filter.set_ids"}->[0];
+		my @searchTerms = map{WeBWorK::ContentGenerator::Instructor::format_set_name($_)} (split /\s*,\s*/, $actionParams->{"action.filter.set_ids"}->[0]);
+		my $regexTerms = join('|', @searchTerms);
+		my @setIDs = grep { /$regexTerms/i } (@{$self->{allSetIDs}});
 		$self->{visibleSetIDs} = \@setIDs;
 	} elsif ($scope eq "match_open_date") {
                 $result = $r->maketext("showing matching sets");
@@ -1115,7 +1116,7 @@ sub create_handler {
 	my $db     = $r->db;
 	my $ce     = $r->ce;
 
-	my $newSetID = $actionParams->{"action.create.name"}->[0];
+	my $newSetID = WeBWorK::ContentGenerator::Instructor::format_set_name($actionParams->{"action.create.name"}->[0]);
 	return CGI::div({class => "ResultsWithError"}, $r->maketext("Failed to create new set: no set name specified!")) unless $newSetID =~ /\S/;
 	return CGI::div({class => "ResultsWithError"},
 			$r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetID)
@@ -1287,7 +1288,7 @@ sub import_handler {
 	my $r = $self->r;
 
 	my @fileNames = @{ $actionParams->{"action.import.source"} };
-	my $newSetName = $actionParams->{"action.import.name"}->[0];
+	my $newSetName = WeBWorK::ContentGenerator::Instructor::format_set_name($actionParams->{"action.import.name"}->[0]);
 	$newSetName = "" if $actionParams->{"action.import.number"}->[0] > 1; # cannot assign set names to multiple imports
 	my $assign = $actionParams->{"action.import.assign"}->[0];
 	my $startdate = 0;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1414,7 +1414,7 @@ sub pre_header_initialize {
 		} else {
 			my $newSetName = $r->param('new_set_name');
 			# if we want to munge the input set name, do it here
-			$newSetName =~ s/\s/_/g;
+			$newSetName = WeBWorK::ContentGenerator::Instructor::format_set_name($newSetName);
 			debug("local_sets was ", $r->param('local_sets'));
 			$r->param('local_sets',$newSetName);  ## use of two parameter param
 			debug("new value of local_sets is ", $r->param('local_sets'));


### PR DESCRIPTION
…nderscore)

I went through every place I could think of where an instructor has the option to type in the name of a set, and made it so they can type spaces. In all cases, the spaces are converted to underscore before anything happens with the set name. It is tedious to explain to new faculty users that they must use underscores when they want spaces. (Even more tedious to explain this repeatedly to instructors who forget).

Places where this has effect:

- Hmwk Sets Editor filter tab
- Hmwk Sets Editor import tab 
- Hmwk Sets Editor create tab 
- Library Browser create a new set button (actually there this was already happening, but not in a way that could be managed consistently with other places)
- Instructor Tools create a new set button
- Problem Set Detail page conditional release field

In each place, you should be able to use spaces in a set name, like for example "Quiz 2". Behind the scenes, it will become "Quiz_2".

There is one other change here with the filtering tool in Hmwk Sets Editor. Before, if you filter set names with say "Quiz", it only counts as a match if there is a set whose name is actually "Quiz". Or you could give a list like "Quiz_1, Quiz_2" and just those sets would appear. This did not seem especially useful. Rather than typing those out, why not just click to select them and filter that way?

Now with this PR, if you use "Quiz" then any set with that string in its name will match. So you might end up seeing Quiz 1, Quiz 2, Readiness Quiz. This seems more useful, like if you wanted to filter to only see your quizzes or some other subset where you have a naming convention that can be leveraged.