### PR TITLE
on problem sets page, show quiz start date using local timezone/locale

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -669,8 +669,11 @@ sub setListRow {
 	  
 	  if ( defined( $set->assignment_type() ) && 
 	       $set->assignment_type() =~ /gateway/ && $gwtype == 1 ) {
-	    $startTime = localtime($set->version_creation_time() || 0); #fixes error message for undefined creation_time
-	    
+			$startTime = $self->formatDateTime(
+				$set->version_creation_time() || 0, #fixes error message for undefined creation_time
+				undef, $ce->{studentDateDisplayFormat}
+			);
+
 	    if ( $authz->hasPermissions($user, "view_hidden_work") || 
 		 $set->hide_score() eq 'N' || 
 		 ( $set->hide_score eq 'BeforeAnswerDate' && time > $tmplSet->answer_date() ) ) {


### PR DESCRIPTION
This addresses item 4 on #1528. Prior to this commit, a quiz version start time is displayed using the server's local time. This changes it to use the course-local timezone locale, the same as other dates are displayed like the close date or open date of a problem set.