### PR TITLE
modifications to allow 'Return-Path' to be specified to be used for r…

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -289,9 +289,11 @@ $mail{smtpServer} = '';  # e.g. 'mail.yourschool.edu' or 'localhost'
 $mail{smtpSender} = '';  # e.g.  'webwork@yourserver.yourschool.edu'
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
 #
-$mail{set_return_path}='noreply@math.rochester.edu'; #discards error messages
+
+$mail{set_return_path}=''; #sets the return_path to the From: field (sender's email address)
 # The return path is used to send error messages about bounced emails
-# "noreply\@$mail{smtpServer}" also discards error messages, using $mail{smtpSender} would deliver error messages to that address.
+# "noreply\@$mail{smtpServer}" discards error messages, 
+# using $mail{smtpSender} would deliver error messages to that address.
 # The default setting should be adjusted for local domain
 # Leaving the return path blank triggers the default which results in Return-Path  being set to the email of the sender.
 #

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -287,6 +287,8 @@ $mail{smtpServer} = '';  # e.g. 'mail.yourschool.edu' or 'localhost'
 # message. It can really be anything, but some mail servers require it contain
 # a valid mail domain, or at least be well-formed.
 $mail{smtpSender} = '';  # e.g.  'webwork@yourserver.yourschool.edu'
+$mail{set_return_path}="noreply\@your.school.edu"; # or to read bounce errors set to  $mail{smptSender}
+
 
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
 

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -287,10 +287,14 @@ $mail{smtpServer} = '';  # e.g. 'mail.yourschool.edu' or 'localhost'
 # message. It can really be anything, but some mail servers require it contain
 # a valid mail domain, or at least be well-formed.
 $mail{smtpSender} = '';  # e.g.  'webwork@yourserver.yourschool.edu'
-$mail{set_return_path}="noreply\@your.school.edu"; # or to read bounce errors set to  $mail{smptSender}
-
-
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
+#
+$mail{set_return_path}='noreply@math.rochester.edu'; #discards error messages
+# The return path is used to send error messages about bounced emails
+# "noreply\@$mail{smtpServer}" also discards error messages, using $mail{smtpSender} would deliver error messages to that address.
+# The default setting should be adjusted for local domain
+# Leaving the return path blank triggers the default which results in Return-Path  being set to the email of the sender.
+#
 
 # Seconds to wait before timing out when connecting to the SMTP server.
 #  the default is 120 seconds.

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -217,17 +217,20 @@ sub body {
 			$remote_port = "UNKNOWN" unless defined $remote_port;
 		}
 
-# 		my $transport = Email::Sender::Transport::SMTP->new({
-# 			host => $ce->{mail}->{smtpServer},
-# 			ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
-# 			timeout => $ce->{mail}->{smtpTimeout}
-# 		});
-#
-# 		$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort};
 
 #           createEmailSenderTransportSMTP is defined in ContentGenerator
 		my $email_address = $user->email_address;
 		my $transport = $self->createEmailSenderTransportSMTP();
+		my $return_path_for_errors = $ce->{mail}->{set_return_path}; 
+	# createEmailSenderTransportSMTP is defined in ContentGenerator
+	# $set_return_path is the address used to report returned email. It is an argument 
+	# used in sendmail() (aka Email::Simple::sendmail).
+	# For arcane historical reasons sendmail  actually sets the field "MAIL FROM" and the smtp server then 
+	# uses that to set "Return-Path".
+	# references:
+	#  stackoverflow: https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
+	#  Email::Simple: https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
+	#
 		my $email = Email::Simple->create(header => [
 			"To" => join(",", @recipients),
 			"From" => $sender,
@@ -235,10 +238,6 @@ sub body {
 			"Content-Type" => "text/plain; charset=UTF-8"
 		]);
 
-		# my $header = Email::Simple::Header->new;
-		# $header->header_set("To",);
-		# $header->header_set("From",$user->email_address);
-		# $header->header_set("Subject",$subject);
 
 		## extra headers
 		$email->header_set("X-Remote-Host: ",$remote_host);
@@ -294,7 +293,7 @@ $emailableURL
     $email->body_set(Encode::encode("UTF-8",$msg));
 
 		try {
-			sendmail($email,{transport => $transport});
+			sendmail($email,{transport => $transport, from=>$return_path_for_errors});
 			print CGI::p($r->maketext("Your message was sent successfully."));
 			print CGI::p(CGI::a({-href => $returnURL}, $r->maketext("Return to your work")));
 			print CGI::pre(wrap("", "", $feedback));
@@ -304,22 +303,6 @@ $emailableURL
 		};
 
 
-		# Close returns the mailer object on success, a negative value on failure,
-		# zero if mailer was not opened.
-		# my $result = $mailer->Close;
-
-		# if (ref $result) {
-		# 	# print confirmation
-		# 	print CGI::p("Your message was sent successfully.");
-		# 	print CGI::p(CGI::a({-href => $returnURL}, "Return to your work"));
-		# 	print CGI::pre(wrap("", "", $feedback));
-		# } else {
-		# 	$self->feedbackForm($user, $returnURL,
-		# 		"Failed to send message ($result): $Mail::Sender::Error");
-		# }
-	} else {
-		# just print the feedback form, with no message
-		$self->feedbackForm($user, $returnURL, "");
 	}
 
 	return "";
@@ -421,6 +404,7 @@ sub format_user {
 
 	return $result;
 }
+
 
 sub format_userset {
 	my ($self, $Set) = @_;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -880,16 +880,22 @@ sub mail_message_to_recipients {
 
 			my $msg = eval { $self->process_message($ur,$rh_merge_data) };
 			$error_messages .= "There were errors in processing user $recipient, merge file $merge_file. \n$@\n" if $@;
-			#warn "message is ok";
-# 			my $transport = Email::Sender::Transport::SMTP->new({
-# 				host => $ce->{mail}->{smtpServer},
-# 				ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
-# 				timeout => $ce->{mail}->{smtpTimeout}
-# 			});
-# 
 
-#           createEmailSenderTransportSMTP is defined in ContentGenerator
+			#createEmailSenderTransportSMTP is defined in ContentGenerator
+    			my $transport = $self->createEmailSenderTransportSMTP();
+    			my $return_path_for_errors = $ce->{mail}->{set_return_path};
+		        # createEmailSenderTransportSMTP is defined in ContentGenerator
+    			# return_path_for_errors is the address used to report returned email. It is an argument
+    			# used in sendmail() (aka Email::Simple::sendmail).
+    			# For arcane historical reasons sendmail  actually sets the field "MAIL FROM" and the smtp server then
+    			# uses that to set "Return-Path".
+    			# references:
+                        #  stackoverflow:
+                        #    https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
+                        #  Email::Simple: https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
+    
 			my $transport = $self->createEmailSenderTransportSMTP();
+			my $return_path_for_errors = $ce->{mail}->{set_return_path};
 			my $email = Email::Simple->create(
 				header => [
 					To => $ur->email_address,
@@ -902,7 +908,12 @@ sub mail_message_to_recipients {
 
 
 			try {
-				sendmail($email,{transport => $transport});
+	                       if ($return_path_for_errors) {
+        	                     sendmail($email,{transport => $transport, from=>$return_path_for_errors});
+                	       }
+                    	       else {
+                      	              sendmail($email,{transport => $transport});
+ 	             	       }
 				debug "email sent successfully to " . $ur->email_address;
 			} catch {
 				  debug "error sending email: $_";
@@ -936,16 +947,10 @@ sub email_notification {
 
 	my $mailing_errors = "";
 
-# 	my $transport = Email::Sender::Transport::SMTP->new({
-# 		host => $ce->{mail}->{smtpServer},
-# 		ssl => $ce->{mail}->{tls_allowed}//1, ## turn on ssl security
-# 		timeout => $ce->{mail}->{smtpTimeout}
-# 	});
-# 
-# 	$transport->port($ce->{mail}->{smtpPort}) if defined $ce->{mail}->{smtpPort}; 
-#           createEmailSenderTransportSMTP is defined in ContentGenerator
+#      createEmailSenderTransportSMTP is defined in ContentGenerator
 	my $transport = $self->createEmailSenderTransportSMTP();
 
+	my $return_path_for_errors = $ce->{mail}->{set_return_path};
 	my $email = Email::Simple->create(
 		header => [
 			To => $self->{defaultFrom},
@@ -958,7 +963,12 @@ sub email_notification {
 	$email->header_set("X-Remote-Host: ",$self->{remote_host});
 
 	try {
-		sendmail($email,{transport => $transport});
+             if ($return_path_for_errors) {
+                 sendmail($email,{transport => $transport, from=>$return_path_for_errors});
+             }
+             else {
+                 sendmail($email,{transport => $transport});
+             }
 	} catch {
 			warn "Error sending email: $_";
 			next;
@@ -1022,7 +1032,7 @@ sub process_message {
 	my $endCol = @COL;
 	# for safety, only evaluate special variables
  	my $msg = $text;
- 	$msg =~ s/\$SID/$SID/ge;
+	$msg =~ s/\$SID/$SID/ge;
  	$msg =~ s/\$LN/$LN/ge;
  	$msg =~ s/\$FN/$FN/ge;
  	$msg =~ s/\$STATUS/$STATUS/ge;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -881,7 +881,6 @@ sub mail_message_to_recipients {
 			my $msg = eval { $self->process_message($ur,$rh_merge_data) };
 			$error_messages .= "There were errors in processing user $recipient, merge file $merge_file. \n$@\n" if $@;
 
-			#createEmailSenderTransportSMTP is defined in ContentGenerator
     			my $transport = $self->createEmailSenderTransportSMTP();
     			my $return_path_for_errors = $ce->{mail}->{set_return_path};
 		        # createEmailSenderTransportSMTP is defined in ContentGenerator
@@ -894,8 +893,6 @@ sub mail_message_to_recipients {
                         #    https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
                         #  Email::Simple: https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
     
-			my $transport = $self->createEmailSenderTransportSMTP();
-			my $return_path_for_errors = $ce->{mail}->{set_return_path};
 			my $email = Email::Simple->create(
 				header => [
 					To => $ur->email_address,

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -614,24 +614,33 @@ sub jitar_send_warning_email {
     # at present, this does not seem to be necessary.
 
 
-#       createEmailSenderTransportSMTP is defined in ContentGenerator
-		my $transport = $self->createEmailSenderTransportSMTP();
-		my $email = Email::Simple->create(header => [
+    my $transport = $self->createEmailSenderTransportSMTP();
+    my $return_path_for_errors = $ce->{mail}->{set_return_path};
+    # createEmailSenderTransportSMTP is defined in ContentGenerator
+    # return_path_for_errors is the address used to report returned email. It is an argument
+    # used in sendmail() (aka Email::Simple::sendmail).
+    # For arcane historical reasons sendmail  actually sets the field "MAIL FROM" and the smtp server then
+    # uses that to set "Return-Path".
+    # references:
+    #  stackoverflow:
+    #     https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
+    #  Email::Simple: https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
+               
+    my $email = Email::Simple->create(header => [
 			"To" => join(",", @recipients),
 			"From" => $sender,
 			"Subject" => $subject,
 			"Content-Type" => "text/plain; charset=UTF-8"
-		]);
-
-		## extra headers
-		$email->header_set("X-WeBWorK-Course: ",$courseID) if defined $courseID;
-		if ($user) {
-			$email->header_set("X-WeBWorK-User: ",$user->user_id);
-			$email->header_set("X-WeBWorK-Section: ",$user->section);
-			$email->header_set("X-WeBWorK-Recitation: ",$user->recitation);
-		}
-		$email->header_set("X-WeBWorK-Set: ",$setID) if defined $setID;
-		$email->header_set("X-WeBWorK-Problem: ",$problemID) if defined $problemID;
+    ]);
+    ## extra headers
+    $email->header_set("X-WeBWorK-Course: ",$courseID) if defined $courseID;
+    if ($user) {
+        $email->header_set("X-WeBWorK-User: ",$user->user_id);
+	$email->header_set("X-WeBWorK-Section: ",$user->section);
+	$email->header_set("X-WeBWorK-Recitation: ",$user->recitation);
+    }
+    $email->header_set("X-WeBWorK-Set: ",$setID) if defined $setID;
+    $email->header_set("X-WeBWorK-Problem: ",$problemID) if defined $problemID;
 
     my $full_name = $user->full_name;
     my $email_address = $user->email_address;
@@ -663,7 +672,12 @@ Comment:    $comment
 		## try to send the email
 
 		try {
-			sendmail($email,{transport => $transport});
+                       if ($return_path_for_errors) {
+                               sendmail($email,{transport => $transport, from=>$return_path_for_errors});
+                       }
+                       else {
+                               sendmail($email,{transport => $transport});
+                       }
 				debug("Successfully sent JITAR alert message");
 		} catch {
       $r->log_error("Failed to send JITAR alert message: $_");


### PR DESCRIPTION
…eporting bounce back messages
     $mail{set_return_path} is set in the SMTP configuration section of site.conf
	my $return_path_for_errors = $ce->{mail}->{set_return_path}; 
	# $set_return_path is the address used to report returned email. It is an argument 
	# used in sendmail() (aka Email::Simple::sendmail).
	# For arcane historical reasons sendmail  actually sets the field "MAIL FROM" and the smtp server then 
	# uses that to set "Return-Path".
	# references:
	#  stackoverflow: https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
	#  Email::Simple: https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
	#