### PR TITLE
Add a standalone style output mode to html2xml

### DIFF
--- a/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/renderViaXMLRPC.pm
@@ -184,7 +184,7 @@ sub pre_header_initialize {
 	$xmlrpc_client->{inputs_ref} = \%inputs_ref;  # contains form data
 	# print STDERR WebworkClient::pretty_print($r->{paramcache});
 
-	$self->{wantsjson} = 1 if $inputs_ref{outputformat} eq 'json' || $inputs_ref{send_pg_flags};
+	$self->{wantsjson} = 1 if $inputs_ref{outputformat} eq 'json' || $inputs_ref{send_pg_flags} || $inputs_ref{standalone_style};
 	
 	##############################
 	# xmlrpc_client calls webservice to have problem rendered


### PR DESCRIPTION
Add a `standalone_style` JSON output format (quite similar to the output generated by https://github.com/drdrew42/renderer when JSON output is requested) which can be requested by using a "regular" output format, and adding `standalone_style=1` to the request parameters.

The intention is that this feature allows a regular WeBWorK server with an open `daemon_course` to reasonable simulate the behavior of the Standalone renderer. That will helpfully allow testing of code intended to work with a Standalone renderer's output to work sufficiently well also with access to such a daemon course.

Having the full rendered HTML available inside a JSON format was already possible using `send_pg_flags=1`, but this feature makes data available in a convenient form which otherwise would need to be reconstructed using either the `raw` output mode, or using the `json_format` and significant work to rebuild the full HTML needed for iFrame inclusion.