### PR TITLE
Hotfix: LTI grade passback

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -36,7 +36,7 @@ use URI::Escape;
 use Net::OAuth;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
-use constant TIME_DIFF_THRESHOLD => 5; # seconds, threshold to report different between system time and oauth_timestamp time
+use constant TIME_DIFF_THRESHOLD => 15; # seconds, threshold to report different between system time and oauth_timestamp time
 
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -36,8 +36,6 @@ use URI::Escape;
 use Net::OAuth;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
-use constant TIME_DIFF_THRESHOLD => 15; # seconds, threshold to report different between system time and oauth_timestamp time
-
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;
 
 BEGIN {
@@ -149,8 +147,7 @@ sub get_credentials {
   my $curr_time = time();
   my $delta_time = $curr_time - $oauth_time;
   my $delta_min = (0.0 + $delta_time) / (60.0);
-  if ( $ce->{debug_lti_parameters} ||
-	 ( abs($delta_time) > TIME_DIFF_THRESHOLD ) ) {
+  if ( $ce->{debug_lti_parameters} ) {
     warn join("\n",
 	"============================",
 	"===== timestamp info =======",

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -250,7 +250,9 @@ sub submit_grade {
   # which should be dependent on the student + the assignment if a
   # "homework" level sourcedid. This part can be used twice
   my $uuid_p1 = create_uuid_as_string(UUID_SHA1, UUID_NS_URL, $sourcedid);
-  my $uuid_p2;
+
+  # Second part is a time dependent portion
+  my $uuid_p2 = create_uuid_as_string(UUID_TIME);
 
   my $lti_check_prior = $ce->{lti_check_prior} // 0; # Should we first poll the LMS for the current grade
 
@@ -296,13 +298,9 @@ EOS
     warn("Retrieving prior grade using sourcedid: $sourcedid") if
       $ce->{debug_lti_parameters};
 
-
     $requestGen = Net::OAuth->request("consumer");
 
     $requestGen->add_required_message_params('body_hash');
-
-    # Generate a better nonce, second part is a time dependent portion
-    $uuid_p2 = create_uuid_as_string(UUID_TIME);
 
     $gradeRequest = $requestGen->new(
 		  request_url => $request_url,


### PR DESCRIPTION
Bug:  When `$lti_check_prior` is false, then the generation of the time-dependent portion of the nonce is not occurring, as it was incorrectly moved inside the `if ( $lti_check_prior )`block in the version in https://github.com/openwebwork/webwork2/pull/1177. (My fault.)

This bug is causing grade passback to fail when `$lti_check_prior` is not enabled after the first grade-passback call until the LMS expires the nonce which is constantly being reused.

Reports:
  - https://github.com/openwebwork/webwork2/issues/1453
  - https://webwork.maa.org/moodle/mod/forum/discuss.php?d=5628

---
 
Fix: Move the generation of `$uuid_p2` back where it belongs (outside the `if` block).

---

History: The code has once done it in the correct location (see: https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4906#p14846 and https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4770#p14184).

For some reason when the `$lti_check_prior`  control switch was added, the code ended up inside the if block. See for example the file posted in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4770#p15256 .

Apparently that version was only tested sufficiently when `$lti_check_prior=1` was set.