### PR TITLE
Rework how reducedScoring is computed and stored.

### DIFF
--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -105,7 +105,6 @@ sub checkForAchievements {
     # $pg->{result} reflects the current submission, $pg->{state} holds the best result
     # close the unlimited achievement points loophole by only using the current result!
     $problem->status($pg->{result}->{score});
-    $problem->sub_status($pg->{state}->{sub_recorded_score});
     $problem->attempted(1);
     $problem->num_correct($pg->{state}->{num_of_correct_ans});
     $problem->num_incorrect($pg->{state}->{num_of_incorrect_ans});

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1456,11 +1456,17 @@ sub body {
 
 			# next, store the state in the database if that makes sense
 			if ($submitAnswers && $will{recordAnswers}) {
-				$problems[$i]->status(wwRound(2,$pg_results[$i]->{state}->{recorded_score}));
+				# Reduced scoring adjustments
+				my $new_score = WeBWorK::ContentGenerator::ProblemUtil::ProblemUtil::compute_reduced_score(
+						$self, $pureProblem, $set, $pg_results[$i]->{state}->{recorded_score});
+
+				$problems[$i]->status(wwRound(2,$new_score));
+				$problems[$i]->sub_status($pg_results[$i]->{state}->{recorded_score});
 				$problems[$i]->attempted(1);
 				$problems[$i]->num_correct($pg_results[$i]->{state}->{num_of_correct_ans});
 				$problems[$i]->num_incorrect($pg_results[$i]->{state}->{num_of_incorrect_ans});
-				$pureProblem->status(wwRound(2,$pg_results[$i]->{state}->{recorded_score}));
+				$pureProblem->status(wwRound(2,$new_score));
+				$pureProblem->sub_status($pg_results[$i]->{state}->{recorded_score});
 				$pureProblem->attempted(1);
 				$pureProblem->num_correct($pg_results[$i]->{state}->{num_of_correct_ans});
 				$pureProblem->num_incorrect($pg_results[$i]->{state}->{num_of_incorrect_ans});
@@ -1746,8 +1752,9 @@ sub body {
 			my $pScore = 0;
 			my $numParts = 0;
 			if (ref($pg)) {  # then we have a pg object
-				###
-				$pScore = $pg->{state}->{recorded_score};
+				# Reduced scoring adjustments
+				$pScore = WeBWorK::ContentGenerator::ProblemUtil::ProblemUtil::compute_reduced_score(
+						$self, $problems[$i], $set, $pg->{state}->{recorded_score});
 				$probStatus[$i] = $pScore;
 				$numParts = 1;
 				###

--- a/lib/WeBWorK/DB/Record/UserProblem.pm
+++ b/lib/WeBWorK/DB/Record/UserProblem.pm
@@ -43,14 +43,14 @@ BEGIN {
 		# periodic re-randomization number of attempts for the current seed
 		prCount => {type => "INT"},
 		problem_seed  => { type=>"INT" },
-		status        => { type=>"FLOAT" },
+		status        => { type=>"FLOAT" },   # The adjusted problem score
 		attempted     => { type=>"INT" },
 		last_answer   => { type=>"TEXT" },
 		num_correct   => { type=>"INT" },
 		num_incorrect => { type=>"INT" },
 		att_to_open_children => { type=>"INT" },
 		counts_parent_grade => { type=>"INT" },
-		sub_status    => { type=>"FLOAT" },    # A subsidiary status used to implement the reduced scoring period
+		sub_status    => { type=>"FLOAT" },    # The raw problem score before any adjustments
 		# a field for flags which need to be set
 		flags => { type=>"TEXT" },
 	);

--- a/lib/WeBWorK/PG/Local.pm
+++ b/lib/WeBWorK/PG/Local.pm
@@ -375,8 +375,7 @@ EOF
 		#warn "PG: retrieving the problem state and giving it to the translator\n";
 		
 		$translator->rh_problem_state({
-			recorded_score =>       $problem->status,
-			sub_recorded_score =>   $problem->sub_status,
+			recorded_score =>       $problem->sub_status, # using sub_status since it is the raw score.
 			num_of_correct_ans =>   $problem->num_correct,
 			num_of_incorrect_ans => $problem->num_incorrect,
 		});

--- a/lib/WeBWorK/PG/Remote.pm
+++ b/lib/WeBWorK/PG/Remote.pm
@@ -99,8 +99,7 @@ EOF
 		extra_packages_to_load => [ @extra_packages_to_load ],
 		envir                  => $envir,
 		problem_state          => {
-			recorded_score       => $problem->status,
-			sub_recorded_score =>   $problem->sub_status,
+			recorded_score       => $problem->sub_status, # Using sub_status since it is the raw score.
 			num_of_correct_ans   => $problem->num_correct,
 			num_of_incorrect_ans => $problem->num_incorrect,
 		},


### PR DESCRIPTION
This is paired with removing reducedScoring from PG. Instead webwork should handle taking the raw score from PG and adjusting the score based on reducedScoring options.

This adds a method `apply_reduced_scoring_adjustment` to ProblemUtils. This method needs to be run after the raw score is returned from PG, but before writing it to the database to apply any reduced scoring adjustments to the raw score. The method updates the current problem right before writing it to the database.

This also changes how the columns `status` and `sub_status` in the `problem_user` table are used. `status` still contains the actual adjusted grade used by webwork, while `sub_status` now stores the raw non adjusted grade. Provided the reducedScoringValue has not changed, it is possible to use the previous `status` and `sub_status` to recover the portion of the problem that was done before the reduced scoring date and the portion that was done after, so only the part of the problem done after the reduced scoring date is adjusted.

This needs to be merged with <https://github.com/openwebwork/pg/pull/650> and stems from the discussion <https://github.com/openwebwork/pg/issues/648>.

Now that `sub_status` contains the raw score, it is now possible to address some of the concerns mentioned by @Alex-Jordan for places that should check the raw score and not the adjusted score when determining what to due (such as conditional release or indicating that a problem has been completed).