### PR TITLE
Update the javascript for the gateway quiz module.

### DIFF
--- a/htdocs/js/apps/GatewayQuiz/gateway.js
+++ b/htdocs/js/apps/GatewayQuiz/gateway.js
@@ -25,7 +25,7 @@
 	const alertToast = (message, delay = 5000) => {
 		const toastContainer = document.createElement('div');
 		toastContainer.classList.add(
-			'toast-container', 'position-fixed', 'top-0', 'start-50',  'translate-middle-x', 'p-3');
+			'gwAlert', 'toast-container', 'position-fixed', 'top-0', 'start-50',  'translate-middle-x', 'p-3');
 		toastContainer.innerHTML =
 			'<div class="toast bg-white" role="alert" aria-live="assertive" aria-atomic="true">' +
 			'<div class="toast-header">' +

--- a/htdocs/js/apps/GatewayQuiz/gateway.js
+++ b/htdocs/js/apps/GatewayQuiz/gateway.js
@@ -1,114 +1,133 @@
-/***********************************************************
- *
- * Javascript for gateway tests.
- *
- * This file includes the routines allowing navigation
- * within gateway tests, manages the timer, and posts
- * alerts when test time is winding up.
- *
- * The code here relies heavily on the existence of form elements
- * created by GatewayQuiz.pm
- *
- ***********************************************************/
+// Javascript for gateway tests.
+//
+// This file includes the routines allowing navigation within gateway tests, manages the timer, and posts alerts when
+// test time is winding up.
+//
+// The timer code relies on the existence of data attributes for the gwTimer div created by GatewayQuiz.pm.
 
-function jumpTo(ref) {  // scrolling javascript function
-	if ( ref ) {
-		var pn = ref - 1; // we start anchors at 1, not zero
+(() => {
+	// Gateway timer
+	const timerDiv = document.getElementById('gwTimer'); // The timer div element
+	let timeDelta; // The difference between the browser time and the server time
+	let serverDueTime; // The time the test is due
+	let gracePeriod; // The grace period
+	let remainingTimeString = timerDiv?.textContent.replace('00:00:00', '');
 
-		$('html, body').animate({
-			scrollTop: $("#prob"+pn).offset().top
-		}, 500);
-		$("#prob"+pn).attr('tabIndex',-1).focus();
-	}
-	return false; // prevent link from being followed
-}
+	// Convert seconds to hh:mm:ss format
+	const formatTime = (t) => {
+		// Don't deal with negative times.
+		if (t < 0) t = 0;
+		const date = new Date(0);
+		date.setSeconds(t);
+		return date.toISOString().substring(11, 19);
+	};
 
-// timer for gateway
-var theTimer;		// variable for the timer
-var browserTime;	// on load, the time on the client's computer
-var serverTime;		// on load, the time on the server
-var timeDelta;		// the difference between those
-var serverDueTime;	// the time the test is due
+	const alertToast = (message, delay = 5000) => {
+		const toastContainer = document.createElement('div');
+		toastContainer.classList.add(
+			'toast-container', 'position-fixed', 'top-0', 'start-50',  'translate-middle-x', 'p-3');
+		toastContainer.innerHTML =
+			'<div class="toast bg-white" role="alert" aria-live="assertive" aria-atomic="true">' +
+			'<div class="toast-header">' +
+			`<strong class="me-auto">${timerDiv.dataset.alertTitle ?? 'Test Time Notification'}</strong>` +
+			'<button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="close"></button>' +
+			'</div>' +
+			`<div class="toast-body alert alert-danger mb-0 text-center">${message}</div>` +
+			'</div>';
+		document.body.prepend(toastContainer);
+		const bsToast = new bootstrap.Toast(toastContainer.firstElementChild, { delay });
+		toastContainer.addEventListener('hidden.bs.toast', () => { bsToast.dispose(); toastContainer.remove(); })
+		bsToast.show();
+	};
 
-function runtimer() {
-	// function to start the timer, initializing the time variables
-	if ( document.getElementById('gwTimer') == null ) {  // no timer
-		return;
-	} else {
-		theTimer = document.getElementById('gwTimer');
-		var dateNow = new Date();
-		browserTime = Math.round(dateNow.getTime()/1000);
-		serverTime = document.gwTimeData.serverTime.value;
-		serverDueTime = document.gwTimeData.serverDueTime.value;
-		timeDelta = browserTime - serverTime;
+	// Update the timer
+	const updateTimer = () => {
+		const dateNow = new Date();
+		const browserTime = Math.round(dateNow.getTime() / 1000);
+		const remainingTime = serverDueTime - browserTime + timeDelta;
 
-		var remainingTime = serverDueTime - browserTime + 1.*timeDelta;
-
-		if ( remainingTime >= 0 ) {
-			theTimer.innerHTML = "Remaining time: " + toMinSec(remainingTime) + " (min:sec)";
-			setTimeout(updateTimer, 1000);
-			setTimeout(checkAlert, 1000);
+		// Set the timer text.
+		if (remainingTime >= 0) {
+			timerDiv.textContent = `${remainingTimeString}${formatTime(remainingTime)}`;
 		} else {
-			theTimer.innerHTML = "Remaining time: 0 min";
+			timerDiv.textContent = `${remainingTimeString}00:00:00`;
 		}
-	}
-}
 
-function updateTimer() {
-	// update the timer
-	var dateNow = new Date();
-	browserTime = Math.round(dateNow.getTime()/1000);
-	var remainingTime = serverDueTime - browserTime + 1.*timeDelta;
-	if ( remainingTime >= 0 ) {
-		theTimer.innerHTML = "Remaining time: " + toMinSec(remainingTime) + " (min:sec)";
-		setTimeout(updateTimer, 1000);
-	}
-}
+		if (!timerDiv.dataset.acting) {
+			// Check to see if we should put up a low time alert, or submit the test if
+			// the time is near the end of the grace period.
+			const alertStatus = sessionStorage.getItem('gatewayAlertStatus');
 
-function checkAlert() {
-	// check to see if we should put up a low time alert
-	var dateNow = new Date();
-	browserTime = Math.round(dateNow.getTime()/1000);
-	var timeRemaining = serverDueTime - browserTime + 1.*timeDelta;
+			if (remainingTime <= 10 - gracePeriod) {
+				sessionStorage.removeItem('gatewayAlertStatus');
+				document.gwquiz.submitAnswers.click();
+			} else if (remainingTime > 10 - gracePeriod && remainingTime <= 0) {
+				if (alertStatus !== '1') {
+					alertToast(timerDiv.dataset.alertOne ??
+						'<div>You are out of time!</div><div>Press "Grade Test" now!</div>',
+						(remainingTime + gracePeriod) * 1000);
+					sessionStorage.setItem('gatewayAlertStatus', '1');
+				}
+			} else if (remainingTime > 0 && remainingTime <= 45) {
+				if (alertStatus !== '2') {
+					alertToast(timerDiv.dataset.alertTwo ??
+						'<div>You have less than 45 seconds left!</div><div>Press "Grade Test" soon!</div>',
+						remainingTime * 1000);
+					sessionStorage.setItem('gatewayAlertStatus', '2');
+				}
+			} else if (remainingTime > 45 && remainingTime <= 90) {
+				if (alertStatus !== '3') {
+					alertToast(timerDiv.dataset.alertThree ??
+						'You have less than 90 seconds left to complete this assignment. You should finish it soon!',
+						(remainingTime - 45) * 1000);
+					sessionStorage.setItem('gatewayAlertStatus', '3');
+				}
+			}
+		}
+	};
 
-	if ( timeRemaining <= 0 ) {
-		alert("* You are out of time! *\n" +
-			"* Press grade now!     *");
-	} else if ( timeRemaining <= 45 && timeRemaining > 40 ) {
-		alert("* You have less than 45 seconds left! *\n" +
-			"*      Press Grade very soon!         *");
-	} else if ( timeRemaining <= 90 && timeRemaining > 85 ) {
-		alert("* You only have less than 90 sec left to complete  *\n" +
-			"* this assignment. You should finish it very soon! *");
-	}
-	if ( timeRemaining > 0 ) {
-		setTimeout(checkAlert, 5000);
-	}
-}
+	if (timerDiv) {
+		// Initialize the time variables and start the timer.
+		const dateNow = new Date();
+		const browserTime = Math.round(dateNow.getTime() / 1000);
+		serverDueTime = parseInt(timerDiv.dataset.serverDueTime);
+		timeDelta = browserTime - parseInt(timerDiv.dataset.serverTime);
+		gracePeriod = parseInt(timerDiv.dataset.gracePeriod);
 
-function toMinSec(t) {
-	// convert to min:sec
-	if ( t < 0 ) {     // don't deal with negative times
-		t = 0;
-	}
-	mn = Math.floor(t/60);
-	sc = t - 60*mn;
-	if ( mn < 10 && mn > -1 ) {
-		mn = "0" + mn;
-	}
-	if ( sc < 10 ) {
-		sc = "0" + sc;
-	}
-	return mn + ":" + sc;
-}
+		const remainingTime = serverDueTime - browserTime + timeDelta;
 
-// Start timer after the DOM is ready
-$(setTimeout(runtimer, 500));
+		if (!timerDiv.dataset.acting) {
+			if (remainingTime <= 10 - gracePeriod)
+				// Submit the test if time is expired and near the end of grace period.
+				document.gwquiz.submitAnswers.click();
+			else {
+				// Set the timer text and check alerts at page load.
+				updateTimer();
 
-// Show the achievement toast if there is one.
-document.addEventListener('load', () => {
+				// Start the timer.
+				setInterval(updateTimer, 1000);
+			}
+		}
+	};
+
+
+	// Scroll to a problem when the problem number link is clicked.
+	document.querySelectorAll('.problem-jump-link').forEach((jumpLink) => {
+		jumpLink.addEventListener('click', (evt) => {
+			// Prevent the link from being followed.
+			evt.preventDefault()
+			if (jumpLink.dataset.problemNumber) {
+				// Note that the anchor indexing starts at 0, not 1.
+				const problem = document.getElementById(`prob${parseInt(jumpLink.dataset.problemNumber) - 1}`);
+				problem.focus();
+				problem.scrollIntoView({ behavior: 'smooth' });
+			}
+		});
+	});
+
+	// Show any achievement toasts if there are any.
 	document.querySelectorAll('.cheevo-toast').forEach((toast) => {
 		const bsToast = new bootstrap.Toast(toast, { delay: 5000 });
 		bsToast.show();
 	});
-});
+})();

--- a/htdocs/themes/math4/gateway.scss
+++ b/htdocs/themes/math4/gateway.scss
@@ -14,7 +14,7 @@
 
 /* gateway styles */
 
-div.gwMessage { 
+div.gwMessage {
 	background-color: #ffeeaa;
 	box-shadow: 3px 3px 3px darkgray;
 	margin: 1em 0;
@@ -26,21 +26,15 @@ div.gwMessage {
 	display: block;
 }
 
-div#gwTimer {
-	background-color:#ffeeaa;
-	color: black;
-	position: fixed; 
-	right: 1em;
-	top: 3.5em;
-	padding: 0.5em;
+#gwTimer {
+	position: sticky;
+	width: 15em;
+	top: 0.75rem;
+	left: calc(100% - 15em - 0.75rem);
+	right: 0.75rem;
 	text-align: center;
 	z-index: 2;
-	box-shadow: 3px 3px 0.5em darkgray;
-	-webkit-border-radius: 4px;
-	-moz-border-radius: 4px;
-	border-radius: 4px;
-
-} 
+}
 
 #gwScoreSummary {
 	background-color:#ffeeaa;

--- a/htdocs/themes/math4/gateway.scss
+++ b/htdocs/themes/math4/gateway.scss
@@ -17,8 +17,8 @@
 div.gwMessage {
 	background-color: #ffeeaa;
 	box-shadow: 3px 3px 3px darkgray;
-	margin: 1em 0;
-	padding: 0.5em;
+	margin: 0 0 1rem 0;
+	padding: 0.25rem;
 	border-radius: 3px;
 }
 

--- a/htdocs/themes/math4/gateway.scss
+++ b/htdocs/themes/math4/gateway.scss
@@ -36,6 +36,10 @@ div.gwMessage {
 	z-index: 2;
 }
 
+.gwAlert {
+	z-index: 10;
+}
+
 #gwScoreSummary {
 	background-color:#ffeeaa;
 	color: black;


### PR DESCRIPTION
This utilizes data attributes to pass in the timing inforamtion, rather than a defunct form with hidden inputs.  The timer is placed much more appropriately.

Instead of using a native alert for notifications near the end of a test, use bootstrap toasts.  The native alerts interupt a student's
work, forcing the student to close them.  Boostrap toasts sit quietly at the top, and the student can continue to enter answers while the toast is still visible.  The toasts are set to stay open until the next alert message, although the student can close the toast earlier.

Add a quiz auto submission at the end of the quiz that occurs approximately 10 seconds before the end of the grace period.