### PR TITLE
fix for wwsh

### DIFF
--- a/bin/wwsh
+++ b/bin/wwsh
@@ -30,10 +30,6 @@ BEGIN {
 	die "WEBWORK_ROOT not found in environment.\n" unless exists $ENV{WEBWORK_ROOT};
 	$pg_dir = $ENV{PG_ROOT} // "$ENV{WEBWORK_ROOT}/../pg";
 	die "The pg directory must be defined in PG_ROOT" unless (-e $pg_dir);
-
-	use File::Basename qw/dirname/;
-	use Cwd qw/abs_path/;
-	$bin_dir = abs_path(dirname(__FILE__));
 }
 
 our $ce;
@@ -52,6 +48,8 @@ unless ($courseID and $scriptFile) {
 	die "usage: $0 courseID  scriptFile\n";
 }
 
+die "You must pass scriptFile in as a path to the file" unless -e $scriptFile;
+
 $ce = WeBWorK::CourseEnvironment->new({
 	webwork_dir => $ENV{WEBWORK_ROOT},
 	courseName => $courseID,
@@ -68,7 +66,7 @@ Available modules: Data::Dumper
 
 EOF
 print "courseID: $courseID and scriptFile:  $scriptFile\n--------------------------------\n";
-do "$bin_dir/$scriptFile";
+do "$scriptFile";
 if ($@) {
 	print "errors ", $@,"\n" ;
 } else {

--- a/bin/wwsh
+++ b/bin/wwsh
@@ -25,7 +25,7 @@ use strict;
 use warnings;
 
 
-my ($pg_dir, $bin_dir);
+my $pg_dir;
 BEGIN {
 	die "WEBWORK_ROOT not found in environment.\n" unless exists $ENV{WEBWORK_ROOT};
 	$pg_dir = $ENV{PG_ROOT} // "$ENV{WEBWORK_ROOT}/../pg";
@@ -48,7 +48,7 @@ unless ($courseID and $scriptFile) {
 	die "usage: $0 courseID  scriptFile\n";
 }
 
-die "You must pass scriptFile in as a path to the file" unless -e $scriptFile;
+die 'You must pass scriptFile in as a path to the file' unless -e $scriptFile;
 
 $ce = WeBWorK::CourseEnvironment->new({
 	webwork_dir => $ENV{WEBWORK_ROOT},
@@ -66,7 +66,7 @@ Available modules: Data::Dumper
 
 EOF
 print "courseID: $courseID and scriptFile:  $scriptFile\n--------------------------------\n";
-do "$scriptFile";
+do $scriptFile;
 if ($@) {
 	print "errors ", $@,"\n" ;
 } else {

--- a/bin/wwsh
+++ b/bin/wwsh
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
@@ -25,11 +25,15 @@ use strict;
 use warnings;
 
 
-my $pg_dir;
+my ($pg_dir, $bin_dir);
 BEGIN {
 	die "WEBWORK_ROOT not found in environment.\n" unless exists $ENV{WEBWORK_ROOT};
 	$pg_dir = $ENV{PG_ROOT} // "$ENV{WEBWORK_ROOT}/../pg";
 	die "The pg directory must be defined in PG_ROOT" unless (-e $pg_dir);
+
+	use File::Basename qw/dirname/;
+	use Cwd qw/abs_path/;
+	$bin_dir = abs_path(dirname(__FILE__));
 }
 
 our $ce;
@@ -64,7 +68,7 @@ Available modules: Data::Dumper
 
 EOF
 print "courseID: $courseID and scriptFile:  $scriptFile\n--------------------------------\n";
-do "$scriptFile";
+do "$bin_dir/$scriptFile";
 if ($@) {
 	print "errors ", $@,"\n" ;
 } else {


### PR DESCRIPTION
This fixes issue #1511 in that recent perl versions (at least 30) would not run a script using `wwsh`. 

Note: this should now run in the following forms:
```
wwsh myCourse addAdmin      # if WEBWORK_HOME is in PATH
./wwsh myCourse addAdmin    # inside bin directory
perl wwsh myCourse addAdmin  # inside bin directory
perl bin/wwsh myCourse addAdmin # inside $WEBWORK_HOME
```