### PR TITLE
Configurable modelcourses list for admin add course

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -682,6 +682,10 @@ $courseFiles{logs}{activity_log} = '';
 # to the new course being created.
 $siteDefaults{default_templates_course} ="modelCourse";
 
+# Provide a list of model courses which are not real courses, but from which
+# the templates for a new course can be copied.
+$modelCoursesForCopy = [ "modelCourse" ];
+
 ################################################################################
 # Authentication system
 ################################################################################

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -122,6 +122,13 @@ $mail{feedbackRecipients}    = [
 #$webworkFiles{screenSnippets}{setHeader} = "$courseDirs{templates}/ASimpleCombinedHeaderFile.pg";
 #$webworkFiles{screenSnippets}{setHeader} = "$courseDirs{templates}/ASimpleScreenHeaderFile.pg";
 
+################################################################################
+# Settings for the admin course
+################################################################################
+
+# Provide a list of model courses which are not real courses, but from which
+# the templates for a new course can be copied.
+#$modelCoursesForCopy = [ "modelCourse", "anotherModelCourse", "aThirdOne" ];
 
 ################################################################################
 # OpenProblemLibrary

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -484,8 +484,8 @@ sub add_course_form {
 	#});
 	
 	my @existingCourses = listCourses($ce);
-	push @existingCourses, 'modelCourse';
 	@existingCourses = sort { lc($a) cmp lc ($b) } @existingCourses; #make sort case insensitive 
+	unshift( @existingCourses, @{$ce->{modelCoursesForCopy}});
 	
 	print CGI::h2($r->maketext("Add Course"));
 	


### PR DESCRIPTION
This is intended to supplement what was just done as a hot fix in https://github.com/openwebwork/webwork2/pull/1447 but to make it possible to configure a list of model courses which get prepended to the provided list.