### PR TITLE
Docker updates early 2022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,8 @@ RUN apt-get update \
 	libjson-xs-perl \
 	libjson-maybexs-perl \
 	libcpanel-json-xs-perl \
+	libyaml-libyaml-perl \
+	sass \
 	make \
 	netpbm \
 	patch \
@@ -244,8 +246,8 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && cd $APP_ROOT/pg/lib/chromatic && gcc color.c -o color  \
     && cd $APP_ROOT/webwork2/ \
-      && chown www-data DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic \
-      && chmod -R u+w DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic   \
+      && chown www-data DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic \
+      && chmod -R u+w DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic   \
     && echo "en_US ISO-8859-1\nen_US.UTF-8 UTF-8" > /etc/locale.gen \
       && /usr/sbin/locale-gen \
       && echo "locales locales/default_environment_locale select en_US.UTF-8\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt \
@@ -253,7 +255,9 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && rm /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
       &&   dpkg-reconfigure -f noninteractive tzdata \
     && cd $WEBWORK_ROOT/htdocs \
-      && npm install
+      && npm install --unsafe-perm \
+    && cd $APP_ROOT/pg/htdocs \
+      && npm install --unsafe-perm
 
 # These lines were moved into docker-entrypoint.sh so the bind mount of courses will be available
 #RUN cd $APP_ROOT/webwork2/courses.dist \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -100,6 +100,8 @@ RUN apt-get update \
 	libjson-xs-perl \
 	libjson-maybexs-perl \
 	libcpanel-json-xs-perl \
+	libyaml-libyaml-perl \
+	sass \
 	make \
 	netpbm \
 	patch \

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -71,7 +71,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # we need to change FROM before setting the ENV variables
 
-FROM webwork-base:forWW216
+FROM webwork-base:forWW217
 
 ENV WEBWORK_URL=/webwork2 \
     WEBWORK_ROOT_URL=http://localhost \
@@ -96,7 +96,6 @@ ENV WEBWORK_URL=/webwork2 \
 ENV WEBWORK_ROOT=$APP_ROOT/webwork2 \
     PG_ROOT=$APP_ROOT/pg \
     PATH=$PATH:$APP_ROOT/webwork2/bin
-
 # ==================================================================
 
 # Phase 3 - Install webwork2 and pg which were downloaded to /opt/base/ in phase 1
@@ -125,8 +124,8 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && cd $APP_ROOT/pg/lib/chromatic && gcc color.c -o color  \
     && cd $APP_ROOT/webwork2/ \
-      && chown www-data DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic \
-      && chmod -R u+w DATA ../courses  htdocs/applets logs tmp $APP_ROOT/pg/lib/chromatic   \
+      && chown www-data DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic \
+      && chmod -R u+w DATA ../courses logs tmp $APP_ROOT/pg/lib/chromatic   \
     && echo "en_US ISO-8859-1\nen_US.UTF-8 UTF-8" > /etc/locale.gen \
       && /usr/sbin/locale-gen \
       && echo "locales locales/default_environment_locale select en_US.UTF-8\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt \
@@ -134,7 +133,9 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
     && rm /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
       &&   dpkg-reconfigure -f noninteractive tzdata \
     && cd $WEBWORK_ROOT/htdocs \
-      && npm install
+      && npm install --unsafe-perm \
+    && cd $APP_ROOT/pg/htdocs \
+      && npm install --unsafe-perm
 
 # These lines were moved into docker-entrypoint.sh so the bind mount of courses will be available
 #RUN cd $APP_ROOT/webwork2/courses.dist \

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -157,7 +157,7 @@ my @modulesList = qw(
 	XML::Simple
 	XML::Writer
 	XMLRPC::Lite
-	YAML
+	YAML::XS
 );
 
 my %moduleVersion = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
         # If you are using the 2 stage build process uncomment the next line
         dockerfile: DockerfileStage2
         # and first run
-        #     docker build --tag webwork-base:forWW216 -f DockerfileStage1 .
+        #     docker build --tag webwork-base:forWW217 -f DockerfileStage1 .
         # and then
         #     docker-compose build
 

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.2",
+        "@popperjs/core": "^2.11.2",
         "bootstrap": "^5.1.3",
         "codemirror": "^5.14.3",
         "iframe-resizer": "^4.3.1",


### PR DESCRIPTION
Updates for Docker for develop branch and later WW 2.17.
Depends on the changes in https://github.com/openwebwork/webwork2/pull/1572 which are also included here.

---
To test before merging it is necessary to have the Docker build run using the `Dockerfile` (or the 2 stage files) from the source branch of this PR.

One could start:
```
git remote add tani https://github.com/taniwallach/webwork2.git
git fetch tani
git checkout docker-updates-early-2022 
```
or get the files from the branch in some other manner.

You may want to update the images our build process depends on:
```
docker pull alpine/git
docker pull ubuntu:20.04
```

You then need 2 temporary local changes in `docker-compose.yml`:
Set:
  1. `WEBWORK2_GIT_URL=https://github.com/taniwallach/webwork2.git`
  2. `WEBWORK2_BRANCH=docker-updates-early-2022`
so the build will run with the updated `htdocs/package.json` file.

I recommend testing using the 2 stage build.
```
docker build --tag webwork-base:forWW217 -f DockerfileStage1 .
docker-compose build
```

---

Summary of what was changed:
1. Installs two new core dependencies from Ubuntu.
2. `htdocs/applets` no longer exists, and the use in the `Dockerfile` triggered an error and broke the build process.
3. Use `npm install --unsafe-perm` as in Docker `npm install` is run as root, and without that it would report:
```npm WARN lifecycle webwork.javascript_package_manager@~prepare: cannot run in wd webwork.javascript_package_manager@ npm run generate-css && npm run css-prefix (wd=/opt/webwork/webwork2/htdocs)
```
and
```
npm WARN lifecycle pg.javascript_package_manager@~prepare: cannot run in wd pg.javascript_package_manager@ npm run generate-css (wd=/opt/webwork/pg/htdocs)
```