### PR TITLE
Past answer table: resize fields + limit allowed length of a set name accordingly

### DIFF
--- a/bin/addcourse
+++ b/bin/addcourse
@@ -189,6 +189,11 @@ $ce = WeBWorK::CourseEnvironment->new({
 	courseName => $courseID
 });
 
+# Do not attempt to create a course whose name is too long.
+if ( length($courseID) > $ce->{maxCourseIdLength} ) {
+	die "Aborting addcourse: Course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters.";
+}
+
 if ($dbLayout) {
 	die "Database layout $dbLayout does not exist in the course environment.",
 			" (It must be defined in defaults.config.)\n"

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -576,11 +576,13 @@ $dbLayoutName = "sql_single";
 *dbLayout     = $dbLayouts{$dbLayoutName};
 
 # This sets the max course id length.  It might need to be changed depending
-# on what database tables are present.  Mysql allows a max table length of 68
+# on what database tables are present.  Mysql allows a max table length of 64
 # characters.  With the ${course_id}_global_user_achievement table that means
-# the max ${course_id} is about 40 characters
+# the max ${course_id} is exactly 40 characters.
 
 $maxCourseIdLength = 40;
+
+# Reference:  https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
 
 ################################################################################
 # Problem library options

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -380,7 +380,7 @@ sub body {
 	);
 	
 	print( CGI::p({style=>"text-align: center"}, $self->display_registration_form() ) ) if $self->display_registration_form();
-	
+
 	my @errors = @{$self->{errors}};
 	
 	
@@ -493,7 +493,7 @@ sub add_course_form {
 	print $self->hidden_authen_fields;
 	print $self->hidden_fields("subDisplay");
 	
-	print CGI::p($r->maketext("Specify an ID, title, and institution for the new course. The course ID may contain only letters, numbers, hyphens, and underscores."));
+	print CGI::p($r->maketext("Specify an ID, title, and institution for the new course. The course ID may contain only letters, numbers, hyphens, and underscores, and may have at most [_1] characters.", $ce->{maxCourseIdLength}));
 	
 	print CGI::table({class=>"FormLayout"},
 		CGI::Tr({},
@@ -653,7 +653,10 @@ sub add_course_validate {
 	if (grep { $add_courseID eq $_ } listCourses($ce)) {
 		push @errors, $r->maketext("A course with ID [_1] already exists.", $add_courseID);
 	}
-	
+	if ( length($add_courseID) > $ce->{maxCourseIdLength} ) {
+                @errors, $r->maketext("Course ID cannot exceed [_1] characters.", $ce->{maxCourseIdLength});
+	}
+
 	if ($add_initial_userID ne "") {
 		if ($add_initial_password eq "") {
 			push @errors, $r->maketext("You must specify a password for the initial instructor.");
@@ -1228,6 +1231,9 @@ sub rename_course_validate {
 	}
 	if ($rename_oldCourseID eq $rename_newCourseID and $rename_newCourseID_checkbox eq 'on') {
 		push @errors, $r->maketext("Can't rename to the same name.");
+	}
+	if ($rename_newCourseID_checkbox eq 'on' && length($rename_newCourseID) > $ce->{maxCourseIdLength} ) {
+		push @errors, $r->maketext("Course ID cannot exceed [_1] characters.", $ce->{maxCourseIdLength});
 	}
 	unless ($rename_newCourseID =~ /^[\w-]*$/) { # regex copied from CourseAdministration.pm
 		push @errors, $r->maketext("Course ID may only contain letters, numbers, hyphens, and underscores.");
@@ -2166,6 +2172,8 @@ sub unarchive_course_validate {
 	} elsif ( -d $ce->{webworkDirs}->{courses}."/$courseID" ) {
 	    #Check that a directory for this course doesn't already exist
 		push @errors, $r->maketext("A directory already exists with the name [_1]. You must first delete this existing course before you can unarchive.",$courseID);
+	} elsif ( length($courseID) > $ce->{maxCourseIdLength} ) {
+		push @errors, $r->maketext("Course ID cannot exceed [_1] characters.", $ce->{maxCourseIdLength});
 	}
 
 	

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1086,6 +1086,7 @@ sub create_form {
 				-name => "action.create.name",
 				-value => $actionParams{"action.create.name"}->[0] || "",
 				-width => "50",
+				-maxlength => "100",
 				-'aria-required'=>'true',
 			}
 		),
@@ -1116,6 +1117,7 @@ sub create_handler {
 	my $ce     = $r->ce;
 
 	my $newSetID = $actionParams->{"action.create.name"}->[0];
+	return CGI::div({class => "ResultsWithError"}, $r->maketext("Failed to create new set: set name cannot exceed 100 characters.")) if (length($newSetID) > 100);
 	return CGI::div({class => "ResultsWithError"}, $r->maketext("Failed to create new set: no set name specified!")) unless $newSetID =~ /\S/;
 	return CGI::div({class => "ResultsWithError"},
 			$r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetID)

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -29,16 +29,16 @@ use warnings;
 BEGIN {
 	__PACKAGE__->_fields(
 
-	    answer_id         => {   type=>"INT AUTO_INCREMENT", key=>1},
-	    course_id         => { type=>"VARCHAR(40) NOT NULL", key=>1},
-	    user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},
-	    set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
-	    problem_id        => { type=>"INT NOT NULL", key=>1},
-	    source_file       => { type=>"TEXT"},
-	    timestamp         => { type=>"INT" }, 
-	    scores            => { type=>"TINYTEXT"}, 
-        answer_string     => { type=>"VARCHAR(5012)"},
-	    comment_string    => { type=>"VARCHAR(5012)"},    
+		answer_id         => { type=>"INT AUTO_INCREMENT", key=>1},
+		course_id         => { type=>"VARCHAR(40) NOT NULL", key=>1},
+		user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},
+		set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
+		problem_id        => { type=>"INT NOT NULL", key=>1},
+		source_file       => { type=>"TEXT"},
+		timestamp         => { type=>"INT" }, 
+		scores            => { type=>"TINYTEXT"}, 
+		answer_string     => { type=>"VARCHAR(5012)"},
+		comment_string    => { type=>"VARCHAR(5012)"},    
 
 	);
 }

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -30,9 +30,9 @@ BEGIN {
 	__PACKAGE__->_fields(
 
 	    answer_id         => {   type=>"INT AUTO_INCREMENT", key=>1},
-	    course_id         => { type=>"VARCHAR(80) NOT NULL", key=>1},
-	    user_id           => { type=>"VARCHAR(80) NOT NULL", key=>1},
-	    set_id            => { type=>"VARCHAR(80) NOT NULL", key=>1},
+	    course_id         => { type=>"VARCHAR(40) NOT NULL", key=>1},
+	    user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},
+	    set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
 	    problem_id        => { type=>"INT NOT NULL", key=>1},
 	    source_file       => { type=>"TEXT"},
 	    timestamp         => { type=>"INT" }, 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -189,6 +189,10 @@ sub addCourse {
 	croak "Invalid characters in course ID: '$courseID' (valid characters are [-A-Za-z0-9_])"
 		unless $courseID =~ m/^[-A-Za-z0-9_]*$/;
 	
+	# fail if requested course ID is too long
+	croak "Course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters."
+		if ( length($courseID) > $ce->{maxCourseIdLength} );
+
 	# if we didn't get a database layout, use the default one
 	if (not defined $dbLayoutName) {
 		$dbLayoutName = $ce->{dbLayoutName};
@@ -417,6 +421,10 @@ sub renameCourse {
 	if (-e $newCourseDir) {
 		croak "$newCourseID: course exists";
 	}
+
+	# fail if the target courseID is too long
+	croak "New course ID cannot exceed " . $oldCE->{maxCourseIdLength} . " characters."
+		if ( length($newCourseID) > $oldCE->{maxCourseIdLength} );
 	
 	# fail if the source course does not exist
 	unless (-e $oldCourseDir) {
@@ -838,6 +846,11 @@ sub unarchiveCourse {
 		die "Cannot overwrite existing course $coursesDir/$newCourseID";
 	}
 	
+	# fail if the target courseID is too long
+	croak "New course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters."
+		if ( length($newCourseID) > $ce->{maxCourseIdLength} );
+
+
 	##### step 1: move a conflicting course away #####
 	
 	# if this function returns undef, it means there was no course in the way

--- a/lib/WebworkWebservice/CourseActions.pm
+++ b/lib/WebworkWebservice/CourseActions.pm
@@ -58,6 +58,12 @@ sub create {
 		$out->{message} = "Insufficient permission level.";
 		return $out
 	}
+	if ( length($newcourse) > $ce->{maxCourseIdLength} ) {
+		debug("Course creation attempt failed: course ID was too long.");
+		$out->{status} = "failure";
+		$out->{message} = "Course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters.";
+		return $out
+	}
 	
 	# declare params
 	my @professors = ();


### PR DESCRIPTION
@dlglin pointed out in the meeting this week that the change to the field lengths in the `past_answer` table causes problems for instructors who are used to being able to use the previously allowed 100 characters in their set names.

This PR is intended to change the limit back to what it used to be, to prevent such issues.

The field lengths were changed in 
https://github.com/openwebwork/webwork2/commit/b840e28f802dd69f6251aa4c4096bcca43c2ad90 in order for the total key-length to remain under the limit when `utf8mb4` is in use (as mySQL/MariaDB will reserve 4 bytes per character when `utf8mb4` is in use).

Both `set_id` and `user_id` were returned to the prior `VARCHAR(100)`. In other tables these are `TINYBLOB`which can actually hold 255 bytes.

In order to remain under the key length limit, `course_id` was reduced down to ` VARCHAR(40)` (from the current `VARCHAR(100)` which was also`VARCHAR(100)` before WeBWorK-2.15).

Note: This fields does not appear in any other course table, and ideally would not be here either. However, there is existing code which expects this column to exist.

For practical purposes it seems unlikely that this change can break anything in an operational course. mySQL has a limit of 64 characters for a table name (https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html) and the longest table name suffix in use in WeBWorK is `_global_user_achievement` (24 characters) which effectively limits the `course_id` of a fully functional course to 40 characters.

Under standard settings, this is certainly sufficiently long, as the admin course limits the length of the `course_id` which can be created using the admin interface using `-maxlength=>$ce->{maxCourseIdLength}` in the attributes on the input box. By default this is set by `conf/defaults.config` to 40 characters. Creating a course called `MaxLongNameViaAdmin123456789012345678901` (exactly 40 characters) seems to have worked properly: all 15 database tables were created, and that course works properly.

Although in principle that limit may have been overridden on some installations, and use of the `bin/addcourse` script does not set a limit on the length of the `course_id`, the mySQL limit of 64 characters in a table name should mean that any attempt to create a course with a `course_id` of over 40 characters will fail to work.

For example, an attempt to create a course with 41 characters in the name using `bin/addcourse` triggers an error, and 
```
root@localhost:/opt/webwork/webwork2# bin/addcourse --users=../courses/adminClasslist.lst MaxLongNameViaAdmin1234567890123456789012
addcourse:  WeBWorK root directory set to /opt/webwork/webwork2
addcourse:  WeBWorK server is starting
addcourse:  WeBWorK root directory set to /opt/webwork/webwork2 in webwork2/conf/webwork.apache2-config
addcourse:  The following locations and urls are set in webwork2/conf/site.conf
addcourse:  PG root directory set to /opt/webwork/pg
addcourse:  WeBWorK server userID is www-data
addcourse:  WeBWorK server groupID is www-data
addcourse:  The webwork url on this site is http://localhost/webwork2
DBD::MariaDB::db do failed: Incorrect table name 'MaxLongNameViaAdmin1234567890123456789012_global_user_achievement' at /opt/webwork/webwork2/lib/WeBWorK/DB/Schema/NewSQL/Std.pm line 891.
```
and so did an attempt to do so using the admin course:
```
An error occured while creating the course AMaxLongNameViaAdmin123456789012345678901:

DBD::MariaDB::db do failed: Incorrect table name 'AMaxLongNameViaAdmin123456789012345678901_global_user_achievement' at /opt/webwork/webwork2/lib/WeBWorK/DB/Schema/NewSQL/Std.pm line 891.
```

Also note that since this field is really of no value as this is a per-course table, any data-loss due to possible truncation is really not important.

The only potential problem I can think of is that some code uses a version if `listProblemPastAnswers` of the form `listProblemPastAnswers($courseID,$userID,$setID,$problemID)` where the `course_id` is used as a `where` condition on the database all.  If someone was able to create a functional course with a `course_id` of over 40 characters (and probably missing the `_global_user_achievement` table) - the code may misbehave when processing where conditions with the full `course_id`.

---

On the other side of things, the system did not enforce that a `set_id` should not exceed 100 characters. Creating such a set was possible before the code in this PR, but when an answer is submitted an error occurs:
```
Error messages

DBD::MariaDB::st execute failed: Data too long for column 'set_id' at row 1 
```

This PR both uses a `maxlength` parameter on the input box, and checks `length($newSetID)` inside the `create_handler` to prevent a set being created with a `set_id` of over 100 characters.

**Future work**: Handling the import functionality to enforce the limit.

