### PR TITLE
Improve the MathQuill editor toolbar

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -1,139 +1,114 @@
-span[id^=mq-answer].correct /* green */
-{
-    border-color: rgba(81,153,81, 0.8);
-    outline: 0;
-    outline: thin dotted \9;
-    /* IE6-9 */
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81, ,.6);
-    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
-    color:inherit;
+span[id^="mq-answer"].correct {
+	border-color: rgba(81, 153, 81, 0.8);
+	outline: 0;
+	outline: thin dotted \9;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(81, 153, 81, .6);
+	color:inherit;
 }
 
-span[id^=mq-answer].incorrect /* red */
-{
-    border-color: rgba(191, 84, 84, 0.8);
-    outline: 0;
-    outline: thin dotted \9;
-    /* IE6-9 */
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
-    -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(191,84,84,.6);
-    color: inherit;
+span[id^="mq-answer"].incorrect {
+	border-color: rgba(191, 84, 84, 0.8);
+	outline: 0;
+	outline: thin dotted \9;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px rgba(191, 84, 84, .6);
+	color: inherit;
 }
 
-span[id^=mq-answer]
-{
-    direction: ltr;
-    padding: 4px 5px 2px 5px;
-    border-radius: 4px !important;
-    background-color: white;
-    margin-right: 0;
-    margin-left: 0
+span[id^="mq-answer"] {
+	direction: ltr;
+	padding: 4px 5px 2px 5px;
+	border-radius: 4px !important;
+	background-color: white;
+	margin-right: 0;
+	margin-left: 0
 }
 
-input[type=text].codeshard.mq-edit
-{
-    display: none !important;
+input[type="text"].codeshard.mq-edit {
+	display: none !important;
 }
 
-.quill-toolbar
-{
-    font-size: .75em;
-    display: inline-block;
-    direction: ltr;
-    position: fixed;
-    top: 50%;
-    transform: translateY(-55%);
-    right: 10px;
+.quill-toolbar {
+	box-sizing: border-box;
+	max-height: 95vh;
+	position: fixed;
+	font-size: .75em;
+	direction: ltr;
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
+	justify-content: center;
+	border-radius: 4px;
+	border: 2px solid darkgray;
+	background-color: white;
+	top: 50%;
+	right: 10px;
+	width: 53px;
+    transform: translateY(-50%);
+	z-index: 1001;
 }
 
-.quill-toolbar .symbol-button
-{
-    box-sizing: border-box;
-    width: 50px;
-    text-align: center;
-    padding: 3px;
-    margin: 0;
-    display: block;
-    width: 100%;
-    border-top: 0;
-    border-radius: 0;
+@media only screen and (max-height: 519px) {
+	.quill-toolbar {
+		width: 102px;
+	}
 }
 
-.quill-toolbar .symbol-button:first-child
-{
-    border-top: 1px solid #cccccc;
-    border-radius: 4px 4px 0 0;
+@media only screen and (max-height: 262px) {
+	.quill-toolbar {
+		width: 151px;
+	}
 }
 
-.quill-toolbar .symbol-button:last-child
-{
-    border-radius: 0 0 4px 4px;
+.quill-toolbar .symbol-button {
+	box-sizing: border-box;
+	text-align: center;
+	padding: 3px;
+	margin: 2px;
+	display: block;
+	width: 45px;
+	height: 45px;
+	border-radius: 4px;
+	background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 
 .quill-toolbar > .symbol-button:focus,
-.quill-toolbar > .symbol-button.ui-visual-focus
-{
-    z-index: 9999;
+.quill-toolbar > .symbol-button.ui-visual-focus {
+	z-index: 9999;
 }
 
-.quill-toolbar .symbol-button .ui-button-text
-{
-    padding: 0;
+.quill-toolbar .symbol-button .ui-button-text {
+	padding: 0;
 }
 
-.quill-toolbar .symbol-button span[id^=icon-]:hover
-{
-    cursor: pointer;
+.quill-toolbar .symbol-button span[id^="icon-"]:hover {
+	cursor: pointer;
 }
 
-.quill-toolbar .symbol-button:not([id^="text-mq-answer"]) .mq-text-mode
-{
-    height: 10px;
-    width: 8px;
-    transform: translateY(2px);
-    background-color: skyblue !important;
+.quill-toolbar .symbol-button:not([id^="text-mq-answer"]) .mq-text-mode {
+	height: 10px;
+	width: 8px;
+	transform: translateY(2px);
+	background-color: skyblue !important;
 }
 
 .quill-toolbar .symbol-button .mq-nthroot > .mq-text-mode,
 .quill-toolbar .symbol-button .mq-sup > .mq-text-mode,
-.quill-toolbar .symbol-button .mq-sub > .mq-text-mode
-{
-    height: 6px;
-    width: 6px;
+.quill-toolbar .symbol-button .mq-sub > .mq-text-mode {
+	height: 6px;
+	width: 6px;
 }
 
-.quill-toolbar .symbol-button .mq-sup > .mq-text-mode
-{
-    transform: translateY(2px);
+.quill-toolbar .symbol-button .mq-sup > .mq-text-mode {
+	transform: translateY(2px);
 }
 
-.quill-toolbar .symbol-button .mq-sub > .mq-text-mode
-{
-    transform: translateY(0px);
+.quill-toolbar .symbol-button .mq-sub > .mq-text-mode {
+	transform: translateY(0);
 }
 
-.quill-toolbar .symbol-button .mq-supsub
-{
-    height: 6px;
-    width: 6px;
-    margin-left: 2px;
-}
-
-.ui-tooltip.ui-widget.ui-widget-content
-{
-    padding: 5px;
-    background: black;
-    border: 1px solid black;
-    border-radius: 4px;
-    display: inline-block;
-}
-
-.ui-tooltip-content
-{
-    text-align: center;
-    font-size: 0.7em;
-    background: black;
-    color: white;
+.quill-toolbar .symbol-button .mq-supsub {
+	height: 6px;
+	width: 6px;
+	margin-left: 2px;
 }

--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -117,7 +117,7 @@ window.answerQuills = {};
 					$tooltip.addClass('left')
 						.css({
 							top: ($element.position().top + ($element.outerHeight() - $tooltip.outerHeight()) / 2) + 'px',
-							right: $element.outerWidth() + 4 + 'px',
+							right: answerQuill.toolbar.width() - $element.position().left + 'px',
 							left: 'unset'
 						});
 					$tooltip.find('.tooltip-arrow').css({ left: 'unset' });
@@ -138,6 +138,7 @@ window.answerQuills = {};
 			// toolbar by the problem or if the window height is excessively small, those may be incorrect.  So this
 			// adjusts the width in those cases.
 			const adjustWidth = () => {
+				if (!answerQuill.toolbar) return;
 				const left = answerQuill.toolbar.find('.symbol-button:first-child')[0].getBoundingClientRect().left;
 				const right = answerQuill.toolbar.find('.symbol-button:last-child')[0].getBoundingClientRect().right;
 				answerQuill.toolbar.css({ width: `${right - left + 8}px` });
@@ -159,7 +160,7 @@ window.answerQuills = {};
 
 		// Trigger an answer preview when the enter key is pressed in an answer box.
 		answerQuill.on('keypress.preview', (e) => {
-			if (e.key == 'Enter' || e.which == 13 || e.keyCode == 13) {
+			if (e.key == 'Enter') {
 				// For homework
 				$('#previewAnswers_id').trigger('click');
 				// For gateway quizzes

--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -1,179 +1,223 @@
-"use strict"
+'use strict';
 
-// initialize MathQuill
-var MQ = MathQuill.getInterface(2);
-var answerQuills = {};
+/* global MathQuill, $, bootstrap */
 
-// Avoid conflicts with bootstrap.
-$.widget.bridge('uitooltip', $.ui.tooltip);
+// Global list of all MathQuill answer inputs.
+window.answerQuills = {};
 
-$("[id^=MaThQuIlL_]").each(function() {
-	var answerLabel = this.id.replace(/^MaThQuIlL_/, "");
-	var input = $("#" + answerLabel);
-	var inputType = input.attr('type');
-	if (typeof(inputType) != 'string' || inputType.toLowerCase() !== "text" || !input.hasClass('codeshard')) return;
+(() => {
+	// initialize MathQuill
+	const MQ = MathQuill.getInterface(2);
 
-	var answerQuill = $("<span id='mq-answer-" + answerLabel + "'></span>");
-	answerQuill.input = input;
-	input.addClass('mq-edit');
-	answerQuill.latexInput = $(this);
+	const setupMQInput = (mq_input) => {
+		const answerLabel = mq_input.id.replace(/^MaThQuIlL_/, '');
+		const input = $('#' + answerLabel);
+		const inputType = input.attr('type');
+		if (typeof(inputType) != 'string' || inputType.toLowerCase() !== 'text' || !input.hasClass('codeshard')) return;
 
-	input.after(answerQuill);
+		const answerQuill = $("<span id='mq-answer-" + answerLabel + "'></span>");
+		answerQuill.input = input;
+		input.addClass('mq-edit');
+		answerQuill.latexInput = $(mq_input);
 
-	// Default options.
-	var cfgOptions = {
-		spaceBehavesLikeTab: true,
-		leftRightIntoCmdGoes: 'up',
-		restrictMismatchedBrackets: true,
-		sumStartsWithNEquals: true,
-		supSubsRequireOperand: true,
-		autoCommands: 'pi sqrt root vert inf union abs',
-		rootsAreExponents: true,
-		maxDepth: 10
-	};
+		input.after(answerQuill);
 
-	// Merge options that are set by the problem.
-	var optOverrides = answerQuill.latexInput.data("mq-opts");
-	if (typeof(optOverrides) == 'object') $.extend(cfgOptions, optOverrides);
+		// Default options.
+		const cfgOptions = {
+			spaceBehavesLikeTab: true,
+			leftRightIntoCmdGoes: 'up',
+			restrictMismatchedBrackets: true,
+			sumStartsWithNEquals: true,
+			supSubsRequireOperand: true,
+			autoCommands: 'pi sqrt root vert inf union abs',
+			rootsAreExponents: true,
+			maxDepth: 10
+		};
 
-	// This is after the option merge to prevent handlers from being overridden.
-	cfgOptions.handlers = {
-		edit: function(mq) {
-			if (mq.text() !== "") {
-				answerQuill.input.val(mq.text().trim());
-				answerQuill.latexInput
-					.val(mq.latex().replace(/^(?:\\\s)*(.*?)(?:\\\s)*$/, '$1'));
-			} else {
-				answerQuill.input.val('');
-				answerQuill.latexInput.val('');
+		// Merge options that are set by the problem.
+		const optOverrides = answerQuill.latexInput.data('mq-opts');
+		if (typeof(optOverrides) == 'object') $.extend(cfgOptions, optOverrides);
+
+		// This is after the option merge to prevent handlers from being overridden.
+		cfgOptions.handlers = {
+			edit: (mq) => {
+				if (mq.text() !== '') {
+					answerQuill.input.val(mq.text().trim());
+					answerQuill.latexInput
+						.val(mq.latex().replace(/^(?:\\\s)*(.*?)(?:\\\s)*$/, '$1'));
+				} else {
+					answerQuill.input.val('');
+					answerQuill.latexInput.val('');
+				}
+			},
+			// Disable the toolbar when a text block is entered.
+			textBlockEnter: () => {
+				if (answerQuill.toolbar)
+					answerQuill.toolbar.find('button').prop('disabled', true);
+			},
+			// Re-enable the toolbar when a text block is exited.
+			textBlockExit: () => {
+				if (answerQuill.toolbar)
+					answerQuill.toolbar.find('button').prop('disabled', false);
 			}
-		},
-		// Disable the toolbar when a text block is entered.
-		textBlockEnter: function() {
-			if (answerQuill.toolbar)
-				answerQuill.toolbar.find("button").prop("disabled", true);
-		},
-		// Re-enable the toolbar when a text block is exited.
-		textBlockExit: function() {
-			if (answerQuill.toolbar)
-				answerQuill.toolbar.find("button").prop("disabled", false);
-		}
-	};
+		};
 
-	answerQuill.mathField = MQ.MathField(answerQuill[0], cfgOptions);
+		answerQuill.mathField = MQ.MathField(answerQuill[0], cfgOptions);
 
-	answerQuill.textarea = answerQuill.find("textarea");
+		answerQuill.textarea = answerQuill.find('textarea');
 
-	answerQuill.hasFocus = false;
+		answerQuill.buttons = [
+			{ id: 'frac', latex: '/', tooltip: 'fraction (/)', icon: '\\frac{\\text{ }}{\\text{ }}' },
+			{ id: 'abs', latex: '|', tooltip: 'absolute value (|)', icon: '|\\text{ }|' },
+			{ id: 'sqrt', latex: '\\sqrt', tooltip: 'square root (sqrt)', icon: '\\sqrt{\\text{ }}' },
+			{ id: 'nthroot', latex: '\\root', tooltip: 'nth root (root)', icon: '\\sqrt[\\text{ }]{\\text{ }}' },
+			{ id: 'exponent', latex: '^', tooltip: 'exponent (^)', icon: '\\text{ }^\\text{ }' },
+			{ id: 'infty', latex: '\\infty', tooltip: 'infinity (inf)', icon: '\\infty' },
+			{ id: 'pi', latex: '\\pi', tooltip: 'pi (pi)', icon: '\\pi' },
+			{ id: 'vert', latex: '\\vert', tooltip: 'such that (vert)', icon: '|' },
+			{ id: 'cup', latex: '\\cup', tooltip: 'union (union)', icon: '\\cup' },
+			// { id: 'leq', latex: '\\leq', tooltip: 'less than or equal (<=)', icon: '\\leq' },
+			// { id: 'geq', latex: '\\geq', tooltip: 'greater than or equal (>=)', icon: '\\geq' },
+			{ id: 'text', latex: '\\text', tooltip: 'text mode (")', icon: 'Tt' }
+		];
 
-	answerQuill.buttons = [
-		{ id: 'frac', latex: '/', tooltip: 'fraction (/)', icon: '\\frac{\\text{\ \ }}{\\text{\ \ }}' },
-		{ id: 'abs', latex: '|', tooltip: 'absolute value (|)', icon: '|\\text{\ \ }|' },
-		{ id: 'sqrt', latex: '\\sqrt', tooltip: 'square root (sqrt)', icon: '\\sqrt{\\text{\ \ }}' },
-		{ id: 'nthroot', latex: '\\root', tooltip: 'nth root (root)', icon: '\\sqrt[\\text{\ \ }]{\\text{\ \ }}' },
-		{ id: 'exponent', latex: '^', tooltip: 'exponent (^)', icon: '\\text{\ \ }^\\text{\ \ }' },
-		{ id: 'infty', latex: '\\infty', tooltip: 'infinity (inf)', icon: '\\infty' },
-		{ id: 'pi', latex: '\\pi', tooltip: 'pi (pi)', icon: '\\pi' },
-		{ id: 'vert', latex: '\\vert', tooltip: 'such that (vert)', icon: '|' },
-		{ id: 'cup', latex: '\\cup', tooltip: 'union (union)', icon: '\\cup' },
-		// { id: 'leq', latex: '\\leq', tooltip: 'less than or equal (<=)', icon: '\\leq' },
-		// { id: 'geq', latex: '\\geq', tooltip: 'greater than or equal (>=)', icon: '\\geq' },
-		{ id: 'text', latex: '\\text', tooltip: 'text mode (")', icon: 'Tt' }
-	];
+		// Open the toolbar when the mathquill answer box gains focus.
+		answerQuill.textarea.on('focusin', () => {
+			if (answerQuill.toolbar) return;
+			answerQuill.toolbar = $("<div class='quill-toolbar'>" +
+				answerQuill.buttons.reduce(
+					(returnString, curButton) => {
+						return returnString +
+							"<button type='button' id='" + curButton.id + '-' + answerQuill.attr('id') +
+							"' class='symbol-button btn btn-inverse' " +
+							"' data-latex='" + curButton.latex +
+							"' data-toggle='tooltip' title='" + curButton.tooltip + "'>" +
+							"<span id='icon-" + curButton.id + '-' + answerQuill.attr('id') + "'>"
+							+ curButton.icon +
+							'</span>' +
+							'</button>';
+					}, ''
+				) + '</div>');
+			answerQuill.toolbar.appendTo(document.body);
 
-	// Open the toolbar when the mathquill answer box gains focus.
-	answerQuill.textarea.on('focusin', function() {
-		answerQuill.hasFocus = true;
-		if (answerQuill.toolbar) return;
-		answerQuill.toolbar = $("<div class='quill-toolbar'>" +
-			answerQuill.buttons.reduce(
-				function(returnString, curButton) {
-					return returnString +
-						"<button id='" + curButton.id + "-" + answerQuill.attr('id') +
-						"' class='symbol-button btn' " +
-						"' data-latex='" + curButton.latex +
-						"' data-tooltip='" + curButton.tooltip + "'>" +
-						"<span id='icon-" + curButton.id + "-" + answerQuill.attr('id') + "'>"
-						+ curButton.icon +
-						"</span>" +
-						"</button>";
-				}, ""
-			) + "</div>");
-		answerQuill.toolbar.appendTo(document.body);
+			answerQuill.toolbar.find('.symbol-button').each(function() {
+				MQ.StaticMath($('#icon-' + this.id)[0]);
+			});
 
-		answerQuill.toolbar.find(".symbol-button").each(function() {
-			MQ.StaticMath($("#icon-" + this.id)[0]);
-		});
-
-		$(".symbol-button").uitooltip( {
-			items: "[data-tooltip]",
-			position: {my: "right center", at: "left-5px center"},
-			show: {delay: 500, effect: "none"},
-			hide: {delay: 0, effect: "none"},
-			content: function() {
-				var element = $(this);
-				if (element.prop("disabled")) return;
-				if (element.is("[data-tooltip]")) { return element.attr("data-tooltip"); }
+			// There is a bug in bootstrap version 2.3.2 that makes the "placement: left" option fail for tooltips.
+			// This ugly hackery fixes the position of the tooltip.
+			function positionTooltip(tooltip, element) {
+				var $tooltip = $(tooltip);
+				$tooltip.css('display', 'none');
+				$tooltip.find('.tooltip-inner').css('display', 'none');
+				var $element = $(element);
+				setTimeout(function () {
+					$tooltip.css('display', 'block');
+					$tooltip.find('.tooltip-inner').css({ whiteSpace: 'nowrap', display: 'block' });
+					$tooltip.addClass('left')
+						.css({
+							top: ($element.position().top + ($element.outerHeight() - $tooltip.outerHeight()) / 2) + 'px',
+							right: $element.outerWidth() + 4 + 'px',
+							left: 'unset'
+						});
+					$tooltip.find('.tooltip-arrow').css({ left: 'unset' });
+					$tooltip.addClass('in');
+				}, 0);
 			}
+
+			$('.symbol-button[data-toggle="tooltip"]').tooltip({
+				trigger: 'hover', placement: positionTooltip, delay: { show: 500, hide: 0 }
+			});
+
+			$('.symbol-button').on('click', function() {
+				answerQuill.mathField.cmd(this.getAttribute('data-latex'));
+				answerQuill.textarea.focus();
+			});
+
+			// This is covered by css for the standard toolbar sizes.  However, if buttons are added or removed from the
+			// toolbar by the problem or if the window height is excessively small, those may be incorrect.  So this
+			// adjusts the width in those cases.
+			const adjustWidth = () => {
+				const left = answerQuill.toolbar.find('.symbol-button:first-child')[0].getBoundingClientRect().left;
+				const right = answerQuill.toolbar.find('.symbol-button:last-child')[0].getBoundingClientRect().right;
+				answerQuill.toolbar.css({ width: `${right - left + 8}px` });
+			};
+			$(window).on('resize.adjustWidth', adjustWidth);
+			setTimeout(adjustWidth);
 		});
 
-		$(".symbol-button").on("click", function() {
-			answerQuill.hasFocus = true;
-			answerQuill.mathField.cmd(this.getAttribute("data-latex"));
-			answerQuill.textarea.focus();
-		});
-	});
-
-	answerQuill.textarea.on('focusout', function() {
-		answerQuill.hasFocus = false;
-		setTimeout(function() {
-			if (!answerQuill.hasFocus && answerQuill.toolbar)
-			{
+		answerQuill.textarea.on('focusout', (e) => {
+			if (e.relatedTarget && (e.relatedTarget.closest('.quill-toolbar') ||
+				e.relatedTarget.classList.contains('symbol-button')))
+				return;
+			if (answerQuill.toolbar) {
+				$(window).off('resize.adjustWidth');
 				answerQuill.toolbar.remove();
 				delete answerQuill.toolbar;
 			}
-		}, 200);
-	});
+		});
 
-	// Trigger an answer preview when the enter key is pressed in an answer box.
-	answerQuill.on('keypress.preview', function(e) {
-		if (e.key == 'Enter' || e.which == 13 || e.keyCode == 13) {
-			// For homework
-			$("#previewAnswers_id").trigger('click');
-			// For gateway quizzes
-			$("input[name=previewAnswers]").trigger('click');
-		}
-	});
+		// Trigger an answer preview when the enter key is pressed in an answer box.
+		answerQuill.on('keypress.preview', (e) => {
+			if (e.key == 'Enter' || e.which == 13 || e.keyCode == 13) {
+				// For homework
+				$('#previewAnswers_id').trigger('click');
+				// For gateway quizzes
+				$('input[name=previewAnswers]').trigger('click');
+			}
+		});
 
-	answerQuill.mathField.latex(answerQuill.latexInput.val());
-	answerQuill.mathField.moveToLeftEnd();
-	answerQuill.mathField.blur();
+		answerQuill.mathField.latex(answerQuill.latexInput.val());
+		answerQuill.mathField.moveToLeftEnd();
+		answerQuill.mathField.blur();
 
-	// Give the mathquill answer box the correct/incorrect colors.
-	setTimeout(function() {
-		if (answerQuill.input.hasClass('correct')) answerQuill.addClass('correct');
-		else if (answerQuill.input.hasClass('incorrect')) answerQuill.addClass('incorrect');
-	}, 300);
+		// Give the mathquill answer box the correct/incorrect colors.
+		setTimeout(() => {
+			if (answerQuill.input.hasClass('correct')) answerQuill.addClass('correct');
+			else if (answerQuill.input.hasClass('incorrect')) answerQuill.addClass('incorrect');
+		}, 300);
 
-	// Replace the result table correct/incorrect javascript that gives focus
-	// to the original input, with javascript that gives focus to the mathquill
-	// answer box.
-	var resultsTableRows = jQuery("table.attemptResults tr:not(:first-child)");
-	if (resultsTableRows.length)
-	{
-		resultsTableRows.each(function()
-			{
-				var result = $(this).find("td > a");
-				var href = result.attr('href');
-				if (result.length && href !== undefined && href.indexOf(answerLabel) != -1)
-				{
+		// Replace the result table correct/incorrect javascript that gives focus
+		// to the original input, with javascript that gives focus to the mathquill
+		// answer box.
+		const resultsTableRows = $('table.attemptResults tr:not(:first-child)');
+		if (resultsTableRows.length) {
+			resultsTableRows.each(function() {
+				const result = $(this).find('td > a');
+				const href = result.attr('href');
+				if (result.length && href !== undefined && href.indexOf(answerLabel) != -1) {
 					// Set focus to the mathquill answer box if the correct/incorrect link is clicked.
 					result.attr('href',
 						"javascript:void(window.answerQuills['" + answerLabel + "'].textarea.focus())");
 				}
 			}
-		);
-	}
+			);
+		}
 
-	answerQuills[answerLabel] = answerQuill;
-});
+		window.answerQuills[answerLabel] = answerQuill;
+	};
+
+	// Set up MathQuill inputs that are already in the page.
+	document.querySelectorAll('[id^=MaThQuIlL_]').forEach((input) => setupMQInput(input));
+
+	// Observer that sets up MathQuill inputs.
+	const observer = new MutationObserver((mutationsList) => {
+		mutationsList.forEach((mutation) => {
+			mutation.addedNodes.forEach((node) => {
+				if (node instanceof Element) {
+					if (node.id && node.id.startsWith('MaThQuIlL_')) {
+						setupMQInput(node);
+					} else {
+						node.querySelectorAll('input[id^=MaThQuIlL_]').forEach((input) => {
+							setupMQInput(input);
+						});
+					}
+				}
+			});
+		});
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+
+	// Stop the mutation observer when the window is closed.
+	window.addEventListener('unload', () => observer.disconnect());
+})();


### PR DESCRIPTION
Much of this is just the changes that have been made to the MathQuill editor that are implemented for ww3 and the standalone renderer.  This is code that will eventually work for webwork2, ww3, and the standalone renderer directly.  Although for that to happen, webwork2 will need to be updated to use bootstrap 5.

Clean up the way that the MathQuill toolbar is added and removed when a MathQuill input is focused and blurred.

Make the MathQuill toolbar responsive to the window height.  This makes the toolbar work better for short windows, for example on a mobile device or the case of a short problem in an iframe.

Make the button separated and give the container a border and background to make the appearance more uniform and clean.

Change the toolbar buttons to a dark color.

Switch to using bootstrap tooltips instead of jquery-ui tooltips.  This takes an annoying work around as bootstrap 2 has a bug with tooltips that are positioned to the left.

I recommend viewing the changes ignoring white space changes.  That helps a little at least.