### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -77,7 +77,7 @@ if [ "$1" = 'apache2' ]; then
                     -e 's/^\$database_port="3306"/$database_port = $ENV{"WEBWORK_DB_PORT"}/' \
                     -e 's/^\$database_name="webwork"/$database_name = $ENV{"WEBWORK_DB_NAME"}/' \
                     -e 's/database_username ="webworkWrite"/database_username =$ENV{"WEBWORK_DB_USER"}/' \
-                    -e 's/database_password ="passwordRW"/database_password =$ENV{"WEBWORK_DB_PASSWORD"}/' \
+                    -e 's/database_password ='passwordRW'/database_password =$ENV{"WEBWORK_DB_PASSWORD"}/' \
                     -e 's/mail{smtpServer} = '\'''\''/mail{smtpServer} = $ENV{"WEBWORK_SMTP_SERVER"}/' \
                     -e 's/mail{smtpSender} = '\'''\''/mail{smtpSender} = $ENV{"WEBWORK_SMTP_SENDER"}/' \
                     -e 's/siteDefaults{timezone} = "America\/New_York"/siteDefaults{timezone} = $ENV{"WEBWORK_TIMEZONE"}/' \


### PR DESCRIPTION
changed "passwordRW" to 'passwordRW' in  -e 's/database_password ='passwordRW'/database_password =$ENV{"WEBWORK_DB_PASSWORD"}/' \
literally specifying passwords in the configuration files allowing interpolation wrecks havoc if the  password has special characrers such as @ and %
so the quoting of passwordRW must match the quotes used in site.conf.dist (which are single quotes)