### PR TITLE
Fixing a strange bug with hardcopy generator

### DIFF
--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -69,6 +69,7 @@ sub scrollingRecordList {
 
 	if (@Records) {
 		my $class = ref $Records[0];
+        $class = $1 if $class =~ /(.*)Version$/;
 
 		($filters, $filter_labels) = getFiltersForClass(@Records);
 		if (defined $r->param("$name!filter")) {


### PR DESCRIPTION
If you have a WeBWorK course, and in that course, there are only gateway assignments, then a strange thing occurs with the hardcopy generator page.

As it already stands, if you (instructor/admin) have not generated a version of the gateway assignment, then you will be unable to generate hardcopies of said assignment -- unless you're acting as another user who *has* generated a version. This is a known inconvenience.

But if your course assignments consist solely of gateways, then despite acting as a user who has generated a version of some gateway gives an error that the user has not taken the assignment. `Can't generate hardcopy for set ''effectiveUser!AssignmentName,v1!1' for user 'selectedUser' -- set is not assigned to that user.`

The 'name' for the set gives us some information that probably the request was malformed. Indeed it was, as the set name should have been just `AssignmentName,v1`. The cause for this is around L#400 of Hardcopy.pm, where we build lists of global sets and versioned sets to be listed on the hardcopy generator page. Both lists are eventually passed to `scrollingRecordList`, but the list of global sets is passed first. This is important because `scrollingRecordList` assumes that all incoming records have the same class, and grabs the class of the first listed record as the class for all records. This only becomes a problem if the global set list is empty, i.e. the first record passed to `scrollingRecordList` is a `WeBWorK::DB::Record::SetVersion`. In this case, the `<select>` form elements are built with malformed values (because the values are built from the KEYFIELDS of the class that is determined by the first incoming record).

So why all this background? I'm not thrilled with the solution I'm proposing... it's concise, but that's about all. I did check that `scrollingRecordList` is never called with any "Version"ed records anywhere else in the code, so this change should not affect any other functionality. If anyone has a better solution, please chime in -- though, understandably, this bug is incredibly unlikely to be encountered.