### PR TITLE
Error with utf8 characters when exporting classlist.

### DIFF
--- a/lib/WeBWorK/File/Classlist.pm
+++ b/lib/WeBWorK/File/Classlist.pm
@@ -91,7 +91,7 @@ sub parse_classlist($) {
 sub write_classlist($@) {
 	my ($file, @records) = @_;
 	
-	my $fh = new IO::File($file, ">")
+	my $fh = new IO::File($file, '>:encoding(UTF-8)')
 		or die "Failed to open classist '$file' for writing: $!\n";
 	
 	my $csv = Text::CSV->new({ binary => 1});


### PR DESCRIPTION
There was an error in the file .lst when exporting the users with utf8 characters. I corrected the bug. Can you test that it's working on your end.

Thank you! 