### PR TITLE
Ignore any custom theme directories that may exist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,17 @@ conf/*.apache-config
 math4-overrides.css
 math4-overrides.js
 htdocs/themes/*/images/*
+!htdocs/themes/*/images/maa_logo.png
+!htdocs/themes/*/images/webwork_logo.svg
+!htdocs/themes/math4/images/webwork_square.svg
 htdocs/themes/*/*.css
 htdocs/themes/*/*.css.map
 htdocs/package-lock.json
+htdocs/themes/*
+!htdocs/themes/math4
+!htdocs/themes/math4-red
+!htdocs/themes/math4-green
+!htdocs/themes/math4-yellow
 DATA/*
 *.swp
 .dump_past_answers_salt


### PR DESCRIPTION
This works by ignoring all files in `htdocs/themes` except the four provided theme directories (math4, math4-green, math4-red, and math4-yellow).

I also added exceptions to start tracking the theme image files that are in the repository.  Added custom theme images will still be ignored.