### PR TITLE
Fix the instructor help for the problem sets page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -119,14 +119,7 @@ sub info {
 		return "";
 	}
 }
-sub help {   # non-standard help, since the file path includes the course name
-	my $self = shift;
-	my $args = shift;
-	my $name = $args->{name};
-	$name = lc('course home') unless defined($name);
-	$name =~ s/\s/_/g;
-	$self->helpMacro($name, { class => 'nav-link' });
-}
+
 sub templateName {
 	my $self = shift;
 	my $r = $self->r;


### PR DESCRIPTION
The override method was not working, and not needed.

This is easy to test.  Without this pull request clicking on the `?` link in the site nav on the Homework Sets page opens to "There is no help ...".  With this pull request clicking on the `?` link opens to "Course Home Help Page ...".