### PR TITLE
LTI bug fix + reimplement test of when to update the nonce in the DB

### DIFF
--- a/bin/ww_purge_old_nonces
+++ b/bin/ww_purge_old_nonces
@@ -57,6 +57,8 @@ use lib "$pg_dir/lib";
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 
+use constant NONCE_LIFETIME => 21600; # 6 hours
+
 sub usage {
 	print STDERR "usage: $0  course \n";
 	exit 1;
@@ -79,11 +81,13 @@ my @listKeys = $db -> listKeys();
 
 foreach my $user_id (@listKeys) {
 	my $Key;
-	eval { $Key = $db -> getKey($user_id);};
+	eval { $Key = $db->getKey($user_id);};
 	if ($@) { push @errors, "$user_id: ". $@ ;}
 	else {
-		if ($Key -> key eq "nonce" && $Key -> timestamp +10 < time()) {
-			eval {$db -> deleteKey($user_id);};
+		if ($Key->key eq "nonce" &&
+			(time()-$Key->timestamp > NONCE_LIFETIME)
+		) {
+			eval {$db->deleteKey($user_id);};
 			if ($@) { push @errors, "$user_id: ". $@ ;}
 		}
 	}

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -806,9 +806,12 @@ sub ok {
     return 1;
   } else {
     # The nonce is in the database - so was used "recently" so should NOT be allowed
-    # Update timestamp - so deletion will be delayed from now and not from original timestamp.
-    $Key->timestamp($self->{"timestamp"});
-    $db->put($Key);
+    if ( $Key->timestamp <  $self->{"timestamp"} ) {
+      # Update timestamp - so deletion will be delayed from the most recent value
+      # of oauth_timestamp sent by the LTI consumer and not from an earlier timestamp.
+      $Key->timestamp($self->{"timestamp"});
+      $db->putKey($Key);
+    }
     return 0;
   }
 }


### PR DESCRIPTION
**This has been rebased to be a PR to develop and force pushed.**

Fix "$db->put($Key)" bug.

See: https://github.com/openwebwork/webwork2/issues/1512

Put back the test condition which was removed in https://github.com/openwebwork/webwork2/pull/1199 for when the nonce should be updated in the DB. The value being used as an update comes from the `oauth_timestamp` value provided by the LMS (remote LTI consumer) so should not be assumed to be larger than the value currently stored in the database.

I'm not sure how we can trigger the code, as this code only runs when a remote LMS sends an LTI connection using a nonce which is still stored in the database. 