### PR TITLE
change the name of the answer log file from answer_log to answer.log

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -643,7 +643,7 @@ $webworkFiles{logs}{hosted_courses} = "$webworkDirs{logs}/hosted_courses.log";
 $webworkFiles{logs}{transaction}    = "$webworkDirs{logs}/${courseName}_transaction.log";
 
 # The answer log stores a history of all users' submitted answers.
-$courseFiles{logs}{answer_log}      = "$courseDirs{logs}/answer_log";
+$courseFiles{logs}{answer_log}      = "$courseDirs{logs}/answer.log";
 
 # Log logins.
 $courseFiles{logs}{login_log}       = "$courseDirs{logs}/login.log";


### PR DESCRIPTION
I think it has just been a typo that the name of the answer log file is `answer_log`. This changes it to `answer.log`. If a course already has an `answer_log` file, that file will stay there, but new entries will be added to `answer.log`.