### PR TITLE
html2xml add hideAuthData switch (for man-in-the-middle use)

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -131,6 +131,15 @@ sub formatRenderedProblem {
 	my $displayMode = $self->{inputs_ref}{displayMode};
 	my $hideWasNotRecordedMessage = $ce->{hideWasNotRecordedMessage} // 0;
 
+	# Provide an option to hide the authentication data when ht2ml2xml is being used
+	# by a man-in-the-middle system.
+	if ( $ce->{hideAuthData} ) {
+		$course_password = "hidden";
+		$session_key = "hidden";
+		$userID = "hidden";
+		$courseID = "hidden";
+	}
+
 	# HTML document language settings
 	my $formLanguage = $self->{inputs_ref}{language} // 'en';
 	my $COURSE_LANG_AND_DIR = get_lang_and_dir($formLanguage);


### PR DESCRIPTION
Adds a `hideAuthData` control setting which when enabled will replace the values of the hidden input fields of authentication data in `html2xml` generated problems with "hidden".

Such a change is only feasible when the problems are being requested by a man-in-the-middle system which can add the authentication data when processing a request/submission, so that it need not be provided to the end user's browser (and thus essentially made public).

The goal at present is to protect the daemon `course_password`, etc. when problems are rendered by `html2xml` for the WeBWorK XBlock:       https://github.com/Technion-WeBWorK/xblock-webwork

Note: Submitting a problem loaded into an HTML page using `html2xml` when this setting is enables will **not** allow submissions of answers. That is intentional, and this new setting should **not** be used when plain HTML embedding is required.