### PR TITLE
Update the docker build for recent changes.

### DIFF
--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
+	&& apt-get install -y --no-install-recommends --no-install-suggests \
 	apache2 \
 	curl \
 	dvipng \
@@ -100,6 +100,7 @@ RUN apt-get update \
 	libjson-xs-perl \
 	libjson-maybexs-perl \
 	libcpanel-json-xs-perl \
+	libyaml-libyaml-perl \
 	make \
 	netpbm \
 	patch \
@@ -129,8 +130,8 @@ RUN apt-get update \
 	imagemagick \
 	jq \
 	npm \
-    && apt-get clean \
-    && rm -fr /var/lib/apt/lists/* /tmp/*
+	&& apt-get clean \
+	&& rm -fr /var/lib/apt/lists/* /tmp/*
 
 # Developers may want to add additional packages inside the image
 # such as: telnet vim mc file

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -71,7 +71,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # we need to change FROM before setting the ENV variables
 
-FROM webwork-base:forWW216
+FROM webwork-base:forWW217
 
 ENV WEBWORK_URL=/webwork2 \
     WEBWORK_ROOT_URL=http://localhost \

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -125,8 +125,8 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && cd $APP_ROOT/pg/lib/chromatic && gcc color.c -o color  \
     && cd $APP_ROOT/webwork2/ \
-      && chown www-data DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic \
-      && chmod -R u+w DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic   \
+      && chown www-data DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic \
+      && chmod -R u+w DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic   \
     && echo "en_US ISO-8859-1\nen_US.UTF-8 UTF-8" > /etc/locale.gen \
       && /usr/sbin/locale-gen \
       && echo "locales locales/default_environment_locale select en_US.UTF-8\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt \
@@ -134,7 +134,9 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && rm /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
       &&   dpkg-reconfigure -f noninteractive tzdata \
     && cd $WEBWORK_ROOT/htdocs \
-      && npm install
+      && npm install --unsafe-perm \
+    && cd $PG_ROOT/htdocs \
+      && npm install --unsafe-perm
 
 # These lines were moved into docker-entrypoint.sh so the bind mount of courses will be available
 #RUN cd $APP_ROOT/webwork2/courses.dist \
@@ -161,7 +163,7 @@ RUN cd $APP_ROOT/webwork2/conf \
     && cp webwork.apache2.4-config.dist webwork.apache2.4-config \
     && cp $APP_ROOT/webwork2/conf/webwork.apache2.4-config /etc/apache2/conf-enabled/webwork.conf \
     && a2dismod mpm_event \
-    && a2enmod mpm_prefork \
+    && a2enmod mpm_prefork rewrite \
     && sed -i -e 's/Timeout 300/Timeout 1200/' /etc/apache2/apache2.conf \
     && sed -i -e 's/MaxRequestWorkers     150/MaxRequestWorkers     20/' \
 	  -e 's/MaxConnectionsPerChild   0/MaxConnectionsPerChild   100/' \
@@ -169,7 +171,6 @@ RUN cd $APP_ROOT/webwork2/conf \
     && cp $APP_ROOT/webwork2/htdocs/favicon.ico /var/www/html \
     && mkdir -p $APACHE_RUN_DIR $APACHE_LOCK_DIR $APACHE_LOG_DIR \
     && mkdir /etc/ssl/local  \
-    && a2enmod rewrite \
     && sed -i -e 's/^<Perl>$/\
 	PerlPassEnv WEBWORK_URL\n\
 	PerlPassEnv WEBWORK_ROOT_URL\n\

--- a/bin/addcourse
+++ b/bin/addcourse
@@ -1,13 +1,13 @@
 #!/usr/bin/env perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, https://github.com/openwebwork
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -61,80 +61,35 @@ The name of the course to create.
 
 =cut
 
-BEGIN {
-	# hide arguments (there could be passwords there!)
-	$0 = "$0";
-}
-
 use strict;
 use warnings;
 use Getopt::Long;
 
+my $webwork_dir;
+my $pg_dir;
 
 BEGIN {
 	die "WEBWORK_ROOT not found in environment.\n"
 		unless exists $ENV{WEBWORK_ROOT};
-	  my $webwork_dir = $ENV{WEBWORK_ROOT};
-	  print "addcourse:  WeBWorK root directory set to $webwork_dir\n";
+	$webwork_dir = $ENV{WEBWORK_ROOT};
 
-	# link to WeBWorK code libraries
-      eval "use lib '$webwork_dir/lib'"; die $@ if $@;
-      eval "use WeBWorK::CourseEnvironment"; die $@ if $@;
-
-		
+	$pg_dir = $ENV{PG_ROOT} // "$ENV{WEBWORK_ROOT}/../pg";
+	die "The pg directory must be defined in PG_ROOT" unless (-e $pg_dir);
 }
 
-our $webwork_dir = $ENV{WEBWORK_ROOT};
+# link to WeBWorK and pg code libraries
+use lib "$webwork_dir/lib";
+use lib "$pg_dir/lib";
 
+use WeBWorK::CourseEnvironment;
 
-BEGIN { $main::VERSION = "2.4"; }  #hack to set version
-
-
-
-
-# link to WeBWorK code libraries
-eval "use lib '$webwork_dir/lib'"; die $@ if $@;
-eval "use WeBWorK::CourseEnvironment"; die $@ if $@;
-
-#################################################################
-# The folloinwg code reads defaults.config and extracts the remaining configuration
-# variables. There is no need to modify it.
-#################################################################
-
-# link to WeBWorK code libraries
-eval "use lib '$webwork_dir/lib'"; die $@ if $@;
-eval "use WeBWorK::CourseEnvironment"; die $@ if $@;
-
-# grab course environment (by reading webwork2/conf/defaults.config)
+# Grab course environment (by reading webwork2/conf/defaults.config)
 my $ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
 
-#  set important configuration variables (from defaults.config)
-
-my $webwork_url = $ce->{webwork_url};                    # e.g.  /webwork2
-my $pg_dir = $ce->{pg_dir};                              # e.g.  /opt/webwork/pg         
-
-#################################################################
-# report server setup when child process starts up -- for example when restarting the server
-#################################################################
-print "addcourse:  WeBWorK server is starting\n";
-print "addcourse:  WeBWorK root directory set to $webwork_dir in webwork2/conf/webwork.apache2-config\n";
-print "addcourse:  The following locations and urls are set in webwork2/conf/site.conf\n";
-print "addcourse:  PG root directory set to $pg_dir\n";
-print "addcourse:  WeBWorK server userID is ", $ce->{server_userID}, "\n";
-print "addcourse:  WeBWorK server groupID is ", $ce->{server_groupID}, "\n";
-print "addcourse:  The webwork url on this site is ", $ce->{server_root_url},"$webwork_url\n";
-
-
-# link to PG code libraries
-eval "use lib '$pg_dir/lib'"; die $@ if $@;
-
-eval q{
-use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use WeBWorK::File::Classlist;
 use WeBWorK::Utils qw(runtime_use readFile cryptPassword);
 use WeBWorK::Utils::CourseManagement qw(addCourse deleteCourse listCourses);
-}; die $@ if $@;
 
 sub usage {
 	print STDERR "usage: $0 [options] COURSEID\n";
@@ -149,35 +104,35 @@ sub usage_error {
 	usage();
 }
 
-my $dbLayout = "";
-my $sql_host = "";
-my $sql_port = "";
-my $sql_user = "";
-my $sql_pass = "";
-my $sql_db = "";
-my $sql_wwhost = "";
-my $globalUserID = "";
-my $users = "";
-my @professors = ();
+my $dbLayout       = "";
+my $sql_host       = "";
+my $sql_port       = "";
+my $sql_user       = "";
+my $sql_pass       = "";
+my $sql_db         = "";
+my $sql_wwhost     = "";
+my $globalUserID   = "";
+my $users          = "";
+my @professors     = ();
 my $templates_from = "";
 
 ##### get command-line options #####
 
 GetOptions(
-	"db-layout=s" => \$dbLayout,
-	"sql-host=s" => \$sql_host,
-	"sql-port=s" => \$sql_port,
-	"sql-user=s" => \$sql_user,
-	"sql-pass=s" => \$sql_pass,
-	"sql-db=s" => \$sql_db,
-	"sql-wwhost=s" => \$sql_wwhost,
-	"global-user=s" => \$globalUserID,
-	"users=s" => \$users,
-	"professors=s" => \@professors,
+	"db-layout=s"      => \$dbLayout,
+	"sql-host=s"       => \$sql_host,
+	"sql-port=s"       => \$sql_port,
+	"sql-user=s"       => \$sql_user,
+	"sql-pass=s"       => \$sql_pass,
+	"sql-db=s"         => \$sql_db,
+	"sql-wwhost=s"     => \$sql_wwhost,
+	"global-user=s"    => \$globalUserID,
+	"users=s"          => \$users,
+	"professors=s"     => \@professors,
 	"templates-from=s" => \$templates_from,
 );
 my %professors = map { $_ => 1 } map { split /,/ } @professors;
-my $courseID = shift;
+my $courseID   = shift;
 
 ##### perform sanity checks #####
 
@@ -186,17 +141,17 @@ usage_error("must specify COURSEID.") unless $courseID;
 # bring up a minimal course environment
 $ce = WeBWorK::CourseEnvironment->new({
 	webwork_dir => $ENV{WEBWORK_ROOT},
-	courseName => $courseID
+	courseName  => $courseID
 });
 
 # Do not attempt to create a course whose name is too long.
-if ( length($courseID) > $ce->{maxCourseIdLength} ) {
+if (length($courseID) > $ce->{maxCourseIdLength}) {
 	die "Aborting addcourse: Course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters.";
 }
 
 if ($dbLayout) {
 	die "Database layout $dbLayout does not exist in the course environment.",
-			" (It must be defined in defaults.config.)\n"
+		" (It must be defined in defaults.config.)\n"
 		unless exists $ce->{dbLayouts}->{$dbLayout};
 } else {
 	# use default value
@@ -208,7 +163,7 @@ usage_error("can't specify --professors without also specifying --users.")
 
 ##### set up parameters to pass to addCourse() #####
 
-my %courseOptions = ( dbLayoutName => $dbLayout );
+my %courseOptions = (dbLayoutName => $dbLayout);
 
 # this is kinda left over from when we had 'gdbm' and 'sql' database layouts
 # below this line, we would grab values from getopt and put them in this hash
@@ -219,29 +174,29 @@ my @users;
 if ($users) {
 	# this is a hack to create records without bringing up a DB object
 	#my $db = WeBWorK::DB->new($ce->{dbLayouts}->{$dbLayout});
-	my $userClass = $ce->{dbLayouts}->{$dbLayout}->{user}->{record};
-	my $passwordClass = $ce->{dbLayouts}->{$dbLayout}->{password}->{record};
+	my $userClass       = $ce->{dbLayouts}->{$dbLayout}->{user}->{record};
+	my $passwordClass   = $ce->{dbLayouts}->{$dbLayout}->{password}->{record};
 	my $permissionClass = $ce->{dbLayouts}->{$dbLayout}->{permission}->{record};
-	
+
 	runtime_use($userClass);
 	runtime_use($passwordClass);
 	runtime_use($permissionClass);
-	
+
 	# Default status is enrolled -- fetch abbreviation for enrolled
 	my $default_status_abbrev = $ce->{statuses}->{Enrolled}->{abbrevs}->[0];
-	
+
 	# default permission level
 	my $default_permission_level = $ce->{default_permission_level};
-	
+
 	my @classlist = parse_classlist($users);
 	foreach my $record (@classlist) {
-		my %record = %$record;
+		my %record  = %$record;
 		my $user_id = $record{user_id};
-		
+
 		# set default status is status field is "empty"
 		$record{status} = $default_status_abbrev
 			unless defined $record{status} and $record{status} ne "";
-		
+
 		# set password from student ID if password field is "empty"
 		if (not defined $record{password} or $record{password} eq "") {
 			if (defined $record{student_id} and $record{student_id} ne "") {
@@ -252,20 +207,20 @@ if ($users) {
 				$record{password} = "";
 			}
 		}
-		
-		# set default permission level if pedefault_permission_levelrmission level is "empty"
+
+		# set permission
 		if (not defined $record{status} and $record{status} ne "") {
 			if (exists $professors{$user_id}) {
-				$record{permission} = $ce->{userRoles}{professor}; # FIXME hardcoded role name is bad
+				$record{permission} = $ce->{userRoles}{professor};
 			} else {
 				$record{permission} = $default_permission_level;
 			}
 		}
-		
-		my $User = $userClass->new(%record);
+
+		my $User            = $userClass->new(%record);
 		my $PermissionLevel = $permissionClass->new(user_id => $user_id, permission => $record{permission});
-		my $Password = $passwordClass->new(user_id => $user_id, password => $record{password});
-		
+		my $Password        = $passwordClass->new(user_id => $user_id, password => $record{password});
+
 		if (exists $record{permission}) {
 			$PermissionLevel->permission($record{permission});
 			delete $professors{$user_id};
@@ -273,14 +228,14 @@ if ($users) {
 			$PermissionLevel->permission(10);
 			delete $professors{$user_id};
 		}
-		
+
 		if (exists $record{password}) {
 			$Password->password($record{password});
 		}
-		
+
 		push @users, [ $User, $Password, $PermissionLevel ];
 	}
-	
+
 	if (my @ids = keys %professors) {
 		print STDERR "warning: @ids not in imported user list.\n";
 	}
@@ -308,6 +263,8 @@ if ($@) {
 	my $error = $@;
 	print STDERR "$error\n";
 	exit;
+} else {
+	print "Successfully added '$courseID' course.\n";
 }
 
 =head1 AUTHOR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,9 +95,9 @@ services:
             - WEBWORK2_BRANCH=develop
             - PG_BRANCH=develop
 
-        # If you are using the 2 stage build process uncomment the next line
+        # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
         dockerfile: DockerfileStage2
-        # and first run
+        # For the 2 stage build process run
         #     docker build --tag webwork-base:forWW216 -f DockerfileStage1 .
         # and then
         #     docker-compose build
@@ -234,7 +234,7 @@ services:
 
       # Extra Ubuntu packages to install during startup
       # Commenting the following line out will speed up container startup time.
-      ADD_APT_PACKAGES: nano less 
+      ADD_APT_PACKAGES: nano less
 
       # The system timezone for the container can be set using
       #SYSTEM_TIMEZONE: zone/city

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
         # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
         dockerfile: DockerfileStage2
         # For the 2 stage build process run
-        #     docker build --tag webwork-base:forWW216 -f DockerfileStage1 .
+        #     docker build --tag webwork-base:forWW217 -f DockerfileStage1 .
         # and then
         #     docker-compose build
 

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -82,7 +82,7 @@ if [ "$1" = 'apache2' ]; then
                     -e 's/siteDefaults{timezone} = "America\/New_York"/siteDefaults{timezone} = $ENV{"WEBWORK_TIMEZONE"}/' \
                     -e 's/^# $server_userID     = '\''www-data/$server_userID     = '\''www-data/'  \
                     -e 's/^# $server_groupID    = '\''www-data/$server_groupID    = '\''www-data/' $WEBWORK_ROOT/conf/site.conf
-                
+
                 echo "$WEBWORK_ROOT/conf/$i has been modified."
             fi
 
@@ -92,16 +92,16 @@ if [ "$1" = 'apache2' ]; then
                 echo "$WEBWORK_ROOT/conf/$i has been modified."
             fi
         fi
-        
+
     done
     # create admin course if not existing
-    # check first if the admin courses directory exists then check that at 
+    # check first if the admin courses directory exists then check that at
     # least one of the tables associated with the course (the admin_user table) exists
-    
+
     echo "check admin course and admin tables"
     wait_for_db
     ADMIN_TABLE_EXISTS=`mysql -u $WEBWORK_DB_USER  -p$WEBWORK_DB_PASSWORD -B -N -h db -e "select count(*) from information_schema.tables where table_schema='webwork' and table_name = 'admin_user';"  2>/dev/null`
- 
+
     if [ ! -d "$APP_ROOT/courses/admin" ]; then
         newgrp www-data
         umask 2
@@ -116,19 +116,19 @@ if [ "$1" = 'apache2' ]; then
         $WEBWORK_ROOT/bin/upgrade_admin_db.pl
         $WEBWORK_ROOT/bin/wwsh admin $WEBWORK_ROOT/bin/addadmin
         echo "admin course tables created with one user: admin   whose password is admin"
-    else 
+    else
         echo "using pre-existing admin course and admin tables"
     fi
-    
+
     # use case for the extra check for the admin:
-    # In rebuilding a docker box one might clear out the docker containers, 
-    # images and volumes including mariaDB, BUT leave the 
-    # contents of ww-docker-data directory in place.  It now holds the shell of the courses 
-    # including the admin course directory. This means that once you rebuild the box 
-    # you can't access the admin course (because the admin_user table is missing) 
-    # and you need to run bin/upgrade_admin_db.pl from inside the container. 
-    # This check insures that if the admin_user table is missing the whole admin course is rebuilt 
-    # even if the admin directory is in place. 
+    # In rebuilding a docker box one might clear out the docker containers,
+    # images and volumes including mariaDB, BUT leave the
+    # contents of ww-docker-data directory in place.  It now holds the shell of the courses
+    # including the admin course directory. This means that once you rebuild the box
+    # you can't access the admin course (because the admin_user table is missing)
+    # and you need to run bin/upgrade_admin_db.pl from inside the container.
+    # This check insures that if the admin_user table is missing the whole admin course is rebuilt
+    # even if the admin directory is in place.
 
     # modelCourses link if not existing
     if [ ! -d "$APP_ROOT/courses/modelCourse" ]; then
@@ -241,14 +241,14 @@ if [ "$1" = 'apache2' ]; then
     # This change significantly speeds up Docker startup time on production
     # servers with many files/courses (on Linux).
 
-    chown -R www-data:www-data logs tmp DATA 
-    chmod -R ug+w logs tmp DATA 
+    chown -R www-data:www-data logs tmp DATA
+    chmod -R ug+w logs tmp DATA
     chown  www-data:www-data htdocs/tmp
     chmod ug+w htdocs/tmp
-    
+
     # even if the admin and courses directories already existed their permissions might not have been correct
     # chown www-data:www-data  $APP_ROOT/courses
-    chown www-data:www-data  $APP_ROOT/courses/admin/*    
+    chown www-data:www-data  $APP_ROOT/courses/admin/*
 
     # Symbolic links which have no target outside the Docker container
     # cause problems duringt the rebuild process on some systems.


### PR DESCRIPTION
Run `npm install` from the `pg/htdocs` location.  Also both of the `npm install` commands need to be run with `--unsafe-perm` so that the `prepare` script will run.

Don't try to change ownership and permissions on the now non-existent applets directory.

Fix the bin/addcourse script for the new WWSafe.pm location.  This script was missed in #1533.

Add the Ubuntu package libyaml-libyaml-perl which is needed for the new PGEnvironment.pm module.

Note that to test this you will need to change line 81 of docker-compose.yml to `- WEBWORK2_GIT_URL=https://github.com/drgrice1/webwork2.git` and line 95 to `- WEBWORK2_BRANCH=fix-docker`.