### PR TITLE
Remove the last (unused) uses of CGI_labeled_input and the method itself

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright © 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK.pm,v 1.104 2010/05/15 18:44:26 gage Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -92,7 +92,7 @@ our %SeedCE;
 sub dispatch($) {
 	my ($apache) = @_;
 	my $r = WeBWorK::Request->new($apache);
-	
+
 	my $method = $r->method;
 	my $location = $r->location;
 	my $uri = $r->uri;
@@ -101,11 +101,11 @@ sub dispatch($) {
 	my $dir_config = $r->dir_config;
 	my %conf_vars = map { $_ => $dir_config->{$_} } grep { /^webwork_/ } keys %$dir_config;
 	@SeedCE{keys %conf_vars} = values %conf_vars;
-	
+
 	debug("\n\n===> Begin " . __PACKAGE__ . "::dispatch() <===\n\n");
 	debug("Hi, I'm the new dispatcher!\n");
 	debug(("-" x 80) . "\n");
-	
+
 	debug("Okay, I got some basic information:\n");
 	debug("The apache location is $location\n");
 	debug("The request method is $method\n");
@@ -115,80 +115,80 @@ sub dispatch($) {
 	#debug("The WeBWorK root directory is $webwork_root\n");
 	#debug("The PG root directory is $pg_root\n");
 	debug(("-" x 80) . "\n");
-	
+
 	debug("The first thing we need to do is munge the path a little:\n");
-	
+
 	######################################################################
 	# Create a URLPath  object
 	######################################################################
 	my ($path) = $uri =~ m/$location(.*)/;
 	$path = "/" if $path eq ""; # no path at all
-	
+
 	debug("We can't trust the path-info, so we make our own path.\n");
 	debug("path-info claims: $path_info\n");
 	debug("but it's really: $path\n");
 	debug("(if it's empty, we set it to \"/\".)\n");
-	
+
 	$path =~ s|/+|/|g;
 	debug("...and here it is without repeated slashes: $path\n");
-	
+
 	# lookbehind assertion for "not a slash"
 	# matches the boundary after the last char
 	$path =~ s|(?<=[^/])$|/|;
 	debug("...and here it is with a trailing slash: $path\n");
-	
+
 	debug(("-" x 80) . "\n");
-	
+
 	debug("Now we need to look at the path a little to figure out where we are\n");
-	
+
 	debug("-------------------- call to WeBWorK::URLPath::newFromPath\n");
 	my $urlPath = WeBWorK::URLPath->newFromPath($path, $r);
 	                            # pointer to parent request for access to the $ce and language translation ability
 	                            # need to add this pointer whenever a new URLPath is created.
 	debug("-------------------- call to WeBWorK::URLPath::newFromPath\n");
-	
+
 	unless ($urlPath) {
 		debug("This path is invalid... see you later!\n");
 		die "The path '$path' is not valid.\n";
 	}
-	
+
 	my $displayModule = $urlPath->module;
 	my %displayArgs = $urlPath->args;
-	
+
 	unless ($displayModule) {
 	    debug("The display module is empty, so we can DECLINE here.\n");
 	    $path = encode_entities($path);
 	    die "No display module found for path '$path'.";
 	}
-	
+
 	debug("The display module for this path is: $displayModule\n");
 	debug("...and here are the arguments we'll pass to it:\n");
 	foreach my $key (keys %displayArgs) {
 		debug("\t$key => $displayArgs{$key}\n");
 	}
-	
+
 	my $selfPath = $urlPath->path;
 	my $parent = $urlPath->parent;
 	my $parentPath = $parent ? $parent->path : "<no parent>";
-	
+
 	debug("Reconstructing the original path gets us: $selfPath\n");
 	debug("And we can generate the path to our parent, too: $parentPath\n");
 	debug("(We could also figure out who our children are, but we'd need to supply additional arguments.)\n");
 	debug(("-" x 80) . "\n");
-	
+
 	debug("The URLPath looks good, we'll add it to the request.\n");
 	$r->urlpath($urlPath);
-	
+
 	debug("Now we want to look at the parameters we got.\n");
-	
+
 	debug("The raw params:\n");
 	foreach my $key ($r->param) {
 	    #make it so we dont debug plain text passwords
-	    my $vals;	    
+	    my $vals;
 	    if ($key eq 'passwd'||
 		$key eq 'confirmPassword' ||
 		$key eq 'currPassword' ||
-		$key eq 'newPassword' || 
+		$key eq 'newPassword' ||
 		$key =~ /\.new_password/) {
 		$vals = '**********';
 	    } else {
@@ -197,7 +197,7 @@ sub dispatch($) {
 	    }
 	    debug("\t$key => $vals\n");
 	}
-	
+
 	#mungeParams($r);
 	#
 	#debug("The munged params:\n");
@@ -205,9 +205,9 @@ sub dispatch($) {
 	#	debug("\t$key\n");
 	#	debug("\t\t$_\n") foreach $r->param($key);
 	#}
-	
+
 	debug(("-" x 80) . "\n");
-	
+
 	my $apache_hostname = $r->hostname;
 	my $apache_port     = $r->get_server_port;
 	my $apache_is_ssl   = ($r->subprocess_env('https') ? 1 : "");
@@ -219,8 +219,8 @@ sub dispatch($) {
 		$apache_root_url = "http://$apache_hostname";
 		$apache_root_url .= ":$apache_port" if $apache_port != 80;
 	}
-	
-	
+
+
 	####################################################################
 	# Create Course Environment    $ce
 	####################################################################
@@ -238,8 +238,8 @@ sub dispatch($) {
 	$@ and die "Failed to initialize course environment: $@\n";
 	debug("Here's the course environment: $ce\n");
 	$r->ce($ce);
-	
-	
+
+
 	######################
 	# Localizing language
 	######################
@@ -257,24 +257,24 @@ sub dispatch($) {
 	foreach my $u (@uploads) {
 		# make sure it's a "real" upload
 		next unless $u->filename;
-		
+
 		# store the upload
 		my $upload = WeBWorK::Upload->store($u,
 			dir => $ce->{webworkDirs}->{uploadCache}
 		);
-		
+
 		# store the upload ID and hash in the file upload field
 		my $id = $upload->id;
 		my $hash = $upload->hash;
 		$r->param($u->name => "$id $hash");
 	}
-	
+
 	# create these out here. they should fail if they don't have the right information
 	# this lets us not be so careful about whether these objects are defined when we use them.
 	# instead, we just create the behavior that if they don't have a valid $db they fail.
 	my $authz = new WeBWorK::Authz($r);
 	$r->authz($authz);
-	
+
 	# figure out which authentication modules to use
 	#my $user_authen_module;
 	#my $proctor_authen_module;
@@ -296,36 +296,36 @@ sub dispatch($) {
 	#} else {
 	#	$proctor_authen_module = $ce->{authen}{proctor_module};
 	#}
-	
+
 	my $user_authen_module = WeBWorK::Authen::class($ce, "user_module");
-	
+
 	runtime_use $user_authen_module;
 	my $authen = $user_authen_module->new($r);
 	debug("Using user_authen_module $user_authen_module: $authen\n");
 	$r->authen($authen);
-	
+
 	my $db;
-	
+
 	if ($displayArgs{courseID}) {
 		debug("We got a courseID from the URLPath, now we can do some stuff:\n");
-		
+
 		unless (-e $ce->{courseDirs}->{root}) {
 			die "Course '$displayArgs{courseID}' not found: $!";
 		}
-		
+
 		debug("...we can create a database object...\n");
 		$db = new WeBWorK::DB($ce->{dbLayout});
 		debug("(here's the DB handle: $db)\n");
 		$r->db($db);
-		
+
 		my $authenOK = $authen->verify;
 		if ($authenOK) {
 			my $userID = $r->param("user");
 			debug("Hi, $userID, glad you made it.\n");
-			
+
 			# tell authorizer to cache this user's permission level
 			$authz->setCachedUser($userID);
-			
+
 			debug("Now we deal with the effective user:\n");
 			my $eUserID = $r->param("effectiveUser") || $userID;
 			debug("userID=$userID eUserID=$eUserID\n");
@@ -336,15 +336,15 @@ sub dispatch($) {
 					debug("Ok, looks like you're allowed to become $eUserID. Whoopie!\n");
 				} else {
 					debug("Uh oh, you're not allowed to become $eUserID. Nice try!\n");
-					die "You do not have permission to act as another user. 
-					Close down your browser (this clears temporary cookies), 
+					die "You do not have permission to act as another user.
+					Close down your browser (this clears temporary cookies),
 					restart and try again.\n";
 				}
 			}
-			
+
 			# set effectiveUser in case it was changed or not set to begin with
 			$r->param("effectiveUser" => $eUserID);
-			
+
 			# if we're doing a proctored test, after the user has been authenticated
 			# we need to also check on the proctor.  note that in the gateway quiz
 			# module we double check this, to be sure that someone isn't taking a
@@ -356,7 +356,7 @@ sub dispatch($) {
 				my $authenProctor = $proctor_authen_module->new($r);
 				debug("Using proctor_authen_module $proctor_authen_module: $authenProctor\n");
 			    my $procAuthOK = $authenProctor->verify();
-				
+
 				if (not $procAuthOK) {
 					$displayModule = PROCTOR_LOGIN_MODULE;
 				}
@@ -367,49 +367,49 @@ sub dispatch($) {
 			debug("set displayModule to $displayModule\n");
 		}
 	}
-	
+
 	# store the time before we invoke the content generator
 	my $cg_start = time; # this is Time::HiRes's time, which gives floating point values
-	
+
 	debug(("-" x 80) . "\n");
 	debug("Finally, we'll load the display module...\n");
-	
+
 	runtime_use($displayModule);
-	
+
 	debug("...instantiate it...\n");
-	
+
 	my $instance = $displayModule->new($r);
-	
+
 	debug("...and call it:\n");
 	debug("-------------------- call to ${displayModule}::go\n");
-	
+
 	my $result = $instance->go();
-	
+
 	debug("-------------------- call to ${displayModule}::go\n");
-	
+
 	my $cg_end = time;
 	my $cg_duration = $cg_end - $cg_start;
 	writeTimingLogEntry($ce, "[".$r->uri."]", sprintf("runTime = %.3f sec", $cg_duration)." ".$ce->{dbLayoutName}, "");
-	
+
 	debug("returning result: " . (defined $result ? $result : "UNDEF") . "\n");
 	return $result;
 }
 
 sub mungeParams {
 	my ($r) = @_;
-	
+
 	my @paramQueue;
-	
+
 	# remove all the params from the request, and store them in the param queue
 	foreach my $key ($r->param) {
 		push @paramQueue, [ $key => [ $r->param($key) ] ];
 		$r->parms->unset($key)
 	}
-	
+
 	# exhaust the param queue, decoding encoded params
 	while (@paramQueue) {
 		my ($key, $values) = @{ shift @paramQueue };
-		
+
 		if ($key =~ m/\,/) {
 			# we have multiple params encoded in a single param
 			# split them up and add them to the end of the queue
@@ -433,86 +433,6 @@ sub mungeParams {
 	}
 }
 
-
-# labeled_input subroutine
-#
-# Creates a form input element with a label added to the correct place.
-# Takes in up to six parameters:
-#
-# -type (type of input element), -name (name of input element), -id (id of the input element), -value (value of the input element), -label_text (the text on the label), -label_id (the id of the label)
-#
-# If any of the parameters are not specified, they default to "none". 
-#
-# UPDATE: updated lable tags so that their "for" property will point to the id of the element that they are labeling. This means that entering an id for the input element becomes essentially mandatory if you want the tag to work correctly.
-
-# DEPRECATED - see below
-
-# sub labeled_input
-# {
-	# my %param = (-type=>"none", -name=>"none", -value=>"none", -id=>"none", -label_text=>"none", -label_id=>"none", @_);
-	
-	# if($param{-type} eq "text" or $param{-type} eq "password" or $param{-type} eq "file"){
-		# return CGI::label({-id=>$param{-label_id}, -for=>$param{-id}},$param{-label_text}).CGI::input({-type=>$param{-type}, -name=>$param{-name}, -value=>$param{-value}, -id=>$param{-id}}).CGI::br();
-	# }
-	# elsif($param{-type} eq "checkbox" or $param{-type} eq "radio"){
-		# return CGI::input({-type=>$param{-type}, -name=>$param{-name}, -value=>$param{-value}, -id=>$param{-id}}).CGI::label({-id=>$param{-label_id}, -for=>$param{-id}},$param{-label_text}).CGI::br();
-	# }
-	# elsif($param{-type} eq "submit" or $param{-type} eq "button" or $param{-type} eq "reset"){
-		# return CGI::input({-type=>$param{-type}, -name=>$param{-name}, -value=>$param{-value}, -id=>$param{-id}}).CGI::br();
-	# }
-	# else{
-		# return "Not a valid input type";
-	# }
-# }
-
-
-# CGI_labeled_input subroutine
-
-# A replacement to the labeled_input subroutine above, created when it was determined that the old subroutine was limited in that it did not allow for attributes other than the ones that it specified.
-
-# This subroutine rectifies that problem by taking in attributes for the input elements and label elements as hashes and simply entering them into the CGI routines, which already support attributes as hash parameters.
-
-# The way it attaches label tags is similar to the labeled_input subroutine.
-
-# This subroutine has also been expanded to be able to handle select elements.
-
-# Five parameters are taken in as a hash: -type (specifying the type of the input element), -id (specifying the id of the input element), -label_text (specifying the text to go in the label), -input_attr (a hash specifying any additional attributes for the input element, if any), and -label_attr (a hash specifying additional attributes for the label element, if any).
-
-# As before, all parameters are optional, with the scalar parameters defaulting to "none" and the hash parameters defaulting to empty. 
-
-
-sub CGI_labeled_input
-{
-	my %param = (-type=>"none", -id=>"none", -label_text=>"none", -input_attr=>{}, -label_attr=>{}, @_);
-	
-	$param{-input_attr}{-type} = $param{-type};
-	$param{-input_attr}{-id} = $param{-id};
-	$param{-label_attr}{-for} = $param{-id};
-	
-	if($param{-type} eq "text" or $param{-type} eq "password" or $param{-type} eq "file"){
-		return CGI::label($param{-label_attr},$param{-label_text}).CGI::input($param{-input_attr});
-	}
-	elsif($param{-type} eq "checkbox" or $param{-type} eq "radio"){
-		return CGI::label($param{-label_attr},CGI::input($param{-input_attr}),$param{-label_text});
-	}
-	elsif($param{-type} eq "submit" or $param{-type} eq "button" or $param{-type} eq "reset"){
-		return CGI::input($param{-input_attr});
-	}
-	elsif($param{-type} eq "select"){
-	    if (defined $param{-input_attr}{-multiple}) {
-		return CGI::label($param{-label_attr},$param{-label_text}).CGI::scrolling_list($param{-input_attr});
-	    } else {
-		return CGI::label($param{-label_attr},$param{-label_text}).CGI::popup_menu($param{-input_attr});
-	    }
-	}
-	elsif($param{-type} eq "textarea"){
-		return CGI::label($param{-label_attr},$param{-label_text}).CGI::br().CGI::br().CGI::textarea($param{-input_attr});
-	}
-	else{
-		"Not a valid input type";
-	}
-}
-
 # split_cap subroutine - ghe3
 
 # A sort of wrapper for the built-in split function which uses capital letters as a delimiter, and returns a string containing the separated substrings separated by a whitespace.  Used to make actionID's more readable.
@@ -520,10 +440,10 @@ sub CGI_labeled_input
 sub split_cap
 {
 	my $str = shift;
-	
+
 	my @str_arr = split(//,$str);
 	my $count = scalar(@str_arr);
-	
+
 	my $i = 0;
 	my $prev = 0;
 	my @result = ();
@@ -536,12 +456,12 @@ sub split_cap
 		}
 		$i++;
 	}
-	
+
 	unless($hasCapital){
 		return $str;
 	}
 	else{
-		push(@result, join("", @str_arr[$prev..$count-1]));	
+		push(@result, join("", @str_arr[$prev..$count-1]));
 		return join(" ",@result);
 	}
 }
@@ -552,25 +472,25 @@ sub split_cap
 
 sub underscore_to_whitespace{
 	my $str = shift;
-	
+
 	my @strArr = split("",$str);
 	foreach(@strArr){
 		if($_ eq "_"){
 			$_ = " "
 		}
 	}
-	
+
 	my $result = join("",@strArr);
-	
+
 	return $result;
 }
 
 sub remove_duplicates{
 	my @arr = @_;
-	
+
 	my %unique;
 	my @result;
-	
+
 	foreach(@arr){
 		if(defined $unique{$_}){
 			next;
@@ -580,9 +500,9 @@ sub remove_duplicates{
 			$unique{$_} = "seen";
 		}
 	}
-	
+
 	return @result;
-	
+
 }
 
 =head1 AUTHOR

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -1674,7 +1674,6 @@ sub fieldEditHTML {
 	my $type                 = $properties->{type};
 	my $access               = $properties->{access};
 	my $items                = $properties->{items};
-	my $synonyms             = $properties->{synonyms};
 
 	if ($type eq "email") {
 		if ($value eq '&nbsp;') {
@@ -1704,34 +1703,6 @@ sub fieldEditHTML {
 			size  => $size,
 			class => 'form-control form-control-sm d-inline w-auto'
 		});
-	}
-
-	if ($type eq "enumerable") {
-		my $matched = undef;    # Whether a synonym match has occurred
-
-		# Process synonyms for enumerable objects
-		foreach my $synonym (keys %$synonyms) {
-			if ($synonym ne "*" and $value =~ m/$synonym/) {
-				$value   = $synonyms->{$synonym};
-				$matched = 1;
-			}
-		}
-
-		if (!$matched and exists $synonyms->{"*"}) {
-			$value = $synonyms->{"*"};
-		}
-
-		return WeBWorK::CGI_labeled_input(
-			-type       => "select",
-			-id         => $fieldName . "_id",
-			-label_text => $r->maketext(ucfirst($fieldName)),
-			-input_attr => {
-				name    => $fieldName,
-				values  => [ keys %$items ],
-				default => $value,
-				labels  => $items,
-			}
-		);
 	}
 
 	if ($type eq "status") {

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -418,7 +418,8 @@ sub process_editorLink{
 
 # output_main_form subroutine.
 
-# prints out the main form for the page.  This particular subroutine also takes in $editorLink and $scoreRecordedMessage as required parameters. Also uses CGI_labeled_input for its input elements for accessibility reasons.  Also prints out the score summary where applicable.
+# prints out the main form for the page.  This particular subroutine also takes in $editorLink and $scoreRecordedMessage
+# as required parameters.  Also prints out the score summary where applicable.
 
 sub output_main_form{
 


### PR DESCRIPTION
Most of the uses of that method were removed in my bootstrap 5 update.  In fact all of them that were actually still in use.  The remaining occurrences are in obsolete code.

Furthermore, that method is unwieldy and not really useful.  It is actually harder to use that method than to use the CGI methods directly.  Also, it is not versatile enough to handle modern html mark up.