### PR TITLE
Fix and improve some things on the new Gateway quiz ProblemSet.pm page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2177,7 +2177,7 @@ sub body {
 
 				# Initialize the problem graders for the problem.
 				if ($self->{will}{showProblemGrader}) {
-					my $problem_grader = new WeBWorK::ContentGenerator::Instructor::SingleProblemGrader(
+					my $problem_grader = WeBWorK::ContentGenerator::Instructor::SingleProblemGrader->new(
 						$self->r, $pg, $problems[$probOrder[$i]]);
 					$problem_grader->insertGrader;
 				}

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -529,7 +529,7 @@ sub body {
 					$seconds %= 60;
 					my $timeText = '';
 
-					# Two cases to format time to work well with translation.
+					# Several cases are needed to format time to work well with translation.
 					if ($hours && $minutes) {
 						print CGI::div(
 							{ class => 'alert alert-warning' },
@@ -539,7 +539,7 @@ sub body {
 								$hours, $minutes
 							)
 						);
-					} elsif ($hours || $minutes) {
+					} elsif ($hours || ($minutes && (!$seconds || $seconds > 299))) {
 						# Translation Note: In this case only one of hours or minutes is non-zero,
 						# so the zero case of the "quant" will be used for the other one.
 						print CGI::div(
@@ -551,12 +551,25 @@ sub body {
 							)
 						);
 					} else {
-						print CGI::div(
-							{ class => 'alert alert-warning' },
-							$r->maketext(
-								'You have [quant,_1,second] remaining to complete the currently open test.', $seconds
-							)
-						);
+						if ($minutes) {
+							print CGI::div(
+								{ class => 'alert alert-warning' },
+								$r->maketext(
+									'You have [quant,_1,minute] and [quant,_2,second] '
+										. 'remaining to complete the currently open test.',
+									$minutes, $seconds
+								)
+							);
+
+						} else {
+							print CGI::div(
+								{ class => 'alert alert-warning' },
+								$r->maketext(
+									'You have [quant,_1,second] remaining to complete the currently open test.',
+									$seconds
+								)
+							);
+						}
 					}
 				}
 			}

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -658,13 +658,13 @@ sub body {
 				CGI::th({ scope => 'col'}, 'Start'),
 				CGI::th({ scope => 'col'}, 'End'),
 				CGI::th(
-					{ scope => 'col', class => 'hardcopy'},
+					{ scope => 'col', class => 'hardcopy' },
 					CGI::i(
 						{
-							class => 'icon far fa-lg fa-arrow-alt-circle-down',
+							class       => 'icon far fa-lg fa-arrow-alt-circle-down',
 							aria_hidden => 'true',
-							title => $r->maketext('Generate Hardcopy'),
-							data_alt => $r->maketext('Generate Hardcopy')
+							title       => $r->maketext('Generate Hardcopy'),
+							data_alt    => $r->maketext('Generate Hardcopy')
 						},
 						''
 					)
@@ -674,6 +674,23 @@ sub body {
 		}
 
 		foreach my $ver (@versData) {
+			my $interactive = $r->maketext('Version #[_1]', $ver->{version});
+			if ($authz->hasPermissions($user, 'view_hidden_work') || $ver->{show_link}) {
+				my $interactiveURL = $self->systemLink(
+					$urlpath->newFromModule($urlModule, $r,
+						courseID => $courseID, setID => $ver->{id} ));
+				$interactive = CGI::a(
+					{
+						class             => 'set-id-tooltip',
+						data_bs_toggle    => 'tooltip',
+						data_bs_placement => 'right',
+						data_bs_title     => $set->description(),
+						href              => $interactiveURL
+					},
+					$interactive
+				);
+			}
+
 			# Download hardcopy.
 			my $control = '';
 			if ($multiSet) {
@@ -684,11 +701,15 @@ sub body {
 					value => $ver->{id},
 					class => 'form-check-input'
 				});
-
-			# Only display download option if answers are available.
+				# make sure interactive is the label for control
+				$interactive = CGI::label({ "for" => $ver->{id} }, $interactive);
 			} elsif ($ver->{show_download}) {
-				my $hardcopyPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::Hardcopy", $r,
-					courseID => $courseID, setID => $ver->{id});
+				# Only display download option if answers are available.
+				my $hardcopyPage = $urlpath->newFromModule(
+					"WeBWorK::ContentGenerator::Hardcopy", $r,
+					courseID => $courseID,
+					setID    => $ver->{id}
+				);
 				my $link = $self->systemLink($hardcopyPage, params => { selected_sets => $ver->{id} });
 				$control = CGI::a(
 					{ class => 'hardcopy-link', href => $link },
@@ -701,23 +722,6 @@ sub body {
 						},
 						''
 					)
-				);
-			}
-
-			my $interactive = $r->maketext('Version #[_1]', $ver->{version});
-			if ($authz->hasPermissions($user, 'view_hidden_work') || $ver->{show_link}) {
-				my $interactiveURL = $self->systemLink(
-					$urlpath->newFromModule($urlModule, $r,
-						courseID => $courseID, setID => $ver->{id} ));
-				$interactive = CGI::a(
-					{
-						class             => 'set-id-tooltip',
-						data_bs_toggle    => 'tooltip',
-						data_bs_placement => 'right',
-						data_bs_title     => $set->description(),
-						href  => $interactiveURL
-					},
-					$interactive
 				);
 			}
 


### PR DESCRIPTION
The current implemenation assumes that when an un-versions quiz_mode link is used, a new version of the Gateway quiz will be created, but that is not always the case.
    
If a gateway quiz is set to allow more than one submission per version (but not infinite), then the page shows "Start New Test" and presents the un-versioned quiz_mode link after the first submission of the current version.  The result is that when this button is clicked, the current quiz with that one submission is opened instead.  Not a new test.  This changes it so that the "Continue Open Test" button is shown until all submissions are used up.  The only way to obtain the behavior that was intended would be to modify the GatewayQuiz.pm module.
    
Also, the current implementation does not take the grace period into account.  If the test is in the grace period, the GatewayQuiz.pm module will also re-enter the currently open quiz if the un-versioned link is used.  The page currently shows the "Start New Test" button in this case as well, and using the button again results in that current version being opened, and not a new test.  In this case this is changed so that if the quiz is in the grace period, a message is displaying telling the student this and what needs to be done to submit the test for a grade. Of course the "Continue Open Test" button is also displayed in this case.
    
Another issue that is fixed is that for accessibility purposes a checkbox should always have a visible label.  The ProblemSets.pm page uses the set name for this, and when the quiz versions were listed there the quiz version was used for the label for those.  So that is done here as well.
    
Another issue is that if the quiz is in the last minute, the message is displayed as "You have remaining to complete the current test."  So this changes it so that seconds are shown during the last minute.  Should this be taken further and show minutes and seconds near the end of the test?  Currently when there is 1 minute and 59 seconds left, the display shows "1 minute".

The time remaining is removed from the "Test Versions" table.  That information is already displayed above for the currently open version, and so it isn't needed in the table.  Furthermore that display was also plagued with more issues than the time remaining display above.  In the last minute it shows "remain", and in the minute before that it shows "1 minute remain".
    
This also makes the messages at the top of the page stand out by using a bootstrap alert.

Another change is that the "Continue Open Test" button now opens the "last" open version, and not the "first".  It doesn't make sense to open the first one, when the last one is the one the student would be working on.  Generally this is going to be the same thing anyway, since other than the unlimited submission case, the gateway quiz module only allows one open test.
    
The "#" is removed from the numbers in the test version list.  That wasn't there when these were on the ProblemSets.pm page, and isn't needed here.  Also, the `text-nowrap` class is added to prevent that version number from going to the next line.