### PR TITLE
copy simple.conf when making a new course

### DIFF
--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -323,6 +323,10 @@ h2.page-title {
     text-align:center;
 }
 
+.new-course-options label span {
+	vertical-align: middle;
+}
+
 /* Home Page */
 ul.courses-list {
 	list-style-type: none;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -510,9 +510,21 @@ sub add_course_form {
 		),
 	);
 	
-	print CGI::p($r->maketext("To add the WeBWorK administrators to the new course (as administrators) check the box below."));
 	my @checked = ($add_admin_users) ?(checked=>1): ();  # workaround because CGI::checkbox seems to have a bug -- it won't default to checked.
-	print CGI::p({},CGI::input({-type=>'checkbox', -name=>"add_admin_users", @checked }, $r->maketext("Add WeBWorK administrators to new course")));
+	print CGI::div(
+		{class => 'new-course-options'},
+		CGI::p($r->maketext("To add the WeBWorK administrators to the new course (as administrators) check the box below.")),
+		CGI::label(
+			{for => "add_admin_users"},
+			CGI::input({-type=>'checkbox', -name=>"add_admin_users", @checked }, ''),
+			CGI::span($r->maketext("Add WeBWorK administrators to new course"))
+		),
+		CGI::label(
+			{for => "add_config_file"},
+			CGI::input({-type=>'checkbox', -name=>"add_config_file", @checked }, ''),
+			CGI::span($r->maketext("Copy simple configuration file to new course"))
+		),
+	);
 
 	print CGI::p($r->maketext("To add an additional instructor to the new course, specify user information below. The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.\n"));
 	
@@ -622,6 +634,7 @@ sub add_course_validate {
 	my $add_initial_lastName             = trim_spaces( $r->param("add_initial_lastName") ) || "";
 	my $add_initial_email                = trim_spaces( $r->param("add_initial_email") ) || "";
 	my $add_templates_course             = trim_spaces( $r->param("add_templates_course") ) || "";
+	my $add_config_file                  = trim_spaces( $r->param("add_config_file") ) || "";
 	my $add_dbLayout                     = trim_spaces( $r->param("add_dbLayout") ) || "";
 	
 	
@@ -698,6 +711,7 @@ sub do_add_course {
 	my $add_initial_email                = trim_spaces( $r->param("add_initial_email") ) || "";
 	
 	my $add_templates_course             = trim_spaces( $r->param("add_templates_course") ) || "";
+	my $add_config_file                  = trim_spaces( $r->param("add_config_file") ) || "";
 	
 	my $add_dbLayout                     = trim_spaces( $r->param("add_dbLayout") ) || "";
 	
@@ -770,6 +784,9 @@ sub do_add_course {
 	my %optional_arguments;
 	if ($add_templates_course ne "") {
 		$optional_arguments{templatesFrom} = $add_templates_course;
+	}
+	if ($add_config_file ne "") {
+		$optional_arguments{copySimpleConfig} = $add_config_file;
 	}
 	if ($add_courseTitle ne "") {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -337,8 +337,6 @@ sub addCourse {
 					my $core = $? & 128;
 					warn "Failed to copy simple.conf from course '$sourceCourse' with command '$cp_cmd' (exit=$exit signal=$signal core=$core): $cp_out\n";
 				}
-			} else {
-				warn "Failed to copy simple.conf from course '$sourceCourse': file '$sourceFile' does not exist.\n";
 			}
 		}
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -323,6 +323,25 @@ sub addCourse {
 		} else {
 			warn "Failed to copy html from course '$sourceCourse': html directory '$sourceDir' does not exist.\n";
 		}
+		## copy config files ##
+		#  this copies the simple.conf file if desired
+		if (exists $options{copySimpleConfig}) {
+			my $sourceFile = $sourceCE->{courseFiles}->{simpleConfig};
+			if (-e $sourceFile) {
+				my $destFile = $ce->{courseFiles}{simpleConfig};
+				my $cp_cmd = join(" ", ("2>&1", $ce->{externalPrograms}{cp}, shell_quote($sourceFile), shell_quote($destFile)));
+				my $cp_out = readpipe $cp_cmd;
+				if ($?) {
+					my $exit = $? >> 8;
+					my $signal = $? & 127;
+					my $core = $? & 128;
+					warn "Failed to copy simple.conf from course '$sourceCourse' with command '$cp_cmd' (exit=$exit signal=$signal core=$core): $cp_out\n";
+				}
+			} else {
+				warn "Failed to copy simple.conf from course '$sourceCourse': file '$sourceFile' does not exist.\n";
+			}
+		}
+
 	}
 	######## set 6: copy html/achievements contents ##############
 }


### PR DESCRIPTION
This makes it so that when you create a new course from the admin course, there is an option to copy the simple.conf file along with the templates folder.  It is checked by default.

Note I would like to do the same thing with the course.conf file, but it's not as simple as just copying that one. That one has this in it:
```
$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR}
```

which has the course instructor listed. So you don't want to copy course.conf and overwrite the original course.conf, in case it's a new instructor. If it were OK to take that out of course.conf (and manage PRINT_FILE_NAMES_FOR as a permission) then I could copy both config files this way. Would there be any objections to that?

Copying config files is nice for an instructor who has some settings they like and use term after term. It would be nice to fully clone their old courses when making a new course for them.