### PR TITLE
fixes broken links.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -356,8 +356,8 @@ $webworkURLs{SiteMap}       = "https://webwork.maa.org/wiki/WeBWorK_Sites";
 $webworkURLs{problemTechniquesHelpURL}='https://webwork.maa.org/wiki/Category:Problem_Techniques';
 $webworkURLs{MathObjectsHelpURL}      ='https://webwork.maa.org/wiki/Category:MathObjects';
 $webworkURLs{PODHelpURL}              ='https://webwork.maa.org/pod/';
-$webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/?login_practice_user=true';
-$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/2?login_practice_user=true;
+$webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2?login_practice_user=true';
+$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/1?login_practice_user=true;
 $webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Authors';
 
 # Location of CSS

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -355,9 +355,9 @@ $webworkURLs{SiteMap}       = "https://webwork.maa.org/wiki/WeBWorK_Sites";
 #URL for help buttons on the PGProblemEditor pages:
 $webworkURLs{problemTechniquesHelpURL}='https://webwork.maa.org/wiki/Category:Problem_Techniques';
 $webworkURLs{MathObjectsHelpURL}      ='https://webwork.maa.org/wiki/Category:MathObjects';
-$webworkURLs{PODHelpURL}              ='https://demo.webwork.rochester.edu/wwdocs/';
-$webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2/?login_practice_user=true';
-$webworkURLs{PGMLHelpURL}             ='https://courses1.webwork.maa.org/webwork2/cervone_course/PGML/1/?login_practice_user=true';
+$webworkURLs{PODHelpURL}              ='https://webwork.maa.org/pod/';
+# $webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2/?login_practice_user=true';
+$webworkURLs{PGMLHelpURL}             ='https://webwork.maa.org/wiki/Category:PGML';
 $webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Authors';
 
 # Location of CSS

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -357,7 +357,7 @@ $webworkURLs{problemTechniquesHelpURL}='https://webwork.maa.org/wiki/Category:Pr
 $webworkURLs{MathObjectsHelpURL}      ='https://webwork.maa.org/wiki/Category:MathObjects';
 $webworkURLs{PODHelpURL}              ='https://webwork.maa.org/pod/';
 $webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/?login_practice_user=true';
-$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/2';
+$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/2?login_practice_user=true;
 $webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Authors';
 
 # Location of CSS

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -356,8 +356,8 @@ $webworkURLs{SiteMap}       = "https://webwork.maa.org/wiki/WeBWorK_Sites";
 $webworkURLs{problemTechniquesHelpURL}='https://webwork.maa.org/wiki/Category:Problem_Techniques';
 $webworkURLs{MathObjectsHelpURL}      ='https://webwork.maa.org/wiki/Category:MathObjects';
 $webworkURLs{PODHelpURL}              ='https://webwork.maa.org/pod/';
-# $webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2/?login_practice_user=true';
-$webworkURLs{PGMLHelpURL}             ='https://webwork.maa.org/wiki/Category:PGML';
+$webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/?login_practice_user=true';
+$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/2';
 $webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Authors';
 
 # Location of CSS

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -505,11 +505,11 @@ sub body {
 			tooltip => 'Documentation from source code for PG modules and macro files. Often the most up-to-date information.',
 		}, {
 			#'http://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2/?login_practice_user=true',
-			label   => $r->maketext('PGLab'),
-			url     => $ce->{webworkURLs}{PGLabHelpURL},
-			target  => 'PGLab',
-			tooltip => 'Test snippets of PG code in interactive lab.  This is a good way to learn the PG language.',
-		}, {
+		# 	label   => $r->maketext('PGLab'),
+		# 	url     => $ce->{webworkURLs}{PGLabHelpURL},
+		# 	target  => 'PGLab',
+		# 	tooltip => 'Test snippets of PG code in interactive lab.  This is a good way to learn the PG language.',
+		# }, {
 			#'https://courses1.webwork.maa.org/webwork2/cervone_course/PGML/1/?login_practice_user=true',
 			label   => $r->maketext('PGML'),
 			url     => $ce->{webworkURLs}{PGMLHelpURL},


### PR DESCRIPTION
The ProblemEditor has many broken links.  This fixes two of them and hides a third.  This is a fix for #1262. 

In short, the demo course at Rochester isn't working and I don't think will be reliable in the future. I removed the PGLab link.  Is there somewhere else that is hosted?  The other two are pointing to documentation at webwork.maa.org. 