### PR TITLE
New utility script: bin/crypt_passwords_in_classlist.pl

### DIFF
--- a/bin/crypt_passwords_in_classlist.pl
+++ b/bin/crypt_passwords_in_classlist.pl
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use open IO => ':encoding(UTF-8)';
+
+# ==================================================================
+
+# 2 subroutines copied from lib/WeBWorK/Utils.pm from WW 2.16 version
+
+sub cryptPassword($) {
+	my ($clearPassword) = @_;
+	#Use an SHA512 salt with 16 digits
+	my $salt = '$6$';
+	for (my $i=0; $i<16; $i++) {
+		$salt .= ('.','/','0'..'9','A'..'Z','a'..'z')[rand 64];
+	}
+
+	my $cryptPassword = crypt(trim_spaces($clearPassword), $salt);
+	return $cryptPassword;
+}
+
+## Utility function to trim whitespace off the start and end of its input
+sub trim_spaces {
+	my $in = shift;
+	return '' unless $in;  # skip blank spaces
+	$in =~ s/^\s*|\s*$//g;
+	return($in);
+}
+
+# ==================================================================
+my $inputfile = shift;
+my $outfile = "crypted_" . $inputfile;
+
+if ( -e $inputfile && -r $inputfile ) {
+	my $fh; my $outfh;
+	open( my $fh, "<", $inputfile ) or die "cannot open $inputfile";
+	open( my $outfh, ">", $outfile ) or die "cannot open $outfile";
+	my $line;
+	my @fields;
+	while ( $line = <$fh> ) {
+		if ( $line =~ /^#/ ) {
+			# Do not process comment lines
+			print $outfh $line;
+		} else {
+			@fields = split( ",", $line );
+			$fields[9] = cryptPassword( $fields[9] );
+			print $outfh join(",",@fields);
+		}
+	}
+	close $outfh or die "cannot close $outfile";
+	close $fh or die "cannot close $inputfile";
+	print "Output is in the file $outfile\n";
+} else {
+	print "Usage: crypt_passwords_in_classlist.pl filename";
+}

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1015,6 +1015,10 @@ sub pretty_print_rh($) {
 	}
 }
 
+# If you modify the code of cryptPassword, please also make the change
+# in bin/crypt_passwords_in_classlist.pl, which has a copy of this
+# routine so it can easily be used without needed access to a WW webwork2
+# directory.
 sub cryptPassword($) {
 	my ($clearPassword) = @_;
 	#Use an SHA512 salt with 16 digits


### PR DESCRIPTION
Add `bin/crypt_passwords_in_classlist.pl` to provide a reasonable manner of preparing a classlist file with properly crypted passwords.

The script was coded with a copy of the 2 needed subroutines from `lib/WeBWorK/Utils.pm` so it can easily be used on a machine with Perl but without WeBWorK.

This is meant to help address the fact that https://webwork.maa.org/wiki/Classlist_Files#Password_details had long outdated instructions on how to prepare `crypt`-ed passwords for classlist files.