### PR TITLE
Rework the path that is displayed in the breadcrumb for gateway quizzes.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1250,28 +1250,23 @@ associated with the current request.
 
 sub title {
 	my ($self, $args) = @_;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $db = $r->db;
+	my $r       = $self->r;
+	my $ce      = $r->ce;
+	my $db      = $r->db;
 	my $urlpath = $r->urlpath;
 
-	# If the urlpath name is the courseID, and if the course has
-	# a course title then display that instead.
-	if (defined($urlpath->arg("courseID")) &&
-	    $urlpath->name eq $urlpath->arg("courseID") &&
-	    $db->settingExists('courseTitle')) {
-	    print $db->getSettingValue('courseTitle');
+	# If the urlpath name is the courseID and the course has a course title then display that instead.
+	if (defined($urlpath->arg('courseID'))
+		&& $urlpath->name eq $urlpath->arg('courseID')
+		&& $db->settingExists('courseTitle'))
+	{
+		print $db->getSettingValue('courseTitle');
 	} else {
-	    # just display the urlpath name
-	    #print "\n<!-- BEGIN " . __PACKAGE__ . "::title -->\n";
-	    #print underscore2nbsp($r->urlpath->name);
-	    my $name = $urlpath->name;
-	    # $name =~ s/_/ /g;
-	    print $name;
-	    #print "<!-- END " . __PACKAGE__ . "::title -->\n";
+		# Display the urlpath name
+		print $urlpath->name =~ s/_/ /gr;
 	}
 
-	return "";
+	return '';
 }
 
 =item warnings()
@@ -1536,14 +1531,14 @@ we have systemLink().
 
 sub pathMacro {
 	my ($self, $args, @path) = @_;
-	my $r = $self->r;
+	my $r    = $self->r;
 	my %args = %$args;
-	$args{style} = "text" if $args{textonly};
+	$args{style} = 'text' if $args{textonly};
 
 	my $auth = $self->url_authen_args;
 	my $sep;
-	if ($args{style} eq "image") {
-		$sep = CGI::img({-src=>$args{image}, -alt=>$args{text}});
+	if ($args{style} eq 'image') {
+		$sep = CGI::img({ src => $args{image}, alt => $args{text} });
 	} else {
 		$sep = $args{text};
 	}
@@ -1551,24 +1546,29 @@ sub pathMacro {
 	my @result;
 	while (@path) {
 		my $name = shift @path;
-		my $url = shift @path;
-		next unless $name =~/\S/;  #skip blank names. Blanks can happen for course header and set header files.
+		my $url  = shift @path;
+
+		# Skip blank names. Blanks can happen for course header and set header files.
+		next unless $name =~ /\S/;
+
+		$name =~ s/_/ /g;
+
 		if ($url and not $args{textonly}) {
-		    if($args{style} eq "bootstrap"){
-		        push @result, CGI::li({ class => 'breadcrumb-item' }, CGI::a({ href => "$url?$auth" }, lc($name)));
-		    } else {
-			    push @result, CGI::a({-href=>"$url?$auth"}, lc($name));
-		    }
+			if ($args{style} eq 'bootstrap') {
+				push @result, CGI::li({ class => 'breadcrumb-item' }, CGI::a({ href => "$url?$auth" }, $name));
+			} else {
+				push @result, CGI::a({ href => "$url?$auth" }, $name);
+			}
 		} else {
-		    if($args{style} eq "bootstrap"){
-                push @result, CGI::li({ class => "breadcrumb-item active" }, $name);
-            } else {
-			    push @result, $name;
+			if ($args{style} eq 'bootstrap') {
+				push @result, CGI::li({ class => 'breadcrumb-item active' }, $name);
+			} else {
+				push @result, $name;
 			}
 		}
 	}
 
-	return join($sep, @result), "\n";
+	return join($sep, @result);
 }
 
 =item siblingsMacro(@siblings)

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1141,15 +1141,28 @@ sub head {
 sub path {
 	my ($self, $args) = @_;
 
-	my $r = $self->{r};
-	my $setName = $r->urlpath->arg("setID");
-	my $ce = $self->{ce};
-	my $root = $ce->{webworkURLs}->{root};
+	my $r          = $self->{r};
+	my $ce         = $self->{ce};
+	my $setName    = $r->urlpath->arg("setID");
+	my $root       = $ce->{webworkURLs}{root};
 	my $courseName = $ce->{courseName};
 
-	return $self->pathMacro($args, "Home" => "$root",
+	return $self->pathMacro(
+		$args,
+		'Home'      => $root,
 		$courseName => "$root/$courseName",
-		$setName => "");
+		$setName eq "Undefined_Set" || $self->{invalidSet}
+		? ($setName => '')
+		: (
+			$self->{set}->set_id => "$root/"
+				. $r->urlpath->newFromModule(
+				'WeBWorK::ContentGenerator::ProblemSet', $r,
+				courseID => $courseName,
+				setID    => $self->{set}->set_id
+			)->path,
+			'v' . $self->{set}->version_id => ''
+		),
+	);
 }
 
 sub nav {


### PR DESCRIPTION
Instead of showing 'Home / courseId / setId,v?' in the breadcrumb, show 'Home / courseId / setId / v?'.  The `setId` in this is a link back to the new gateway quiz problem set page that lists the quiz versions and such.

Also, replace all underscores with spaces in the names displayed in the breadcrumb and don't convert those names to lowercase.  This just looks better.

For all pages, replace underscores in a path when it is used for a page title.  This used to be done this way, but for some reason it was commented out.  There is no situation where an underscore needs to be displayed in the page title.