### PR TITLE
Stop making ping calls to webwork.maa.org during Apache startup

### DIFF
--- a/conf/webwork.apache2-config.dist
+++ b/conf/webwork.apache2-config.dist
@@ -122,19 +122,6 @@ eval "use lib '$pg_dir/lib'"; die $@ if $@;
 
 require Apache::WeBWorK; # force compilation of pretty much everything
 
-
-print "Check in with MAA site\n";
-system("ping -c1 -s100 webwork.maa.org "); # check MAA site
-print "End connectivity check\n";
-# this snippet checks the connectivity with the internet.
-# it also alerts MAA that a webwork site is starting up.
-# The MAA site runs the following command
-#   tcpdump -l icmp |grep 100 >tcpdump.txt 
-# to collect pings with packet length 108 (8 more bytes then sent)
-# icmp says listen for pings only. -l says to output tcpdump one line
-# a time. One of the items in the line is "length 108"
-# This stores the ip address of a webwork site each time it starts up.
-
 # At this point, the following configuration variables should be present for use
 # in wiring WeBWorK into Apache:
 # 

--- a/conf/webwork.apache2.4-config.dist
+++ b/conf/webwork.apache2.4-config.dist
@@ -148,20 +148,6 @@ if (exists(($ce->{mail}->{smtpPort})) )  { # port not chosen automatically
 
 require Apache::WeBWorK; # force compilation of pretty much everything
 
-print "Check in with MAA site\n";
-system("ping -c1 -s100 webwork.maa.org "); # check MAA site
-print "End connectivity check\n";
-# this snippet checks the connectivity with the internet.
-
-# it also alerts MAA that a webwork site is starting up.
-# The MAA site runs the following command
-#   tcpdump -l icmp |grep 100 >tcpdump.txt 
-# to collect pings with packet length 108 (8 more bytes then sent)
-# icmp says listen for pings only. -l says to output tcpdump one line
-# a time. One of the items in the line is "length 108"
-
-# This stores the ip address of a webwork site each time it starts up.
-
 # At this point, the following configuration variables should be present for use
 # in wiring WeBWorK into Apache:
 # 


### PR DESCRIPTION
Drop the code which triggered a ping to webwork.maa.org on Apache startup.

That was added in https://github.com/openwebwork/webwork2/commit/60c520392859594181d56186d48e5f832918713f
as part of https://github.com/openwebwork/webwork2/pull/976

It does not seem necessary to force sites to send those `ping` packets automatically, and expecting people to realize it is happening and to opt-out is unlikely to occur.