### PR TITLE
Fix a few accessibility issues.

### DIFF
--- a/htdocs/themes/math4/bootstrap.scss
+++ b/htdocs/themes/math4/bootstrap.scss
@@ -19,7 +19,6 @@
 
 // Enable shadows and gradients.  These are disabled by default.
 $enable-shadows: true;
-$enable-gradients: true;
 
 // Use a smaller grid gutter width.  The default is 1.5rem.
 $grid-gutter-width: 1rem;
@@ -31,6 +30,10 @@ $headings-font-weight: 600;
 // Links
 $link-decoration: none;
 $link-hover-decoration: underline;
+
+// Make breadcrumb dividers and active items a bit darker.
+$breadcrumb-divider-color: #495057;
+$breadcrumb-active-color: #495057;
 
 @import "./theme-colors";
 

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -92,7 +92,7 @@
 
 	// Turn help boxes into popovers
 	document.querySelectorAll('.help-popup').forEach((popover) => {
-		new bootstrap.Popover(popover, {trigger: 'hover'});
+		new bootstrap.Popover(popover, {trigger: 'hover focus'});
 	});
 
 	// Problem page popovers

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -33,7 +33,7 @@ table caption {
 }
 
 .required-field {
-	color: red;
+	color: #dc3545;
 }
 
 /* Screen Reader */
@@ -89,7 +89,7 @@ table caption {
 	display: flex;
 	align-items: center;
 	padding: 5px 0;
-	background-color: var(--ww-logo-background-color, #104aad);
+	background-color: var(--ww-logo-background-color, #104aac);
 
 	img {
 		max-height: 57px;
@@ -186,7 +186,7 @@ table caption {
 		color: black;
 		font-weight: bold;
 		font-size: 0.9rem;
-		opacity: 0.5;
+		opacity: 0.6;
 	}
 
 	.info-box {
@@ -372,6 +372,7 @@ h2.page-title {
 .Warnings {
 	code {
 		white-space: normal;
+		color: inherit;
 	}
 }
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -89,7 +89,7 @@ table caption {
 	display: flex;
 	align-items: center;
 	padding: 5px 0;
-	background-color: var(--ww-logo-background-color, #104aac);
+	background-color: var(--ww-logo-background-color, #104aad);
 
 	img {
 		max-height: 57px;
@@ -213,7 +213,7 @@ table caption {
 		}
 	}
 
-	#site-links > ul {
+	#site-links {
 		border: 1px solid #e6e6e6;
 	}
 

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -112,7 +112,7 @@
 <!--#if can="links" can="siblings" can="options"-->
 <div id="site-navigation" class="d-flex flex-column" role="navigation" aria-label="main navigation">
 	<!--#if can="links"-->
-		<div id="site-links">
+		<div id="site-links" class="bg-light">
 			<!--#links-->
 		</div>
 	<!--#endif-->

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -773,8 +773,8 @@ sub links {
 	my %systemlink_args;
 	$systemlink_args{params} = \%params if %params;
 
-	print CGI::start_ul({ class => 'nav flex-column bg-light' });
-	print CGI::span({ class => 'navbar-brand' }, $r->maketext('Main Menu'));
+	print CGI::h2({ class => 'navbar-brand mb-0' }, $r->maketext('Main Menu'));
+	print CGI::start_ul({ class => 'nav flex-column' });
 	print CGI::start_li({ class => 'nav-item' }); # Courses
 	print &$makelink("${pfx}Home", text=>$r->maketext("Courses"), systemlink_args=>{authen=>0});
 	print CGI::end_li(); # end Courses
@@ -1002,11 +1002,17 @@ sub links {
 				print CGI::end_li(); # end Instructor Tools
 			} # /* access_instructor_tools */
 
-			if (exists $ce->{webworkURLs}{bugReporter} and $ce->{webworkURLs}{bugReporter} ne ""
-				and $authz->hasPermissions($userID, "report_bugs")) {
-				print CGI::li({class=>'divider', 'aria-hidden'=>'true'},"");
-				print CGI::li({ class => 'nav-item' },
-					CGI::a({ href => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' }, $r->maketext("Report bugs")));
+			if (exists $ce->{webworkURLs}{bugReporter}
+				&& $ce->{webworkURLs}{bugReporter} ne ''
+				&& $authz->hasPermissions($userID, 'report_bugs'))
+			{
+				print CGI::li(
+					{ class => 'nav-item' },
+					CGI::a(
+						{ href => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' },
+						$r->maketext("Report bugs")
+					)
+				);
 			}
 
 		} # /* authentication was_verified */

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -774,7 +774,7 @@ sub links {
 	$systemlink_args{params} = \%params if %params;
 
 	print CGI::start_ul({ class => 'nav flex-column bg-light' });
-	print CGI::a({ class => "navbar-brand" }, $r->maketext("Main Menu"));
+	print CGI::span({ class => 'navbar-brand' }, $r->maketext('Main Menu'));
 	print CGI::start_li({ class => 'nav-item' }); # Courses
 	print &$makelink("${pfx}Home", text=>$r->maketext("Courses"), systemlink_args=>{authen=>0});
 	print CGI::end_li(); # end Courses

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -231,7 +231,7 @@ sub body {
 				class         => 'form-control',
 				placeholder   => ''
 			}),
-			CGI::label({ for => 'uname' }, $r->maketext('Password'))
+			CGI::label({ for => 'pswd' }, $r->maketext('Password'))
 		);
 
 		if ($ce->{session_management_via} ne 'session_cookie') {

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -813,22 +813,37 @@ sub body {
 						"link on the name of the problem to take you to the problem page.")
 				});
 			print CGI::caption($r->maketext("Problems"));
-			my $AdjustedStatusPopover = "&nbsp;" . CGI::a({
-					class => 'help-popup',
-					data_bs_content => $r->maketext('The adjusted status of a problem is the larger of the problem\'s ' .
-						'status and the weighted average of the status of those problems which count towards the ' .
-						'parent grade.'),
-					data_bs_placement => 'top',
-					data_bs_toggle => 'popover'
-				}, CGI::i({ class => "icon fas fa-question-circle", aria_hidden => "true", data_alt => "Help Icon" }, ""));
 
 			my $thRow = [ CGI::th($r->maketext("Name")),
 				CGI::th($r->maketext("Attempts")),
 				CGI::th($r->maketext("Remaining")),
 				CGI::th($r->maketext("Worth")),
 				CGI::th($r->maketext("Status")) ];
+
 			if ($isJitarSet) {
-				push @$thRow, CGI::th($r->maketext("Adjusted Status") . $AdjustedStatusPopover);
+				push @$thRow,
+					CGI::th(
+					$r->maketext("Adjusted Status")
+						. "&nbsp;"
+						. CGI::a(
+						{
+							class             => 'help-popup',
+							data_bs_placement => 'top',
+							data_bs_toggle    => 'popover',
+							tabindex          => 0,
+							role              => 'button',
+							data_bs_content   => $r->maketext(
+								'The adjusted status of a problem is the larger of the problem\'s status and'
+									. 'the weighted average of the status of those problems which count towards '
+									. 'the parent grade.'
+							)
+						},
+						CGI::i(
+							{ class => "icon fas fa-question-circle", aria_hidden => "true", data_alt => "Help Icon" },
+							""
+						)
+						)
+					);
 				push @$thRow, CGI::th($r->maketext("Counts for Parent"));
 			}
 


### PR DESCRIPTION
These are mainly foreground/background contrast ratios issues.

Disabling gradients fixes some issues with contrast of buttons.  That is probably why bootstrap disables this by default.

See #1574.  This fixes all of the issues currently listed there.  The Firefox accessibility tool shows no other issues on the student pages (other than the check boxes on the new quiz page fixed in another pull request).  On the other hand, there are quite a few on instructor only pages.