### PR TITLE
force modelCourse to be listed as template source

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -485,6 +485,7 @@ sub add_course_form {
 	#});
 	
 	my @existingCourses = listCourses($ce);
+	push @existingCourses, 'modelCourse';
 	@existingCourses = sort { lc($a) cmp lc ($b) } @existingCourses; #make sort case insensitive 
 	
 	print CGI::h2($r->maketext("Add Course"));


### PR DESCRIPTION
recent changes to CourseAdmin.pm `listCourses` has stopped listing `modelCourse` under the available sources for template files during course creation.

This PR forcibly adds `modelCourse` to the list of available template sources. It should be merged into main as a hotfix for 2.16