### PR TITLE
Bugfix: JITAR problem sets 'save' not respecting nested problems

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
@@ -101,9 +101,9 @@
 	// This uses recursion to set the #prob_num_id fields to the
 	// new position in the tree whenever the tree is updated or
 	// the renumber button is clicked
-	var recurse_on_heirarchy = function (heirarchy,array) {
-		for (var i=0; i < heirarchy.length; i++) {
-			var id = heirarchy[i].id;
+	var recurse_on_hierarchy = function (hierarchy,array) {
+		for (var i=0; i < hierarchy.length; i++) {
+			var id = hierarchy[i].id;
 
 			$('#prob_num_'+id).val(i+1);
 
@@ -112,13 +112,13 @@
 			});
 
 			for (var j=0; j < array.length; j++) {
-				if (array[j].item_id == id) {
+				if (array[j].id == id) {
 					$('#prob_parent_id_'+id).val(array[j].parent_id);
 				}
 			}
 
-			if (typeof heirarchy[i].children != 'undefined') {
-				recurse_on_heirarchy(heirarchy[i].children,array);
+			if (typeof hierarchy[i].children != 'undefined') {
+				recurse_on_hierarchy(hierarchy[i].children,array);
 			}
 		}
 	};
@@ -127,10 +127,10 @@
 	// to WeBWorK as a parameter
 	var set_prob_num_fields = function () {
 		var array = $('#psd_list').nestedSortable("toArray");
-		var heirarchy = $('#psd_list').nestedSortable("toHierarchy");
+		var hierarchy = $('#psd_list').nestedSortable("toHierarchy");
 
 		$('.pdr_handle > span').html('');
-		recurse_on_heirarchy(heirarchy,array);
+		recurse_on_hierarchy(hierarchy,array);
 
 		$('.pdr_handle > span').each(function() {
 			$(this).html($(this).html().slice(0, -1));
@@ -152,7 +152,7 @@
 				if (!has_children && array[i].parent_id == id) {
 					$('#problem\\.'+id+'\\.att_to_open_children_id').parents('tr:first').removeClass('hidden');
 					has_children = true;
-				} else if (array[i].item_id == id) {
+				} else if (array[i].id == id) {
 					// If its a top level problem counts_for_parent is disabled
 					if (!array[i].parent_id) {
 						$('#problem\\.'+id+'\\.counts_parent_grade_id').parents('tr:first').addClass('hidden');


### PR DESCRIPTION
* nestedSortable changed their object structure, and this broke our Hmwk Sets Editor script
* Also, fixing a persistent typo

Thanks to Monica VanDieren for pointing out this issue

### To test:
**BEFORE PATCH:**
1. create a new set of blank problems, or use an existing set with at least two problems
2. convert the set to just-in-time and save
3. drag a problem to the right to make it a child of the previous problem
4. attempt to save and notice that the parent has gone missing, and the child has taken its place.
5. also note that 'top-level' problems display "Counts For Parent" configuration setting

**AFTER PATCH:**

  1-3. Same
  4. attempt to save and see that you've kept the parent, and it has a child (you might need to click to expand).
  5. note that top-level problems do not display "Counts For Parent" (as it should be)