### PR TITLE
Update some dependency data (develop pre-2.17)

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -157,7 +157,7 @@ my @modulesList = qw(
 	XML::Simple
 	XML::Writer
 	XMLRPC::Lite
-	YAML
+	YAML::XS
 );
 
 my %moduleVersion = (


### PR DESCRIPTION
When trying to get Docker to build the current develop (which will become WW 2.17 eventually) I ran into some minor issues.

This is intended to help with those which are "dependency" issues not in the Docker files themselves.

1. `npm install` gave a warning about needing to install `popperjs/core@^2.10.2`:
  - @drgrice1 If this should be done differently - please explain how.
  - The recommended solution on https://getbootstrap.com/docs/5.1/getting-started/parcel/#install-bootstrap is to run `npm install @popperjs/core` which essentially adds the line I put in `package.json`.
  - **Update**: @drgrice1 explained that this can be ignored. So the change to add `@popperjs/core` to `package.json` was removed.
```
npm WARN bootstrap@5.1.3 requires a peer of @popperjs/core@^2.10.2 but none is installed. You must install peer dependencies yourself.
```
2. After I got a Docker image built, on startup I got an error message and the startup failed due to a missing module `YAML:XS`, so that is being added to `bin/check_modules.pl`.
  - The install instructions should mention this additional module. It is being added to the Dockerfile to be included in the image.
```
Can't locate YAML/XS.pm in @INC (you may need to install the YAML::XS module) (@INC contains: /opt/webwork/pg/lib /opt/webwork/webwork2/lib /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /etc/apache2) at /opt/webwork/pg/lib/PGEnvironment.pm line 38.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/PGEnvironment.pm line 38.\nCompilation failed in require at /opt/webwork/pg/lib/WeBWorK/PG/IO.pm line 15.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/WeBWorK/PG/IO.pm line 15.\nCompilation failed in require at /opt/webwork/pg/lib/WeBWorK/PG/Translator.pm line 16.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/WeBWorK/PG/Translator.pm line 16.\nCompilation failed in require at /opt/webwork/pg/lib/PGloadfiles.pm line 76.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/PGloadfiles.pm line 76.\nCompilation failed in require at /opt/webwork/pg/lib/PGcore.pm line 34.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/PGcore.pm line 34.\nCompilation failed in require at /opt/webwork/pg/lib/WeBWorK/PG/ImageGenerator.pm line 30.\nBEGIN failed--compilation aborted at /opt/webwork/pg/lib/WeBWorK/PG/ImageGenerator.pm line 30.\nCompilation failed in require at /opt/webwork/webwork2/lib/WeBWorK/PG.pm line 29.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/PG.pm line 29.\nCompilation failed in require at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm line 52.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm line 52.\nCompilation failed in require at /usr/share/perl/5.30/base.pm line 137.\n\t...propagated at /usr/share/perl/5.30/base.pm line 159.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm line 18.\nCompilation failed in require at /usr/share/perl/5.30/base.pm line 137.\n\t...propagated at /usr/share/perl/5.30/base.pm line 159.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm line 17.\nCompilation failed in require at (eval 292) line 1.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK.pm line 88.\nCompilation failed in require at /opt/webwork/webwork2/lib/Apache/WeBWorK.pm line 37.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/Apache/WeBWorK.pm line 37.\n
```

@drgrice1 @pstaabp If you know of other dependency changes of a similar nature - more can be added to this PR.