### PR TITLE
Hotfix? Update for WordPress Q&A plugin

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1711,7 +1711,7 @@ sub feedbackMacro_form {
 	    if ($key eq 'pg_object') {
 	        my $tmp = $value->{body_text};
 	        $tmp .= CGI::p(CGI::b("Note: "). CGI::i($value->{result}->{msg})) if $value->{result}->{msg} ;
-	        $result .= CGI::hidden($key, encode_base64($tmp, "") );
+	        $result .= CGI::hidden($key, encode_base64(Encode::encode('UTF-8', $tmp), "") );
 	    } else {
 			$result .= CGI::hidden($key, $value) . "\n";
 		}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2257,6 +2257,8 @@ sub output_past_answer_button{
 sub output_email_instructor{
 	my $self = shift;
 	my $r = $self->r;
+	my $urlpath    = $r->urlpath;
+	my $courseName = $urlpath->arg("courseID");
 	my $problem = $self->{problem};
 	my %will = %{ $self->{will} };
 	my $pg = $self->{pg};
@@ -2265,6 +2267,7 @@ sub output_email_instructor{
 
 	print $self->feedbackMacro(
 		module             => __PACKAGE__,
+		courseId           => $courseName,
 		set                => $self->{set}->set_id,
 		problem            => $problem->problem_id,
 		problemPath        => $problem->source_file,

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -2257,8 +2257,7 @@ sub output_past_answer_button{
 sub output_email_instructor{
 	my $self = shift;
 	my $r = $self->r;
-	my $urlpath    = $r->urlpath;
-	my $courseName = $urlpath->arg("courseID");
+	my $courseName = $r->urlpath->arg("courseID");
 	my $problem = $self->{problem};
 	my %will = %{ $self->{will} };
 	my $pg = $self->{pg};


### PR DESCRIPTION
CityTech is releasing a [Q&A plugin for WordPress](https://github.com/openlab-at-city-tech/webworkqa).

The design is intended to accommodate more than just WeBWorK, so the courseID needs to be included in the submitted form-data, rather than parsed from the URL.

The release date is coming up very quickly, and this *should* be the final update necessary before release -- otherwise, this would be directed at develop.