### PR TITLE
Improve database usage by consolidating and removing database calls

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,22 @@
+# PBP .perltidyrc file
+-l=120  # Max line width is 120 cols
+-et=4   # Use tabs instead of spaces.
+-i=4    # Indent level is 4 cols
+-ci=4   # Continuation indent is 4 cols
+-b      # Write the file inline and create a .bak file
+-vt=0   # Minimal vertical tightness
+-cti=0  # No extra indentation for closing brackets
+-pt=2   # Maximum parenthesis tightness
+-bt=1   # Medium brace tightness
+-sbt=1  # Medium square bracket tightness
+-bbt=1  # Medium block brace tightness
+-nsfs   # No space before semicolons
+-nolq   # Don't outdent long quoted strings
+-mbl=1  # Do not allow multiple empty lines
+-ce     # Cuddled else
+-cb     # Cuddled blocks
+-nbbc   # Do not add blank lines before full length comments
+-nbot   # No line break on ternary
+-nlop   # No logical padding (this causes mixed tabs and spaces)
+-wn     # Weld nested containers
+-xci    # Extended continuation indentation

--- a/bin/importClassList.pl
+++ b/bin/importClassList.pl
@@ -69,7 +69,7 @@ my (@replaced, @added, @skipped);
 sub importUsersFromCSV {
 	my ($fileName, $createNew, $replaceExisting, @replaceList) = @_;
 
-	my @allUserIDs = grep {$_ !~ /^set_id:/} $db->listUsers;
+	my @allUserIDs = $db->listUsers;
 	my %allUserIDs = map { $_ => 1 } @allUserIDs;
 
 	my %replaceOK;

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -33,324 +33,309 @@ use WWSafe;
 
 sub checkForAchievements {
 
-    our $problem = shift;
-    my $pg = shift;
-    my $r = shift;
-    my %options = @_;
-    my $db = $r->db;
-    my $ce = $r->ce;
+	our $problem = shift;
+	my $pg      = shift;
+	my $r       = shift;
+	my %options = @_;
+	my $db      = $r->db;
+	my $ce      = $r->ce;
 
-    my $course_display_tz = $ce->{siteDefaults}{timezone};
-    # the following line from Utils.pm
-    $course_display_tz ||= "local";    # do our best to provide default vaules
+	my $course_display_tz = $ce->{siteDefaults}{timezone};
+	# the following line from Utils.pm
+	$course_display_tz ||= "local";    # do our best to provide default vaules
 
-    # Date and time for course timezone (may differ from the server timezone)
-    # Saved into separate array
-    # https://metacpan.org/pod/DateTime
-    my $dtCourseTime = DateTime->from_epoch( epoch => time(), time_zone  => $course_display_tz);
+	# Date and time for course timezone (may differ from the server timezone)
+	# Saved into separate array
+	# https://metacpan.org/pod/DateTime
+	my $dtCourseTime = DateTime->from_epoch(epoch => time(), time_zone => $course_display_tz);
 
-    #set up variables and get achievements
-    my $cheevoMessage = '';
-    my $user_id = $problem->user_id;
-    my $set_id = $problem->set_id;
-    # exit early if the set is to be ignored by achievements
-    foreach my $excludedSet (@{ $ce->{achievementExcludeSet} }) {
-	return '' if $set_id eq $excludedSet;
-    }
-    our $set = $db->getMergedSet($user_id,$problem->set_id);
-    my @allAchievementIDs = $db->listAchievements;
-    my @achievements = $db->getAchievements(@allAchievementIDs);
-    @achievements = sortAchievements(@achievements);
-    my $globalUserAchievement = $db->getGlobalUserAchievement($user_id);
+	#set up variables and get achievements
+	my $cheevoMessage = '';
+	my $user_id       = $problem->user_id;
+	my $set_id        = $problem->set_id;
 
-    my $isGatewaySet = ( $set->assignment_type =~ /gateway/ ) ? 1 : 0;
-    my $isJitarSet = ( $set->assignment_type eq 'jitar' ) ? 1 : 0;
+	# exit early if the set is to be ignored by achievements
+	foreach my $excludedSet (@{ $ce->{achievementExcludeSet} }) {
+		return '' if $set_id eq $excludedSet;
+	}
 
-    #### Temporary Transition Code ####
-    # If an achievement doesn't have either a number or an assignment_type
-    # then its probably an old achievement in which case we should
-    # update its assignment_type to include 'default'.
-    # This whole block of code can be removed once people have had time
-    # to transition over.  (I.E. around 2017)
+	our $set = $db->getMergedSet($user_id, $problem->set_id);
+	my @achievements          = sortAchievements($db->getAchievementsWhere());
+	my $globalUserAchievement = $db->getGlobalUserAchievement($user_id);
 
-    foreach my $achievement (@achievements) {
-      unless ($achievement->assignment_type || $achievement->number) {
-	$achievement->assignment_type('default');
-	$db->putAchievement($achievement);
-      }
-    }
+	my $isGatewaySet = ($set->assignment_type =~ /gateway/) ? 1 : 0;
+	my $isJitarSet   = ($set->assignment_type eq 'jitar')   ? 1 : 0;
 
-    ### End Transition Code.  ###
+	# If its a gateway set get the current version
+	if ($isGatewaySet) {
+		$set = $db->getSetVersion($user_id, $set_id, $options{setVersion});
+	}
 
+	# If no global data then initialize
+	if (not $globalUserAchievement) {
+		$globalUserAchievement = $db->newGlobalUserAchievement();
+		$globalUserAchievement->user_id($user_id);
+		$globalUserAchievement->achievement_points(0);
+		$db->addGlobalUserAchievement($globalUserAchievement);
+	}
 
-    # If its a gateway set get the current version
-    if ($isGatewaySet) {
-	$set = $db->getSetVersion($user_id, $set_id, $options{setVersion});
-    }
+	#update the problem with stuff from the pg.
+	# this is kind of a hack.  The achievement checking happens *before* the system has
+	# updated $problem with the new results from $pg.  So we cheat and update the
+	# important bits here.  The only thing that gets left behind is last_answer, which is
+	# still the previous last answer.
 
-    # If no global data then initialize
-    if (not $globalUserAchievement) {
-	$globalUserAchievement = $db->newGlobalUserAchievement();
-	$globalUserAchievement->user_id($user_id);
-	$globalUserAchievement->achievement_points(0);
-	$db->addGlobalUserAchievement($globalUserAchievement);
-    }
+	# $pg->{result} reflects the current submission, $pg->{state} holds the best result
+	# close the unlimited achievement points loophole by only using the current result!
+	$problem->status($pg->{result}->{score});
+	$problem->sub_status($pg->{state}->{sub_recorded_score});
+	$problem->attempted(1);
+	$problem->num_correct($pg->{state}->{num_of_correct_ans});
+	$problem->num_incorrect($pg->{state}->{num_of_incorrect_ans});
 
-    #update the problem with stuff from the pg.
-    # this is kind of a hack.  The achievement checking happens *before* the system has
-    # updated $problem with the new results from $pg.  So we cheat and update the
-    # important bits here.  The only thing that gets left behind is last_answer, which is
-    # still the previous last answer.
+	#These need to be "our" so that they can share to the safe container
+	our $counter;
+	our $maxCounter;
+	our $achievementPoints = $globalUserAchievement->achievement_points;
+	our $nextLevelPoints   = $globalUserAchievement->next_level_points;
+	our $localData         = {};
+	our $globalData        = {};
+	our $tags;
+	our @setProblems;
+	our @courseDateTime = (
+		$dtCourseTime->sec,   $dtCourseTime->min,  $dtCourseTime->hour, $dtCourseTime->day,
+		$dtCourseTime->month, $dtCourseTime->year, $dtCourseTime->day_of_week
+	);
 
-    # $pg->{result} reflects the current submission, $pg->{state} holds the best result
-    # close the unlimited achievement points loophole by only using the current result!
-    $problem->status($pg->{result}->{score});
-    $problem->sub_status($pg->{state}->{sub_recorded_score});
-    $problem->attempted(1);
-    $problem->num_correct($pg->{state}->{num_of_correct_ans});
-    $problem->num_incorrect($pg->{state}->{num_of_incorrect_ans});
+	my $compartment = new WWSafe;
 
-    #These need to be "our" so that they can share to the safe container
-    our $counter;
-    our $maxCounter;
-    our $achievementPoints = $globalUserAchievement->achievement_points;
-    our $nextLevelPoints = $globalUserAchievement->next_level_points;
-    our $localData = {};
-    our $globalData = {};
-    our $tags;
-    our @setProblems = ();
-    our @courseDateTime = ($dtCourseTime->sec,$dtCourseTime->min,$dtCourseTime->hour,$dtCourseTime->day,$dtCourseTime->month,$dtCourseTime->year,$dtCourseTime->day_of_week);
-
-    my $compartment = new WWSafe;
-
-    #initialize things that are ""
-    if (not $achievementPoints) {
+	#initialize things that are ""
+	if (not $achievementPoints) {
 		$achievementPoints = 0;
 		$globalUserAchievement->achievement_points(0);
-    }
+	}
 
-    #Methods alowed in the safe container
-    $compartment->permit(qw(time localtime));
+	#Methods alowed in the safe container
+	$compartment->permit(qw(time localtime));
 
-    #Thaw_Base64 globalData hash
-    if ($globalUserAchievement->frozen_hash) {
+	#Thaw_Base64 globalData hash
+	if ($globalUserAchievement->frozen_hash) {
 
 		$globalData = thaw_base64($globalUserAchievement->frozen_hash);
-    }
-
-    #Update a couple of "standard" variables in globalData hash.
-    my $allcorrect = 0;
-
-    if ($isGatewaySet) {
-	@setProblems = $db->getAllMergedProblemVersions($user_id, $set_id, $options{setVersion});
-    } else {
-	@setProblems = $db->getAllUserProblems( $user_id, $set_id);
-    }
-
-    # for gateway sets we have to do check all of the problems to see
-    # if we need to reward points since we submit all at once
-    # otherwise we only do the main problem.
-    my @problemsToCheck = ($problem);
-
-    if ($isGatewaySet) {
-	@problemsToCheck = @setProblems;
-    }
-
-    foreach my $thisProblem (@problemsToCheck) {
-
-	if ($thisProblem->status == 1 && $thisProblem->num_correct == 1) {
-	    $globalUserAchievement->achievement_points(
-		$globalUserAchievement->achievement_points +
-		$ce->{achievementPointsPerProblem});
-	    #this variable is shared and should be considered iffy
-	    $achievementPoints += $ce->{achievementPointsPerProblem};
-	    $globalData->{'completeProblems'} += 1;
-	    $allcorrect = 1;
-	}
-    }
-
-    #check and see of all problems are correct.  (also update the current
-    # problem in setProblems, since the database might be out of date)
-    my $index = 0;
-    foreach my $thisProblem (@setProblems) {
-	if ($thisProblem->problem_id eq $problem->problem_id) {
-	    $setProblems[$index] = $problem;
-	} elsif ($thisProblem->status != 1) {
-	    $allcorrect = 0;
-	}
-	$index++;
-    }
-
-    if ($allcorrect) {
-	$globalData->{'completeSets'}++;
-    }
-
-    # get the problem tags if its not a gatway
-    # if it is a gateway get rid of $problem since it doensn't make sense
-    if ($isGatewaySet) {
-	$problem = undef;
-    } else {
-	my $templateDir = $ce->{courseDirs}->{templates};
-	$tags = WeBWorK::Utils::Tags->new($templateDir.'/'.$problem->source_file());
-    }
-
-    #These variables are shared with the safe compartment.  The achievement evaulators
-    # have access too
-    # $problem - the problem data;
-    # @setProblems - the problem data for everything from this set;
-    # $localData - the hash that is used only for this achievement
-    # $globalData - the hash that is shared between all achievements
-    # $maxCounter - the "max counter" associated with this achievement (if there is one);
-    # $counter - the "counter" associated with this achievement (used in level bars)
-    # $nextLevelPoints - only should be used by 'level' achievements
-    # $set - the set data
-    # $achievementPoints - the number of achievmeent points
-    # $tags -this is the tag data associated to the problem from the problem library
-    # @courseDateTime - array of time information in course timezone (sec,min,hour,day,month,year,day_of_week)
-
-    $compartment->share(qw( $problem @setProblems $localData $maxCounter
-             $globalData $counter $nextLevelPoints $set $achievementPoints $tags @courseDateTime));
-
-    #load any preamble code
-    # this line causes the whole file to be read into one string
-    local $/;
-    my $preamble = '';
-    my $source;
-    if (-e
-	"$ce->{courseDirs}->{achievements}/$ce->{achievementPreambleFile}") {
-	open(PREAMB, '<', "$ce->{courseDirs}->{achievements}/$ce->{achievementPreambleFile}");
-	$preamble = <PREAMB>;
-	close(PREAMB);
-    }
-    #loop through the various achievements, see if they have been obtained,
-    foreach my $achievement (@achievements) {
-	#skip achievements not assigned, not enabled, and that are already earned, or if it doesn't match the set type
-	next unless $achievement->enabled;
-	my $achievement_id = $achievement->achievement_id;
-	next unless ($db->existsUserAchievement($user_id,$achievement_id));
-	my $userAchievement = $db->getUserAchievement($user_id,$achievement_id);
-	next if ($userAchievement->earned);
-	my $setType = $set->assignment_type;
-	next unless $achievement->assignment_type =~ /$setType/;
-
-	#thaw_base64 localData hash
-	if ($userAchievement->frozen_hash) {
-	    $localData = thaw_base64($userAchievement->frozen_hash);
 	}
 
-	#recover counter information (for progress bar achievements)
-	$counter = $userAchievement->counter;
-	$maxCounter = $achievement->max_counter;
+	#Update a couple of "standard" variables in globalData hash.
+	my $allcorrect = 0;
 
-	#check the achievement using Safe
-	my $sourceFilePath = $ce->{courseDirs}->{achievements}.'/'.$achievement->test;
-	if (-e $sourceFilePath) {
-	    open(SOURCE,'<',$sourceFilePath);
-	    $source = <SOURCE>;
-	    close(SOURCE);
+	if ($isGatewaySet) {
+		@setProblems = $db->getAllMergedProblemVersions($user_id, $set_id, $options{setVersion});
 	} else {
-	    warn('Couldnt find achievement evaluator $sourceFilePath');
-	    next;
-	};
+		@setProblems = $db->getAllUserProblems($user_id, $set_id);
+	}
 
-	my $earned = $compartment->reval($preamble."\n".$source);
-	warn "There were errors in achievement $achievement_id\n".$@ if $@;
+	# for gateway sets we have to do check all of the problems to see
+	# if we need to reward points since we submit all at once
+	# otherwise we only do the main problem.
+	my @problemsToCheck = ($problem);
 
-	#if we have a new achievement then update achievement points
-	if ($earned) {
-	    $userAchievement->earned(1);
+	if ($isGatewaySet) {
+		@problemsToCheck = @setProblems;
+	}
 
-	    if ($achievement->category eq 'level') {
-			$globalUserAchievement->level_achievement_id($achievement_id);
-			$globalUserAchievement->next_level_points($nextLevelPoints);
-	    }
+	foreach my $thisProblem (@problemsToCheck) {
 
-	    #build the cheevo message. New level messages are slightly different
-	    my $imgSrc = $ce->{server_root_url};
-	    if ($achievement->{icon}) {
-			$imgSrc .= $ce->{courseURLs}->{achievements}."/".$achievement->{icon};
-	    } else {
-			$imgSrc .= $ce->{webworkURLs}->{htdocs}."/images/defaulticon.png";
-	    }
+		if ($thisProblem->status == 1 && $thisProblem->num_correct == 1) {
+			$globalUserAchievement->achievement_points(
+				$globalUserAchievement->achievement_points + $ce->{achievementPointsPerProblem});
+			#this variable is shared and should be considered iffy
+			$achievementPoints += $ce->{achievementPointsPerProblem};
+			$globalData->{'completeProblems'} += 1;
+			$allcorrect = 1;
+		}
+	}
 
-	    $cheevoMessage .= CGI::start_div({
-			   	class => 'cheevo-toast toast hide',
-				role => 'alert',
-				aria_live => 'polite',
-				aria_atomic => 'true'
-		   	});
-		$cheevoMessage .= CGI::start_div({ class => 'toast-body d-flex align-items-center' });
+	#check and see of all problems are correct.  (also update the current
+	# problem in setProblems, since the database might be out of date)
+	my $index = 0;
+	foreach my $thisProblem (@setProblems) {
+		if ($thisProblem->problem_id eq $problem->problem_id) {
+			$setProblems[$index] = $problem;
+		} elsif ($thisProblem->status != 1) {
+			$allcorrect = 0;
+		}
+		$index++;
+	}
 
-	    $cheevoMessage .= CGI::img({src=>$imgSrc, alt=>'Achievement Icon'});
+	$globalData->{'completeSets'}++ if ($allcorrect);
 
-	    $cheevoMessage .= CGI::start_div({class=>'cheevopopuptext'});
-	    if ($achievement->category eq 'level') {
-			$cheevoMessage = $cheevoMessage . CGI::h2("$achievement->{name}");
-			# Print the description as part of the message if we are using items.
-			$cheevoMessage .= CGI::div($ce->{achievementItemsEnabled}
-				? $achievement->{description}
-				: $r->maketext("Congratulations, you earned a new level!"));
-	    } else {
-			$cheevoMessage .= CGI::h2("$achievement->{name}");
-			$cheevoMessage .= CGI::div("<i>$achievement->{points} Points</i>: $achievement->{description}");
-	    }
-		$cheevoMessage .= CGI::end_div();
+	# get the problem tags if its not a gatway
+	# if it is a gateway get rid of $problem since it doensn't make sense
+	if ($isGatewaySet) {
+		$problem = undef;
+	} else {
+		my $templateDir = $ce->{courseDirs}->{templates};
+		$tags = WeBWorK::Utils::Tags->new($templateDir . '/' . $problem->source_file());
+	}
 
-		# This feature doesn't really work anymore because of a change in facebook's api.
-	    # If facebook integration is enabled, then create a facebook popup.
-	    if ($ce->{allowFacebooking}&& $globalUserAchievement->facebooker) {
-			$cheevoMessage .= CGI::div({id=>'fb-root'},'');
-			$cheevoMessage .= CGI::script({src=>'http://connect.facebook.net/en_US/all.js'},'');
-			$cheevoMessage .= CGI::start_script();
+	#These variables are shared with the safe compartment.  The achievement evaulators
+	# have access too
+	# $problem - the problem data;
+	# @setProblems - the problem data for everything from this set;
+	# $localData - the hash that is used only for this achievement
+	# $globalData - the hash that is shared between all achievements
+	# $maxCounter - the "max counter" associated with this achievement (if there is one);
+	# $counter - the "counter" associated with this achievement (used in level bars)
+	# $nextLevelPoints - only should be used by 'level' achievements
+	# $set - the set data
+	# $achievementPoints - the number of achievmeent points
+	# $tags -this is the tag data associated to the problem from the problem library
+	# @courseDateTime - array of time information in course timezone (sec,min,hour,day,month,year,day_of_week)
 
-			$cheevoMessage .= "FB.init({appId:'".$ce->{facebookAppId}."', cookie:true,status:true, xfbml:true });\n";
+	$compartment->share(qw( $problem @setProblems $localData $maxCounter
+		$globalData $counter $nextLevelPoints $set $achievementPoints $tags @courseDateTime));
 
-			my $facebookmessage;
+	#load any preamble code
+	# this line causes the whole file to be read into one string
+	local $/;
+	my $preamble = '';
+	my $source;
+	if (-e "$ce->{courseDirs}->{achievements}/$ce->{achievementPreambleFile}") {
+		open(PREAMB, '<', "$ce->{courseDirs}->{achievements}/$ce->{achievementPreambleFile}");
+		$preamble = <PREAMB>;
+		close(PREAMB);
+	}
+	#loop through the various achievements, see if they have been obtained,
+	foreach my $achievement (@achievements) {
+		#skip achievements not assigned, not enabled, and that are already earned, or if it doesn't match the set type
+		next unless $achievement->enabled;
+		my $achievement_id = $achievement->achievement_id;
+		next unless ($db->existsUserAchievement($user_id, $achievement_id));
+		my $userAchievement = $db->getUserAchievement($user_id, $achievement_id);
+		next if ($userAchievement->earned);
+		my $setType = $set->assignment_type;
+		next unless $achievement->assignment_type =~ /$setType/;
+
+		#thaw_base64 localData hash
+		if ($userAchievement->frozen_hash) {
+			$localData = thaw_base64($userAchievement->frozen_hash);
+		}
+
+		#recover counter information (for progress bar achievements)
+		$counter    = $userAchievement->counter;
+		$maxCounter = $achievement->max_counter;
+
+		#check the achievement using Safe
+		my $sourceFilePath = $ce->{courseDirs}->{achievements} . '/' . $achievement->test;
+		if (-e $sourceFilePath) {
+			open(SOURCE, '<', $sourceFilePath);
+			$source = <SOURCE>;
+			close(SOURCE);
+		} else {
+			warn('Couldnt find achievement evaluator $sourceFilePath');
+			next;
+		}
+
+		my $earned = $compartment->reval($preamble . "\n" . $source);
+		warn "There were errors in achievement $achievement_id\n" . $@ if $@;
+
+		#if we have a new achievement then update achievement points
+		if ($earned) {
+			$userAchievement->earned(1);
+
 			if ($achievement->category eq 'level') {
-				$facebookmessage = sprintf("I leveled up and am now a %s",$achievement->{name});
-			} else {
-				$facebookmessage = sprintf("%s: %s",$achievement->{name},$achievement->{description});
+				$globalUserAchievement->level_achievement_id($achievement_id);
+				$globalUserAchievement->next_level_points($nextLevelPoints);
 			}
 
-			$cheevoMessage .= "FB.ui({ method: 'feed', display: 'popup', picture: '$imgSrc', description: '$facebookmessage'});\n";
-			$cheevoMessage .= CGI::end_script();
-	    }
+			#build the cheevo message. New level messages are slightly different
+			my $imgSrc = $ce->{server_root_url};
+			if ($achievement->{icon}) {
+				$imgSrc .= $ce->{courseURLs}->{achievements} . "/" . $achievement->{icon};
+			} else {
+				$imgSrc .= $ce->{webworkURLs}->{htdocs} . "/images/defaulticon.png";
+			}
 
-		$cheevoMessage .= q{<button type="button" class="btn-close me-2 m-auto"
+			$cheevoMessage .= CGI::start_div({
+				class       => 'cheevo-toast toast hide',
+				role        => 'alert',
+				aria_live   => 'polite',
+				aria_atomic => 'true'
+			});
+			$cheevoMessage .= CGI::start_div({ class => 'toast-body d-flex align-items-center' });
+
+			$cheevoMessage .= CGI::img({ src => $imgSrc, alt => 'Achievement Icon' });
+
+			$cheevoMessage .= CGI::start_div({ class => 'cheevopopuptext' });
+			if ($achievement->category eq 'level') {
+				$cheevoMessage = $cheevoMessage . CGI::h2("$achievement->{name}");
+				# Print the description as part of the message if we are using items.
+				$cheevoMessage .=
+					CGI::div($ce->{achievementItemsEnabled}
+						? $achievement->{description}
+						: $r->maketext("Congratulations, you earned a new level!"));
+			} else {
+				$cheevoMessage .= CGI::h2("$achievement->{name}");
+				$cheevoMessage .= CGI::div("<i>$achievement->{points} Points</i>: $achievement->{description}");
+			}
+			$cheevoMessage .= CGI::end_div();
+
+			# This feature doesn't really work anymore because of a change in facebook's api.
+			# If facebook integration is enabled, then create a facebook popup.
+			if ($ce->{allowFacebooking} && $globalUserAchievement->facebooker) {
+				$cheevoMessage .= CGI::div({ id => 'fb-root' }, '');
+				$cheevoMessage .= CGI::script({ src => 'http://connect.facebook.net/en_US/all.js' }, '');
+				$cheevoMessage .= CGI::start_script();
+
+				$cheevoMessage .=
+					"FB.init({appId:'" . $ce->{facebookAppId} . "', cookie:true,status:true, xfbml:true });\n";
+
+				my $facebookmessage;
+				if ($achievement->category eq 'level') {
+					$facebookmessage = sprintf("I leveled up and am now a %s", $achievement->{name});
+				} else {
+					$facebookmessage = sprintf("%s: %s", $achievement->{name}, $achievement->{description});
+				}
+
+				$cheevoMessage .=
+					"FB.ui({ method: 'feed', display: 'popup', picture: '$imgSrc', description: '$facebookmessage'});\n";
+				$cheevoMessage .= CGI::end_script();
+			}
+
+			$cheevoMessage .= q{<button type="button" class="btn-close me-2 m-auto"
 								data-bs-dismiss="toast" aria-label="Close"></button>};
-	    $cheevoMessage .= CGI::end_div() . CGI::end_div();
+			$cheevoMessage .= CGI::end_div() . CGI::end_div();
 
+			my $points = $achievement->points;
+			#just in case points is an ininitialzied variable
+			$points = 0 unless $points;
 
-	    my $points = $achievement->points;
-	    #just in case points is an ininitialzied variable
-	    $points = 0 unless $points;
+			$globalUserAchievement->achievement_points($globalUserAchievement->achievement_points + $points);
+			#this variable is shared and should be considered iffy
+			$achievementPoints += $points;
+		}
 
-	    $globalUserAchievement->achievement_points(
-		$globalUserAchievement->achievement_points + $points);
-	    #this variable is shared and should be considered iffy
-	    $achievementPoints += $points;
+		#update counter, nfreeze_base64 localData and store
+		$userAchievement->counter($counter);
+		$userAchievement->frozen_hash(nfreeze_base64($localData));
+		$db->putUserAchievement($userAchievement);
+
+	}    #end for loop
+
+	#nfreeze_base64 globalData and store
+	$globalUserAchievement->frozen_hash(nfreeze_base64($globalData));
+	$db->putGlobalUserAchievement($globalUserAchievement);
+
+	if ($cheevoMessage) {
+		$cheevoMessage = CGI::div(
+			{
+				class => "cheevo-toast-container toast-container "
+					. "position-absolute top-0 start-50 translate-middle-x p-3"
+			},
+			$cheevoMessage
+		);
 	}
 
-	#update counter, nfreeze_base64 localData and store
-	$userAchievement->counter($counter);
-	$userAchievement->frozen_hash(nfreeze_base64($localData));
-	$db->putUserAchievement($userAchievement);
-
-    }  #end for loop
-
-    #nfreeze_base64 globalData and store
-    $globalUserAchievement->frozen_hash(nfreeze_base64($globalData));
-    $db->putGlobalUserAchievement($globalUserAchievement);
-
-    if ($cheevoMessage) {
-		$cheevoMessage = CGI::div({
-				class => "cheevo-toast-container toast-container " .
-					"position-absolute top-0 start-50 translate-middle-x p-3"
-			}, $cheevoMessage);
-    }
-
-    return $cheevoMessage;
+	return $cheevoMessage;
 }
 
-#Perl magic
 1;

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -23,19 +23,19 @@ WeBWorK::Authen - Check user identity, manage session keys.
 
  # get the name of the appropriate Authen class, based on the %authen hash in $ce
  my $class_name = WeBWorK::Authen::class($ce, "user_module");
- 
+
  # load that class
  require $class_name;
- 
+
  # create an authen object
  my $authen = $class_name->new($r);
- 
+
  # verify credentials
  $authen->verify or die "Authentication failed";
- 
+
  # verification status is stored for quick retrieval later
  my $auth_ok = $authen->was_verified;
- 
+
  # for some reason, you might want to clear that cache
  $authen->forget_verification;
 
@@ -73,7 +73,7 @@ use Caliper::Entity;
 #use vars qw($GENERIC_ERROR_MESSAGE);
 our $GENERIC_ERROR_MESSAGE = "";  # define in new
 
-## WeBWorK-tr end modification 
+## WeBWorK-tr end modification
 #####################
 
 #use constant GENERIC_ERROR_MESSAGE => "Invalid user ID or password.";
@@ -109,7 +109,7 @@ the %authen hash, an exception is thrown.
 
 sub class {
 	my ($ce, $type) = @_;
-	
+
 	if (exists $ce->{authen}{$type}) {
 		if (ref $ce->{authen}{$type} eq "ARRAY") {
 			my $authen_type = shift @{$ce ->{authen}{$type}};
@@ -147,7 +147,7 @@ sub call_next_authen_method {
 	my $ce = $r -> {ce};
 
 	my $user_authen_module = WeBWorK::Authen::class($ce, "user_module");
-	#debug("user_authen_module = |$user_authen_module|");	
+	#debug("user_authen_module = |$user_authen_module|");
 	if (!defined($user_authen_module) or ($user_authen_module eq "")) {
 		$self->{error} = $r->maketext("No authentication method found for your request.  If this recurs, please speak with your instructor.");
 		$self->{log_error} .= "None of the specified authentication modules could handle the request.";
@@ -217,13 +217,13 @@ sub verify {
 	my $result = $self->do_verify;
 	my $error = $self->{error};
 	my $log_error = $self->{log_error};
-	
+
 	$self->{was_verified} = $result ? 1 : 0;
-	
+
 	if ($self->can("site_fixup")) {
 		$self->site_fixup;
 	}
-	
+
 	if ($result) {
 		$self->write_log_entry("LOGIN OK") if $self->{initial_login};
 		$self->maybe_send_cookie;
@@ -232,7 +232,7 @@ sub verify {
 		if (defined $log_error) {
 			$self->write_log_entry("LOGIN FAILED $log_error");
 		}
-		if (defined($error) and $error=~/\S/) { # if error message has a least one non-space character. 
+		if (defined($error) and $error=~/\S/) { # if error message has a least one non-space character.
 			if ( defined( $log_error ) and $log_error eq "inactivity timeout" ) {
 				# We don't want to override the localized inactivity timeout message.
 				# so do not check next "if" in this case.
@@ -243,12 +243,12 @@ sub verify {
 		}
         #warn "LOGIN FAILED: log_error: $log_error; user error: $error";
 		$self->maybe_kill_cookie;
-		if (defined($error) and $error=~/\S/ and $r->can('notes') ) { # if error message has a least one non-space character. 
+		if (defined($error) and $error=~/\S/ and $r->can('notes') ) { # if error message has a least one non-space character.
 			MP2? $r->notes->set(authen_error => $error) : $r->notes("authen_error" => $error);
 		      # FIXME this is a hack to accomodate the webworkservice remixes
 		}
 	}
-	
+
 	my $caliper_sensor = Caliper::Sensor->new($self->{r}->ce);
 	if ($caliper_sensor->caliperEnabled() && $result && $self->{initial_login}) {
 		my $login_event = {
@@ -273,7 +273,7 @@ Returns true if verify() returned true the last time it was called.
 
 sub was_verified {
 	my ($self) = @_;
-	
+
 	return 1 if exists $self->{was_verified} and $self->{was_verified};
 	return 0;
 }
@@ -288,9 +288,9 @@ sub forget_verification {
 	my ($self) = @_;
 	my $r = $self -> {r};
 	my $ce = $r -> {ce};
-	
+
 	$self->{was_verified} = 0;
-	
+
 }
 
 =back
@@ -306,14 +306,13 @@ sub do_verify {
 	my $r = $self->{r};
 	my $ce = $r->ce;
 	my $db = $r->db;
-	
+
 	return 0 unless $db;
 	debug("db ok");
 	return 0 unless $self->get_credentials;
 	debug("credentials ok");
 	return 0 unless $self->check_user;
 	debug ("check user ok");
-	my $practiceUserPrefix = $ce->{practiceUserPrefix};
 	if (defined($self->{login_type}) && $self->{login_type} eq "guest"){
 		return $self->verify_practice_user;
 	} else {
@@ -343,18 +342,16 @@ sub get_credentials {
 	# allow guest login: if the "Guest Login" button was clicked, we find an unused
 	# practice user and create a session for it.
 	if ($r->param("login_practice_user")) {
-		my $practiceUserPrefix = $ce->{practiceUserPrefix};
-		# DBFIX search should happen in database
-		my @guestUserIDs = grep m/^$practiceUserPrefix/, $db->listUsers;
-		my @GuestUsers = $db->getUsers(@guestUserIDs);
-		my @allowedGuestUsers = grep { $ce->status_abbrev_has_behavior($_->status, "allow_course_access") } @GuestUsers;
-		my @allowedGuestUserIDs = map { $_->user_id } @allowedGuestUsers;
+		my @allowedGuestUserIDs =
+			map  { $_->user_id }
+			grep { $ce->status_abbrev_has_behavior($_->status, "allow_course_access") }
+			$db->getUsersWhere({ user_id => { like => "$ce->{practiceUserPrefix}\%" } });
 
-		foreach my $userID (List::Util::shuffle(@allowedGuestUserIDs)) {
+		for my $userID (List::Util::shuffle(@allowedGuestUserIDs)) {
 			if (not $self->unexpired_session_exists($userID)) {
 				my $newKey = $self->create_session($userID);
 				$self->{initial_login} = 1;
-				
+
 				$self->{user_id} = $userID;
 				$self->{session_key} = $newKey;
 				$self->{login_type} = "guest";
@@ -363,12 +360,12 @@ sub get_credentials {
 				return 1;
 			}
 		}
-		
+
 		$self->{log_error} = "no guest logins are available";
 		$self->{error} = $r->maketext("No guest logins are available. Please try again in a few minutes.");
 		return 0;
 	}
-	
+
 	my ($cookieUser, $cookieKey, $cookieTimeStamp) = $self->fetchCookie;
 
 	if (defined $cookieUser and defined $r->param("user") ) {
@@ -416,7 +413,7 @@ sub get_credentials {
 				"' cookie_timestamp '", $self->{cookieTimeStamp}, "' "
 			);
 			return 1;
-		}	
+		}
 	}
 	# at least the user ID is available in request parameters
 	if (defined $r->param("user")) {
@@ -431,7 +428,7 @@ sub get_credentials {
 		debug("params password '", $self->{password}, "' key '", $self->{session_key}, "'");
 		return 1;
 	}
-	
+
 	if (defined $cookieUser) {
 		$self->{user_id} = $cookieUser;
 		$self->{session_key} = $cookieKey;
@@ -453,37 +450,37 @@ sub check_user {
 	my $ce = $r->ce;
 	my $db = $r->db;
 	my $authz = $r->authz;
-	
+
 	my $user_id = $self->{user_id};
-	
+
 	if (defined $user_id and $user_id eq "") {
 		$self->{log_error} = "no user id specified";
 		$self->{error} .= $r->maketext("You must specify a user ID.");
 		return 0;
 	}
-	
+
 	my $User = $db->getUser($user_id);
-	
+
 	unless ($User) {
 		$self->{log_error} = "user unknown";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	# FIXME "fix invalid status values" used to be here, but it needs to move to $db->getUser
-	
+
 	unless ($ce->status_abbrev_has_behavior($User->status, "allow_course_access")) {
 		$self->{log_error} = "user not allowed course access";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	unless ($authz->hasPermissions($user_id, "login")) {
 		$self->{log_error} = "user not permitted to login";
 		$self->{error} = $GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	return 1;
 }
 
@@ -491,13 +488,13 @@ sub verify_practice_user {
 	my $self = shift;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $user_id = $self->{user_id};
 	my $session_key = $self->{session_key};
-	
+
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 1);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	if ($sessionExists) {
 		if ($keyMatches) {
 			if ($timestampValid) {
@@ -535,18 +532,18 @@ sub verify_practice_user {
 sub verify_normal_user {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	my $user_id = $self->{user_id};
 	my $session_key = $self->{session_key};
-	
+
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 1);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
-	
+
 	if ($sessionExists and $keyMatches and $timestampValid) {
 		return 1;
 	} else {
 		my $auth_result = $self->authenticate;
-		
+
 		if ($auth_result > 0) {
 			$self->{session_key} = $self->create_session($user_id);
 			$self->{initial_login} = 1;
@@ -571,10 +568,10 @@ sub verify_normal_user {
 sub authenticate {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	my $user_id = $self->{user_id};
 	my $password = $self->{password};
-	
+
 	if (defined $password) {
 		return $self->checkPassword($user_id, $password);
 	} else {
@@ -586,32 +583,32 @@ sub maybe_send_cookie {
 	my $self = shift;
 	my $r = $self->{r};
 	my $ce = $r -> {ce};
-	
+
 	my ($cookie_user, $cookie_key, $cookie_timestamp) = $self->fetchCookie;
-	
+
 	# we send a cookie if any of these conditions are met:
-	
+
 	# (a) a cookie was used for authentication
 	my $used_cookie = ($self->{credential_source} eq "cookie");
-	
+
 	# (b) a cookie was sent but not used for authentication, and the
 	#     credentials used for authentication were the same as those in
 	#     the cookie
 	my $unused_valid_cookie = ($self->{credential_source} ne "cookie"
 		and defined $cookie_user and $self->{user_id} eq $cookie_user
 		and defined $cookie_key and $self->{session_key} eq $cookie_key);
-	
+
 	# (c) the user asked to have a cookie sent and is not a guest user.
 	my $user_requests_cookie = ($self->{login_type} ne "guest"
 		and ( $r->param("send_cookie")//0 )); # prevent warning if "send_cookie" param is not defined.
 
 	# (d) session management is done via cookies.
-	my $session_management_via_cookies = 
+	my $session_management_via_cookies =
 		$ce -> {session_management_via} eq "session_cookie";
-	
-	debug("used_cookie='", $used_cookie, "' unused_valid_cookie='", $unused_valid_cookie, "' user_requests_cookie='", $user_requests_cookie, 
+
+	debug("used_cookie='", $used_cookie, "' unused_valid_cookie='", $unused_valid_cookie, "' user_requests_cookie='", $user_requests_cookie,
 			"' session_management_via_cookies ='", $session_management_via_cookies, "'");
-	
+
 	if ($used_cookie or $unused_valid_cookie or $user_requests_cookie or $session_management_via_cookies) {
 		#debug("Authen::maybe_send_cookie is sending a cookie");
 		$self->sendCookie($self->{user_id}, $self->{session_key});
@@ -628,12 +625,12 @@ sub maybe_kill_cookie {
 sub set_params {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	# A2 - params are not non-modifiable, with no explanation or workaround given in docs. WTF!
 	$r->param("user", $self->{user_id});
 	$r->param("key", $self->{session_key});
 	$r->param("passwd", "");
-	
+
 	debug("params user='", $r->param("user"), "' key='", $r->param("key"), "'");
 }
 
@@ -644,16 +641,16 @@ sub set_params {
 sub checkPassword {
 	my ($self, $userID, $possibleClearPassword) = @_;
 	my $db = $self->{r}->db;
-	
+
 	my $Password = $db->getPassword($userID); # checked
 	if (defined $Password) {
 		# check against WW password database
 		my $possibleCryptPassword = crypt $possibleClearPassword, $Password->password;
 		my $dbPassword = $Password->password;
-		# This next line explicitly insures that 
-		# blank or null passwords from the database can never 
+		# This next line explicitly insures that
+		# blank or null passwords from the database can never
 		# succeed in matching an entered password
-		# Use case: Moodle wwassignment stores null passwords and forces the creation 
+		# Use case: Moodle wwassignment stores null passwords and forces the creation
 		# of a key -- Moodle wwassignment does not use  passwords for authentication, only keys.
 		# The following line was modified to also reject cases when the database has a crypted password
 		# which matches a submitted all white-space or null password by requiring that the
@@ -683,12 +680,12 @@ sub checkPassword {
 }
 
 # Site-specific password checking
-# 
+#
 # The site_checkPassword routine can be used to provide a hook to your institution's
 # authentication system. If authentication against the  course's password database, the
 # method $self->site_checkPassword($userID, $clearTextPassword) is called. If this
 # method returns a true value, authentication succeeds.
-# 
+#
 # Here is an example site_checkPassword which checks the password against the Ohio State
 # popmail server:
 # 	sub site_checkPassword {
@@ -700,7 +697,7 @@ sub checkPassword {
 # 		}
 # 		return 0;
 # 	}
-# 
+#
 # Since you have access to the WeBWorK::Authen object, the possibilities are limitless!
 # This example checks the password against the system password database and updates the
 # user's password in the course database if it succeeds:
@@ -730,7 +727,7 @@ sub unexpired_session_exists {
 	my ($self, $userID) = @_;
 	my $ce = $self->{r}->ce;
 	my $db = $self->{r}->db;
-	
+
 	my $Key = $db->getKey($userID); # checked
 	return 0 unless defined $Key;
 	if (time <= $Key->timestamp()+$ce->{sessionKeyTimeout}) {
@@ -753,26 +750,26 @@ sub create_session {
 	my ($self, $userID, $newKey) = @_;
 	my $ce = $self->{r}->ce;
 	my $db = $self->{r}->db;
-	
+
 	my $timestamp = time;
 	unless ($newKey) {
 		my @chars = @{ $ce->{sessionKeyChars} };
 		my $length = $ce->{sessionKeyLength};
-		
+
 		srand;
 		$newKey = join ("", @chars[map rand(@chars), 1 .. $length]);
 	}
-	
-	my $Key = $db->newKey(user_id=>$userID, key=>$newKey, timestamp=>$timestamp);
+
+	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => $timestamp);
 	# DBFIXME this should be a REPLACE
 	eval { $db->deleteKey($userID) };
-	eval {$db->addKey($Key)};
-	my $fail_to_addKey=1 if $@;
+	eval { $db->addKey($Key) };
+	my $fail_to_addKey = 1 if $@;
 	if ($fail_to_addKey) {
 		warn "Difficulty adding key for userID $userID: $@ ";
 	}
 	if ($fail_to_addKey) {
-		eval {$db->putKey($Key) };
+		eval { $db->putKey($Key) };
 		warn "Couldn't put key for userid $userID either: $@" if $@;
 	}
 
@@ -854,9 +851,9 @@ sub fetchCookie {
 	my $r = $self->{r};
 	my $ce = $r->ce;
 	my $urlpath = $r->urlpath;
-	
+
 	my $courseID = $urlpath->arg("courseID");
-	
+
 	my $cookie = undef;
 	my %cookies = WeBWorK::Cookie->fetch();
 	$cookie = $cookies{"WeBWorKCourseAuthen.$courseID"};
@@ -951,11 +948,11 @@ sub write_log_entry {
 	my ($self, $message) = @_;
 	my $r = $self->{r};
 	my $ce = $r->ce;
-	
+
 	my $user_id = defined $self->{user_id} ? $self->{user_id} : "";
 	my $login_type = defined $self->{login_type} ? $self->{login_type} : "";
 	my $credential_source = defined $self->{credential_source} ? $self->{credential_source} : "";
-	
+
 	my ($remote_host, $remote_port);
 
 	my $APACHE24 = 0;
@@ -968,7 +965,7 @@ sub write_log_entry {
 		$ce->{server_apache_version}) {
 		$version = $ce->{server_apache_version};
 	    # otherwise try and get it from the banner
-	    } elsif (Apache2::ServerUtil::get_server_banner() =~ 
+	    } elsif (Apache2::ServerUtil::get_server_banner() =~
 	  m:^Apache/(\d\.\d+):) {
 		$version = $1;
 	    }
@@ -985,7 +982,7 @@ sub write_log_entry {
 		$remote_host = "UNKNOWN" unless defined $remote_host;
 		$remote_port = "UNKNOWN" unless defined $remote_port;
 		$user_agent = "UNKNOWN";
-	} else { 
+	} else {
 		if ($APACHE24) {
 			$remote_host = $r->connection->client_addr->ip_get || "UNKNOWN";
 			$remote_port = $r->connection->client_addr->port   || "UNKNOWN";

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -694,18 +694,12 @@ sub links {
 
 	my $prettyProblemID = $problemID;
 
-	# it's possible that the setID and the problemID are invalid, since they're just taken from the URL path info
+	# It's possible that the setID and the problemID are invalid, since they're just taken from the URL path info.
 	if ($authen->was_verified) {
-		# DBFIXME testing for existence by keyfields -- don't need fetch record
-		if (defined $setID and $db->getUserSet($eUserID, $setID)) {
-
-			if (defined $problemID and $db->getUserProblem($eUserID, $setID, $problemID)) {
-				# both set and poblem exist -- do nothing
-			} else {
-				$problemID = undef;
-			}
+		if (defined $setID && $db->existsUserSet($eUserID, $setID)) {
+			$problemID = undef unless (defined $problemID && $db->existsUserProblem($eUserID, $setID, $problemID));
 		} else {
-			$setID = undef;
+			$setID     = undef;
 			$problemID = undef;
 		}
 	}
@@ -1228,12 +1222,7 @@ $self->{status_message}, if it is present.
 
 sub message {
 	my ($self) = @_;
-
-	print '<!-- BEGIN ' . __PACKAGE__ . '::message -->';
-	print $self->{status_message}
-		if exists $self->{status_message};
-	print '<!-- END ' . __PACKAGE__ . '::message -->';
-
+	print $self->{status_message} if $self->{status_message};
 	return '';
 }
 

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -368,7 +368,6 @@ sub getFeedbackRecipients {
 	my @recipients;
 
 	# send to all users with permission to receive_feedback and an email address
-	# DBFIXME iterator?
 	foreach my $rcptName ($db->listUsers()) {
 		if ($authz->hasPermissions($rcptName, "receive_feedback")) {
 			my $rcpt = $db->getUser($rcptName); # checked

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -32,7 +32,7 @@ use WeBWorK::PG;
 use WeBWorK::PG::ImageGenerator;
 use WeBWorK::PG::IO;
 use WeBWorK::Utils qw(writeLog writeCourseLog encodeAnswers decodeAnswers
-	ref2string makeTempDirectory path_is_subdir sortByName before after
+	ref2string makeTempDirectory path_is_subdir before after
 	between wwRound is_restricted);  # use the ContentGenerator formatDateTime, not the version in Utils
 use WeBWorK::DB::Utils qw(global2user user2global);
 use WeBWorK::Utils::Tasks qw(fake_set fake_set_version fake_problem);
@@ -1158,7 +1158,8 @@ sub nav {
 		my $courseName = $self->{ce}{courseName};
 
 		# Find all versions of this set that have been taken (excluding those taken by the current user).
-		my @users = grep { $_->[0] ne $user } $db->listSetVersionsWhere({ set_id => { like => "$setName,v\%" } });
+		my @users =
+			$db->listSetVersionsWhere({ user_id => { not_like => $user }, set_id => { like => "$setName,v\%" } });
 		my @userRecords = $db->getUsers(map { $_->[0] } @users);
 
 		# Format the student names for display, and associate the users with the test versions.

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -217,7 +217,7 @@ sub displayStudentStats {
 			# We have to have the merged set versions to know what each of their assignment types are
 			# (because proctoring can change this).
 			my @setVersions =
-				$db->getMergedSetVersionsWhere({ user_id => $studentName, set_id => { like => "$setName,\%" } });
+				$db->getMergedSetVersionsWhere({ user_id => $studentName, set_id => { like => "$setName,v\%" } });
 
 			# Add the set versions to our list of sets.
 			$setsByID{ $_->set_id . ",v" . $_->version_id } = $_ for (@setVersions);

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm,v 1.64 2007/08/13 22:59:55 sh002i Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -57,14 +57,14 @@ sub assignSetToUser {
 	my ($self, $userID, $GlobalSet) = @_;
 	my $setID = $GlobalSet->set_id;
 	my $db = $self->{db};
-	
+
 	my $UserSet = $db->newUserSet;
 	$UserSet->user_id($userID);
 	$UserSet->set_id($setID);
-	
+
 	my @results;
 	my $set_assigned = 0;
-	
+
 	eval { $db->addUserSet($UserSet) };
 	if ($@) {
 		if ($@ =~ m/user set exists/) {
@@ -74,13 +74,13 @@ sub assignSetToUser {
 			die $@;
 		}
 	}
-	
+
 	my @GlobalProblems = grep { defined $_ } $db->getAllGlobalProblems($setID);
 	foreach my $GlobalProblem (@GlobalProblems) {
 		my @result = $self->assignProblemToUser($userID, $GlobalProblem);
 		push @results, @result if @result and not $set_assigned;
 	}
-	
+
 	return @results;
 }
 
@@ -133,11 +133,11 @@ sub assignSetVersionToUser {
     foreach my $GlobalProblem ( @GlobalProblems ) {
 	$GlobalProblem->set_id( $setID );
 # this is getting called from within ContentGenerator, so that $self
-#    isn't an Instructor object---therefore, calling $self->assign... 
+#    isn't an Instructor object---therefore, calling $self->assign...
 #    doesn't work.  the following is an ugly workaround that works b/c
 #    both Instructor and ContentGenerator objects have $self->{db}
 # FIXME  it would be nice to have a better solution to this
-	my @result = 
+	my @result =
 	    assignProblemToUserSetVersion( $self, $userID, $userSet,
 	    			           $GlobalProblem, \%groupProblems );
 	push( @results, @result ) if ( @result && not $set_assigned );
@@ -156,7 +156,7 @@ Unassigns the given set and all problems therein from the given user.
 sub unassignSetFromUser {
 	my ($self, $userID, $setID) = @_;
 	my $db = $self->{db};
-	
+
 	$db->deleteUserSet($userID, $setID);
 }
 
@@ -171,13 +171,13 @@ will be given that seed.
 sub assignProblemToUser {
 	my ($self, $userID, $GlobalProblem, $seed) = @_;
 	my $db = $self->{db};
-	
+
 	my $UserProblem = $db->newUserProblem;
 	$UserProblem->user_id($userID);
 	$UserProblem->set_id($GlobalProblem->set_id);
 	$UserProblem->problem_id($GlobalProblem->problem_id);
 	initializeUserProblem($UserProblem, $seed);
-	
+
 	eval { $db->addUserProblem($UserProblem) };
 	if ($@) {
 		if ($@ =~ m/user problem exists/) {
@@ -188,7 +188,7 @@ sub assignProblemToUser {
 			die $@;
 		}
 	}
-	
+
 	return ();
 }
 
@@ -196,30 +196,30 @@ sub assignProblemToUser {
 sub assignProblemToUserSetVersion {
 	my ($self, $userID, $userSet, $GlobalProblem, $groupProbRef, $seed) = @_;
 	my $db = $self->{db};
-	
-# conditional to allow selection of problems from a group of problems, 
-# defined in a set.  
+
+# conditional to allow selection of problems from a group of problems,
+# defined in a set.
 
     # problem groups are indicated by source files "group:problemGroupName"
 	if ( $GlobalProblem->source_file() =~ /^group:(.+)$/ ) {
-	    my $problemGroupName = $1;  
+	    my $problemGroupName = $1;
 
     # get list of problems in group
 	    my @problemList = $db->listGlobalProblems($problemGroupName);
         # sanity check: if the group set hasn't been defined or doesn't
-        # actually contain problems (oops), then we can't very well assign 
-        # this problem to the user.  we could go on and assign all other 
-        # problems, but that results in a partial set.  so we die here if 
+        # actually contain problems (oops), then we can't very well assign
+        # this problem to the user.  we could go on and assign all other
+        # problems, but that results in a partial set.  so we die here if
         # this happens.  philosophically we're requiring that the instructor
         # set up the sets correctly or have to deal with the carnage after-
         # wards.  I'm not sure that this is the best long-term solution.
         # FIXME: this means that we may have created a set version that
-        # doesn't have any problems.  this is bad.  but it's hard to see 
+        # doesn't have any problems.  this is bad.  but it's hard to see
         # where else to deal with it---fixing the problem requires checking
-        # at the set version-creation level that all the problems in the 
+        # at the set version-creation level that all the problems in the
         # set are well defined.  FIXME
 	    die("Error in set version creation: no problems are available " .
-		"in problem group $problemGroupName.  Set " . 
+		"in problem group $problemGroupName.  Set " .
 		$userSet->set_id . " has been created for $userID, but " .
 		"does not contain the right problems.\n") if (! @problemList);
 
@@ -230,7 +230,7 @@ sub assignProblemToUserSetVersion {
     #   be different.  there's probably a better way to do this
 	    if ( defined( $groupProbRef->{$problemGroupName} ) &&
 		 $groupProbRef->{$problemGroupName} =~ /\b$whichProblem\b/ ) {
-		my $nAvail = $nProb - 
+		my $nAvail = $nProb -
 		    ( $groupProbRef->{$problemGroupName} =~ tr/,// ) - 1;
 
 		die("Too many problems selected from group.") if ( ! $nAvail );
@@ -250,7 +250,7 @@ sub assignProblemToUserSetVersion {
 					     $problemList[$whichProblem]);
 	    $GlobalProblem->source_file($prob->source_file());
 	}
-	
+
 # all set; do problem assignment
 	my $UserProblem = $db->newProblemVersion;
 	$UserProblem->user_id($userID);
@@ -259,7 +259,7 @@ sub assignProblemToUserSetVersion {
 	$UserProblem->problem_id($GlobalProblem->problem_id);
 	$UserProblem->source_file($GlobalProblem->source_file);
 	initializeUserProblem($UserProblem, $seed);
-	
+
 	eval { $db->addProblemVersion($UserProblem) };
 	if ($@) {
 		if ($@ =~ m/user problem exists/) {
@@ -283,7 +283,7 @@ Unassigns the given problem from the given user.
 sub unassignProblemFromUser {
 	my ($self, $userID, $setID, $problemID) = @_;
 	my $db = $self->{db};
-	
+
 	$db->deleteUserProblem($userID, $setID, $problemID);
 }
 
@@ -310,19 +310,17 @@ If any assignments fail, a list of failure messages is returned.
 sub assignSetToAllUsers {
 	my ($self, $setID) = @_;
 	my $db = $self->{db};
-	my @userIDs = $db->listUsers;
 
 	debug("$setID: getting user list");
-	# DBFIXME pre-filter with WHERE clause for status abbrevs. that allow assignment (tricky...)
-	my @userRecords = $db->getUsers(@userIDs);
+	my @userRecords = $db->getUsersWhere({ user_id => { not_like => 'set_id:%' } });
 	debug("$setID: (done with that)");
-	
+
 	debug("$setID: getting problem list");
-	my @GlobalProblems = grep { defined $_ } $db->getAllGlobalProblems($setID);
+	my @GlobalProblems = $db->getAllGlobalProblems($setID);
 	debug("$setID: (done with that)");
-	
+
 	my @results;
-	
+
 	foreach my $User (@userRecords) {
 		next unless $self->r->ce->status_abbrev_has_behavior($User->status, "include_in_assignment");
 		my $UserSet = $db->newUserSet;
@@ -336,7 +334,7 @@ sub assignSetToAllUsers {
 			die $@;
 		}
 		debug("$setID: (done with that)");
-		
+
 		debug("$setID: adding UserProblems for $userID");
 		foreach my $GlobalProblem (@GlobalProblems) {
 			my @result = $self->assignProblemToUser($userID, $GlobalProblem);
@@ -344,7 +342,7 @@ sub assignSetToAllUsers {
 		}
 		debug("$setID: (done with that)");
 	}
-	
+
 	return @results;
 }
 
@@ -357,9 +355,9 @@ Unassigns the specified sets and all problems contained therein from all users.
 sub unassignSetFromAllUsers {
 	my ($self, $setID) = @_;
 	my $db = $self->{db};
-	
+
 	my @userIDs = $db->listSetUsers($setID);
-	
+
 	foreach my $userID (@userIDs) {
 		$self->unassignSetFromUser($userID, $setID);
 	}
@@ -368,8 +366,7 @@ sub unassignSetFromAllUsers {
 =item assignAllSetsToUser($userID)
 
 Assigns all sets in the course and all problems contained therein to the
-specified user. This is more efficient than repeatedly calling
-assignSetToUser(). If any assignments fail, a list of failure messages is
+specified user. If any assignments fail, a list of failure messages is
 returned.
 
 =cut
@@ -377,30 +374,16 @@ returned.
 sub assignAllSetsToUser {
 	my ($self, $userID) = @_;
 	my $db = $self->{db};
-	
-	# assign only sets that are not already assigned
-	#my %userSetIDs = map { $_ => 1 } $db->listUserSets($userID);
-	#my @globalSetIDs = grep { not exists $userSetIDs{$_} } $db->listGlobalSets;
-	#my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
-	# FIXME: i don't think we need to do the above, since asignSetToUser fails
-	# silently if a UserSet already exists. instead we do this:
-	# DBFIXME shouldn't need to get list of set IDs
-	my @globalSetIDs = $db->listGlobalSets;
-	my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
-	
+
+	my @GlobalSets = $db->getGlobalSetsWhere();
+
 	my @results;
-	
-	my $i = 0;
-	foreach my $GlobalSet (@GlobalSets) {
-		if (not defined $GlobalSet) {
-			warn "record not found for global set $globalSetIDs[$i]";
-		} else {
-			my @result = $self->assignSetToUser($userID, $GlobalSet);
-			push @results, @result if @result;
-		}
-		$i++;
+
+	for my $GlobalSet (@GlobalSets) {
+		my @result = $self->assignSetToUser($userID, $GlobalSet);
+		push @results, @result if @result;
 	}
-	
+
 	return @results;
 }
 
@@ -413,9 +396,9 @@ Unassigns all sets and all problems contained therein from the specified user.
 sub unassignAllSetsFromUser {
 	my ($self, $userID) = @_;
 	my $db = $self->{db};
-	
+
 	my @setIDs = $db->listUserSets($userID);
-	
+
 	foreach my $setID (@setIDs) {
 		$self->unassignSetFromUser($userID, $setID);
 	}
@@ -443,20 +426,20 @@ fail, a list of failure messages is returned.
 sub assignSetsToUsers {
 	my ($self, $setIDsRef, $userIDsRef) = @_;
 	my $db = $self->{db};
-	
+
 	my @setIDs = @$setIDsRef;
 	my @userIDs = @$userIDsRef;
 	my @GlobalSets = $db->getGlobalSets(@setIDs);
-	
+
 	my @results;
-	
+
 	foreach my $GlobalSet (@GlobalSets) {
 		foreach my $userID (@userIDs) {
 			my @result = $self->assignSetToUser($userID, $GlobalSet);
 			push @results, @result if @result;
 		}
 	}
-	
+
 	return @results;
 }
 
@@ -470,7 +453,7 @@ sub unassignSetsFromUsers {
 	my ($self, $setIDsRef, $userIDsRef) = @_;
 	my @setIDs = @$setIDsRef;
 	my @userIDs = @$userIDsRef;
-	
+
 	foreach my $setID (@setIDs) {
 		foreach my $userID (@userIDs) {
 			$self->unassignSetFromUser($userID, $setID);
@@ -490,14 +473,14 @@ sub assignProblemToAllSetUsers {
 	my $db = $self->{db};
 	my $setID = $GlobalProblem->set_id;
 	my @userIDs = $db->listSetUsers($setID);
-	
+
 	my @results;
-	
+
 	foreach my $userID (@userIDs) {
 		my @result = $self->assignProblemToUser($userID, $GlobalProblem);
 		push @results, @result if @result;
 	}
-	
+
 	return @results;
 }
 
@@ -519,26 +502,26 @@ sub addProblemToSet {
 	my ($self, %args) = @_;
 	my $db = $self->r->db;
 	my $value_default = $self->{ce}->{problemDefaults}->{value};
-	my $max_attempts_default = $self->{ce}->{problemDefaults}->{max_attempts};	
-	my $showMeAnother_default = $self->{ce}->{problemDefaults}->{showMeAnother};	
-	my $att_to_open_children_default = $self->{ce}->{problemDefaults}->{att_to_open_children};	
-	my $counts_parent_grade_default = $self->{ce}->{problemDefaults}->{counts_parent_grade};	
+	my $max_attempts_default = $self->{ce}->{problemDefaults}->{max_attempts};
+	my $showMeAnother_default = $self->{ce}->{problemDefaults}->{showMeAnother};
+	my $att_to_open_children_default = $self->{ce}->{problemDefaults}->{att_to_open_children};
+	my $counts_parent_grade_default = $self->{ce}->{problemDefaults}->{counts_parent_grade};
 	my $prPeriod_default = $self->{ce}->{problemDefaults}->{prPeriod};
     # showMeAnotherCount is the number of times that showMeAnother has been clicked; initially 0
-	my $showMeAnotherCount = 0;	
-	
+	my $showMeAnotherCount = 0;
+
 
 	die "addProblemToSet called without specifying the set name." if $args{setName} eq "";
 	my $setName = $args{setName};
 
-	my $sourceFile = $args{sourceFile} or 
+	my $sourceFile = $args{sourceFile} or
 		die "addProblemToSet called without specifying the sourceFile.";
 
 	# The rest of the arguments are optional
-	
+
 #	my $value = $args{value} || $value_default;
 	my $value = $value_default;
-	if (defined($args{value})){$value = $args{value};}  # 0 is a valid value for $args{value}  
+	if (defined($args{value})){$value = $args{value};}  # 0 is a valid value for $args{value}
 
 	my $maxAttempts = $args{maxAttempts} || $max_attempts_default;
 	my $showMeAnother = $args{showMeAnother} // $showMeAnother_default;
@@ -555,7 +538,7 @@ sub addProblemToSet {
 
 	    my $set = $db->getGlobalSet($setName);
 	    # for jitar sets the new problem id is the one that
-	    # makes it a new top level problem 
+	    # makes it a new top level problem
 	    if ($set && $set->assignment_type eq 'jitar') {
 		my @problemIDs = $db->listGlobalProblems($setName);
 		if (@problemIDs) {
@@ -606,13 +589,13 @@ sub hiddenEditForUserFields {
 	foreach my $editUser (@editForUser) {
 		$return .= CGI::input({type=>"hidden", name=>"editForUser", value=>$editUser});
 	}
-	
+
 	return $return;
 }
 
 sub userCountMessage {
 	my ($self, $count, $numUsers) = @_;
-	
+
 	my $message;
 	if ($count == 0) {
 		$message = CGI::em($self->r->maketext("no students"));
@@ -625,7 +608,7 @@ sub userCountMessage {
 	} else {
 		$message = $self->r->maketext("[_1] students out of [_2]", $count, $numUsers);
 	}
-	
+
 	return $message;
 }
 
@@ -645,7 +628,7 @@ sub setCountMessage {
 	} else {
 		$message = $count." ".$r->maketext("sets");
 	}
-	
+
 	return $message;
 }
 
@@ -653,7 +636,7 @@ sub read_dir {  # read a directory
 	my $self      = shift;
 	my $directory = shift;
 	my $pattern   = shift;
-	my @files = grep /$pattern/, WeBWorK::Utils::readDirectory($directory); 
+	my @files = grep /$pattern/, WeBWorK::Utils::readDirectory($directory);
 	return sort @files;
 }
 
@@ -728,7 +711,7 @@ sub getTemplateFileList {  # find all .pg files under the template tree (time co
 	my $ce = $self->{ce};
 	$subDir = '' unless defined $subDir;
 	my $dir = $ce->{courseDirs}->{templates}."/$subDir";
-	# FIXME  currently allows one to see most files in the templates directory.  
+	# FIXME  currently allows one to see most files in the templates directory.
 	# a better facility for handling auxiliary files would be nice.
 	return $self->read_dir($dir, qr/\.pg$|.*\.html|\.png|\.gif|\.txt|\.pl/);
 }
@@ -737,7 +720,7 @@ sub getTemplateDirList {  # find all .pg files under the template tree (time con
 	my $ce = $self->{ce};
 	my $dir = $ce->{courseDirs}->{templates};
 	my @list = ();
-	my $wanted = sub { if (-d $_ ) { 
+	my $wanted = sub { if (-d $_ ) {
 	                        my $current = $_;
 	                        return if $current =~/CVS/;
 	                        return if -l $current;   # don't list links

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -267,7 +267,6 @@ sub body {
 
 	########## get achievements
 
-	# DBFIXME use an iterator
 	my @Achievements = $db->getAchievements(@allAchievementIDs);
 
 	# sort Achievments.  Achievements are always sorted by in the order they are evaluated

--- a/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
@@ -97,7 +97,7 @@ sub body {
 		)
 	);
 
-	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for the
 	# user if such restrictions are defined.
 	my @Users = $db->getUsersWhere({
 		user_id => { not_like => 'set_id:%' },

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -302,7 +302,7 @@ sub body {
 	print CGI::p({},$r->maketext("Use the interface below to quickly access commonly-used instructor tools, or select a tool from the list to the left."), CGI::br(),
 		$r->maketext("Select user(s) and/or set(s) below and click the action button of your choice."));
 
-	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for the
 	# user if such restrictions are defined.  This list is sorted by last_name, then first_name, then user_id.
 	my @Users = $db->getUsersWhere(
 		{

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -302,39 +302,24 @@ sub body {
 	print CGI::p({},$r->maketext("Use the interface below to quickly access commonly-used instructor tools, or select a tool from the list to the left."), CGI::br(),
 		$r->maketext("Select user(s) and/or set(s) below and click the action button of your choice."));
 
-	# DBFIXME shouldn't need to use list of IDs, use iterator for results, marks edits in WHERE clause
-	# the grep here prevents set-level proctors from being displayed here
-	my @userIDs = grep {$_ !~ /^set_id:/} $db->listUsers;
-	my @Users = $db->getUsers(@userIDs);
+	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# user if such restrictions are defined.  This list is sorted by last_name, then first_name, then user_id.
+	my @Users = $db->getUsersWhere(
+		{
+			user_id => { not_like => 'set_id:%' },
+			$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+			? (
+				-or => [
+					$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+					$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+				]
+				)
+			: ()
+		},
+		[qw/last_name first_name user_id/]
+	);
 
-	## Mark's Edits for filtering
-	my @myUsers;
-
-	my (@viewable_sections,@viewable_recitations);
-
-	if (defined $ce->{viewable_sections}->{$user})
-	{@viewable_sections = @{$ce->{viewable_sections}->{$user}};}
-	if (defined $ce->{viewable_recitations}->{$user})
-	{@viewable_recitations = @{$ce->{viewable_recitations}->{$user}};}
-
-	if (@viewable_sections or @viewable_recitations){
-		foreach my $student (@Users){
-			my $keep = 0;
-			foreach my $sec (@viewable_sections){
-				if ($student->section() eq $sec){$keep = 1;}
-			}
-			foreach my $rec (@viewable_recitations){
-				if ($student->recitation() eq $rec){$keep = 1;}
-			}
-			if ($keep) {push @myUsers, $student;}
-		}
-		@Users = @myUsers;
-	}
-	## End Mark's Edits
-
-	# DBFIXME shouldn't need to use list of IDs, use iterator for results
-	my @globalSetIDs = $db->listGlobalSets;
-	my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
+	my @GlobalSets = $db->getGlobalSetsWhere();
 
 	my @selected_users = $r->param("selected_users");
 	my @selected_sets = $r->param("selected_sets");

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -20,6 +20,7 @@ use base qw(WeBWorK::ContentGenerator);
 use WeBWorK::Utils qw(sortByName );
 use WeBWorK::PG;
 use HTML::Entities;
+
 =head1 NAME
 
 =cut
@@ -27,22 +28,21 @@ use HTML::Entities;
 use strict;
 use warnings;
 
-
 sub pre_header_initialize {
 
-	my ($self) = @_;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $db = $r->db;
-	my $authz = $r->authz;
+	my ($self)  = @_;
+	my $r       = $self->r;
+	my $ce      = $r->ce;
+	my $db      = $r->db;
+	my $authz   = $r->authz;
 	my $urlpath = $r->urlpath;
 
-	my $setName = $urlpath->arg("setID");
-	my $problemNumber = $r->urlpath->arg("problemID");
-	my $userName = $r->param('user');
+	my $setName           = $urlpath->arg("setID");
+	my $problemNumber     = $r->urlpath->arg("problemID");
+	my $userName          = $r->param('user');
 	my $effectiveUserName = $r->param('effectiveUser');
-	my $key = $r->param('key');
-	my $editMode = $r->param("editMode");
+	my $key               = $r->param('key');
+	my $editMode          = $r->param("editMode");
 
 	# Check permissions
 	return unless $authz->hasPermissions($userName, "access_instructor_tools");
@@ -51,14 +51,14 @@ sub pre_header_initialize {
 	my $user = $db->getUser($userName);
 	die "Couldn't find user $user" unless $user;
 
-	my $displayMode  = $user->displayMode ? $user->displayMode : $ce->{pg}->{options}->{displayMode};
-	$self->{displayMode}    = $displayMode;
+	my $displayMode = $user->displayMode ? $user->displayMode : $ce->{pg}->{options}->{displayMode};
+	$self->{displayMode} = $displayMode;
 }
 
 sub head {
 	my $self = shift;
-	my $r = $self->r;
-	my $ce = $r->ce;
+	my $r    = $self->r;
+	my $ce   = $r->ce;
 
 	my $site_url = $ce->{webworkURLs}->{htdocs};
 
@@ -68,14 +68,14 @@ sub head {
 
 }
 
-
 sub initialize {
 	my ($self)     = @_;
 	my $r          = $self->r;
 	my $urlpath    = $r->urlpath;
 	my $authz      = $r->authz;
 	my $db         = $r->db;
-	my $courseName     = $urlpath->arg("courseID");
+	my $ce         = $r->ce;
+	my $courseName = $urlpath->arg("courseID");
 	my $setID      = $urlpath->arg("setID");
 	my $problemID  = $urlpath->arg("problemID");
 	my $user       = $r->param('user');
@@ -84,27 +84,38 @@ sub initialize {
 	return unless $authz->hasPermissions($user, "access_instructor_tools");
 	return unless $authz->hasPermissions($user, "score_sets");
 
+	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# user if such restrictions are defined.  The users are sorted first by section, then by last name.
+	$self->{users} = [
+		$db->getUsersWhere(
+			{
+				user_id => { not_like => 'set_id:%' },
+				-or     => [
+					$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+					$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+				]
+			},
+			[qw/section last_name/]
+		)
+	];
 
 	# if we need to gothrough and update grades
 	if ($r->param('assignGrades')) {
-		$self->addmessage(
-			CGI::div(
-				{ class => 'alert alert-success p-1 mb-0' },
-				$r->maketext("Grades have been saved for all current users.")
-			)
-		);
+		$self->addmessage(CGI::div(
+			{ class => 'alert alert-success p-1 mb-0' },
+			$r->maketext("Grades have been saved for all current users.")
+		));
 
-		my @users = $db->listUsers;
-
-		foreach my $userID (@users) {
-			my $userProblem = $db->getUserProblem($userID,$setID,$problemID);
+		for my $user (@{ $self->{users} }) {
+			my $userID      = $user->user_id;
+			my $userProblem = $db->getUserProblem($userID, $setID, $problemID);
 			next unless $userProblem && defined($r->param("$userID.score"));
 			#update grades and set flags
 			$userProblem->{flags} =~ s/needs_grading/graded/;
-			if  ($r->param("$userID.mark_correct")) {
+			if ($r->param("$userID.mark_correct")) {
 				$userProblem->status(1);
 			} else {
-				my $newscore = $r->param("$userID.score")/100;
+				my $newscore = $r->param("$userID.score") / 100;
 				if ($newscore != $userProblem->status) {
 					$userProblem->status($newscore);
 				}
@@ -114,7 +125,7 @@ sub initialize {
 
 			#if the instructor added a comment we should save that to the latest answer
 			if ($r->param("$userID.comment")) {
-				my $comment = $r->param("$userID.comment");
+				my $comment          = $r->param("$userID.comment");
 				my $userPastAnswerID = $db->latestProblemPastAnswer($courseName, $userID, $setID, $problemID);
 
 				if ($userPastAnswerID) {
@@ -127,25 +138,24 @@ sub initialize {
 	}
 }
 
-
 sub body {
-	my ($self)         = @_;
-	my $r              = $self->r;
-	my $urlpath        = $r->urlpath;
-	my $db             = $r->db;
-	my $ce             = $r->ce;
-	my $authz          = $r->authz;
-	my $webworkRoot    = $ce->{webworkURLs}->{root};
-	my $courseName     = $urlpath->arg("courseID");
-	my $setID          = $urlpath->arg("setID");
-	my $problemID      = $urlpath->arg("problemID");
-	my $userID           = $r->param('user');
-	my $key = $r->param('key');
-	my $displayMode   = $self->{displayMode};
-	my $formFields = { WeBWorK::Form->new_from_paramable($r)->Vars };
+	my ($self)      = @_;
+	my $r           = $self->r;
+	my $urlpath     = $r->urlpath;
+	my $db          = $r->db;
+	my $ce          = $r->ce;
+	my $authz       = $r->authz;
+	my $webworkRoot = $ce->{webworkURLs}->{root};
+	my $courseName  = $urlpath->arg("courseID");
+	my $setID       = $urlpath->arg("setID");
+	my $problemID   = $urlpath->arg("problemID");
+	my $userID      = $r->param('user');
+	my $key         = $r->param('key');
+	my $displayMode = $self->{displayMode};
+	my $formFields  = { WeBWorK::Form->new_from_paramable($r)->Vars };
 
 	# to make grabbing these options easier, we'll pull them out now...
-	my %imagesModeOptions = %{$ce->{pg}->{displayModeOptions}->{images}};
+	my %imagesModeOptions = %{ $ce->{pg}->{displayModeOptions}->{images} };
 
 	# set up some display stuff
 	my $imgGen = WeBWorK::PG::ImageGenerator->new(
@@ -160,7 +170,6 @@ sub body {
 		dvipng_depth_db => $imagesModeOptions{dvipng_depth_db},
 	);
 
-
 	return CGI::div({ class => 'alert alert-danger p-1 mb-0' },
 		CGI::p("You are not authorized to acces the Instructor tools."))
 		unless $authz->hasPermissions($userID, "access_instructor_tools");
@@ -169,11 +178,9 @@ sub body {
 		CGI::p("You are not authorized to grade homework sets."))
 		unless $authz->hasPermissions($userID, "score_sets");
 
-	# DBFIXME duplicate call
-	my @users = $db->listUsers;
-	my $set = $db->getMergedSet($userID, $setID); # checked
-	my $problem = $db->getMergedProblem($userID, $setID, $problemID); # checked
-	my $user = $db->getUser($userID);
+	my $set     = $db->getMergedSet($userID, $setID);                    # checked
+	my $problem = $db->getMergedProblem($userID, $setID, $problemID);    # checked
+	my $user    = $db->getUser($userID);
 
 	return CGI::div({ class => 'alert alert-danger p-1 mb-0' },
 		CGI::p($r->maketext("This set needs to be assigned to you before you can grade it.")))
@@ -186,107 +193,82 @@ sub body {
 		$key,
 		$set,
 		$problem,
-		$set->psvn, # FIXME: this field should be removed
+		$set->psvn,    # FIXME: this field should be removed
 		$formFields,
-		{ # translation options
-			displayMode     => $displayMode,
-			showHints       => 0,
-			showSolutions   => 0,
-			refreshMath2img => 0,
-			processAnswers  => 1,
-			permissionLevel => $db->getPermissionLevel($userID)->permission,
+		{              # translation options
+			displayMode              => $displayMode,
+			showHints                => 0,
+			showSolutions            => 0,
+			refreshMath2img          => 0,
+			processAnswers           => 1,
+			permissionLevel          => $db->getPermissionLevel($userID)->permission,
 			effectivePermissionLevel => $db->getPermissionLevel($userID)->permission,
 		},
 	);
-
 
 	# check to see what type the answers are.  right now it only checks for essay but could do more
 	my %answerHash = %{ $pg->{answers} };
 	my @answerTypes;
 
 	foreach (sortByName(undef, keys %answerHash)) {
-		push(@answerTypes,$answerHash{$_}->{type});
+		push(@answerTypes, $answerHash{$_}->{type});
 	}
 
 	print CGI::div({ class => 'problem-content col-md-12 col-lg-10' }, $pg->{body_text});
 
-	print CGI::start_form({method=>"post", action => $self->systemLink($urlpath, authen=>0),
-			id=>"problem-grader-form", name=>"problem-grader-form" });
+	print CGI::start_form({
+		method => "post",
+		action => $self->systemLink($urlpath, authen => 0),
+		id     => "problem-grader-form",
+		name   => "problem-grader-form"
+	});
 
 	my $selectAll = CGI::input({
-		type => 'button',
-	   	id => 'check_all_mark_corrects',
-	   	value => $r->maketext('Mark All'),
+		type  => 'button',
+		id    => 'check_all_mark_corrects',
+		value => $r->maketext('Mark All'),
 		class => 'btn btn-secondary btn-sm'
 	});
 
 	print CGI::start_div({ class => 'table-responsive' }), CGI::start_table({ width => '1020px' });
-	print CGI::Tr({-valign=>"top"}, CGI::th([$r->maketext("Section"), $r->maketext("Name"),
-				"&nbsp;",$r->maketext("Latest Answers"),"&nbsp;",$r->maketext("Mark Correct")."<br>".$selectAll,
-				"&nbsp;", $r->maketext("Score (%)"), "&nbsp;", $r->maketext("Comment")]));
-	print CGI::Tr(CGI::td([CGI::hr(), CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"&nbsp;"]));
+	print CGI::Tr(
+		{ -valign => "top" },
+		CGI::th([
+			$r->maketext("Section"), $r->maketext("Name"),
+			"&nbsp;",                $r->maketext("Latest Answers"),
+			"&nbsp;",                $r->maketext("Mark Correct") . "<br>" . $selectAll,
+			"&nbsp;",                $r->maketext("Score (%)"),
+			"&nbsp;",                $r->maketext("Comment")
+		])
+	);
+	print CGI::Tr(
+		CGI::td([ CGI::hr(), CGI::hr(), "", CGI::hr(), "", CGI::hr(), "", CGI::hr(), "", CGI::hr(), "&nbsp;" ]));
 
-	my $viewProblemPage = $urlpath->new(type => 'problem_detail',
-		args => { courseID => $courseName, setID => $setID, problemID => $problemID });
+	my $viewProblemPage = $urlpath->new(
+		type => 'problem_detail',
+		args => { courseID => $courseName, setID => $setID, problemID => $problemID }
+	);
 
 	my %dropDown;
 	my $delta = $ce->{options}{problemGraderScoreDelta};
 	#construct the drop down.
-	for (my $i=int(100/$delta); $i>=0; $i--) {
-		$dropDown{$i*$delta}=$i*$delta;
+	for (my $i = int(100 / $delta); $i >= 0; $i--) {
+		$dropDown{ $i * $delta } = $i * $delta;
 	}
 
-	my @scores = sort {$b <=> $a} keys %dropDown;
-
-	my @myUsers = ();
-	my (@viewable_sections, @viewable_recitations);
-	if (defined $ce->{viewable_sections}->{$userID}) {
-		@viewable_sections = @{$ce->{viewable_sections}->{$userID}};
-	}
-	if (defined $ce->{viewable_recitations}->{$userID}) {
-		@viewable_recitations = @{$ce->{viewable_recitations}->{$userID}};
-	}
-	if (@viewable_sections or @viewable_recitations) {
-		foreach my $studentL (@users){
-			my $keep = 0;
-			my $student = $db->getUser($studentL);
-			foreach my $sec (@viewable_sections){
-				if ($student->section() eq $sec){$keep = 1; last;}
-			}
-			foreach my $rec (@viewable_recitations){
-				if ($student->recitation() eq $rec){$keep = 1; last;}
-			}
-			if ($keep) {push @myUsers, $studentL;}
-		}
-	}
-	else {@myUsers = @users;}
-
-
-	# get user records
-	my @userRecords  = ();
-	foreach my $currentUser ( @myUsers) {
-		my $userObj = $db->getUser($currentUser); #checked
-		die "Unable to find user object for $currentUser. " unless $userObj;
-		push (@userRecords, $userObj );
-	}
-
-	@userRecords = sort {
-		( lc($a->section) cmp lc($b->section) ) ||
-		( lc($a->last_name) cmp lc($b->last_name ))
-	} @userRecords;
-
+	my @scores = sort { $b <=> $a } keys %dropDown;
 
 	#for each user get their latest answer from the past answer db
-	foreach my $userRecord (@userRecords) {
+	foreach my $userRecord (@{ $self->{users} }) {
 
 		my $statusClass = $ce->status_abbrev_to_name($userRecord->status) || "";
 
-		my $userID = $userRecord->user_id;
-		my $viewProblemLink = $self->systemLink($viewProblemPage, params => { effectiveUser => $userID });
+		my $userID           = $userRecord->user_id;
+		my $viewProblemLink  = $self->systemLink($viewProblemPage, params => { effectiveUser => $userID });
 		my $userPastAnswerID = $db->latestProblemPastAnswer($courseName, $userID, $setID, $problemID);
 		my $userAnswerString;
-		my $comment = "";
-		my $userProblem = $db->getUserProblem($userID,$setID,$problemID);
+		my $comment        = "";
+		my $userProblem    = $db->getUserProblem($userID, $setID, $problemID);
 		my $noCommentField = 0;
 
 		next unless $userProblem;
@@ -294,17 +276,18 @@ sub body {
 		if ($userPastAnswerID && $userProblem) {
 
 			my $userPastAnswer = $db->getPastAnswer($userPastAnswerID);
-			my @scores = split(//,$userPastAnswer->scores);
-			my @answers = split(/\t/,$userPastAnswer->answer_string);
+			my @scores         = split(//,   $userPastAnswer->scores);
+			my @answers        = split(/\t/, $userPastAnswer->answer_string);
 			$comment = $userPastAnswer->comment_string;
 
 			#Skip this answer if the pg file doesn't match the current pg file
-			if (defined($userPastAnswer->source_file) &&
-				$userPastAnswer->source_file ne $problem->source_file) {
+			if (defined($userPastAnswer->source_file)
+				&& $userPastAnswer->source_file ne $problem->source_file)
+			{
 				next;
 			}
 
-			for (my $i = 0; $i<= $#answers; $i++) {
+			for (my $i = 0; $i <= $#answers; $i++) {
 
 				my $answer = $answers[$i];
 
@@ -322,47 +305,52 @@ sub body {
 
 				} elsif ($answerTypes[$i] eq 'Value (Formula)') {
 					#if its a formula then render it and color it
-					$userAnswerString .= CGI::div({
+					$userAnswerString .= CGI::div(
+						{
 							class => 'graded-answer',
-						   	style => $scores[$i] ? "color:#006600" : "color:#660000"
-					   	}, '`' . HTML::Entities::encode_entities($answer).'`');
+							style => $scores[$i] ? "color:#006600" : "color:#660000"
+						},
+						'`' . HTML::Entities::encode_entities($answer) . '`'
+					);
 
-				}else {
+				} else {
 					# if it isnt an essay then don't render it but color it
-					$userAnswerString .= CGI::div({
+					$userAnswerString .= CGI::div(
+						{
 							class => 'graded-answer',
-							style => $scores[$i] ?  "color:#006600": "color:#660000"
-						}, HTML::Entities::encode_entities($answer));
+							style => $scores[$i] ? "color:#006600" : "color:#660000"
+						},
+						HTML::Entities::encode_entities($answer)
+					);
 				}
 			}
 
 		} else {
-			$noCommentField = 1;
+			$noCommentField   = 1;
 			$userAnswerString = "There are no answers for this student.";
 		}
 
-		my $score = int(100*$userProblem->status);
+		my $score = int(100 * $userProblem->status);
 
-		my $prettyName = $userRecord->last_name
-		. ", "
-		. $userRecord->first_name;
+		my $prettyName = $userRecord->last_name . ", " . $userRecord->first_name;
 
 		#create form for scoring
 
 		my $commentBox = '';
 		$commentBox = CGI::textarea({
-			   name => "$userID.comment",
-			   value => "$comment",
-			   rows => 3,
-			   class => 'form-control'
-		   }) .
-		CGI::br() . CGI::input({
-			class => 'preview btn btn-secondary btn-sm',
-			type => 'button',
-			name => "$userID.preview",
-			value => "Preview"
-		}) unless $noCommentField;
-
+			name  => "$userID.comment",
+			value => "$comment",
+			rows  => 3,
+			class => 'form-control'
+		})
+			. CGI::br()
+			. CGI::input({
+				class => 'preview btn btn-secondary btn-sm',
+				type  => 'button',
+				name  => "$userID.preview",
+				value => "Preview"
+			})
+			unless $noCommentField;
 
 		# this selects the score available in the drop down that is just above the student score
 		my $selectedScore = 0;
@@ -372,34 +360,44 @@ sub body {
 			}
 		}
 
-		print CGI::Tr({ valign => "top" },
-			CGI::td({},[
-					$userRecord->section,
-					CGI::div({
+		print CGI::Tr(
+			{ valign => "top" },
+			CGI::td([
+				$userRecord->section,
+				CGI::div(
+					{
 						class => $userProblem->flags =~ /needs_grading/
-							? "NeedsGrading $statusClass"
-							: $statusClass
-					}, CGI::a({ href => $viewProblemLink, target => "WW_View" }, $prettyName)), " ",
-					$userAnswerString, " ",
-					CGI::checkbox({
-						type => "checkbox",
-						class => "mark_correct form-check-input",
-						name => "$userID.mark_correct",
-						value => "1",
-						label => "",
+						? "NeedsGrading $statusClass"
+						: $statusClass
+					},
+					CGI::a({ href => $viewProblemLink, target => "WW_View" }, $prettyName)
+				),
+				" ",
+				$userAnswerString,
+				" ",
+				CGI::checkbox({
+					type  => "checkbox",
+					class => "mark_correct form-check-input",
+					name  => "$userID.mark_correct",
+					value => "1",
+					label => "",
 
-					}), " ",
-					CGI::popup_menu({
-						name => "$userID.score",
-						class => "score-selector form-select form-select-sm",
-						values => \@scores,
-						default => $selectedScore,
-						labels => \%dropDown
-					}) ," ",
-				   	$commentBox
-				])
+				}),
+				" ",
+				CGI::popup_menu({
+					name    => "$userID.score",
+					class   => "score-selector form-select form-select-sm",
+					values  => \@scores,
+					default => $selectedScore,
+					labels  => \%dropDown
+				}),
+				" ",
+				$commentBox
+			])
 		);
-		print CGI::Tr(CGI::td([CGI::hr(), CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"",CGI::hr(),"&nbsp;"]));
+		print CGI::Tr(
+			CGI::td([ CGI::hr(), CGI::hr(), "", CGI::hr(), "", CGI::hr(), "", CGI::hr(), "", CGI::hr(), "&nbsp;" ])
+		);
 	}
 
 	print CGI::end_table(), CGI::end_div();

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -90,10 +90,14 @@ sub initialize {
 		$db->getUsersWhere(
 			{
 				user_id => { not_like => 'set_id:%' },
-				-or     => [
-					$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
-					$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
-				]
+				$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+				? (
+					-or => [
+						$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+						$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+					]
+					)
+				: ()
 			},
 			[qw/section last_name/]
 		)

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -84,7 +84,7 @@ sub initialize {
 	return unless $authz->hasPermissions($user, "access_instructor_tools");
 	return unless $authz->hasPermissions($user, "score_sets");
 
-	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for the
 	# user if such restrictions are defined.  The users are sorted first by section, then by last name.
 	$self->{users} = [
 		$db->getUsersWhere(

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1240,8 +1240,7 @@ sub initialize {
 			#    not the most robust treatment of the problem
 			#    (FIXME)
 
-			# DBFIXME use a WHERE clause, iterator
-			my @userRecords = $db->getUserSets(map { [$_, $setID] } @editForUser);
+			my @userRecords = $db->getUserSetsWhere({ user_id => [ @editForUser ], set_id => $setID });
 			# if we're editing a set version, we want to edit
 			#    edit that instead of the userset, so get it
 			#    too.
@@ -1526,8 +1525,7 @@ sub initialize {
 		# Save problem information
 		#####################################################################
 
-		# DBFIXME use a WHERE clause, iterator?
-		my @problemIDs = sort { $a <=> $b } $db->listGlobalProblems($setID);;
+		my @problemIDs = map { $_->[1] } $db->listGlobalProblemsWhere({ set_id => $setID }, 'problem_id');
 		my @problemRecords = $db->getGlobalProblems(map { [$setID, $_] } @problemIDs);
 		foreach my $problemRecord (@problemRecords) {
 			my $problemID = $problemRecord->problem_id;
@@ -1543,8 +1541,8 @@ sub initialize {
 				my @userProblemRecords;
 				if ( ! $editingSetVersion ) {
 					my @userProblemIDs = map { [$_, $setID, $problemID] } @userIDs;
-					# DBFIXME where clause? iterator?
-					@userProblemRecords = $db->getUserProblems(@userProblemIDs);
+					@userProblemRecords = $db->getUserProblemsWhere(
+						{ user_id => [@userIDs], set_id => $setID, problem_id => $problemID });
 				} else {
 					## (we know that we're only editing for one user)
 					@userProblemRecords =
@@ -1638,7 +1636,6 @@ sub initialize {
 				}
 				$db->putGlobalProblem($problemRecord) if $changed;
 
-
 				# sometimes (like for status) we might want to change an attribute in
 				# the userProblem record for every assigned user
 				# However, since this data is stored in the UserProblem records,
@@ -1654,10 +1651,7 @@ sub initialize {
 				}
 
 				if (keys %useful) {
-					# DBFIXME where clause, iterator
-					my @userIDs = $db->listProblemUsers($setID, $problemID);
-					my @userProblemIDs = map { [$_, $setID, $problemID] } @userIDs;
-					my @userProblemRecords = $db->getUserProblems(@userProblemIDs);
+					my @userProblemRecords = $db->getUserProblemsWhere({ set_id => $setID, problem_id => $problemID });
 					foreach my $record (@userProblemRecords) {
 						my $changed = 0; # keep track of any changes, if none are made, avoid unnecessary db accesses
 						foreach my $field ( keys %useful ) {
@@ -1680,8 +1674,10 @@ sub initialize {
 		#    version, because this only shows up when editing for users or editing the
 		#    global set/problem, not for one user)
 		foreach my $problemID ($r->param('markCorrect')) {
-			# DBFIXME where clause, iterator
-			my @userProblemIDs = map { [$_, $setID, $problemID] } ($forUsers ? @editForUser : $db->listProblemUsers($setID, $problemID));
+			my @userProblemIDs =
+				$forUsers
+				? (map { [ $_, $setID, $problemID ] } @editForUser)
+				: $db->listUserProblemsWhere({ set_id => $setID, problem_id => $problemID });
 			# if the set is not a gateway set, this requires going through the
 			#    user_problems and resetting their status; if it's a gateway set,
 			#    then we have to go through every *version* of every user_problem.
@@ -1698,7 +1694,7 @@ sub initialize {
 					}
 				}
 			} else {
-				my @userIDs = ( $forUsers ) ? @editForUser : $db->listProblemUsers($setID, $problemID);
+				my @userIDs = $forUsers ? @editForUser : $db->listProblemUsers($setID, $problemID);
 				foreach my $uid ( @userIDs ) {
 					my @versions = $db->listSetVersions( $uid, $setID );
 					my @userProblemVersionIDs =
@@ -2051,7 +2047,6 @@ sub body {
 	my @unassignedUsers;
 	if (scalar @editForUser) {
 		foreach my $ID (@editForUser) {
-			# DBFIXME iterator
 			if ($db->getUserSet($ID, $setID)) {
 				unshift @assignedUsers, $ID;
 			} else {
@@ -2107,12 +2102,11 @@ sub body {
 	my $isGatewaySet = ( $setRecord->assignment_type =~ /gateway/ ) ? 1 : 0;
 	my $isJitarSet = ( $setRecord->assignment_type eq 'jitar' ) ? 1 : 0;
 
-	# DBFIXME no need to get ID lists -- counts would be fine
-	my $userCount        = $db->listUsers();
-	my $setCount         = $db->listGlobalSets(); # if $forOneUser;
-	my $setUserCount     = $db->countSetUsers($setID);
-# if $forOneUser;
-	my $userSetCount     = ($forOneUser && @editForUser) ? $db->countUserSets($editForUser[0]) : 0;
+	my $userCount    = $db->countUsers();
+	my $setCount     = $db->countGlobalSets();       # if $forOneUser;
+	my $setUserCount = $db->countSetUsers($setID);
+	# if $forOneUser;
+	my $userSetCount = ($forOneUser && @editForUser) ? $db->countUserSets($editForUser[0]) : 0;
 
 
 	my $editUsersAssignedToSetURL = $self->systemLink(
@@ -2127,12 +2121,6 @@ sub body {
 	my $setDetailPage  = $urlpath -> newFromModule($urlpath->module, $r, courseID => $courseID, setID => $setID);
 	my $fullsetDetailPage  = $urlpath -> newFromModule($urlpath->module, $r, courseID => $courseID, setID => $fullSetID);
 	my $setDetailURL   = $self->systemLink($fullsetDetailPage, authen=>0);
-
-	my $userCountMessage = CGI::a({href=>$editUsersAssignedToSetURL}, $self->userCountMessage($setUserCount, $userCount));
-	my $setCountMessage = CGI::a({href=>$editSetsAssignedToUserURL}, $self->setCountMessage($userSetCount, $setCount)) if $forOneUser;
-
-	$userCountMessage = $r->maketext("The set [_1] is assigned to [_2].", $setID, $userCountMessage);
-	$setCountMessage  = $r->maketext("The user [_1] has been assigned [_2].", $editForUser[0], $setCountMessage) if $forOneUser;
 
 	if ($forUsers) {
 	    ##############################################
@@ -2413,31 +2401,27 @@ sub body {
 	# Display problem information
 	#####################################################################
 
-        my @problemIDList = sort {$a <=> $b} $db->listGlobalProblems($setID);
+	# Get global problem records for all problems sorted by problem id.
+	my @globalProblems = $db->getGlobalProblemsWhere({ set_id => $setID }, 'problem_id');
+	my @problemIDList  = map { $_->problem_id } @globalProblems;
+	my %GlobalProblems = map { $_->problem_id => $_ } @globalProblems;
 
-	# DBFIXME use iterators instead of getting all at once
-
-	# get global problem records for all problems in one go
-	my %GlobalProblems;
-	my @globalKeypartsRef = map { [$setID, $_] } @problemIDList;
-	# DBFIXME shouldn't need to get key list here
-	@GlobalProblems{@problemIDList} = $db->getGlobalProblems(@globalKeypartsRef);
-
-	# if needed, get user problem records for all problems in one go
+	# If editing for one user, get user problem records for all problems also sorted by problem_id.
 	my (%UserProblems, %MergedProblems);
 	if ($forOneUser) {
-		my @userKeypartsRef = map { [$editForUser[0], $setID, $_] } @problemIDList;
-		# DBFIXME shouldn't need to get key list here
-		@UserProblems{@problemIDList} = $db->getUserProblems(@userKeypartsRef);
-		if ( ! $editingSetVersion ) {
-			@MergedProblems{@problemIDList} = $db->getMergedProblems(@userKeypartsRef);
+		my @userProblems = $db->getUserProblemsWhere({ user_id => $editForUser[0], set_id => $setID }, 'problem_id');
+		%UserProblems = map { $_->problem_id => $_ } @userProblems;
+
+		if ($editingSetVersion) {
+			%MergedProblems = map { $_->problem_id => $_ }
+				$db->getMergedProblemVersionsWhere({ user_id => $editForUser[0], set_id => $setID }, 'problem_id');
 		} else {
-			my @userversionKeypartsRef = map { [$editForUser[0], $setID, $editingSetVersion, $_] } @problemIDList;
-			@MergedProblems{@problemIDList} = $db->getMergedProblemVersions(@userversionKeypartsRef);
+			%MergedProblems = map { $_->problem_id => $_ }
+				$db->getMergedProblemsWhere({ user_id => $editForUser[0], set_id => $setID }, 'problem_id');
 		}
 	}
 
-	if (scalar @problemIDList) {
+	if (scalar @globalProblems) {
 		# Create rows for problems.  This is done using divs instead of tables
 		# the spacing and formatting is done via bootstrap.
 		print CGI::h2($r->maketext('Problems'));

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -2159,7 +2159,7 @@ sub body {
 			. CGI::em(
 			$r->maketext('To edit a specific student version of this set, edit (all of) her/his assigned sets.'))
 			: '';
-		my $vermsg = $editingSetVersion ? ", $editingSetVersion" : '';
+		my $vermsg = $editingSetVersion ? ",v$editingSetVersion" : '';
 
 		print CGI::div(
 			{ class => 'border border-dark mb-2' },
@@ -2413,8 +2413,10 @@ sub body {
 		%UserProblems = map { $_->problem_id => $_ } @userProblems;
 
 		if ($editingSetVersion) {
-			%MergedProblems = map { $_->problem_id => $_ }
-				$db->getMergedProblemVersionsWhere({ user_id => $editForUser[0], set_id => $setID }, 'problem_id');
+			%MergedProblems =
+				map { $_->problem_id => $_ }
+				$db->getMergedProblemVersionsWhere({ user_id => $editForUser[0], set_id => { like => "$setID,v\%" } },
+					'problem_id');
 		} else {
 			%MergedProblems = map { $_->problem_id => $_ }
 				$db->getMergedProblemsWhere({ user_id => $editForUser[0], set_id => $setID }, 'problem_id');

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -138,10 +138,14 @@ sub initialize {
 	my @Users = $db->getUsersWhere(
 		{
 			user_id => [ -and => { not_like => 'set_id:%' }, { not_like => "$ce->{practiceUserPrefix}\%" } ],
-			-or     => [
-				$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
-				$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
-			]
+			$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+			? (
+				-or => [
+					$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+					$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+				]
+				)
+			: ()
 		},
 		'user_id'
 	);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -83,23 +83,23 @@ sub initialize {
   	foreach my $studentUser (@$selectedUsers) {
 	    my @sets;
 
-	    # search for selected sets assigned to students
-	    my @allSets = $db->listUserSets($studentUser);
-	    foreach my $setName (@allSets) {
-	      my $set = $db->getMergedSet($studentUser,$setName);
-	      if (defined($set->assignment_type) && $set->assignment_type =~ /gateway/) {
-		my @versions = $db->listSetVersions($studentUser, $setName);
-		foreach my $version(@versions) {
-		  if (grep/^$setName,v$version$/,@$selectedSets) {
-		    $set = $db->getUserSet($studentUser,"$setName,v$version");
-		    push(@sets, $set);
-		  }
-		}
-	      } elsif (grep(/^$setName$/,@$selectedSets)) {
-		push (@sets, $set);
-	      }
+		# search for selected sets assigned to students
+		my @allSets = $db->listUserSets($studentUser);
+		foreach my $setName (@allSets) {
+			my $set = $db->getMergedSet($studentUser, $setName);
+			if (defined($set->assignment_type) && $set->assignment_type =~ /gateway/) {
+				my @versions = $db->listSetVersions($studentUser, $setName);
+				foreach my $version (@versions) {
+					if (grep /^$setName,v$version$/, @$selectedSets) {
+						$set = $db->getUserSet($studentUser, "$setName,v$version");
+						push(@sets, $set);
+					}
+				}
+			} elsif (grep(/^$setName$/, @$selectedSets)) {
+				push(@sets, $set);
+			}
 
-	    }
+		}
 
 	    next unless @sets;
 
@@ -287,37 +287,17 @@ sub body {
 	#only instructors should be able to veiw other people's answers.
 
 	if ($instructor) {
-		my @userIDs = grep { $_ !~ /^set_id:/ } $db->listUsers;
-		my @Users   = $db->getUsers(@userIDs);
+		# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for
+		# the user if such restrictions are defined.
+		my @Users = $db->getUsersWhere({
+			user_id => { not_like => 'set_id:%' },
+			-or     => [
+				$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+				$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+			]
+		});
 
-		## Mark's Edits for filtering
-		my @myUsers;
-
-		my (@viewable_sections, @viewable_recitations);
-
-		if (defined $ce->{viewable_sections}->{$user}) { @viewable_sections = @{ $ce->{viewable_sections}->{$user} }; }
-		if (defined $ce->{viewable_recitations}->{$user}) {
-			@viewable_recitations = @{ $ce->{viewable_recitations}->{$user} };
-		}
-
-		if (@viewable_sections or @viewable_recitations) {
-			foreach my $student (@Users) {
-				my $keep = 0;
-				foreach my $sec (@viewable_sections) {
-					if ($student->section() eq $sec) { $keep = 1; }
-				}
-				foreach my $rec (@viewable_recitations) {
-					if ($student->recitation() eq $rec) { $keep = 1; }
-				}
-				if ($keep) { push @myUsers, $student; }
-			}
-			@Users = @myUsers;
-		}
-		## End Mark's Edits
-
-		# DBFIXME shouldn't need to use list of IDs, use iterator for results
-		my @globalSetIDs = $db->listGlobalSets;
-		my @GlobalSets   = $db->getGlobalSets(@globalSetIDs);
+		my @GlobalSets = $db->getGlobalSetsWhere({}, 'set_id');
 
 		my @expandedGlobalSetIDs;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -291,10 +291,14 @@ sub body {
 		# the user if such restrictions are defined.
 		my @Users = $db->getUsersWhere({
 			user_id => { not_like => 'set_id:%' },
-			-or     => [
-				$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
-				$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
-			]
+			$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+			? (
+				-or => [
+					$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
+					$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
+				]
+				)
+			: ()
 		});
 
 		my @GlobalSets = $db->getGlobalSetsWhere({}, 'set_id');

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -287,7 +287,7 @@ sub body {
 	#only instructors should be able to veiw other people's answers.
 
 	if ($instructor) {
-		# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for
+		# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for
 		# the user if such restrictions are defined.
 		my @Users = $db->getUsersWhere({
 			user_id => { not_like => 'set_id:%' },

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -197,7 +197,7 @@ sub index {
 	}
 
 	# Get a list of students sorted by user_id.
-	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for the
 	# user if such restrictions are defined.  This list is sorted by last_name, then first_name, then user_id.
 	my @studentRecords = $db->getUsersWhere(
 		{

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -185,7 +185,7 @@ sub index {
 
 	my $user = $r->param("user");
 
-	# Get all users except the set level proctors, and restrict to the sections or recitations that ar allowed for the
+	# Get all users except the set level proctors, and restrict to the sections or recitations that are allowed for the
 	# user if such restrictions are defined.  This list is sorted by last_name, then first_name, then user_id.
 	my @studentRecords = $db->getUsersWhere(
 		{
@@ -341,8 +341,8 @@ sub displaySets {
 	my $max_num_problems  = 0;
 
 	# Get all users except the set level proctors and practice users, and restrict to the sections or recitations that
-	# ar allowed for the user if such restrictions are defined.  This list is sorted by last_name, then first_name, then
-	# user_id.
+	# are allowed for the user if such restrictions are defined.  This list is sorted by last_name, then first_name,
+	# then user_id.
 	debug("Begin obtaining user records for set $setName");
 	my @studentRecords = $db->getUsersWhere(
 		{

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -306,26 +306,13 @@ sub body {
 				map { $_->set_id . ",v" . $_->version_id } @{ $UserSetVersionRecords{ $setsToShow[$i] } });
 		}
 		$i--;
-		my $numit = 0;
 		while ($i >= 0) {
 			if (defined($UserSetVersionRecords{ $setsToShow[$i] })) {
 				splice(@setsToShow, $i + 1, 0,
 					map { $_->set_id . ",v" . $_->version_id } @{ $UserSetVersionRecords{ $setsToShow[$i] } });
 			}
 			$i--;
-			$numit++;
-			# just to be safe
-			last if $numit >= 150;
 		}
-		# FIXME:  This message is completely incorrect, and the limit implemented above is totally not working.  All
-		# global sets are already in the @setsToShow list.  So if there are more than 150 sets, they will still all be
-		# displayed.  This just stops adding versioned sets to the list when you reach the 150th set.  Should the $numit
-		# protection just be removed, or should this be made to actually work?
-		warn(
-			'Truncated display of sets at 150 in UserDetail.pm.  This is a brake to avoid spiraling into the abyss.  '
-				. 'If you really have more than 150 sets in your course, reset the limit at line '
-				. (__LINE__ - 5) . ' in webwork/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm.')
-			if ($numit >= 150);
 	}
 
 	for my $setID (@setsToShow) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -265,10 +265,10 @@ sub body {
 		if ($set->assignment_type =~ /gateway/) {
 			my @setVersions =
 				$db->getSetVersionsWhere({ user_id => $editForUserID, set_id => { like => "$setID,v\%" } },
-					[qw/set_id version_id/]);
+					'version_id');
 			my @mergedVersions =
 				$db->getMergedSetVersionsWhere({ user_id => $editForUserID, set_id => { like => "$setID,v\%" } },
-					'set_id');
+					\"(SUBSTRING(set_id,INSTR(set_id,',v')+2)+0)");
 			$self->outputSetRow($set, $setVersions[$_], $mergedVersions[$_], $setVersions[$_]->version_id)
 				for (0 .. $#setVersions);
 		}

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -251,9 +251,7 @@ sub body {
 		print CGI::end_div();
 
 		# Determine if there are valid practice users.
-		# DBFIXME do this with a WHERE clause
-		my @guestUserIDs = grep m/^$practiceUserPrefix/, $db->listUsers;
-		my @GuestUsers = $db->getUsers(@guestUserIDs);
+		my @GuestUsers = $db->getUsersWhere({ user_id => { like => "$practiceUserPrefix\%" } });
 		my @allowedGuestUsers;
 		foreach my $GuestUser (@GuestUsers) {
 			next unless defined $GuestUser->status;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -35,8 +35,9 @@ use WeBWorK::Form;
 use WeBWorK::PG;
 use WeBWorK::PG::ImageGenerator;
 use WeBWorK::PG::IO;
-use WeBWorK::Utils qw(readFile writeLog writeCourseLog encodeAnswers decodeAnswers is_restricted
-	ref2string makeTempDirectory path_is_subdir sortByName before after between wwRound is_jitar_problem_closed is_jitar_problem_hidden jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id jitar_problem_finished);
+use WeBWorK::Utils qw(readFile writeLog writeCourseLog encodeAnswers decodeAnswers is_restricted ref2string
+	makeTempDirectory path_is_subdir before after between wwRound is_jitar_problem_closed is_jitar_problem_hidden
+	jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id jitar_problem_finished);
 use WeBWorK::DB::Utils qw(global2user user2global);
 require WeBWorK::Utils::ListingDB;
 use URI::Escape;
@@ -437,26 +438,13 @@ sub pre_header_initialize {
 
 	die("You do not have permission to view unopened sets") unless $self->{isOpen};
 
-	# Database fix (in case of undefined visiblity state values)
-	# this is only necessary because some people keep holding to ww1.9 which did not have a visible field
-	# make sure visible is set to 0 or 1
-	if ( $set and $set->visible ne "0" and $set->visible ne "1") {
-		my $globalSet = $db->getGlobalSet($set->set_id);
-		$globalSet->visible("1");	# defaults to visible
-		$db->putGlobalSet($globalSet);
-		$set = $db->getMergedSet($effectiveUserName, $setName);
-	} else {
-		# don't do anything just yet, maybe we're a professor and we're
-		# fabricating a set or haven't assigned it to ourselves just yet
-	}
-		# When a set is created enable_reduced_scoring is null, so we have to set it
+	# When a set is created enable_reduced_scoring is null, so we have to set it
 	if ( $set and $set->enable_reduced_scoring ne "0" and $set->enable_reduced_scoring ne "1") {
 		my $globalSet = $db->getGlobalSet($set->set_id);
 		$globalSet->enable_reduced_scoring("0");	# defaults to disabled
 		$db->putGlobalSet($globalSet);
 		$set = $db->getMergedSet($effectiveUserName, $setName);
 	}
-
 
 	# obtain the merged problem for $effectiveUser
 	my $problem = $db->getMergedProblem($effectiveUserName, $setName, $problemNumber); # checked
@@ -884,19 +872,11 @@ sub siblings {
 	my $courseID = $urlpath->arg("courseID");
 	my $setID = $self->{set}->set_id;
 	my $eUserID = $r->param("effectiveUser");
-	my @problemIDs = sort { $a <=> $b } $db->listUserProblems($eUserID, $setID);
 
-	my $isJitarSet = 0;
+	my @problemRecords = $db->getMergedProblemsWhere({ user_id => $eUserID, set_id => $setID }, 'problem_id');
+	my @problemIDs     = map { $_->problem_id } @problemRecords;
 
-	if ($setID) {
-	    my $set = $r->db->getGlobalSet($setID);
-	    if ($set && $set->assignment_type eq 'jitar') {
-		$isJitarSet = 1;
-	    }
-	}
-
-	my @where = map {[$eUserID, $setID, $_]} @problemIDs;
-	my @problemRecords = $db->getMergedProblems(@where);
+	my $isJitarSet = $setID && $self->{set}->assignment_type eq 'jitar' ? 1 : 0;
 
 	# variables for the progress bar
 	my $num_of_problems  = 0;
@@ -1081,15 +1061,15 @@ sub nav {
 	# Set up a student navigation for those that have permission to act as a student.
 	my $userNav = "";
 	if ($authz->hasPermissions($userID, "become_student") && $eUserID ne $userID) {
-		# Find all users for this set (except the current user).
-		my @userRecords = $db->getUsers(grep { $_ ne $userID } $db->listSetUsers($setID));
-
-		# Sort by last name, then first name, then user_id.
-		@userRecords = sort {
-			lc($a->last_name) cmp lc($b->last_name) ||
-			lc($a->first_name) cmp lc($b->first_name) ||
-			lc($a->user_id) cmp lc($b->user_id)
-		} @userRecords;
+		# Find all users for this set (except the current user) sorted by last_name, then first_name, then user_id.
+		my @userRecords = $db->getUsersWhere(
+			{
+				user_id => [
+					map { $_->[0] } $db->listUserSetsWhere({ set_id => $setID, user_id => { not_like => $userID } })
+				]
+			},
+			[qw/last_name first_name user_id/]
+		);
 
 		# Find the previous, current, and next users, and format the student names for display.
 		my $currentUserIndex = 0;
@@ -1198,10 +1178,8 @@ sub nav {
 	# for jitar sets finding the next or previous problem, and seeing if it
 	# is actually open is a bit more of a process.
 	if (!$self->{invalidProblem}) {
-		my @problemIDs = $db->listUserProblems($eUserID, $setID);
-
-		@problemIDs = sort { $a <=> $b } @problemIDs;
-
+		my @problemIDs =
+			map { $_->[2] } $db->listUserProblemsWhere({ user_id => $eUserID, set_id => $setID }, 'problem_id');
 
 		if ($isJitarSet) {
 		    my @processedProblemIDs;
@@ -1899,8 +1877,8 @@ sub output_score_summary{
 	#print jitar specific informaton for students. (and notify instructor
 	# if necessary
 	if ($set->set_id ne 'Undefined_Set' && $set->assignment_type() eq 'jitar') {
-	  my @problemIDs = $db->listUserProblems($effectiveUser, $set->set_id);
-	  @problemIDs = sort { $a <=> $b } @problemIDs;
+	  my @problemIDs =
+	    map { $_->[2] } $db->listUserProblemsWhere({ user_id => $effectiveUser, set_id => $set->set_id }, 'problem_id');
 
 	  # get some data
 	  my @problemSeqs;
@@ -2168,8 +2146,9 @@ sub output_summary{
 
 	if ($set->set_id ne 'Undefined_Set' && $set->assignment_type() eq 'jitar') {
 	my $hasChildren = 0;
-	my @problemIDs = $db->listUserProblems($effectiveUser, $set->set_id);
-	@problemIDs = sort { $a <=> $b } @problemIDs;
+
+	my @problemIDs =
+		map { $_->[2] } $db->listUserProblemsWhere({ user_id => $effectiveUser, set_id => $set->set_id }, 'problem_id');
 
 	# get some data
 	my @problemSeqs;
@@ -2217,10 +2196,6 @@ sub output_achievement_message{
 
 	my $r = $self->r;
 	my $ce = $r->ce;
-	my $db = $r->db;
-
-	my $authz = $r->authz;
-	my $user = $r->param('user');
 
 	#If achievements enabled, and if we are not in a try it page, check to see if there are new ones.and print them
 	if ($ce->{achievementsEnabled} && $will{recordAnswers}

--- a/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/instructorXMLHandler.pm
@@ -6,7 +6,7 @@
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -15,7 +15,7 @@
 
 =head1 NAME
 
-WeBWorK::ContentGenerator::ProblemRenderer - renderViaXMLRPC is an HTML 
+WeBWorK::ContentGenerator::ProblemRenderer - renderViaXMLRPC is an HTML
 front end for calls to the xmlrpc webservice
 
 =cut
@@ -29,7 +29,7 @@ use WeBWorK::Debug;
 use WeBWorK::Utils qw(readFile);
 use PGUtil qw(not_null);
 
-our $UNIT_TESTS_ON      = 0;  # should be called DEBUG??  FIXME
+our $UNIT_TESTS_ON = 0;    # should be called DEBUG??  FIXME
 
 #use XMLRPC::Lite;
 
@@ -37,7 +37,6 @@ use strict;
 use warnings;
 use WebworkClient;
 use JSON;
-
 
 =head1 Description
 
@@ -49,9 +48,9 @@ use JSON;
  returns xml resutls
 
 =cut
- 
+
 # To configure the target webwork server two URLs are required
-# 1. http://test.webwork.maa.org/mod_xmlrpc 
+# 1. http://test.webwork.maa.org/mod_xmlrpc
 #    points to the Webservice.pm and Webservice/RenderProblem modules
 #    Is used by the client to send the original XML request to the webservice
 #  Note: This NOT the same as the webworkClient->url which does NOT have
@@ -63,78 +62,71 @@ use JSON;
 #
 #     This url is placed as form action url when the rendered HTML from the original
 #     request is returned to the client from Webservice/RenderProblem. The client
-#     reorganizes the XML it receives into an HTML page (with a WeBWorK form) and 
+#     reorganizes the XML it receives into an HTML page (with a WeBWorK form) and
 #     pipes it through a local browser.
 #
 #     The browser uses this url to resubmit the problem (with answers) via the standard
-#     HTML webform used by WeBWorK to the instructorXMLHandler.pm handler.  
+#     HTML webform used by WeBWorK to the instructorXMLHandler.pm handler.
 #
-#     This instructorXMLHandler.pm handler acts as an intermediary between the browser 
-#     and the webservice.  It interprets the HTML form sent by the browser, 
-#     rewrites the form data in XML format, submits it to the WebworkWebservice.pm 
+#     This instructorXMLHandler.pm handler acts as an intermediary between the browser
+#     and the webservice.  It interprets the HTML form sent by the browser,
+#     rewrites the form data in XML format, submits it to the WebworkWebservice.pm
 #     which processes it and sends the the resulting HTML back to renderViaXMLRPC.pm
 #     which in turn passes it back to the browser.
-# 3.  The second time a problem is submitted instructorXMLHandler.pm receives the WeBWorK form 
-#     submitted directly by the browser.  
+# 3.  The second time a problem is submitted instructorXMLHandler.pm receives the WeBWorK form
+#     submitted directly by the browser.
 #     The instructorXMLHandler.pm translates the WeBWorK form, has it processed by the webservice
-#     and returns the result to the browser. 
+#     and returns the result to the browser.
 #     The The client renderProblem.pl script is no longer involved.
-
 
 # Determine the root directory for webwork on this machine (e.g. /opt/webwork/webwork2 )
 # this is set in webwork.apache2-config
 # it specifies the address of the webwork root directory
 
-
-my $webwork_dir  = $WeBWorK::Constants::WEBWORK_DIRECTORY;
+my $webwork_dir = $WeBWorK::Constants::WEBWORK_DIRECTORY;
 unless ($webwork_dir) {
-	die " instructorXMLHandler.pm requires that the top WeBWorK directory be set in ".
-	"\$WeBWorK::Constants::WEBWORK_DIRECTORY by webwork.apache-config or webwork.apache2-config\n";
+	die " instructorXMLHandler.pm requires that the top WeBWorK directory be set in "
+		. "\$WeBWorK::Constants::WEBWORK_DIRECTORY by webwork.apache-config or webwork.apache2-config\n";
 }
 
 # read the webwork2/conf/defaults.config file to determine other parameters
 #
-my $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
+my $seed_ce         = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
 my $server_root_url = $seed_ce->{server_root_url};
 unless ($server_root_url) {
-	die "unable to determine apache server url using course environment |$seed_ce|.".
-	    "check that the variable \$server_root_url has been properly set in conf/site.conf\n";
+	die "unable to determine apache server url using course environment |$seed_ce|."
+		. "check that the variable \$server_root_url has been properly set in conf/site.conf\n";
 }
 
 ############################
 # These variables are set when the child process is started
-# and remain constant through all of the calls handled by the 
+# and remain constant through all of the calls handled by the
 # child
 ############################
 
 our ($SITE_URL, $FORM_ACTION_URL, $XML_PASSWORD, $XML_COURSE);
 
-	$XML_PASSWORD     	 =  'xmluser';
-	$XML_COURSE          =  'daemon_course';
+$XML_PASSWORD = 'xmluser';
+$XML_COURSE   = 'daemon_course';
 
+$SITE_URL        = "$server_root_url";
+$FORM_ACTION_URL = "$server_root_url/webwork2/instructorXMLHandler";
 
+use constant DISPLAYMODE => 'images';    #  Mathjax  is another possibilities.
 
-	$SITE_URL            =  "$server_root_url" ; 
-	$FORM_ACTION_URL     =  "$server_root_url/webwork2/instructorXMLHandler";
-
-use constant DISPLAYMODE   => 'images'; #  Mathjax  is another possibilities.
-
-
-
-our @COMMANDS = qw( listLibraries    renderProblem  ); #listLib  readFile tex2pdf 
-
+our @COMMANDS = qw( listLibraries    renderProblem  );    #listLib  readFile tex2pdf
 
 # error formatting
 sub format_hash_ref {
 	my $hash = shift;
-	warn "Use a hash reference".caller() unless ref($hash) =~/HASH/;
-	my $out_str="";
-	my $count =4;
-	foreach my $key ( sort keys %$hash) {
-		my $value = defined($hash->{$key})? $hash->{$key}:"--";
-		$out_str.= " $key=>$value ";
+	warn "Use a hash reference" . caller() unless ref($hash) =~ /HASH/;
+	my $out_str = "";
+	my $count   = 4;
+	foreach my $key (sort keys %$hash) {
+		my $value = defined($hash->{$key}) ? $hash->{$key} : "--";
+		$out_str .= " $key=>$value ";
 		$count--;
-		unless($count) { $out_str.="\n  ";$count =4;}
+		unless ($count) { $out_str .= "\n  "; $count = 4; }
 	}
 	$out_str;
 }
@@ -146,27 +138,24 @@ sub templateName {
 # end configuration section
 ##################################################
 
-
 sub pre_header_initialize {
 	my ($self) = @_;
 	my $r = $self->r;
- 
- 	# debug($r->param("visible"));	
- 
- 
- 
-    #######################
-    #  setup xmlrpc client
-    #######################
-    my $xmlrpc_client = new WebworkClient;
 
-	$xmlrpc_client->site_url($SITE_URL);  # does NOT include mod_xmlrpc ending
-#	$xmlrpc_client->{site_url} ='';   # make this the site without the mod_xmlrpc ending? ~= s/mod_xmlrpc$
-	$xmlrpc_client->{form_action_url}= $FORM_ACTION_URL;
-	$xmlrpc_client->{user}          = 'xmluser';
-	$xmlrpc_client->{site_password} = $XML_PASSWORD;
-#	$xmlrpc_client->{course}        = $r->param('courseID');
-	$xmlrpc_client->{courseID}      = $r->param('courseID');
+	# debug($r->param("visible"));
+
+	#######################
+	#  setup xmlrpc client
+	#######################
+	my $xmlrpc_client = new WebworkClient;
+
+	$xmlrpc_client->site_url($SITE_URL);    # does NOT include mod_xmlrpc ending
+		#	$xmlrpc_client->{site_url} ='';   # make this the site without the mod_xmlrpc ending? ~= s/mod_xmlrpc$
+	$xmlrpc_client->{form_action_url} = $FORM_ACTION_URL;
+	$xmlrpc_client->{user}            = 'xmluser';
+	$xmlrpc_client->{site_password}   = $XML_PASSWORD;
+	#	$xmlrpc_client->{course}        = $r->param('courseID');
+	$xmlrpc_client->{courseID} = $r->param('courseID');
 
 	# print STDERR WebworkClient::pretty_print($r->{paramcache});
 
@@ -175,44 +164,41 @@ sub pre_header_initialize {
 	delete $input->{user_id};
 	$input->{userID} = $r->param("user") || undef;
 	$input->{source} = '';
-	$input->{id} = $r->param('user_id') || undef;
+	$input->{id}     = $r->param('user_id') || undef;
 
 	if ($UNIT_TESTS_ON) {
-		print STDERR "\tinstructorXMLHandler.pm ".__LINE__." values obtained from form parameters\n\t",
-		   format_hash_ref($input),"\n";
+		print STDERR "\tinstructorXMLHandler.pm " . __LINE__ . " values obtained from form parameters\n\t",
+			format_hash_ref($input), "\n";
 	}
 	my $source = "";
 	#print $r->param('problemPath');
 	my $problemPath = $r->param('problemPath');
 	if (defined($problemPath) and $problemPath) {
-            $input->{path} = $problemPath;
+		$input->{path} = $problemPath;
 	} elsif ($r->param('problemSource')) {
-            $input->{source} = $r->param('problemSource');
-        }
+		$input->{source} = $r->param('problemSource');
+	}
 
 	my $std_input = standard_input();
-	$input = {%$std_input, %$input};
+	$input = { %$std_input, %$input };
 	# Fix the environment display mode and problemSeed
 	# Set environment variables for hints/solutions
 	# Set the permission level and probNum
 	$input->{envir} = {
-		%{$input->{envir}},		# this may have undefined entries
-		showHints 		=> ($r->param('showHints')) ? $r->param('showHints'):0,
-		showSolutions 	=> ($r->param('showSolutions')) ? $r->param('showSolutions'):0,
-		probNum  		=> $r->param("probNum") ||undef, 
-		permissionLevel => ($r->{ce}->{userRoles}->{$r->param('permissionLevel')//0})// 0,
+		%{ $input->{envir} },    # this may have undefined entries
+		showHints       => ($r->param('showHints'))     ? $r->param('showHints')     : 0,
+		showSolutions   => ($r->param('showSolutions')) ? $r->param('showSolutions') : 0,
+		probNum         => $r->param("probNum") || undef,
+		permissionLevel => ($r->{ce}->{userRoles}->{ $r->param('permissionLevel') // 0 }) // 0,
 		displayMode     => $r->param("displayMode") || undef,
-		problemSeed	    => $r->param("problemSeed") || 0,
-		
- 	};
- 	$input->{envir}->{inputs_ref} ={
- 		%{ $input->{envir}->{inputs_ref}},
+		problemSeed     => $r->param("problemSeed") || 0,
+
+	};
+	$input->{envir}->{inputs_ref} = {
+		%{ $input->{envir}->{inputs_ref} },
 		displayMode => $r->param("displayMode") || 0,
 		problemSeed => $r->param("problemSeed") || 0,
 	};
-
-
-	
 
 	##############################
 	# xmlrpc_client calls webservice with the requested command
@@ -223,149 +209,145 @@ sub pre_header_initialize {
 	##############################
 	#if ( $xmlrpc_client->jsXmlrpcCall($r->param("xml_command"), $input) ) {
 	#	print "tried to render a problem";
-		#$self->{output} = ($xmlrpc_client->formatRenderedProblem); #not sure what to do here just yet.
+	#$self->{output} = ($xmlrpc_client->formatRenderedProblem); #not sure what to do here just yet.
 	#} else {
 	#	$self->{output} = $xmlrpc_client->{output};  # error report
 	#	print $xmlrpc_client->{output};
 	#}
-	if($r->param('xml_command') eq "addProblem" || $r->param('xml_command') eq "deleteProblem"){
+	if ($r->param('xml_command') eq "addProblem" || $r->param('xml_command') eq "deleteProblem") {
 		$input->{path} = $r->param('problemPath');
 	}
-	
-	if($r->param('xml_command') eq "renderProblem"){
-	    if (my $problemPath = $r->param('problemPath')) {
-	        $problemPath =~ m|templates/(.*)|;
-	        $problemPath = $1;    # get everything in the path after templates
-	    	$input->{envir}->{fileName}=$problemPath;
-	    }
+
+	if ($r->param('xml_command') eq "renderProblem") {
+		if (my $problemPath = $r->param('problemPath')) {
+			$problemPath =~ m|templates/(.*)|;
+			$problemPath = $1;                            # get everything in the path after templates
+			$input->{envir}->{fileName} = $problemPath;
+		}
 		$xmlrpc_client->xmlrpcCall('renderProblem', $input);
-		# original method of signaling $xmlrpc_client->{renderProblem} = 1; #flag to indicate the renderProblem command was executed.
 		$self->{xml_command} = 'renderProblem';
-		$self->{output} = $xmlrpc_client;
-		my @params = join(" ", $r->param() ); # this seems to be necessary to get things read.?
-		# FIXME  -- figure out why commmenting out the line above means that $envir->{fileName} is not defined. 
-		#$self->{output}->{text} = "Rendered problem";
-	} else {	
+		$self->{output}      = $xmlrpc_client;
+		my @params = join(" ", $r->param());    # this seems to be necessary to get things read.?
+			# FIXME  -- figure out why commmenting out the line above means that $envir->{fileName} is not defined.
+			#$self->{output}->{text} = "Rendered problem";
+	} else {
 		$xmlrpc_client->xmlrpcCall($r->param("xml_command"), $input);
 		$self->{xml_command} = $r->param("xml_command");
-		$self->{output} = $xmlrpc_client
+		$self->{output}      = $xmlrpc_client;
 	}
- }
- 
+}
 
 sub standard_input {
 	my $out = {
-		course_password         =>   '',   # not needed  use site_password??
-		session_key             =>   '',
-		userID          		=>   '',   # not needed
-		set               		=>   '',
-		library_name 			=>  'Library',
-		command      			=>  'all',
-		answer_form_submitted   =>   1,
-		mode                    => 'images',
-		envir                   => { 
-		                inputs_ref => {displayMode => DISPLAYMODE()},
-					    problemValue => -1, 
-					    fileName => ''},
-		problem_state           => {
-		
-			num_of_correct_ans  => 200, # we are picking phoney values so that solutions are available
+		course_password       => '',          # not needed  use site_password??
+		session_key           => '',
+		userID                => '',          # not needed
+		set                   => '',
+		library_name          => 'Library',
+		command               => 'all',
+		answer_form_submitted => 1,
+		mode                  => 'images',
+		envir                 => {
+			inputs_ref   => { displayMode => DISPLAYMODE() },
+			problemValue => -1,
+			fileName     => ''
+		},
+		problem_state => {
+
+			num_of_correct_ans   => 200,    # we are picking phoney values so that solutions are available
 			num_of_incorrect_ans => 400,
 			recorded_score       => 1.0,
 		},
-		source                   => '',  #base64 encoded
-		
-		
-		
+		source => '',                       #base64 encoded
+
 	};
 
 	$out;
 }
 
-
-sub pretty_print_json { 
-    shift if UNIVERSAL::isa($_[0] => __PACKAGE__);
-	my $rh = shift;
+sub pretty_print_json {
+	shift if UNIVERSAL::isa($_[0] => __PACKAGE__);
+	my $rh     = shift;
 	my $indent = shift || 0;
-	
-	my $out = "";
+
+	my $out  = "";
 	my $type = ref($rh);
 
 	if (defined($type) and $type) {
 		#$out .= " type = $type; ";
-	} elsif (! defined($rh )) {
+	} elsif (!defined($rh)) {
 		#$out .= " type = UNDEFINED; ";
 	}
-	return $out."" unless defined($rh);
-	
-	if ( ref($rh) =~/HASH/ or "$rh" =~/HASH/ ) {
-	    $indent++;
- 		foreach my $key (sort keys %{$rh})  {
- 			$out .= "  ".'"'.$key.'" : '. pretty_print_json( $rh->{$key}) . ",";
- 		}
- 		$indent--;
- 		#get rid of the last comma
- 		chop $out;
- 		$out = "{\n$out\n"."}\n";
+	return $out . "" unless defined($rh);
 
- 	} elsif (ref($rh)  =~  /ARRAY/ or "$rh" =~/ARRAY/) {
- 		foreach my $elem ( @{$rh} )  {
- 		 	$out .= pretty_print_json($elem).",";
- 		
- 		}
- 		#get rid of the last comma
- 		chop $out;
- 		$out = "[\n$out\n"."]\n";
- 		#$out =  '"'.$out.'"';
-	} elsif ( ref($rh) =~ /SCALAR/ ) {
-		$out .= "scalar reference ". ${$rh};
-	} elsif ( ref($rh) =~/Base64/ ) {
-		$out .= "base64 reference " .$$rh;
+	if (ref($rh) =~ /HASH/ or "$rh" =~ /HASH/) {
+		$indent++;
+		foreach my $key (sort keys %{$rh}) {
+			$out .= "  " . '"' . $key . '" : ' . pretty_print_json($rh->{$key}) . ",";
+		}
+		$indent--;
+		#get rid of the last comma
+		chop $out;
+		$out = "{\n$out\n" . "}\n";
 
-    } elsif ($rh  =~ /^[+-]?\d+$/){
-        $out .=  $rh;
+	} elsif (ref($rh) =~ /ARRAY/ or "$rh" =~ /ARRAY/) {
+		foreach my $elem (@{$rh}) {
+			$out .= pretty_print_json($elem) . ",";
+
+		}
+		#get rid of the last comma
+		chop $out;
+		$out = "[\n$out\n" . "]\n";
+		#$out =  '"'.$out.'"';
+	} elsif (ref($rh) =~ /SCALAR/) {
+		$out .= "scalar reference " . ${$rh};
+	} elsif (ref($rh) =~ /Base64/) {
+		$out .= "base64 reference " . $$rh;
+
+	} elsif ($rh =~ /^[+-]?\d+$/) {
+		$out .= $rh;
 	} else {
-		$out .=  '"'.$rh.'"';
+		$out .= '"' . $rh . '"';
 	}
-	
-	return $out."";
+
+	return $out . "";
 }
 
 sub content {
-   ###########################
-   # Return content of rendered problem to the browser that requested it
-   ###########################
-   	my $self = shift;
+	###########################
+	# Return content of rendered problem to the browser that requested it
+	###########################
+	my $self = shift;
 	my $xmlrpc_client;
-	if ( ref($self->{output})=~/WebworkClient/) {
+	if (ref($self->{output}) =~ /WebworkClient/) {
 		$xmlrpc_client = $self->{output};
 	} else {
 		Croak("No content was returned by the xmlrpc call");
 	}
-	if ( ($xmlrpc_client->fault) ) {  # error -- print error string
-	    my $err_string = $xmlrpc_client->error_string;	    
-	    die($err_string);
-	} elsif($self->{xml_command} eq 'renderProblem'){
+	if (($xmlrpc_client->fault)) {    # error -- print error string
+		my $err_string = $xmlrpc_client->error_string;
+		die($err_string);
+	} elsif ($self->{xml_command} eq 'renderProblem') {
 		# FIXME hack
 		# we need to regularize the way that text is returned.
 		# it behaves differently when re-randomization in the library takes place
-		# then during the initial rendering. 
+		# then during the initial rendering.
 		# print only the text field (not the ra_out field)
-	        # and print the text directly without formatting.
-	    
+		# and print the text directly without formatting.
+
 		if ($xmlrpc_client->return_object->{problem_out}->{text}) {
 			print $xmlrpc_client->return_object->{problem_out}->{text};
 		} else {
-				print $xmlrpc_client->return_object->{text}; 
+			print $xmlrpc_client->return_object->{text};
 		}
-	} else {  #returned something other than a rendered problem.
-	    	  # in this case format a json string and print it. 
-	    	  # the contents of "{text}" needs to be labeled server response;
-		print '{"server_response":"'.$xmlrpc_client->return_object->{text}.'",';
-		if($xmlrpc_client->return_object->{ra_out}){
+	} else {    #returned something other than a rendered problem.
+				# in this case format a json string and print it.
+				# the contents of "{text}" needs to be labeled server response;
+		print '{"server_response":"' . $xmlrpc_client->return_object->{text} . '",';
+		if ($xmlrpc_client->return_object->{ra_out}) {
 			# print '"result_data":'.pretty_print_json($xmlrpc->return_object->{ra_out}).'}';
 			if (ref($xmlrpc_client->return_object->{ra_out})) {
-				print '"result_data": ' . to_json($xmlrpc_client->return_object->{ra_out}) .'}';
+				print '"result_data": ' . to_json($xmlrpc_client->return_object->{ra_out}) . '}';
 			} else {
 				print '"result_data": "' . $xmlrpc_client->return_object->{ra_out} . '"}';
 			}
@@ -375,8 +357,5 @@ sub content {
 	}
 	#print "".pretty_print_json($self->{output}->{ra_out});
 }
-
-
-
 
 1;

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System>
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/DB.pm,v 1.112 2012/06/08 22:40:00 wheeler Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -23,20 +23,20 @@ WeBWorK::DB - interface with the WeBWorK databases.
 =head1 SYNOPSIS
 
  my $db = WeBWorK::DB->new($dbLayout);
- 
+
  my @userIDs = $db->listUsers();
  my $Sam = $db->{user}->{record}->new();
- 
+
  $Sam->user_id("sammy");
  $Sam->first_name("Sam");
  $Sam->last_name("Hathaway");
  # etc.
- 
+
  $db->addUser($User);
  my $Dennis = $db->getUser("dennis");
  $Dennis->status("C");
  $db->putUser->($Dennis);
- 
+
  $db->deleteUser("sammy");
 
 =head1 DESCRIPTION
@@ -222,18 +222,18 @@ sub new {
 	my $class = ref($invocant) || $invocant;
 	my $self = {};
 	bless $self, $class; # bless this here so we can pass it to the schema
-	
+
 	# load the modules required to handle each table, and create driver
 	foreach my $table (keys %$dbLayout) {
 		$self->init_table($dbLayout, $table);
 	}
-	
+
 	return $self;
 }
 
 sub init_table {
 	my ($self, $dbLayout, $table) = @_;
-	
+
 	if (exists $self->{$table}) {
 		if (defined $self->{$table}) {
 			return;
@@ -241,7 +241,7 @@ sub init_table {
 			die "loop in dbLayout table dependencies involving table '$table'\n";
 		}
 	}
-	
+
 	my $layout = $dbLayout->{$table};
 	my $record = $layout->{record};
 	my $schema = $layout->{schema};
@@ -251,30 +251,30 @@ sub init_table {
 	my $params = $layout->{params};
   	my $engine = $layout->{engine};
   	my $character_set = $layout->{character_set};
-	
+
 	# add a key for this table to the self hash, but don't define it yet
 	# this for loop detection
 	$self->{$table} = undef;
-	
+
 	if ($depend) {
 		foreach my $dep (@$depend) {
 			$self->init_table($dbLayout, $dep);
 		}
 	}
-	
+
 	runtime_use($record);
-	
+
 	runtime_use($driver);
 	my $driverObject = eval { $driver->new($source, $params) };
 	croak "error instantiating DB driver $driver for table $table: $@"
 		if $@;
-	
+
 	runtime_use($schema);
 	my $schemaObject = eval { $schema->new(
 		$self, $driverObject, $table, $record, $params, $engine, $character_set) };
 	croak "error instantiating DB schema $schema for table $table: $@"
 		if $@;
-	
+
 	$self->{$table} = $schemaObject;
 }
 
@@ -370,7 +370,7 @@ sub gen_delete_where {
 
 sub create_tables {
 	my ($self) = @_;
-	
+
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/; # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native}; # skip non-native tables
@@ -381,13 +381,13 @@ sub create_tables {
 			warn "skipping creation of '$table' table: no create_table method\n";
 		}
 	}
-	
+
 	return 1;
 }
 
 sub rename_tables {
 	my ($self, $new_dblayout) = @_;
-	
+
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/; # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native}; # skip non-native tables
@@ -406,13 +406,13 @@ sub rename_tables {
 			warn "skipping renaming of '$table' table: table doesn't exist in new dbLayout\n";
 		}
 	}
-	
+
 	return 1;
 }
 
 sub delete_tables {
 	my ($self) = @_;
-	
+
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/; # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native}; # skip non-native tables
@@ -423,13 +423,13 @@ sub delete_tables {
 			warn "skipping deletion of '$table' table: no delete_table method\n";
 		}
 	}
-	
+
 	return 1;
 }
 
 sub dump_tables {
 	my ($self, $dump_dir) = @_;
-	
+
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/; # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native}; # skip non-native tables
@@ -441,13 +441,13 @@ sub dump_tables {
 			warn "skipping dump of '$table' table: no dump_table method\n";
 		}
 	}
-	
+
 	return 1;
 }
 
 sub restore_tables {
 	my ($self, $dump_dir) = @_;
-	
+
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/; # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native}; # skip non-native tables
@@ -459,7 +459,7 @@ sub restore_tables {
 			warn "skipping restore of '$table' table: no restore_table method\n";
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -478,12 +478,13 @@ BEGIN {
 
 sub countUsers { return scalar shift->listUsers(@_) }
 
+# Note: This returns a list of user_ids for all users except set level proctors.
 sub listUsers {
 	my ($self) = shift->checkArgs(\@_);
 	if (wantarray) {
-		return map { @$_ } $self->{user}->get_fields_where(["user_id"]);
+		return map {@$_} $self->{user}->get_fields_where(['user_id'], { user_id => { not_like => 'set_id:%' } });
 	} else {
-		return $self->{user}->count_where;
+		return $self->{user}->count_where({ user_id => { not_like => 'set_id:%' } });
 	}
 }
 
@@ -517,7 +518,7 @@ sub addUser {
 	# through to the calling code. however, right now we have code that checks
 	# for the string "... exists" in the error message, so we need to convert
 	# here.
-	# 
+	#
 	# WeBWorK::DB::Ex::RecordExists
 	# WeBWorK::DB::Ex::DependencyNotFound - i.e. inserting a password for a nonexistent user
 	# ?
@@ -581,9 +582,9 @@ sub getPassword {
 
 sub getPasswords {
 	my ($self, @userIDs) = shift->checkArgs(\@_, qw/user_id*/);
-	
+
 	my @Passwords = $self->{password}->gets(map { [$_] } @userIDs);
-	
+
 	# AUTO-CREATE missing password records
 	# (this code is duplicated in getPermissionLevels, below)
 	for (my $i = 0; $i < @Passwords; $i++) {
@@ -600,16 +601,16 @@ sub getPasswords {
 			}
 		}
 	}
-	
+
 	return @Passwords;
 }
 
 sub addPassword {
 	my ($self, $Password) = shift->checkArgs(\@_, qw/REC:password/);
-	
+
 	croak "addPassword: user ", $Password->user_id, " not found"
 		unless $self->{user}->exists($Password->user_id);
-	
+
 	eval {
 		return $self->{password}->add($Password);
 	};
@@ -674,9 +675,9 @@ sub getPermissionLevel {
 
 sub getPermissionLevels {
 	my ($self, @userIDs) = shift->checkArgs(\@_, qw/user_id*/);
-	
+
 	my @PermissionLevels = $self->{permission}->gets(map { [$_] } @userIDs);
-	
+
 	# AUTO-CREATE missing permission level records
 	# (this code is duplicated in getPasswords, above)
 	for (my $i = 0; $i < @PermissionLevels; $i++) {
@@ -693,16 +694,16 @@ sub getPermissionLevels {
 			}
 		}
 	}
-	
+
 	return @PermissionLevels;
 }
 
 sub addPermissionLevel {
 	my ($self, $PermissionLevel) = shift->checkArgs(\@_, qw/REC:permission/);
-	
+
 	croak "addPermissionLevel: user ", $PermissionLevel->user_id, " not found"
 		unless $self->{user}->exists($PermissionLevel->user_id);
-	
+
 	eval {
 		return $self->{permission}->add($PermissionLevel);
 	};
@@ -771,12 +772,12 @@ sub getKeys {
 sub addKey {
 	# PROCTORING - allow comma in keyfields
 	my ($self, $Key) = shift->checkArgs(\@_, qw/VREC:key/);
-	
+
 	# PROCTORING -  check for both user and proctor
-	# we allow for two entries for proctor keys, one of the form 
-	#    userid,proctorid (which authorizes login), and the other 
+	# we allow for two entries for proctor keys, one of the form
+	#    userid,proctorid (which authorizes login), and the other
 	#    of the form userid,proctorid,g (which authorizes grading)
-	# (having two of these means that a proctored test will require 
+	# (having two of these means that a proctored test will require
 	#    authorization for both login and grading).
 	if ($Key->user_id =~ /([^,]+)(?:,([^,]*))?(,g)?/) {
 		my ($userID, $proctorID) = ($1, $2);
@@ -791,7 +792,7 @@ sub addKey {
 #			unless $self->{user}->exists($Key->user_id);
 			unless $Key -> key eq "nonce" or $self->{user}->exists($Key->user_id);
 	}
-	
+
 	eval {
 		return $self->{key}->add($Key);
 	};
@@ -879,11 +880,11 @@ sub deleteSetting {
 # locations functions
 ################################################################################
 # this database table is for ip restrictions by assignment
-# the locations table defines names of locations consisting of 
+# the locations table defines names of locations consisting of
 #    lists of ip masks (found in the location_addresses table)
 #    to which assignments can be restricted to or denied from.
 
-BEGIN { 
+BEGIN {
 	*Location = gen_schema_accessor("locations");
 	*newLocation = gen_new("locations");
 	*countLocationsWhere = gen_count_where("locations");
@@ -903,12 +904,12 @@ sub listLocations {
 	}
 }
 
-sub existsLocation { 
+sub existsLocation {
 	my ( $self, $locationID ) = shift->checkArgs(\@_, qw/location_id/);
 	return $self->{locations}->exists($locationID);
 }
 
-sub getLocation { 
+sub getLocation {
 	my ( $self, $locationID ) = shift->checkArgs(\@_, qw/location_id/);
 	return ( $self->getLocations($locationID) )[0];
 }
@@ -918,12 +919,12 @@ sub getLocations {
 	return $self->{locations}->gets(map {[$_]} @locationIDs);
 }
 
-sub getAllLocations { 
+sub getAllLocations {
 	my ( $self ) = shift->checkArgs(\@_);
 	return $self->{locations}->get_records_where();
 }
 
-sub addLocation { 
+sub addLocation {
 	my ( $self, $Location ) = shift->checkArgs(\@_, qw/REC:locations/);
 
 	eval {
@@ -936,7 +937,7 @@ sub addLocation {
 	}
 }
 
-sub putLocation { 
+sub putLocation {
 	my ($self, $Location) = shift->checkArgs(\@_, qw/REC:locations/);
 	my $rows = $self->{locations}->put($Location);
 	if ( $rows == 0 ) {
@@ -955,10 +956,10 @@ sub deleteLocation {
 	$self->deleteGlobalSetLocation(undef, $locationID);
 	$self->deleteUserSetLocation(undef, undef, $locationID);
 
-	# NOTE: the one piece of this that we don't address is if this 
+	# NOTE: the one piece of this that we don't address is if this
 	#    results in all of the locations in a set's restriction being
-	#    cleared; in this case, we should probably also reset the 
-	#    set->restrict_ip setting as well.  but that requires going 
+	#    cleared; in this case, we should probably also reset the
+	#    set->restrict_ip setting as well.  but that requires going
 	#    out and doing a bunch of manipulations that well exceed what
 	#    we want to do in this routine, so we'll assume that the user
 	#    is smart enough to deal with that on her own.
@@ -973,10 +974,10 @@ sub deleteLocation {
 # location_addresses functions
 ################################################################################
 # this database table is for ip restrictions by assignment
-# the location_addresses table defines the ipmasks associate 
+# the location_addresses table defines the ipmasks associate
 #    with the locations that are used for restrictions.
 
-BEGIN { 
+BEGIN {
 	*LocationAddress = gen_schema_accessor("location_addresses");
 	*newLocationAddress = gen_new("location_addresses");
 	*countLocationAddressesWhere = gen_count_where("location_addresses");
@@ -987,7 +988,7 @@ BEGIN {
 
 sub countAddressLocations { return scalar shift->listAddressLocations(@_) }
 
-sub listAddressLocations { 
+sub listAddressLocations {
 	my ($self, $ipmask) = shift->checkArgs(\@_, qw/ip_mask/);
 	my $where = [ip_mask_eq => $ipmask];
 	if ( wantarray ) {
@@ -1002,14 +1003,14 @@ sub countLocationAddresses { return scalar shift->listLocationAddresses(@_) }
 sub listLocationAddresses {
 	my ($self, $locationID) = shift->checkArgs(\@_, qw/location_id/);
 	my $where = [location_id_eq => $locationID];
-	if ( wantarray ) { 
+	if ( wantarray ) {
 		return map {@$_} $self->{location_addresses}->get_fields_where(["ip_mask"],$where);
 	} else {
 		return $self->{location_addresses}->count_where($where);
 	}
 }
 
-sub existsLocationAddress { 
+sub existsLocationAddress {
 	my ($self, $locationID, $ipmask) = shift->checkArgs(\@_, qw/location_id ip_mask/);
 	return $self->{location_addresses}->exists($locationID, $ipmask);
 }
@@ -1017,15 +1018,15 @@ sub existsLocationAddress {
 # we wouldn't ever getLocationAddress or getLocationAddresses; to use those
 #   we would have to know all of the information that we're getting
 
-sub getAllLocationAddresses { 
+sub getAllLocationAddresses {
 	my ($self, $locationID) = shift->checkArgs(\@_, qw/location_id/);
 	my $where = [location_id_eq => $locationID];
 	return $self->{location_addresses}->get_records_where($where);
 }
 
-sub addLocationAddress { 
+sub addLocationAddress {
 	my ($self, $LocationAddress) = shift->checkArgs(\@_, qw/REC:location_addresses/);
-	croak "addLocationAddress: location ", $LocationAddress->location_id, " not found" 
+	croak "addLocationAddress: location ", $LocationAddress->location_id, " not found"
 		unless $self->{locations}->exists($LocationAddress->location_id);
 	eval {
 		return $self->{location_addresses}->add($LocationAddress);
@@ -1037,7 +1038,7 @@ sub addLocationAddress {
 	}
 }
 
-sub putLocationAddress { 
+sub putLocationAddress {
 	my ($self, $LocationAddress) = shift->checkArgs(\@_, qw/REC:location_addresses/);
 	my $rows = $self->{location_addresses}->put($LocationAddress);
 	if ( $rows == 0 ) {
@@ -1047,7 +1048,7 @@ sub putLocationAddress {
 	}
 }
 
-sub deleteLocationAddress { 
+sub deleteLocationAddress {
 	# allow for undef values
 	my $U = caller eq __PACKAGE__ ? "!" : "";
 	my ($self, $locationID, $ipmask) = shift->checkArgs(\@_, "location_id$U", "ip_mask$U");
@@ -1075,7 +1076,7 @@ sub listProblemPastAnswers {
 	$self = shift;
 	$self->checkArgs(\@_, qw/course_id? user_id set_id problem_id/);
 
-	#if a courseID is not provided then just do the search without a course 
+	#if a courseID is not provided then just do the search without a course
 	#id.  This is ok becaus the table is course specific.
 	my $where;
 	if ($#_ == 3) {
@@ -1102,7 +1103,7 @@ sub latestProblemPastAnswer {
 	$self = shift;
 	$self->checkArgs(\@_, qw/course_id? user_id set_id problem_id/);
 
-	#if a courseID is not provided then just do the search without a course 
+	#if a courseID is not provided then just do the search without a course
 	#id.  This is ok becaus the table is course specific.
 	my @answerIDs;
 	if ($#_ == 3) {
@@ -1142,9 +1143,9 @@ sub addPastAnswer {
 #	croak "addPastAnswert: course ", $pastAnswer->course_id, " not found"
 #		unless $self->{course}->exists($pastAnswer->course_id);
 
-	croak "addPastAnswert: user problem ", $pastAnswer->user_id, " ", 
+	croak "addPastAnswert: user problem ", $pastAnswer->user_id, " ",
               $pastAnswer->set_id, " ", $pastAnswer->problem_id, " not found"
-		unless 	$self->{problem_user}->exists($pastAnswer->user_id, 
+		unless 	$self->{problem_user}->exists($pastAnswer->user_id,
 						      $pastAnswer->set_id,
 						      $pastAnswer->problem_id);
 
@@ -1217,7 +1218,7 @@ sub getGlobalSets {
 
 sub addGlobalSet {
 	my ($self, $GlobalSet) = shift->checkArgs(\@_, qw/REC:set/);
-	
+
 	eval {
 
 		return $self->{set}->add($GlobalSet);
@@ -1290,7 +1291,7 @@ sub getAchievements {
 
 sub addAchievement {
 	my ($self, $Achievement) = shift->checkArgs(\@_, qw/REC:achievement/);
-	
+
 	eval {
 
 		return $self->{achievement}->add($Achievement);
@@ -1361,7 +1362,7 @@ sub getGlobalUserAchievements {
 
 sub addGlobalUserAchievement {
 	my ($self, $globalUserAchievement) = shift->checkArgs(\@_, qw/REC:global_user_achievement/);
-	
+
 	eval {
 
 	    return $self->{global_user_achievement}->add($globalUserAchievement);
@@ -1387,12 +1388,12 @@ sub deleteGlobalUserAchievement {
 	# userAchievementID can be undefined if being called from this package
 	my $U = caller eq __PACKAGE__ ? "!" : "";
 	my ($self, $userID) = shift->checkArgs(\@_, "user_id$U");
-	
+
 	my @achievements = $self->listUserAchievements($userID);
 	foreach my $achievement (@achievements) {
 	    $self->deleteUserAchievement($userID,$achievement);
 	}
-	
+
 	if ($self->{global_user_achievement}){
 		return $self->{global_user_achievement}->delete($userID);
 	} else {
@@ -1455,12 +1456,12 @@ sub getUserAchievements {
 
 sub addUserAchievement {
 	my ($self, $UserAchievement) = shift->checkArgs(\@_, qw/REC:achievement_user/);
-	
+
 	croak "addUserAchievement: user ", $UserAchievement->user_id, " not found"
 		unless $self->{user}->exists($UserAchievement->user_id);
 	croak "addUserAchievement: achievement ", $UserAchievement->achievement_id, " not found"
 		unless $self->{achievement}->exists($UserAchievement->achievement_id);
-	
+
 	eval {
 		return $self->{achievement_user}->add($UserAchievement);
 	};
@@ -1540,11 +1541,11 @@ sub getUserSets {
 	return $self->{set_user}->gets(@userSetIDs);
 }
 
-# the code from addUserSet() is duplicated in large part following in 
+# the code from addUserSet() is duplicated in large part following in
 # addVersionedUserSet; changes here should accordingly be propagated down there
 sub addUserSet {
 	my ($self, $UserSet) = shift->checkArgs(\@_, qw/REC:set_user/);
-	
+
 	croak "addUserSet: user ", $UserSet->user_id, " not found"
 		unless $self->{user}->exists($UserSet->user_id);
 	croak "addUserSet: set ", $UserSet->set_id, " not found"
@@ -1657,10 +1658,10 @@ sub getSetVersions {
 # versioned analog of addUserSet
 sub addSetVersion {
 	my ($self, $SetVersion) = shift->checkArgs(\@_, qw/REC:set_version/);
-	
+
 	croak "addSetVersion: set ", $SetVersion->set_id, " not found for user ", $SetVersion->user_id
 		unless $self->{set_user}->exists($SetVersion->user_id, $SetVersion->set_id);
-	
+
 	eval {
 		return $self->{set_version}->add($SetVersion);
 	};
@@ -1723,8 +1724,8 @@ sub getMergedSetVersions {
 # set_locations functions
 ################################################################################
 # this database table is for ip restrictions by assignment
-# the set_locations table defines the association between a 
-#    global set and the locations to which the set may be 
+# the set_locations table defines the association between a
+#    global set and the locations to which the set may be
 #    restricted or denied.
 
 BEGIN {
@@ -1749,12 +1750,12 @@ sub listGlobalSetLocations {
 	}
 }
 
-sub existsGlobalSetLocation { 
+sub existsGlobalSetLocation {
 	my ( $self, $setID, $locationID ) = shift->checkArgs(\@_, qw/set_id location_id/);
 	return $self->{set_locations}->exists( $setID, $locationID );
 }
 
-sub getGlobalSetLocation { 
+sub getGlobalSetLocation {
 	my ( $self, $setID, $locationID ) = shift->checkArgs(\@_, qw/set_id location_id/);
 	return ( $self->getGlobalSetLocations([$setID, $locationID]) )[0];
 }
@@ -1770,11 +1771,11 @@ sub getAllGlobalSetLocations {
 	return $self->{set_locations}->get_records_where( $where );
 }
 
-sub addGlobalSetLocation { 
+sub addGlobalSetLocation {
 	my ( $self, $GlobalSetLocation ) = shift->checkArgs(\@_, qw/REC:set_locations/);
 	croak "addGlobalSetLocation: set ", $GlobalSetLocation->set_id, " not found"
 		unless $self->{set}->exists($GlobalSetLocation->set_id);
-	
+
 	eval {
 		return $self->{set_locations}->add($GlobalSetLocation);
 	};
@@ -1808,7 +1809,7 @@ sub deleteGlobalSetLocation {
 ################################################################################
 # this database table is for ip restrictions by assignment
 # the set_locations_user table defines the set_user level
-#    modifications to the set_locations defined for the 
+#    modifications to the set_locations defined for the
 #    global set
 
 BEGIN {
@@ -1870,10 +1871,10 @@ sub getAllUserSetLocations {
 sub addUserSetLocation {
 	# VERSIONING - accept versioned ID fields
 	my ($self, $UserSetLocation) = shift->checkArgs(\@_, qw/VREC:set_locations_user/);
-	
+
 	croak "addUserSetLocation: user set ", $UserSetLocation->set_id, " for user ", $UserSetLocation->user_id, " not found"
 		unless $self->{set_user}->exists($UserSetLocation->user_id, $UserSetLocation->set_id);
-	
+
 	eval {
 		return $self->{set_locations_user}->add($UserSetLocation);
 	};
@@ -1889,7 +1890,7 @@ sub addUserSetLocation {
 sub putUserSetLocation {
 	my $V = $_[2] ? "V" : "";
 	my ($self, $UserSetLocation, undef) = shift->checkArgs(\@_, "${V}REC:set_locations_user", "versioned_ok!?");
-	
+
 	my $rows = $self->{set_locations_user}->put($UserSetLocation); # DBI returns 0E0 for 0.
 	if ($rows == 0) {
 		croak "putUserSetLocation: user set location not found (perhaps you meant to use addUserSetLocation?)";
@@ -1910,8 +1911,8 @@ sub deleteUserSetLocation {
 ################################################################################
 # this is different from other set_merged functions, because
 #    in this case the only data that we have are the set_id,
-#    location_id, and user_id, and we want to replace all 
-#    locations from GlobalSetLocations with those from 
+#    location_id, and user_id, and we want to replace all
+#    locations from GlobalSetLocations with those from
 #    UserSetLocations if the latter exist.
 
 sub getAllMergedSetLocations {
@@ -1972,10 +1973,10 @@ sub getAllGlobalProblems {
 }
 
 sub addGlobalProblem {	my ($self, $GlobalProblem) = shift->checkArgs(\@_, qw/REC:problem/);
-	
+
 	croak "addGlobalProblem: set ", $GlobalProblem->set_id, " not found"
 		unless $self->{set}->exists($GlobalProblem->set_id);
-	
+
 	eval {
 		return $self->{problem}->add($GlobalProblem);
 	};
@@ -2065,7 +2066,7 @@ sub getAllUserProblems {
 sub addUserProblem {
 	# VERSIONING - accept versioned ID fields
 	my ($self, $UserProblem) = shift->checkArgs(\@_, qw/VREC:problem_user/);
-	
+
 	croak "addUserProblem: user set ", $UserProblem->set_id, " for user ", $UserProblem->user_id, " not found"
 		unless $self->{set_user}->exists($UserProblem->user_id, $UserProblem->set_id);
 
@@ -2073,7 +2074,7 @@ sub addUserProblem {
 
 	croak "addUserProblem: problem ", $UserProblem->problem_id, " in set $nv_set_id not found"
 		unless $self->{problem}->exists($nv_set_id, $UserProblem->problem_id);
-	
+
 	eval {
 		return $self->{problem_user}->add($UserProblem);
 	};
@@ -2088,7 +2089,7 @@ sub addUserProblem {
 sub putUserProblem {
 	my $V = $_[2] ? "V" : "";
 	my ($self, $UserProblem, undef) = shift->checkArgs(\@_, "${V}REC:problem_user", "versioned_ok!?");
-	
+
 	my $rows = $self->{problem_user}->put($UserProblem); # DBI returns 0E0 for 0.
 	if ($rows == 0) {
 		croak "putUserProblem: user problem not found (perhaps you meant to use addUserProblem?)";
@@ -2155,7 +2156,7 @@ BEGIN {
 sub countProblemVersions { return scalar shift->listProblemVersions(@_) }
 
 # versioned analog of listUserProblems
-sub listProblemVersions { 
+sub listProblemVersions {
 	my ($self, $userID, $setID, $versionID) = shift->checkArgs(\@_, qw/user_id set_id version_id/);
 	my $where = [user_id_eq_set_id_eq_version_id_eq => $userID,$setID,$versionID];
 	if (wantarray) {
@@ -2166,7 +2167,7 @@ sub listProblemVersions {
 }
 
 # this code returns a list of all problem versions with the given userID,
-# setID, and problemID, but that is (darn well ought to be) the same as 
+# setID, and problemID, but that is (darn well ought to be) the same as
 # listSetVersions, so it's not so useful as all that; c.f. above.
 # sub listProblemVersions {
 # 	my ($self, $userID, $setID, $problemID) = shift->checkArgs(\@_, qw/user_id set_id problem_id/);
@@ -2208,12 +2209,12 @@ sub getAllProblemVersions {
 # versioned analog of addUserProblem
 sub addProblemVersion {
 	my ($self, $ProblemVersion) = shift->checkArgs(\@_, qw/REC:problem_version/);
-	
+
 	croak "addProblemVersion: set version ", $ProblemVersion->version_id, " of set ", $ProblemVersion->set_id, " not found for user ", $ProblemVersion->user_id
 		unless $self->{set_version}->exists($ProblemVersion->user_id, $ProblemVersion->set_id, $ProblemVersion->version_id);
 	croak "addProblemVersion: problem ", $ProblemVersion->problem_id, " of set ", $ProblemVersion->set_id, " not found for user ", $ProblemVersion->user_id
 		unless $self->{problem_user}->exists($ProblemVersion->user_id, $ProblemVersion->set_id, $ProblemVersion->problem_id);
-	
+
 	eval {
 		return $self->{problem_version}->add($ProblemVersion);
 	};
@@ -2282,7 +2283,7 @@ sub getAllMergedProblemVersions {
 # utilities
 ################################################################################
 
-sub check_user_id { #  (valid characters are [-a-zA-Z0-9_.,@]) 
+sub check_user_id { #  (valid characters are [-a-zA-Z0-9_.,@])
 	my $value = shift;
 	if ($value =~ m/^[-a-zA-Z0-9_.@]*,?(set_id:)?[-a-zA-Z0-9_.@]*(,g)?$/ ) {
 		return 1;
@@ -2293,7 +2294,7 @@ sub check_user_id { #  (valid characters are [-a-zA-Z0-9_.,@])
 }
 # the (optional) second argument to checkKeyfields is to support versioned
 # (gateway) sets, which may include commas in certain fields (in particular,
-# set names (e.g., setDerivativeGateway,v1) and user names (e.g., 
+# set names (e.g., setDerivativeGateway,v1) and user names (e.g.,
 # username,proctorname)
 
 sub checkKeyfields($;$) {
@@ -2309,7 +2310,7 @@ sub checkKeyfields($;$) {
 			unless $value ne "";
 
 		validateKeyfieldValue($keyfield,$value,$versioned);
-		
+
 	}
 }
 
@@ -2324,22 +2325,22 @@ sub validateKeyfieldValue {
     } elsif ($versioned and $keyfield eq "set_id" || $keyfield eq 'setID') {
 	croak "invalid characters in '".encode_entities($keyfield)."' field: '".encode_entities($value)."' (valid characters are [-a-zA-Z0-9_.,])"
 	    unless $value =~ m/^[-a-zA-Z0-9_.,]*$/;
-	# } elsif ($versioned and $keyfield eq "user_id") { 
-    } elsif ($keyfield eq "user_id" || $keyfield eq 'userID') { 
+	# } elsif ($versioned and $keyfield eq "user_id") {
+    } elsif ($keyfield eq "user_id" || $keyfield eq 'userID') {
 	check_user_id($value); #  (valid characters are [-a-zA-Z0-9_.,]) see above.
     } elsif ($keyfield eq "ip_mask") {
 	croak "invalid characters in '$keyfield' field: '$value' (valid characters are [-a-zA-Z0-9_.,])"
 	    unless $value =~ m/^[-a-fA-F0-9_.:\/]*$/;
-	
+
     } else {
 	croak "invalid characters in '".encode_entities($keyfield)."' field: '".encode_entities($value)."' (valid characters are [-a-zA-Z0-9_.])"
 	    unless $value =~ m/^[-a-zA-Z0-9_.]*$/;
     }
-    
+
 }
 
 # checkArgs spec syntax:
-# 
+#
 # spec = list_item | item*
 # list_item = item is_list
 # is_list = "*"
@@ -2351,12 +2352,12 @@ sub validateKeyfieldValue {
 # bare_item = \w+
 # undef_ok = "!"
 # optional = "?"
-# 
+#
 # [[V]REC:]foo[!][?][*]
 
 sub checkArgs {
 	my ($self, $args, @spec) = @_;
-	
+
 	my $is_list = @spec == 1 && $spec[0] =~ s/\*$//;
 	my ($min_args, $max_args);
 	if ($is_list) {
@@ -2372,7 +2373,7 @@ sub checkArgs {
 		$min_args = @spec unless defined $min_args;
 		$max_args = @spec;
 	}
-	
+
 	if (@$args < $min_args or defined $max_args and @$args > $max_args) {
 		if ($min_args == $max_args) {
 			my $s = $min_args == 1 ? "" : "s";
@@ -2384,22 +2385,22 @@ sub checkArgs {
 			croak "requires at least $min_args argument$s";
 		}
 	}
-	
+
 	my ($name, $versioned, $table);
 	if ($is_list) {
 		$name = $spec[0];
 		($versioned, $table) = $name =~ /^(V?)REC:(.*)/;
 	}
-	
+
 	foreach my $i (0..@$args-1) {
 		my $arg = $args->[$i];
 		my $pos = $i+1;
-		
+
 		unless ($is_list) {
 			$name = $spec[$i];
 			($versioned, $table) = $name =~ /^(V?)REC:(.*)/;
 		}
-		
+
 		if (defined $table) {
 			my $class = $self->{$table}{record};
 			#print "arg=$arg class=$class\n";
@@ -2414,7 +2415,7 @@ sub checkArgs {
 			}
 		}
 	}
-	
+
 	return $self, @$args;
 }
 
@@ -2428,7 +2429,7 @@ sub checkArgsRefList {
 		eval { $self->checkArgs($item, @spec) };
 		croak "item $pos $@" if $@;
 	}
-	
+
 	return $self, @$items;
 }
 

--- a/lib/WeBWorK/DB/Driver.pm
+++ b/lib/WeBWorK/DB/Driver.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Driver.pm,v 1.3 2006/01/25 23:13:54 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -32,7 +31,7 @@ use warnings;
 sub new($$$) {
 	my ($proto, $source, $params) = @_;
 	my $class = ref($proto) || $proto;
-	my $self = {
+	my $self  = {
 		source => $source,
 		params => $params,
 	};

--- a/lib/WeBWorK/DB/Driver/Null.pm
+++ b/lib/WeBWorK/DB/Driver/Null.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Driver/Null.pm,v 1.5 2006/01/25 23:13:54 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the

--- a/lib/WeBWorK/DB/Driver/SQL.pm
+++ b/lib/WeBWorK/DB/Driver/SQL.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Driver/SQL.pm,v 1.15 2007/07/19 21:02:42 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -58,16 +57,16 @@ Password for access to SQL database.
 
 sub new($$$) {
 	my ($proto, $source, $params) = @_;
-	
+
 	my $self = $proto->SUPER::new($source, $params);
-	
+
 	# The DBD::MariaDB driver should not get the
 	#    mysql_enable_utf8mb4 or mysql_enable_utf8 settings,
 	# but DBD::mysql should.
 	my %utf8_parameters = ();
-	if ( $source =~ /DBI:mysql/ ) {
-	  $utf8_parameters{mysql_enable_utf8mb4} = 1;
-	  $utf8_parameters{mysql_enable_utf8} = 1;
+	if ($source =~ /DBI:mysql/) {
+		$utf8_parameters{mysql_enable_utf8mb4} = 1;
+		$utf8_parameters{mysql_enable_utf8}    = 1;
 	}
 
 	# add handle
@@ -83,10 +82,10 @@ sub new($$$) {
 		},
 	);
 	die $DBI::errstr unless defined $self->{handle};
-	
+
 	# set trace level from debug param
 	#$self->{handle}->trace($params->{debug}) if $params->{debug};
-	
+
 	return $self;
 }
 

--- a/lib/WeBWorK/DB/Record.pm
+++ b/lib/WeBWorK/DB/Record.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record.pm,v 1.13 2007/07/22 05:25:14 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -44,8 +43,8 @@ must contain keys equal to the field names of the record class.
 
 sub new {
 	my $invocant = shift;
-	my $self = bless {}, ref($invocant) || $invocant;
-	
+	my $self     = bless {}, ref($invocant) || $invocant;
+
 	if (@_) {
 		if (UNIVERSAL::isa($_[0], __PACKAGE__)) {
 			$self->init_from_object($_[0]);
@@ -57,7 +56,7 @@ sub new {
 			$self->init_from_hashref({@_});
 		}
 	}
-	
+
 	return $self;
 }
 
@@ -66,12 +65,12 @@ sub init_from_object { shift->init_from_hashref(shift) }
 
 sub init_from_hashref {
 	my ($self, $prototype) = @_;
-	@$self{$self->FIELDS} = @$prototype{$self->FIELDS};
+	@$self{ $self->FIELDS } = @$prototype{ $self->FIELDS };
 }
 
 sub init_from_arrayref {
 	my ($self, $prototype) = @_;
-	@$self{$self->FIELDS} = @$prototype;
+	@$self{ $self->FIELDS } = @$prototype;
 }
 
 =back
@@ -88,7 +87,7 @@ Returns a string representation of the object's keyfields.
 
 sub idsToString {
 	my $self = shift;
-	return join " ", map { "$_=" . (defined $self->$_ ? "'".$self->$_."'" : "undef") } $self->KEYFIELDS;
+	return join " ", map { "$_=" . (defined $self->$_ ? "'" . $self->$_ . "'" : "undef") } $self->KEYFIELDS;
 }
 
 =item idsToString
@@ -99,7 +98,7 @@ Returns a string representation of the object's fields.
 
 sub toString {
 	my $self = shift;
-	return join " ", map { "$_=" . (defined $self->$_ ? "'".$self->$_."'" : "undef") } $self->FIELDS;
+	return join " ", map { "$_=" . (defined $self->$_ ? "'" . $self->$_ . "'" : "undef") } $self->FIELDS;
 }
 
 =item toHash
@@ -130,47 +129,47 @@ sub toArray {
 =cut
 
 sub _fields {
-	my $invocant = shift;
-	my $class = ref $invocant || $invocant;
+	my $invocant   = shift;
+	my $class      = ref $invocant || $invocant;
 	my @field_data = @_;
-	
-	my %field_data = @field_data;
-	my @field_order = @field_data[ grep {$_%2==0} 0..$#field_data ];
-	my @keyfields = grep { $field_data{$_}{key} } @field_order;
+
+	my %field_data   = @field_data;
+	my @field_order  = @field_data[ grep { $_ % 2 == 0 } 0 .. $#field_data ];
+	my @keyfields    = grep { $field_data{$_}{key} } @field_order;
 	my @nonkeyfields = grep { not $field_data{$_}{key} } @field_order;
-	my @sql_types = map { $field_data{$_}{type} } @field_order;
-	
+	my @sql_types    = map  { $field_data{$_}{type} } @field_order;
+
 	no strict 'refs';
-	
+
 	# class methods that return field info
-	*{$class."::FIELD_DATA"} = sub { return \%field_data };
-	*{$class."::FIELDS"} = sub { return @field_order };
-	*{$class."::KEYFIELDS"} = sub { return @keyfields };
-	*{$class."::NONKEYFIELDS"} = sub { return @nonkeyfields };
-	*{$class."::SQL_TYPES"} = sub { return @sql_types };
-	
+	*{ $class . "::FIELD_DATA" }   = sub { return \%field_data };
+	*{ $class . "::FIELDS" }       = sub { return @field_order };
+	*{ $class . "::KEYFIELDS" }    = sub { return @keyfields };
+	*{ $class . "::NONKEYFIELDS" } = sub { return @nonkeyfields };
+	*{ $class . "::SQL_TYPES" }    = sub { return @sql_types };
+
 	# accessor functions
 	foreach my $field (@field_order) {
 		# always define a "base" accessor
 		# custom public accessors can use this to actually do the getting and setting
-		*{$class."::_base_$field"} = sub {
+		*{ $class . "::_base_$field" } = sub {
 			my $self = shift;
 			$self->{$field} = shift if @_;
 			return $self->{$field};
 		};
 		# if there isn't a public accessor in the subclass, alias it to the base accessor
-		next if exists ${$class."::"}{$field};
-		*{$class."::$field"} = *{$class."::_base_$field"};
+		next if exists ${ $class . "::" }{$field};
+		*{ $class . "::$field" } = *{ $class . "::_base_$field" };
 	}
 }
 
 sub _initial_records {
-	my $invocant = shift;
-	my $class = ref $invocant || $invocant;
+	my $invocant     = shift;
+	my $class        = ref $invocant || $invocant;
 	my @initializers = @_;
-	
+
 	no strict 'refs';
-	*{$class."::INITIAL_RECORDS"} = sub { return @initializers };
+	*{ $class . "::INITIAL_RECORDS" } = sub { return @initializers };
 }
 
 1;

--- a/lib/WeBWorK/DB/Record/Achievement.pm
+++ b/lib/WeBWorK/DB/Record/Achievement.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,17 +27,17 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		achievement_id            => { type=>"TINYBLOB NOT NULL", key=>1 },
-		name                      => { type=>"TEXT" },
-		description               => { type=>"TEXT" },
-		points                    => { type=>"INT"  },
-		test                      => { type=>"TEXT" },
-		icon                      => { type=>"TEXT" },
-		category                  => { type=>"TEXT" },
-  	        enabled                   => { type=>"INT"  },
-	        max_counter               => { type=>"INT"  },
-	        number                    => { type=>"INT"  },
-	        assignment_type           => { type=>"TEXT"  },
+		achievement_id  => { type => "TINYBLOB NOT NULL", key => 1 },
+		name            => { type => "TEXT" },
+		description     => { type => "TEXT" },
+		points          => { type => "INT" },
+		test            => { type => "TEXT" },
+		icon            => { type => "TEXT" },
+		category        => { type => "TEXT" },
+		enabled         => { type => "INT" },
+		max_counter     => { type => "INT" },
+		number          => { type => "INT" },
+		assignment_type => { type => "TEXT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/Depths.pm
+++ b/lib/WeBWorK/DB/Record/Depths.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Setting.pm,v 1.2 2007/07/22 05:25:17 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -30,8 +29,8 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		md5   => { type=>"CHAR(33) NOT NULL", key=>1 },
-		depth => { type=>"SMALLINT" },
+		md5   => { type => "CHAR(33) NOT NULL", key => 1 },
+		depth => { type => "SMALLINT" },
 	);
 
 }

--- a/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
+++ b/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,15 +27,15 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id             => { type=>"TINYBLOB NOT NULL", key=>1 },
-		achievement_points  => { type=>"INT" },
-                next_level_points   => { type=>"INT" },
-	        level_achievement_id => { type=>"VARCHAR(100)" },
-	    # VARCHAR(1024) is only supported by MySQL version 5.0.3 and 
-	    # later, but it makes freezing and thawing safer to have 
-	    # more available characters
-  	        frozen_hash         => { type=>"VARCHAR(1024)" },
-                facebooker          => { type=>"INT" },
+		user_id              => { type => "TINYBLOB NOT NULL", key => 1 },
+		achievement_points   => { type => "INT" },
+		next_level_points    => { type => "INT" },
+		level_achievement_id => { type => "VARCHAR(100)" },
+		# VARCHAR(1024) is only supported by MySQL version 5.0.3 and
+		# later, but it makes freezing and thawing safer to have
+		# more available characters
+		frozen_hash => { type => "VARCHAR(1024)" },
+		facebooker  => { type => "INT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/Key.pm
+++ b/lib/WeBWorK/DB/Record/Key.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Key.pm,v 1.10 2006/10/02 15:04:27 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,9 +27,9 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id   => { type=>"TINYBLOB NOT NULL", key=>1 },
-		key       => { type=>"TEXT" },
-		timestamp => { type=>"BIGINT" },
+		user_id   => { type => "TINYBLOB NOT NULL", key => 1 },
+		key       => { type => "TEXT" },
+		timestamp => { type => "BIGINT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/LocationAddresses.pm
+++ b/lib/WeBWorK/DB/Record/LocationAddresses.pm
@@ -1,7 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -25,10 +24,10 @@ WeBWorK::DB::Record::LocationAddresses - represent a record from the location_ad
 use strict;
 use warnings;
 
-BEGIN { 
+BEGIN {
 	__PACKAGE__->_fields(
-		location_id => { type=>"TINYBLOB NOT NULL", key=> 1 }, # requires up to 256 bytes
-		ip_mask     => { type=>"VARCHAR(180)", key=> 1 }, # was VARCHAR(255), reduced to VARCHAR(180) for utf8mb4
+		location_id => { type => "TINYBLOB NOT NULL", key => 1 },    # requires up to 256 bytes
+		ip_mask     => { type => "VARCHAR(180)", key => 1 },    # was VARCHAR(255), reduced to VARCHAR(180) for utf8mb4
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/Locations.pm
+++ b/lib/WeBWorK/DB/Record/Locations.pm
@@ -1,7 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -25,10 +24,10 @@ WeBWorK::DB::Record::Locations - represent a record from the locations table.
 use strict;
 use warnings;
 
-BEGIN { 
+BEGIN {
 	__PACKAGE__->_fields(
-		location_id => { type=>"TINYBLOB NOT NULL", key=>1 },
-		description => { type=>"TEXT" },
+		location_id => { type => "TINYBLOB NOT NULL", key => 1 },
+		description => { type => "TEXT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/Password.pm
+++ b/lib/WeBWorK/DB/Record/Password.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Password.pm,v 1.9 2006/10/02 15:04:27 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,8 +27,8 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id  => { type=>"TINYBLOB NOT NULL", key=>1 },
-		password => { type=>"TEXT" },
+		user_id  => { type => "TINYBLOB NOT NULL", key => 1 },
+		password => { type => "TEXT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -29,16 +28,16 @@ use warnings;
 BEGIN {
 	__PACKAGE__->_fields(
 
-		answer_id         => { type=>"INT AUTO_INCREMENT", key=>1},
-		course_id         => { type=>"VARCHAR(40) NOT NULL", key=>1},
-		user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},
-		set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
-		problem_id        => { type=>"INT NOT NULL", key=>1},
-		source_file       => { type=>"TEXT"},
-		timestamp         => { type=>"INT" }, 
-		scores            => { type=>"TINYTEXT"}, 
-		answer_string     => { type=>"VARCHAR(5012)"},
-		comment_string    => { type=>"VARCHAR(5012)"},    
+		answer_id      => { type => "INT AUTO_INCREMENT",    key => 1 },
+		course_id      => { type => "VARCHAR(40) NOT NULL",  key => 1 },
+		user_id        => { type => "VARCHAR(100) NOT NULL", key => 1 },
+		set_id         => { type => "VARCHAR(100) NOT NULL", key => 1 },
+		problem_id     => { type => "INT NOT NULL",          key => 1 },
+		source_file    => { type => "TEXT" },
+		timestamp      => { type => "INT" },
+		scores         => { type => "TINYTEXT" },
+		answer_string  => { type => "VARCHAR(5012)" },
+		comment_string => { type => "VARCHAR(5012)" },
 
 	);
 }

--- a/lib/WeBWorK/DB/Record/PermissionLevel.pm
+++ b/lib/WeBWorK/DB/Record/PermissionLevel.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/PermissionLevel.pm,v 1.10 2006/10/02 15:04:27 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -29,8 +28,8 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id    => { type=>"TINYBLOB NOT NULL", key=>1 },
-		permission => { type=>"INT" },
+		user_id    => { type => "TINYBLOB NOT NULL", key => 1 },
+		permission => { type => "INT" },
 
 	);
 }

--- a/lib/WeBWorK/DB/Record/Problem.pm
+++ b/lib/WeBWorK/DB/Record/Problem.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Problem.pm,v 1.9 2006/10/02 15:04:27 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,21 +27,21 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		set_id       => { type=>"TINYBLOB NOT NULL", key=>1 },
-		problem_id   => { type=>"INT NOT NULL", key=>1 },
-		source_file  => { type=>"TEXT" },
-		value        => { type=>"INT" },
-		max_attempts => { type=>"INT" },
-		att_to_open_children => { type=>"INT" },
-		counts_parent_grade => { type=>"INT" },
-		showMeAnother => { type=>"INT" },
-		showMeAnotherCount => { type=>"INT" },
+		set_id               => { type => "TINYBLOB NOT NULL", key => 1 },
+		problem_id           => { type => "INT NOT NULL",      key => 1 },
+		source_file          => { type => "TEXT" },
+		value                => { type => "INT" },
+		max_attempts         => { type => "INT" },
+		att_to_open_children => { type => "INT" },
+		counts_parent_grade  => { type => "INT" },
+		showMeAnother        => { type => "INT" },
+		showMeAnotherCount   => { type => "INT" },
 		# periodic re-randomization period
-		prPeriod => {type => "INT"},
+		prPeriod => { type => "INT" },
 		# periodic re-randomization number of attempts for the current seed
-		prCount => {type => "INT"},
+		prCount => { type => "INT" },
 		# a field for flags relating to this problem
-		flags => { type =>"TEXT" },
+		flags => { type => "TEXT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/ProblemVersion.pm
+++ b/lib/WeBWorK/DB/Record/ProblemVersion.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/ProblemVersion.pm,v 1.2 2007/02/22 01:25:11 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -19,7 +18,7 @@ use base WeBWorK::DB::Record::UserProblem;
 
 =head1 NAME
 
-WeBWorK::DB::Record::ProblemVersion - represent a record from the virtual 
+WeBWorK::DB::Record::ProblemVersion - represent a record from the virtual
 problem_version table.
 
 =cut
@@ -29,14 +28,14 @@ use warnings;
 
 BEGIN {
 	our @ISA;
-	my $base = $ISA[0];
-	my $field_data = $base->FIELD_DATA;
+	my $base         = $ISA[0];
+	my $field_data   = $base->FIELD_DATA;
 	my @nonkeyfields = map { $_ => $field_data->{$_} } $base->NONKEYFIELDS;
 	__PACKAGE__->_fields(
-		user_id       => { type=>"TINYBLOB NOT NULL", key=>1 },
-		set_id        => { type=>"TINYBLOB NOT NULL", key=>1 },
-		version_id    => { type=>"INT NOT NULL", key=>1 },
-		problem_id    => { type=>"INT NOT NULL", key=>1 },
+		user_id    => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_id     => { type => "TINYBLOB NOT NULL", key => 1 },
+		version_id => { type => "INT NOT NULL",      key => 1 },
+		problem_id => { type => "INT NOT NULL",      key => 1 },
 		@nonkeyfields,
 	);
 }

--- a/lib/WeBWorK/DB/Record/Set.pm
+++ b/lib/WeBWorK/DB/Record/Set.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,37 +27,37 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		set_id                    => { type=>"TINYBLOB NOT NULL", key=>1 },
-		set_header                => { type=>"TEXT" },
-		hardcopy_header           => { type=>"TEXT" },
-		open_date                 => { type=>"BIGINT" },
-		due_date                  => { type=>"BIGINT" },
-		answer_date               => { type=>"BIGINT" },
-		reduced_scoring_date       => { type=>"BIGINT" },
-		visible                   => { type=>"INT" },
-		enable_reduced_scoring    => { type=>"INT" },
-		assignment_type           => { type=>"TEXT" },
-	        description               => { type=>"TEXT" },
-		restricted_release	  	  => { type=>"TEXT" },
-		restricted_status	      => { type=>"FLOAT" },
-		attempts_per_version      => { type=>"INT" },
-		time_interval             => { type=>"INT" },
-		versions_per_interval     => { type=>"INT" },
-		version_time_limit        => { type=>"INT" },
-		version_creation_time     => { type=>"BIGINT" },
-		problem_randorder         => { type=>"INT" },
-		version_last_attempt_time => { type=>"BIGINT" },
-		problems_per_page         => { type=>"INT" },
-		hide_score                => { type=>"ENUM('N','Y','BeforeAnswerDate')" },
-		hide_score_by_problem     => { type=>"ENUM('N','Y')" },
-		hide_work                 => { type=>"ENUM('N','Y','BeforeAnswerDate')" },
-		time_limit_cap            => { type=>"ENUM('0','1')" },
-		restrict_ip               => { type=>"ENUM('No','RestrictTo','DenyFrom') DEFAULT 'No'" },
-		relax_restrict_ip         => { type=>"ENUM('No','AfterAnswerDate','AfterVersionAnswerDate') DEFAULT 'No'" },
-		restricted_login_proctor  => { type=>"ENUM('No','Yes')" },
-		hide_hint                 => { type=>"INT" },
-		restrict_prob_progression => { type=>"INT" },
-		email_instructor          => { type=>"INT" },
+		set_id                    => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_header                => { type => "TEXT" },
+		hardcopy_header           => { type => "TEXT" },
+		open_date                 => { type => "BIGINT" },
+		due_date                  => { type => "BIGINT" },
+		answer_date               => { type => "BIGINT" },
+		reduced_scoring_date      => { type => "BIGINT" },
+		visible                   => { type => "INT" },
+		enable_reduced_scoring    => { type => "INT" },
+		assignment_type           => { type => "TEXT" },
+		description               => { type => "TEXT" },
+		restricted_release        => { type => "TEXT" },
+		restricted_status         => { type => "FLOAT" },
+		attempts_per_version      => { type => "INT" },
+		time_interval             => { type => "INT" },
+		versions_per_interval     => { type => "INT" },
+		version_time_limit        => { type => "INT" },
+		version_creation_time     => { type => "BIGINT" },
+		problem_randorder         => { type => "INT" },
+		version_last_attempt_time => { type => "BIGINT" },
+		problems_per_page         => { type => "INT" },
+		hide_score                => { type => "ENUM('N','Y','BeforeAnswerDate')" },
+		hide_score_by_problem     => { type => "ENUM('N','Y')" },
+		hide_work                 => { type => "ENUM('N','Y','BeforeAnswerDate')" },
+		time_limit_cap            => { type => "ENUM('0','1')" },
+		restrict_ip               => { type => "ENUM('No','RestrictTo','DenyFrom') DEFAULT 'No'" },
+		relax_restrict_ip         => { type => "ENUM('No','AfterAnswerDate','AfterVersionAnswerDate') DEFAULT 'No'" },
+		restricted_login_proctor  => { type => "ENUM('No','Yes')" },
+		hide_hint                 => { type => "INT" },
+		restrict_prob_progression => { type => "INT" },
+		email_instructor          => { type => "INT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/SetLocations.pm
+++ b/lib/WeBWorK/DB/Record/SetLocations.pm
@@ -1,7 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -26,10 +25,10 @@ use strict;
 use warnings;
 
 BEGIN {
-        __PACKAGE__->_fields(
-                set_id      => { type=>"TINYBLOB NOT NULL", key=>1 },
-                location_id => { type=>"TINYBLOB NOT NULL", key=>1 },
-        );
+	__PACKAGE__->_fields(
+		set_id      => { type => "TINYBLOB NOT NULL", key => 1 },
+		location_id => { type => "TINYBLOB NOT NULL", key => 1 },
+	);
 }
 
 1;

--- a/lib/WeBWorK/DB/Record/SetVersion.pm
+++ b/lib/WeBWorK/DB/Record/SetVersion.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/SetVersion.pm,v 1.2 2007/02/22 01:25:11 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -19,7 +18,7 @@ use base WeBWorK::DB::Record::UserSet;
 
 =head1 NAME
 
-WeBWorK::DB::Record::SetVersion - represent a record from the virtual 
+WeBWorK::DB::Record::SetVersion - represent a record from the virtual
 set_version table.
 
 =cut
@@ -29,13 +28,13 @@ use warnings;
 
 BEGIN {
 	our @ISA;
-	my $base = $ISA[0];
-	my $field_data = $base->FIELD_DATA;
+	my $base         = $ISA[0];
+	my $field_data   = $base->FIELD_DATA;
 	my @nonkeyfields = map { $_ => $field_data->{$_} } $base->NONKEYFIELDS;
 	__PACKAGE__->_fields(
-		user_id    => { type=>"TINYBLOB NOT NULL", key=>1 },
-		set_id     => { type=>"TINYBLOB NOT NULL", key=>1 },
-		version_id => { type=>"INT NOT NULL", key=>1 },
+		user_id    => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_id     => { type => "TINYBLOB NOT NULL", key => 1 },
+		version_id => { type => "INT NOT NULL",      key => 1 },
 		@nonkeyfields,
 	);
 }

--- a/lib/WeBWorK/DB/Record/Setting.pm
+++ b/lib/WeBWorK/DB/Record/Setting.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Setting.pm,v 1.2 2007/07/22 05:25:17 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -30,11 +29,13 @@ use WeBWorK::Utils::DBUpgrade;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		name  => { type=>"VARCHAR(240) NOT NULL", key=>1 },
-		value => { type=>"TEXT" },
+		name  => { type => "VARCHAR(240) NOT NULL", key => 1 },
+		value => { type => "TEXT" },
 	);
 	__PACKAGE__->_initial_records(
-		{ name=>"db_version", value=> 3.1415926   # $WeBWorK::Utils::DBUpgrade::THIS_DB_VERSION 
+		{
+			name  => "db_version",
+			value => 3.1415926       # $WeBWorK::Utils::DBUpgrade::THIS_DB_VERSION
 		},
 	);
 }

--- a/lib/WeBWorK/DB/Record/User.pm
+++ b/lib/WeBWorK/DB/Record/User.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/User.pm,v 1.12 2006/10/02 15:04:27 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -29,30 +28,30 @@ use Encode qw(encode);
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id       => { type=>"TINYBLOB NOT NULL", key=>1 },
-		first_name    => { type=>"TEXT" },
-		last_name     => { type=>"TEXT" },
-		email_address => { type=>"TEXT" },
-		student_id    => { type=>"TEXT" },
-		status        => { type=>"TEXT" },
-		section       => { type=>"TEXT" },
-		recitation    => { type=>"TEXT" },
-		comment       => { type=>"TEXT" },
-		displayMode   => { type=>"TEXT" },
-		showOldAnswers => { type=>"INT" },
-		useMathView   => { type=>"INT"  },
-		useWirisEditor   => { type=>"INT"  },
-		useMathQuill   => { type=>"INT"  },
-		lis_source_did  => { type=>"BLOB" },
+		user_id        => { type => "TINYBLOB NOT NULL", key => 1 },
+		first_name     => { type => "TEXT" },
+		last_name      => { type => "TEXT" },
+		email_address  => { type => "TEXT" },
+		student_id     => { type => "TEXT" },
+		status         => { type => "TEXT" },
+		section        => { type => "TEXT" },
+		recitation     => { type => "TEXT" },
+		comment        => { type => "TEXT" },
+		displayMode    => { type => "TEXT" },
+		showOldAnswers => { type => "INT" },
+		useMathView    => { type => "INT" },
+		useWirisEditor => { type => "INT" },
+		useMathQuill   => { type => "INT" },
+		lis_source_did => { type => "BLOB" },
 	);
 }
 
 sub full_name {
 	my ($self) = @_;
-	
+
 	my $first = $self->first_name;
-	my $last = $self->last_name;
-	
+	my $last  = $self->last_name;
+
 	if (defined $first and $first ne "" and defined $last and $last ne "") {
 		return "$first $last";
 	} elsif (defined $first and $first ne "") {
@@ -99,10 +98,10 @@ sub full_name {
 
 sub rfc822_mailbox {
 	my ($self) = @_;
-	
+
 	my $full_name = $self->full_name;
-	my $address = $self->email_address;
-	
+	my $address   = $self->email_address;
+
 	if (defined $address and $address ne "") {
 		if (defined $full_name and $full_name ne "") {
 			# Encode the user name using "MIME-Header" encoding,

--- a/lib/WeBWorK/DB/Record/UserAchievement.pm
+++ b/lib/WeBWorK/DB/Record/UserAchievement.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/Set.pm,v 1.22 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,14 +27,14 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id                   => { type=>"TINYBLOB NOT NULL", key=>1 },
-		achievement_id            => { type=>"TINYBLOB NOT NULL", key=>1 },
-		earned                    => { type=>"INT" },
-		counter                   => { type=>"INT" },
-	    # VARCHAR(1024) is only supported by MySQL version 5.0.3 and 
-	    # later, but it makes freezing and thawing safer to have 
-	    # more available characters
-  	        frozen_hash               => { type=>"VARCHAR(1024)" },
+		user_id        => { type => "TINYBLOB NOT NULL", key => 1 },
+		achievement_id => { type => "TINYBLOB NOT NULL", key => 1 },
+		earned         => { type => "INT" },
+		counter        => { type => "INT" },
+		# VARCHAR(1024) is only supported by MySQL version 5.0.3 and
+		# later, but it makes freezing and thawing safer to have
+		# more available characters
+		frozen_hash => { type => "VARCHAR(1024)" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/UserProblem.pm
+++ b/lib/WeBWorK/DB/Record/UserProblem.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/UserProblem.pm,v 1.11 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -29,30 +28,30 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id       => { type=>"TINYBLOB NOT NULL", key=>1 },
-		set_id        => { type=>"TINYBLOB NOT NULL", key=>1 },
-		problem_id    => { type=>"INT NOT NULL", key=>1 },
-		source_file   => { type=>"TEXT" },
+		user_id     => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_id      => { type => "TINYBLOB NOT NULL", key => 1 },
+		problem_id  => { type => "INT NOT NULL",      key => 1 },
+		source_file => { type => "TEXT" },
 		# FIXME i think value should be able to hold decimal values...
-		value         => { type=>"INT" },
-		max_attempts  => { type=>"INT" },
-		showMeAnother  => { type=>"INT" },
-		showMeAnotherCount  => { type=>"INT" },
+		value              => { type => "INT" },
+		max_attempts       => { type => "INT" },
+		showMeAnother      => { type => "INT" },
+		showMeAnotherCount => { type => "INT" },
 		# periodic re-randomization period
-		prPeriod => {type => "INT"},
+		prPeriod => { type => "INT" },
 		# periodic re-randomization number of attempts for the current seed
-		prCount => {type => "INT"},
-		problem_seed  => { type=>"INT" },
-		status        => { type=>"FLOAT" },
-		attempted     => { type=>"INT" },
-		last_answer   => { type=>"TEXT" },
-		num_correct   => { type=>"INT" },
-		num_incorrect => { type=>"INT" },
-		att_to_open_children => { type=>"INT" },
-		counts_parent_grade => { type=>"INT" },
-		sub_status    => { type=>"FLOAT" },    # A subsidiary status used to implement the reduced scoring period
-		# a field for flags which need to be set
-		flags => { type=>"TEXT" },
+		prCount              => { type => "INT" },
+		problem_seed         => { type => "INT" },
+		status               => { type => "FLOAT" },
+		attempted            => { type => "INT" },
+		last_answer          => { type => "TEXT" },
+		num_correct          => { type => "INT" },
+		num_incorrect        => { type => "INT" },
+		att_to_open_children => { type => "INT" },
+		counts_parent_grade  => { type => "INT" },
+		sub_status           => { type => "FLOAT" },  # A subsidiary status used to implement the reduced scoring period
+													  # a field for flags which need to be set
+		flags                => { type => "TEXT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/UserSet.pm
+++ b/lib/WeBWorK/DB/Record/UserSet.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Record/UserSet.pm,v 1.21 2007/08/13 22:59:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -28,40 +27,40 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id                   => { type=>"TINYBLOB NOT NULL", key=>1 },
-		set_id                    => { type=>"TINYBLOB NOT NULL", key=>1 },
-		psvn                      => { type=>"INT UNIQUE NOT NULL AUTO_INCREMENT" },
-		set_header                => { type=>"TEXT" },
-		hardcopy_header           => { type=>"TEXT" },
-		open_date                 => { type=>"BIGINT" },
-		due_date                  => { type=>"BIGINT" },
-		answer_date               => { type=>"BIGINT" },
-		reduced_scoring_date      => { type=>"BIGINT" },
-		visible                   => { type=>"INT" },
-		enable_reduced_scoring    => { type=>"INT" },
-		assignment_type           => { type=>"TEXT" },
-		description               => { type=>"TEXT" },
-		restricted_release        => { type=>"TEXT" },
-		restricted_status         => { type=>"FLOAT" },
-		attempts_per_version      => { type=>"INT" },
-		time_interval             => { type=>"INT" },
-		versions_per_interval     => { type=>"INT" },
-		version_time_limit        => { type=>"INT" },
-		version_creation_time     => { type=>"BIGINT" },
-		problem_randorder         => { type=>"INT" },
-		version_last_attempt_time => { type=>"BIGINT" },
-		problems_per_page         => { type=>"INT" },
-		hide_score                => { type=>"ENUM('N','Y','BeforeAnswerDate')" },
-		hide_score_by_problem     => { type=>"ENUM('N','Y')" },
-		hide_work                 => { type=>"ENUM('N','Y','BeforeAnswerDate')" },
-		time_limit_cap            => { type=>"ENUM('0','1')" },
-		restrict_ip               => { type=>"ENUM('No','RestrictTo','DenyFrom')" },
-		relax_restrict_ip         => { type=>"ENUM('No','AfterAnswerDate','AfterVersionAnswerDate')" },
-		restricted_login_proctor  => { type=>"ENUM('No','Yes')" },
-		hide_hint                 => { type=>"INT" },
-		restrict_prob_progression => { type=>"INT" },
-		email_instructor          => { type=>"INT" },
-		lis_source_did            => { type=>"BLOB"},	     
+		user_id                   => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_id                    => { type => "TINYBLOB NOT NULL", key => 1 },
+		psvn                      => { type => "INT UNIQUE NOT NULL AUTO_INCREMENT" },
+		set_header                => { type => "TEXT" },
+		hardcopy_header           => { type => "TEXT" },
+		open_date                 => { type => "BIGINT" },
+		due_date                  => { type => "BIGINT" },
+		answer_date               => { type => "BIGINT" },
+		reduced_scoring_date      => { type => "BIGINT" },
+		visible                   => { type => "INT" },
+		enable_reduced_scoring    => { type => "INT" },
+		assignment_type           => { type => "TEXT" },
+		description               => { type => "TEXT" },
+		restricted_release        => { type => "TEXT" },
+		restricted_status         => { type => "FLOAT" },
+		attempts_per_version      => { type => "INT" },
+		time_interval             => { type => "INT" },
+		versions_per_interval     => { type => "INT" },
+		version_time_limit        => { type => "INT" },
+		version_creation_time     => { type => "BIGINT" },
+		problem_randorder         => { type => "INT" },
+		version_last_attempt_time => { type => "BIGINT" },
+		problems_per_page         => { type => "INT" },
+		hide_score                => { type => "ENUM('N','Y','BeforeAnswerDate')" },
+		hide_score_by_problem     => { type => "ENUM('N','Y')" },
+		hide_work                 => { type => "ENUM('N','Y','BeforeAnswerDate')" },
+		time_limit_cap            => { type => "ENUM('0','1')" },
+		restrict_ip               => { type => "ENUM('No','RestrictTo','DenyFrom')" },
+		relax_restrict_ip         => { type => "ENUM('No','AfterAnswerDate','AfterVersionAnswerDate')" },
+		restricted_login_proctor  => { type => "ENUM('No','Yes')" },
+		hide_hint                 => { type => "INT" },
+		restrict_prob_progression => { type => "INT" },
+		email_instructor          => { type => "INT" },
+		lis_source_did            => { type => "BLOB" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/UserSetLocations.pm
+++ b/lib/WeBWorK/DB/Record/UserSetLocations.pm
@@ -1,7 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/bin/readURClassList.pl,v 1.2.2.1 2007/08/13 22:53:39 sh002i Exp $
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -26,11 +25,11 @@ use strict;
 use warnings;
 
 BEGIN {
-        __PACKAGE__->_fields(
-		user_id     => { type=>"TINYBLOB NOT NULL", key=>1 },
-                set_id      => { type=>"TINYBLOB NOT NULL", key=>1 },
-                location_id => { type=>"TINYBLOB NOT NULL", key=>1 },
-        );
+	__PACKAGE__->_fields(
+		user_id     => { type => "TINYBLOB NOT NULL", key => 1 },
+		set_id      => { type => "TINYBLOB NOT NULL", key => 1 },
+		location_id => { type => "TINYBLOB NOT NULL", key => 1 },
+	);
 }
 
 1;

--- a/lib/WeBWorK/DB/Schema.pm
+++ b/lib/WeBWorK/DB/Schema.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema.pm,v 1.13 2009/01/25 15:30:35 gage Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -85,23 +84,23 @@ dependent. C<$db> is provided so that schemas can query other schemas.
 sub new {
 	my ($proto, $db, $driver, $table, $record, $params, $engine, $character_set) = @_;
 	my $class = ref($proto) || $proto;
-	
+
 	my @supportedTables = $proto->TABLES();
 	die "unsupported table (schema supports: @supportedTables)"
 		unless grep { $_ eq "*" or $_ eq $table } @supportedTables;
-	
+
 	my ($driverStyle, $schemaStyle) = ($driver->STYLE(), $proto->STYLE());
 	die "schema/driver style mismatch (driver provides $driverStyle, schema requires $schemaStyle)"
 		unless $driverStyle eq $schemaStyle;
-	
+
 	my $self = {
-		db     => $db,
-		driver => $driver,
-		table  => $table,
-		record => $record,
-		params => $params,
-    	engine => $engine,
-    	character_set => $character_set,
+		db            => $db,
+		driver        => $driver,
+		table         => $table,
+		record        => $record,
+		params        => $params,
+		engine        => $engine,
+		character_set => $character_set,
 	};
 	bless $self, $class;
 	return $self;

--- a/lib/WeBWorK/DB/Schema/NewSQL.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL.pm,v 1.25 2008/06/21 16:38:49 gage Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -43,95 +42,95 @@ sub where_DEFAULT {
 # can be used for user,password,permission,key,set_user,problem_user,vset_user
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>$user_id};
+	return { user_id => $user_id };
 }
 
 # can be used for achievement_user
 sub where_achievement_id_eq {
-    my ($self, $flags, $achievement_id) = @_;
-    return {achievement_id=>$achievement_id};
+	my ($self, $flags, $achievement_id) = @_;
+	return { achievement_id => $achievement_id };
 }
 
 #can be used for past answers
 sub where_answer_id_eq {
-    my ($self, $flags, $answer_id) = @_;
-    return {answer_id=>$answer_id};
+	my ($self, $flags, $answer_id) = @_;
+	return { answer_id => $answer_id };
 }
 
 # can be used for past_answers
 sub where_course_id_eq_user_id_eq_set_id_eq_problem_id_eq {
-    my ($self, $flags, $course_id, $user_id, $set_id, $problem_id) = @_;
-    return {course_id=>$course_id, user_id=>$user_id, set_id=>$set_id, problem_id=>$problem_id};
+	my ($self, $flags, $course_id, $user_id, $set_id, $problem_id) = @_;
+	return { course_id => $course_id, user_id => $user_id, set_id => $set_id, problem_id => $problem_id };
 }
 
 sub where_user_id_eq_set_id_eq_problem_id_eq {
-    my ($self, $flags, $user_id, $set_id, $problem_id) = @_;
-    return {user_id=>$user_id, set_id=>$set_id, problem_id=>$problem_id};
+	my ($self, $flags, $user_id, $set_id, $problem_id) = @_;
+	return { user_id => $user_id, set_id => $set_id, problem_id => $problem_id };
 }
 
 # can be used for user,password,permission,key,set_user,problem_user
 sub where_user_id_like {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>{LIKE=>$user_id}};
+	return { user_id => { LIKE => $user_id } };
 }
 
 # can be used for user
 sub where_email_address_nonempty {
 	my ($self, $flags) = @_;
-	return {email_address=>{'!=',[undef,""]}};
+	return { email_address => { '!=', [ undef, "" ] } };
 }
 
 # can be used for user
 sub where_status_eq {
 	my ($self, $flags, $status) = @_;
-	return {status=>$status};
+	return { status => $status };
 }
 
 # can be used for user
 sub where_section_eq {
 	my ($self, $flags, $section) = @_;
-	return {section=>$section};
+	return { section => $section };
 }
 
 # can be used for user
 sub where_recitation_eq {
 	my ($self, $flags, $recitation) = @_;
-	return {recitation=>$recitation};
+	return { recitation => $recitation };
 }
 
 # can be used for user
 sub where_section_eq_recitation_eq {
 	my ($self, $flags, $section, $recitation) = @_;
-	return {section=>$section,recitation=>$recitation};
+	return { section => $section, recitation => $recitation };
 }
 
 # can be used for user
 sub where_student_id_eq {
-        my ($self, $flags, $student_id) = @_;
-        return {student_id=>$student_id};
+	my ($self, $flags, $student_id) = @_;
+	return { student_id => $student_id };
 }
 
 # can be used for password
 sub where_password_eq {
 	my ($self, $flags, $password) = @_;
-	return {password=>$password};
+	return { password => $password };
 }
 
 # can be used for permission
 sub where_permission_eq {
 	my ($self, $flags, $permission) = @_;
-	return {permission=>$permission};
+	return { permission => $permission };
 }
 
 # can be used for permission
 sub where_permission_in_range {
 	my ($self, $flags, $min, $max) = @_;
 	if (defined $min and defined $max) {
-		return {-and=>[ {permission=>{">=",$min}}, {permission=>{"<=",$max}} ]};
+		return { -and => [ { permission => { ">=", $min } }, { permission => { "<=", $max } } ] };
 	} elsif (defined $min) {
-		return {permission=>{">=",$min}};
+		return { permission => { ">=", $min } };
 	} elsif (defined $max) {
-		return {permission=>{"<=",$max}};
+		return { permission => { "<=", $max } };
 	} else {
 		return {};
 	}
@@ -140,42 +139,42 @@ sub where_permission_in_range {
 # can be used for set,set_user,problem,problem_user
 sub where_set_id_eq {
 	my ($self, $flags, $set_id) = @_;
-	return {set_id=>$set_id};
+	return { set_id => $set_id };
 }
 
 # can be used for problem,problem_user
 sub where_set_id_eq_problem_id_eq {
 	my ($self, $flags, $set_id, $problem_id) = @_;
-	return {set_id=>$set_id,problem_id=>$problem_id};
+	return { set_id => $set_id, problem_id => $problem_id };
 }
 
 # can be used for set_user,problem_user
 sub where_user_id_eq_set_id_eq {
 	my ($self, $flags, $user_id, $set_id) = @_;
-	return {user_id=>$user_id,set_id=>$set_id};
+	return { user_id => $user_id, set_id => $set_id };
 }
 
 # added where clauses for locations and set_locations
 
-sub where_location_id_eq { 
+sub where_location_id_eq {
 	my ($self, $flags, $location_id) = @_;
-	return {location_id=>$location_id};
+	return { location_id => $location_id };
 }
 
 sub where_set_id_eq_location_id_eq {
 	my ($self, $flags, $set_id, $location_id) = @_;
-	return {set_id=>$set_id,location_id=>$location_id};
+	return { set_id => $set_id, location_id => $location_id };
 }
 
 sub where_ip_mask_eq {
 	my ($self, $flags, $ip_mask) = @_;
-	return {ip_mask=>$ip_mask};
+	return { ip_mask => $ip_mask };
 }
 
 sub where_name_eq {
 	my ($self, $flags, $name) = @_;
-	return {name=>$name};
-} # gotta get rid of this stupid way of specifying where clauses...
+	return { name => $name };
+}    # gotta get rid of this stupid way of specifying where clauses...
 
 ################################################################################
 # utility methods
@@ -250,49 +249,50 @@ sub conv_where {
 
 sub keyparts_to_where {
 	my ($self, @keyparts) = @_;
-	
-	my $table = $self->{table};
+
+	my $table    = $self->{table};
 	my @keynames = $self->keyfields;
 	croak "got ", scalar @keyparts, " keyparts, expected at most ", scalar @keynames, " (@keynames) for table $table"
 		if @keyparts > @keynames;
-	
+
 	# generate a where clause for the keyparts spec
 	my %where;
-	
+
 	foreach my $i (0 .. $#keyparts) {
-		next if not defined $keyparts[$i]; # undefined keypart == not restrained
-		$where{$keynames[$i]} = $keyparts[$i];
+		next if not defined $keyparts[$i];    # undefined keypart == not restrained
+		$where{ $keynames[$i] } = $keyparts[$i];
 	}
-	
+
 	return \%where;
 }
 
 sub keyparts_list_to_where {
 	my ($self, @keyparts_list) = @_;
-	
+
 	map { $_ = $self->keyparts_to_where(@$_) } @keyparts_list;
 	return \@keyparts_list;
 }
 
 sub gen_update_hashes {
 	my ($self, $fields) = @_;
-	
+
 	# the values for the values hash are the index of each field in the fields list
 	my %values;
-	@values{@$fields} = (0..@$fields-1);
-	
+	@values{@$fields} = (0 .. @$fields - 1);
+
 	# the values for the where hash are the index of each keyfield in the fields list
 	my @keyfields = $self->keyfields;
 	my %where;
 	@where{@keyfields} = map { exists $values{$_} ? $values{$_} : die "missing keypart '$_'" } @keyfields;
-	
+
 	# don't need to update keyfields, so take them out of the values hash
 	delete @values{@keyfields};
-	
+
 	return \%values, \%where;
 }
 
 our $__PACKAGE__ = __PACKAGE__;
+
 sub debug_stmt {
 	my ($self, $sth, @bind_vals) = @_;
 	return unless $self->{params}{debug};
@@ -315,14 +315,14 @@ sub bind {
 # checking Tables
 ####################################################
 sub tableExists {
-	my $self = shift;
-	my $stmt = $self->_exists_table_stmt;
+	my $self   = shift;
+	my $stmt   = $self->_exists_table_stmt;
 	my $result = eval { $self->dbh->do($stmt); };
-	( caught WeBWorK::DB::Ex::TableMissing ) ? 0:1;
+	(caught WeBWorK::DB::Ex::TableMissing) ? 0 : 1;
 }
 
 sub _exists_table_stmt {
-	my $self = shift;	
+	my $self           = shift;
 	my $sql_table_name = $self->sql_table_name;
 	return "Describe `$sql_table_name` ";
 }
@@ -332,48 +332,50 @@ sub _exists_table_stmt {
 ################################################################################
 
 our %API;
-@API{qw/
-	create_table
-	rename_table
-	delete_table
-	count_where
-	exists_where
-	get_fields_where
-	get_fields_where_i
-	list_where
-	list_where_i
-	get_records_where
-	get_records_where_i
-	insert_fields
-	insert_fields_i
-	insert_records
-	insert_records_i
-	update_where
-	update_fields
-	update_fields_i
-	update_records
-	update_records_i
-	delete_where
-	delete_fields
-	delete_fields_i
-	delete_records
-	delete_records_i
-	count
-	list
-	exists
-	get
-	gets
-	add
-	put
-	delete
-/} = ();
+@API{
+	qw/
+		create_table
+		rename_table
+		delete_table
+		count_where
+		exists_where
+		get_fields_where
+		get_fields_where_i
+		list_where
+		list_where_i
+		get_records_where
+		get_records_where_i
+		insert_fields
+		insert_fields_i
+		insert_records
+		insert_records_i
+		update_where
+		update_fields
+		update_fields_i
+		update_records
+		update_records_i
+		delete_where
+		delete_fields
+		delete_fields_i
+		delete_records
+		delete_records_i
+		count
+		list
+		exists
+		get
+		gets
+		add
+		put
+		delete
+		/
+} = ();
 
 sub AUTOLOAD {
 	our $AUTOLOAD =~ /(.*)::(.*)/;
 	if (exists $API{$2}) {
 		croak sprintf("%s does not implement &%s", $1, $2);
 	} else {
-		croak sprintf("Undefined subroutine &%s called ", $AUTOLOAD," stack trace: ", caller());
+		croak sprintf("Undefined subroutine &%s called ", $AUTOLOAD, " stack trace: ", caller());
 	}
 }
 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/Merge.pm,v 1.11 2007/03/02 23:26:30 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -53,50 +52,50 @@ lowest priority.
 
 sub new {
 	my $self = shift->SUPER::new(@_);
-	
+
 	$self->merge_init;
 	$self->sql_init;
-	
+
 	return $self;
 }
 
 sub merge_init {
 	my $self = shift;
-	my $db = $self->{db};
-	
-	my @merge_tables = @{$self->{params}{merge}};
-	
+	my $db   = $self->{db};
+
+	my @merge_tables = @{ $self->{params}{merge} };
+
 	my %sql_table_aliases;
-	@sql_table_aliases{@merge_tables} = map { "merge$_" } 1 .. @merge_tables;
-	
+	@sql_table_aliases{@merge_tables} = map {"merge$_"} 1 .. @merge_tables;
+
 	my @sql_tableexprs;
 	my %sql_field_names;
 	foreach my $table (@merge_tables) {
 		push @sql_tableexprs, "`" . $db->{$table}->sql_table_name . "` AS `$sql_table_aliases{$table}`";
 		my @fields = $db->{$table}->fields;
-		@{$sql_field_names{$table}}{@fields} = map { $db->{$table}->sql_field_name($_) } @fields;
+		@{ $sql_field_names{$table} }{@fields} = map { $db->{$table}->sql_field_name($_) } @fields;
 	}
-	
+
 	my $pri = $merge_tables[0];
-	
+
 	my %sql_fieldexprs;
 	my @sql_whereprefix;
-	
+
 	foreach my $field ($db->{$pri}->fields) {
 		my $sql_field_name = $sql_field_names{$pri}{$field};
-		
+
 		if ($db->{$pri}->field_data->{$field}{key}) {
 			# if it's a keyfield, use the version from the primary table
 			# (they're all going to be the same anyway)
 			$sql_fieldexprs{$field} = $db->{$pri}->sql_field_expression($field, $sql_table_aliases{$pri});
-			
+
 			# add this field to the where clause, by matching the value in the
 			# primary table to the values in all other tables that have that field
-			foreach my $table (@merge_tables[1..$#merge_tables]) {
+			foreach my $table (@merge_tables[ 1 .. $#merge_tables ]) {
 				next unless exists $db->{$table}->field_data->{$field};
 				push @sql_whereprefix,
-					$db->{$pri}->sql_field_expression($field, $sql_table_aliases{$pri})
-					. "=" . $db->{$table}->sql_field_expression($field, $sql_table_aliases{$table});
+					$db->{$pri}->sql_field_expression($field, $sql_table_aliases{$pri}) . "="
+					. $db->{$table}->sql_field_expression($field, $sql_table_aliases{$table});
 			}
 		} else {
 			# if it's not a keyfield, we use the COALESCE function to select a
@@ -106,23 +105,23 @@ sub merge_init {
 				next unless exists $db->{$table}->field_data->{$field};
 				push @coalesce, $db->{$table}->sql_field_expression($field, $sql_table_aliases{$table});
 			}
-			# VERSIONING: we may need something other than COALESCE() here as well, because 
+			# VERSIONING: we may need something other than COALESCE() here as well, because
 			# it works with NULL/not-NULL, and SUBSTRING() returns empty strings if no match.
 			$sql_fieldexprs{$field} = "COALESCE(" . join(",", @coalesce) . ")";
 		}
 	}
-	
-	$self->{pri} = $pri;
+
+	$self->{pri}               = $pri;
 	$self->{sql_table_aliases} = \%sql_table_aliases;
-	$self->{sql_field_names} = \%sql_field_names;
-	$self->{sql_fieldexprs} = \%sql_fieldexprs;
-	$self->{sql_whereprefix} = join(" AND ", @sql_whereprefix);
-	$self->{sql_tableexpr} = join(", ", @sql_tableexprs);
+	$self->{sql_field_names}   = \%sql_field_names;
+	$self->{sql_fieldexprs}    = \%sql_fieldexprs;
+	$self->{sql_whereprefix}   = join(" AND ", @sql_whereprefix);
+	$self->{sql_tableexpr}     = join(", ",    @sql_tableexprs);
 }
 
 sub sql_init {
 	my $self = shift;
-	
+
 	# transformation functions for table and field names: these allow us to pass
 	# the WeBWorK table/field names to SQL::Abstract::Classic, and have it translate them
 	# to the SQL table/field names from tableOverride and fieldOverride.
@@ -137,7 +136,7 @@ sub sql_init {
 			return $label;
 		}
 	};
-	
+
 	# This transformation is called both on bare field names and on qualified
 	# field names (i.e. "table.field"), but not on bare table names.
 	my $transform_all = sub {
@@ -152,13 +151,13 @@ sub sql_init {
 		$table = $transform_table->($table);
 		return "`$table`.`$field`";
 	};
-	
+
 	# add SQL statement generation object
 	$self->{sql} = new WeBWorK::DB::Utils::SQLAbstractIdentTrans(
-		quote_char => "`",
-		name_sep => ".",
+		quote_char      => "`",
+		name_sep        => ".",
 		transform_table => $transform_table,
-		transform_all => $transform_all,
+		transform_all   => $transform_all,
 	);
 }
 
@@ -166,36 +165,35 @@ sub sql_init {
 # lowlevel get
 ################################################################################
 
-*get_fields_where = *WeBWorK::DB::Schema::NewSQL::Std::get_fields_where;
+*get_fields_where   = *WeBWorK::DB::Schema::NewSQL::Std::get_fields_where;
 *get_fields_where_i = *WeBWorK::DB::Schema::NewSQL::Std::get_fields_where_i;
 
 # helper, returns a prepared statement handle
 sub _get_fields_where_prepex {
 	my ($self, $fields, $where, $order) = @_;
 	$where = $self->conv_where($where);
-	
+
 	# pull the requested fields out of $self->{sql_fieldexprs}
-	my $sql_fields = join(", ", @{$self->{sql_fieldexprs}}{@$fields});
-	
+	my $sql_fields = join(", ", @{ $self->{sql_fieldexprs} }{@$fields});
+
 	my @where = $self->{sql_whereprefix};
 	my @bind_vals;
-	
+
 	my ($base_where_clause, @base_bind_vals) = $self->sql->_recurse_where($where) if $where;
 	if (defined $base_where_clause and $base_where_clause =~ /\S/) {
-		push @where, $base_where_clause;
+		push @where,     $base_where_clause;
 		push @bind_vals, @base_bind_vals;
 	}
-	
-	my $where_clause = @where ? "WHERE " . join(" AND ", @where) : "";
-	my $order_by_clause = $order ? $self->sql->_order_by($order) : "";
-	
+
+	my $where_clause    = @where ? "WHERE " . join(" AND ", @where) : "";
+	my $order_by_clause = $order ? $self->sql->_order_by($order)    : "";
+
 	# scalar ref so _quote_table will leave table expression alone
-	my $stmt = $self->sql->select(\($self->{sql_tableexpr}), $sql_fields)
-		. " $where_clause $order_by_clause";
-	
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3); # 3: see DBI docs
+	my $stmt = $self->sql->select(\($self->{sql_tableexpr}), $sql_fields) . " $where_clause $order_by_clause";
+
+	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
 	$self->debug_stmt($sth, @bind_vals);
-	$sth->execute(@bind_vals);	
+	$sth->execute(@bind_vals);
 	return $sth;
 }
 
@@ -205,43 +203,42 @@ sub _get_fields_where_prepex {
 
 sub conv_where {
 	my $self = shift;
-	return $self->{db}{$self->{pri}}->conv_where(@_);
+	return $self->{db}{ $self->{pri} }->conv_where(@_);
 }
 
 sub keyparts_to_where {
 	my $self = shift;
-	return $self->{db}{$self->{pri}}->keyparts_to_where(@_);
+	return $self->{db}{ $self->{pri} }->keyparts_to_where(@_);
 }
 
 ################################################################################
 # getting keyfields (a.k.a. listing)
 ################################################################################
 
-*list_where = *WeBWorK::DB::Schema::NewSQL::Std::list_where;
+*list_where   = *WeBWorK::DB::Schema::NewSQL::Std::list_where;
 *list_where_i = *WeBWorK::DB::Schema::NewSQL::Std::list_where_i;
 
 ################################################################################
 # getting records
 ################################################################################
 
-*get_records_where = *WeBWorK::DB::Schema::NewSQL::Std::get_records_where;
+*get_records_where   = *WeBWorK::DB::Schema::NewSQL::Std::get_records_where;
 *get_records_where_i = *WeBWorK::DB::Schema::NewSQL::Std::get_records_where_i;
 
 ################################################################################
 # compatibility methods for old API
 ################################################################################
 
-*get = *WeBWorK::DB::Schema::NewSQL::Std::get;
+*get  = *WeBWorK::DB::Schema::NewSQL::Std::get;
 *gets = *WeBWorK::DB::Schema::NewSQL::Std::gets;
 
 ################################################################################
 # utility methods
 ################################################################################
 
-*sql = *WeBWorK::DB::Schema::NewSQL::Std::sql;
-*sql_table_name=  *WeBWorK::DB::Schema::NewSQL::Std::sql_table_name;
-*sql_field_name=  *WeBWorK::DB::Schema::NewSQL::Std::sql_field_name;
-
+*sql            = *WeBWorK::DB::Schema::NewSQL::Std::sql;
+*sql_table_name = *WeBWorK::DB::Schema::NewSQL::Std::sql_table_name;
+*sql_field_name = *WeBWorK::DB::Schema::NewSQL::Std::sql_field_name;
 
 sub DESTROY {
 }

--- a/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm,v 1.5 2007/08/10 16:44:57 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -38,17 +37,17 @@ use constant TABLES => qw/set_user problem_user/;
 
 sub where_DEFAULT {
 	my ($self, $flags) = @_;
-	return {set_id=>{NOT_LIKE=>make_vsetID("%","%")}};
+	return { set_id => { NOT_LIKE => make_vsetID("%", "%") } };
 }
 
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>$user_id,set_id=>{NOT_LIKE=>make_vsetID("%","%")}};
+	return { user_id => $user_id, set_id => { NOT_LIKE => make_vsetID("%", "%") } };
 }
 
 sub where_user_id_like {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>{LIKE=>$user_id},set_id=>{NOT_LIKE=>make_vsetID("%","%")}};
+	return { user_id => { LIKE => $user_id }, set_id => { NOT_LIKE => make_vsetID("%", "%") } };
 }
 
 ################################################################################
@@ -57,13 +56,13 @@ sub where_user_id_like {
 
 sub keyparts_to_where {
 	my ($self, @keyparts) = @_;
-	
+
 	my $where = $self->SUPER::keyparts_to_where(@keyparts);
-	
+
 	unless (exists $where->{set_id}) {
-		$where->{set_id} = {NOT_LIKE=>make_vsetID("%","%")};
+		$where->{set_id} = { NOT_LIKE => make_vsetID("%", "%") };
 	}
-	
+
 	return $where;
 }
 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm,v 1.7 2007/03/02 23:11:42 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -39,57 +38,57 @@ use constant TABLES => qw/set_version problem_version/;
 
 sub where_DEFAULT {
 	my ($self, $flags) = @_;
-	return {set_id=>{LIKE=>make_vsetID("%","%")}};
+	return { set_id => { LIKE => make_vsetID("%", "%") } };
 }
 
 # replaces where_versionedset_user_id_eq in NewSQL
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>$user_id,set_id=>{LIKE=>make_vsetID("%","%")}};
+	return { user_id => $user_id, set_id => { LIKE => make_vsetID("%", "%") } };
 }
 
 sub where_user_id_like {
 	my ($self, $flags, $user_id) = @_;
-	return {user_id=>{LIKE=>$user_id},set_id=>{LIKE=>make_vsetID("%","%")}};
+	return { user_id => { LIKE => $user_id }, set_id => { LIKE => make_vsetID("%", "%") } };
 }
 
 sub where_set_id_eq {
 	my ($self, $flags, $set_id) = @_;
-	return {set_id=>{LIKE=>make_vsetID($set_id,"%")}};
+	return { set_id => { LIKE => make_vsetID($set_id, "%") } };
 }
 
 # replaces where_versionedset_user_id_eq_set_id_eq in NewSQL
 sub where_user_id_eq_set_id_eq {
 	my ($self, $flags, $user_id, $set_id) = @_;
-	return {user_id=>$user_id,set_id=>{LIKE=>make_vsetID($set_id,"%")}};
+	return { user_id => $user_id, set_id => { LIKE => make_vsetID($set_id, "%") } };
 }
 
 # replaces where_versionedset_user_id_eq_set_id_eq_version_id_le in NewSQL
 sub where_user_id_eq_set_id_eq_version_id_le {
 	my ($self, $flags, $user_id, $set_id, $version_id) = @_;
 	if ($version_id >= 1) {
-		my @vsetIDs = map { make_vsetID($set_id,$_) } 1 .. $version_id;
-		return {user_id=>$user_id,set_id=>\@vsetIDs};
+		my @vsetIDs = map { make_vsetID($set_id, $_) } 1 .. $version_id;
+		return { user_id => $user_id, set_id => \@vsetIDs };
 	} else {
 		# nothing matches an invalid version id
-		return {-and=>\("0==1")};
+		return { -and => \("0==1") };
 	}
 }
 
 sub where_user_id_eq_set_id_eq_version_id_eq {
 	my ($self, $flags, $user_id, $set_id, $version_id) = @_;
 	if ($version_id >= 1) {
-		return {user_id=>$user_id,set_id=>make_vsetID($set_id,$version_id)};
+		return { user_id => $user_id, set_id => make_vsetID($set_id, $version_id) };
 	} else {
 		# nothing matches an invalid version id
-		return {-and=>\("0==1")};
+		return { -and => \("0==1") };
 	}
 }
 
 # for problem versions only (set versions don't have a problem_id field)
 sub where_user_id_eq_set_id_eq_problem_id_eq {
-	my ( $self, $flags, $user_id, $set_id, $problem_id ) = @_;
-	return {user_id=>$user_id,set_id=>{LIKE=>make_vsetID($set_id,"%")},problem_id=>$problem_id};
+	my ($self, $flags, $user_id, $set_id, $problem_id) = @_;
+	return { user_id => $user_id, set_id => { LIKE => make_vsetID($set_id, "%") }, problem_id => $problem_id };
 }
 
 ################################################################################
@@ -102,11 +101,11 @@ sub where_user_id_eq_set_id_eq_problem_id_eq {
 # the other methods can't.
 sub sql_field_expression {
 	my ($self, $field, $table) = @_;
-	
+
 	if ($field eq "set_id" or $field eq "version_id") {
 		# this value will already be properly quoted
 		my $sql_field_name = $self->SUPER::sql_field_expression("set_id", $table);
-		
+
 		if ($field eq "set_id") {
 			return grok_setID_from_vsetID_sql($sql_field_name);
 		} elsif ($field eq "version_id") {
@@ -126,19 +125,19 @@ sub sql_field_expression {
 
 sub keyparts_to_where {
 	my ($self, @keyparts) = @_;
-	
+
 	my $where = $self->SUPER::keyparts_to_where(@keyparts);
-	
+
 	if (exists $where->{set_id} and exists $where->{version_id}) {
 		$where->{set_id} = make_vsetID($where->{set_id}, $where->{version_id});
 		delete $where->{version_id};
 	} else {
-		my $set_id_part = exists $where->{set_id} ? $where->{set_id} : "%";
+		my $set_id_part     = exists $where->{set_id}     ? $where->{set_id}     : "%";
 		my $version_id_part = exists $where->{version_id} ? $where->{version_id} : "%";
-		$where->{set_id} = {LIKE => make_vsetID($set_id_part, $version_id_part)};
+		$where->{set_id} = { LIKE => make_vsetID($set_id_part, $version_id_part) };
 		delete $where->{version_id};
 	}
-	
+
 	return $where;
 }
 
@@ -150,25 +149,25 @@ sub keyparts_to_where {
 # the set and version IDs from the real set_id field
 sub _get_fields_where_prepex {
 	my ($self, $fields, $where, $order) = @_;
-	
+
 	if (ref $fields eq "ARRAY") {
-		my @fields = @$fields; # don't want to mess up caller's copy
+		my @fields = @$fields;    # don't want to mess up caller's copy
 		foreach my $field (@fields) {
 			if (lc $field eq "set_id") {
 				# FIXME use sql_field_expression here
-				$field = grok_setID_from_vsetID_sql($self->sql->_quote("set_id"))
-					. " AS " . $self->sql->_quote("set_id");
+				$field =
+					grok_setID_from_vsetID_sql($self->sql->_quote("set_id")) . " AS " . $self->sql->_quote("set_id");
 			} elsif (lc $field eq "version_id") {
 				# FIXME use sql_field_expression here
-				$field = grok_versionID_from_vsetID_sql($self->sql->_quote("set_id"))
-					. " AS " . $self->sql->_quote("version_id");
+				$field = grok_versionID_from_vsetID_sql($self->sql->_quote("set_id")) . " AS "
+					. $self->sql->_quote("version_id");
 			} else {
 				$field = $self->sql->_quote($field);
 			}
 		}
 		$fields = join(", ", @fields);
 	}
-	
+
 	return $self->SUPER::_get_fields_where_prepex($fields, $where, $order);
 }
 
@@ -177,15 +176,15 @@ sub _get_fields_where_prepex {
 # this is mostly a copy of Std::_insert_fields_prep
 sub _insert_fields_prep {
 	my ($self, $fields) = @_;
-	
+
 	# we'll use dummy values to determine bind order
 	my %values;
-	@values{@$fields} = (0..@$fields-1);
-	
+	@values{@$fields} = (0 .. @$fields - 1);
+
 	# VERSIONING
 	if (exists $values{set_id} and exists $values{version_id}) {
 		# the array form allows raw SQL and bind values
-		$values{set_id} = [make_vsetID_sql("?","?"), @values{qw/set_id version_id/}];
+		$values{set_id} = [ make_vsetID_sql("?", "?"), @values{qw/set_id version_id/} ];
 		delete $values{version_id};
 	} elsif (exists $values{set_id} or exists $values{version_id}) {
 		die "can't re-create versioned set_id field without virtual set_id and version_id fields";
@@ -193,9 +192,9 @@ sub _insert_fields_prep {
 		# neither set_id nor version_id present, so that's fine
 		# (fine with us that is, mysql will complain that keys are missing)
 	}
-	
+
 	my ($stmt, @order) = $self->sql->insert($self->table, \%values);
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3); # 3: see DBI docs
+	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
 	return $sth, @order;
 }
 
@@ -208,9 +207,9 @@ sub _insert_fields_prep {
 #   -set_id, -version_id => not included
 sub update_where {
 	my ($self, $fieldvals, $where) = @_;
-	
-	my %fieldvals = %$fieldvals; # don't want to mess up the caller's version
-	
+
+	my %fieldvals = %$fieldvals;    # don't want to mess up the caller's version
+
 	if (exists $fieldvals{set_id} or exists $fieldvals{version_id}) {
 		my ($set_id_part, $version_id_part, @bind);
 		if (exists $fieldvals{set_id}) {
@@ -227,35 +226,35 @@ sub update_where {
 			# FIXME use sql_field_expression here?
 			$version_id_part = grok_versionID_from_vsetID_sql($self->sql->_quote("set_id"));
 		}
-		$fieldvals{set_id} = [make_vsetID_sql($set_id_part, $version_id_part), @bind];
+		$fieldvals{set_id} = [ make_vsetID_sql($set_id_part, $version_id_part), @bind ];
 		delete $fieldvals{version_id};
 	}
-	
+
 	$self->SUPER::update_where(\%fieldvals, $where);
 }
 
 # this is mostly a copy of Std::_update_fields_prep
 sub _update_fields_prep {
 	my ($self, $fields) = @_;
-	
+
 	# get hashes to pass to update() and where()
 	# (dies if any keyfield is missing from @$fields)
 	my ($values, $where) = $self->gen_update_hashes($fields);
-	
+
 	# grab bind order for set_id/version_id virtual fields
-	my $set_id_index = $where->{set_id};
+	my $set_id_index     = $where->{set_id};
 	my $version_id_index = $where->{version_id};
 	delete @$where{qw/set_id version_id/};
-	
+
 	# do the where clause separately so we get a separate bind list (cute substr trick, huh?)
 	my ($stmt, @val_order) = $self->sql->update($self->table, $values);
-	(substr($stmt,length($stmt),0), my @where_order) = $self->sql->where($where);
-	
+	(substr($stmt, length($stmt), 0), my @where_order) = $self->sql->where($where);
+
 	# append physical set_id match clause
-	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?","?");
+	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?", "?");
 	push @where_order, $set_id_index, $version_id_index;
-	
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3); # 3: see DBI docs
+
+	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
 	return $sth, \@val_order, \@where_order;
 }
 
@@ -266,25 +265,25 @@ sub _update_fields_prep {
 # this is mostly a copy of Std::_delete_fields_prep
 sub _delete_fields_prep {
 	my ($self, $fields) = @_;
-	
+
 	# get hashes to pass to update() and where()
 	# (dies if any keyfield is missing from @$fields)
 	my (undef, $where) = $self->gen_update_hashes($fields);
-	
+
 	# grab bind order for set_id/version_id virtual fields
-	my $set_id_index = $where->{set_id};
+	my $set_id_index     = $where->{set_id};
 	my $version_id_index = $where->{version_id};
 	delete @$where{qw/set_id version_id/};
-	
+
 	# do the where clause separately so we get a separate bind list (cute substr trick, huh?)
 	my ($stmt, @order) = $self->sql->delete($self->table, $where);
-	
+
 	# append physical set_id match clause
-	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?","?");
+	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?", "?");
 	push @order, $set_id_index, $version_id_index;
-	
+
 	print STDERR "stmt=$stmt\norder=@order\n";
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3); # 3: see DBI docs
+	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
 	return $sth, @order;
 }
 

--- a/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Schema/NewSQL/VersionedMerge.pm,v 1.1 2007/03/01 22:09:51 glarose Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -19,7 +18,7 @@ use base qw(WeBWorK::DB::Schema::NewSQL::Merge);
 
 =head1 NAME
 
-WeBWorK::DB::Schema::NewSQL::VersionedMerge - hack to get merged records 
+WeBWorK::DB::Schema::NewSQL::VersionedMerge - hack to get merged records
 from multiple tables in the SQL database, for versioned sets and problems
 
 =cut
@@ -49,7 +48,7 @@ lowest priority.
 =cut
 
 ################################################################################
-# constructor for merge-specific behavior, and methods fundamental 
+# constructor for merge-specific behavior, and methods fundamental
 # to the merge, are inherited from Merge.pm
 ################################################################################
 
@@ -58,145 +57,146 @@ lowest priority.
 ################################################################################
 
 sub get_fields_where {
-	my ( $self, $fields, $where, $order ) = @_;
+	my ($self, $fields, $where, $order) = @_;
 
-	# note: this is ugly because we've got two different table models 
-        #   that we're combining: {}_user and {}_version.  $self is inheriting
+	# note: this is ugly because we've got two different table models
+	#   that we're combining: {}_user and {}_version.  $self is inheriting
 	#   from Merge.pm, and so is using the first model; thus it doesn't
-        #   know how to deal with where clauses that include version_ids, 
-        #   and calling $self->conv_where() will therefore bail when we have
-        #   a restriction on the version_id.  if we use 
+	#   know how to deal with where clauses that include version_ids,
+	#   and calling $self->conv_where() will therefore bail when we have
+	#   a restriction on the version_id.  if we use
 	#   $db->{*_version}->conv_where(), there's no error, and the set_id
-	#   gets converted to the form we need to find the record in the 
+	#   gets converted to the form we need to find the record in the
 	#   *_user table.
-        # however, to make things more interesting, if we're entering here 
-        #   from a call of $db->{set_version_merged}->gets(), there's no 
-	#   trouble, because we're using $self->keyparts_to_where(), which 
+	# however, to make things more interesting, if we're entering here
+	#   from a call of $db->{set_version_merged}->gets(), there's no
+	#   trouble, because we're using $self->keyparts_to_where(), which
 	#   has no trouble returning a %$where hash including a version_id key.
 	# the result is that we have to check for what $where is saying
 	#   here, even though we'd like to suppress that for the different
-	#   _get_fields_where_prepex() routines, because we have to be sure 
-	#   that we don't hand a @$where clause including version_id 
+	#   _get_fields_where_prepex() routines, because we have to be sure
+	#   that we don't hand a @$where clause including version_id
 	#   information to $self->conv_where().  yuck!
 
-	if ( ref($where) eq 'ARRAY' ) {
-	    my ( $nvtable ) = ( $self->table =~ /(.+)_merged/ );
-	    my $newWhere = $self->{db}->{$nvtable}->conv_where( $where );
-	    if ( defined( $newWhere->{set_id} ) && 
-		 $newWhere->{set_id} =~ /,v(\d+)$/ ) {
-		$newWhere->{version_id} = $1;
-		$newWhere->{set_id} =~ s/,v(\d+)$//; 
-	    }
-	    $where = $newWhere;
+	if (ref($where) eq 'ARRAY') {
+		my ($nvtable) = ($self->table =~ /(.+)_merged/);
+		my $newWhere = $self->{db}->{$nvtable}->conv_where($where);
+		if (defined($newWhere->{set_id})
+			&& $newWhere->{set_id} =~ /,v(\d+)$/)
+		{
+			$newWhere->{version_id} = $1;
+			$newWhere->{set_id} =~ s/,v(\d+)$//;
+		}
+		$where = $newWhere;
 	}
 
-	# get merged {}_user and {} records; to do this we have to be 
+	# get merged {}_user and {} records; to do this we have to be
 	# careful that we don't get fooled by references to versions
 	my %nvWhere = %$where;
-	for my $key ( keys %nvWhere ) {
-		delete( $nvWhere{$key} ) if $key eq 'version_id';
+	for my $key (keys %nvWhere) {
+		delete($nvWhere{$key}) if $key eq 'version_id';
 	}
 	my @nvFields = grep { $_ ne 'version_id' } @$fields;
 
-	my $sth = $self->_get_fields_where_prepex(\@nvFields, \%nvWhere, $order);
+	my $sth     = $self->_get_fields_where_prepex(\@nvFields, \%nvWhere, $order);
 	my @results = @{ $sth->fetchall_arrayref };
 	$sth->finish;
 
 	# then get data for this version
-	$sth = $self->_get_fields_where_prepex_extra( $fields, $where, $order );
+	$sth = $self->_get_fields_where_prepex_extra($fields, $where, $order);
 	my @vresults = @{ $sth->fetchall_arrayref };
 	$sth->finish;
 
 	# build a set of results hashes to facilitate merging the two sets
 	# of data, which will have different fields
 	my @res = ();
-	foreach my $r ( @results ) {
-		push(@res, { map {$nvFields[$_]=>$r->[$_]} (0..$#nvFields) });
+	foreach my $r (@results) {
+		push(@res, { map { $nvFields[$_] => $r->[$_] } (0 .. $#nvFields) });
 	}
 	my @vres = ();
-	foreach my $r ( @vresults ) {
-		push(@vres, {map {$fields->[$_]=>$r->[$_]} (0..$#{@$fields})});
+	foreach my $r (@vresults) {
+		push(@vres, { map { $fields->[$_] => $r->[$_] } (0 .. $#{@$fields}) });
 	}
 
-# 	my $rstr = "( ";
-# 	foreach (@results) { $rstr .= "[" . join(',', @{$_}) . "]\n"; }
-# 	warn("$rstr )\n");
-# 	my $vstr = "( ";
-# 	foreach (@vresults) { $vstr .= "[" . join(',', @{$_}) . "]\n"; }
-# 	warn("$vstr )\n");
+	# 	my $rstr = "( ";
+	# 	foreach (@results) { $rstr .= "[" . join(',', @{$_}) . "]\n"; }
+	# 	warn("$rstr )\n");
+	# 	my $vstr = "( ";
+	# 	foreach (@vresults) { $vstr .= "[" . join(',', @{$_}) . "]\n"; }
+	# 	warn("$vstr )\n");
 
 	# finally, brutally merge these
 	my @mergedResults = ();
-	for ( my $i=0; $i<@vres; $i++ ) {
+	for (my $i = 0; $i < @vres; $i++) {
 		my @mres = ();
-		foreach my $f ( @$fields ) {
-		    # there should be a more elegant way of doing this
-			if ( defined( $vres[$i]->{$f} ) ) {
-				push( @mres, $vres[$i]->{$f} );
-			} elsif ( defined( $res[$i]->{$f} ) ) {
-				push( @mres, $res[$i]->{$f} );
+		foreach my $f (@$fields) {
+			# there should be a more elegant way of doing this
+			if (defined($vres[$i]->{$f})) {
+				push(@mres, $vres[$i]->{$f});
+			} elsif (defined($res[$i]->{$f})) {
+				push(@mres, $res[$i]->{$f});
 			} else {
-				push( @mres, undef );
+				push(@mres, undef);
 			}
 		}
-		push( @mergedResults, [ @mres ] );
+		push(@mergedResults, [@mres]);
 	}
 
-# 	$rstr = "( ";
-# 	foreach (@mergedResults) { $rstr .= "[" . join(',', @{$_}) . "]\n"; }
-# 	warn("$rstr )\n");
+	# 	$rstr = "( ";
+	# 	foreach (@mergedResults) { $rstr .= "[" . join(',', @{$_}) . "]\n"; }
+	# 	warn("$rstr )\n");
 
 	return @mergedResults;
 }
 
-sub _get_fields_where_prepex_extra { 
-	my ( $self, $fields, $where, $order ) = @_;
+sub _get_fields_where_prepex_extra {
+	my ($self, $fields, $where, $order) = @_;
 
-	# we have a problem with the $where parameters, because they 
+	# we have a problem with the $where parameters, because they
 	# haven't been sent through the Versioned where clause generators
 	# manually fix those to deal with the set_id and version_id keys
 	my %vWhere = %$where;
-	if ( defined($vWhere{'set_id'}) && defined($vWhere{'version_id'}) ) {
+	if (defined($vWhere{'set_id'}) && defined($vWhere{'version_id'})) {
 		$vWhere{'set_id'} = make_vsetID($vWhere{'set_id'}, $vWhere{'version_id'});
-		delete( $vWhere{'version_id'} );
-	} elsif ( defined($vWhere{'set_id'}) || defined($vWhere{'version_id'}) ) {
-		if ( defined($vWhere{'version_id'}) ) {
+		delete($vWhere{'version_id'});
+	} elsif (defined($vWhere{'set_id'}) || defined($vWhere{'version_id'})) {
+		if (defined($vWhere{'version_id'})) {
 			warn("Error: where clause includes version_id and not a set_id.\n");
-			delete( $vWhere{'version_id'} );
+			delete($vWhere{'version_id'});
 		}
-		if ( defined($vWhere{'set_id'}) ) {
+		if (defined($vWhere{'set_id'})) {
 			warn("Error: where clause includes set_id and not a version_id ($vWhere{set_id}).\n");
-			delete( $vWhere{'set_id'} );
+			delete($vWhere{'set_id'});
 		}
 	}
-# 	warn("fields = ", "@$fields", "\n");
-# 	warn("vWhere = ", join("; ", map{"$_=>$vWhere{$_}"} keys %vWhere), "\n");
+	# 	warn("fields = ", "@$fields", "\n");
+	# 	warn("vWhere = ", join("; ", map{"$_=>$vWhere{$_}"} keys %vWhere), "\n");
 
 	my $db = $self->{db};
 
 	my ($table) = ($self->table =~ /(.+)_merged/);
-	return $db->{$table}->_get_fields_where_prepex( $fields, \%vWhere, $order );
+	return $db->{$table}->_get_fields_where_prepex($fields, \%vWhere, $order);
 }
 
 ################################################################################
 # getting keyfields (a.k.a. listing)
 ################################################################################
 
-*list_where = *WeBWorK::DB::Schema::NewSQL::Versioned::list_where;
+*list_where   = *WeBWorK::DB::Schema::NewSQL::Versioned::list_where;
 *list_where_i = *WeBWorK::DB::Schema::NewSQL::Versioned::list_where_i;
 
 ################################################################################
 # getting records
 ################################################################################
 
-*get_records_where = *WeBWorK::DB::Schema::NewSQL::Versioned::get_records_where;
+*get_records_where   = *WeBWorK::DB::Schema::NewSQL::Versioned::get_records_where;
 *get_records_where_i = *WeBWorK::DB::Schema::NewSQL::Versioned::get_records_where_i;
 
 ################################################################################
 # compatibility methods for old API
 ################################################################################
 
-*get = *WeBWorK::DB::Schema::NewSQL::Versioned::get;
+*get  = *WeBWorK::DB::Schema::NewSQL::Versioned::get;
 *gets = *WeBWorK::DB::Schema::NewSQL::Versioned::gets;
 
 ################################################################################

--- a/lib/WeBWorK/DB/Utils.pm
+++ b/lib/WeBWorK/DB/Utils.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Utils.pm,v 1.24 2007/08/13 22:59:56 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the

--- a/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
+++ b/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: webwork2/lib/WeBWorK/DB/Utils/SQLAbstractIdentTrans.pm,v 1.4 2007/03/02 23:12:28 sh002i Exp $
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.	 See either the GNU General Public License or the
@@ -16,6 +15,7 @@
 
 package WeBWorK::DB::Utils::SQLAbstractIdentTrans;
 my $BASE;
+
 BEGIN {
 	my $sql_abstract = eval {
 		require SQL::Abstract;
@@ -23,7 +23,7 @@ BEGIN {
 			0;
 		} else {
 			1;
-		};
+		}
 	};
 	$BASE = qw(SQL::Abstract) if $sql_abstract;
 	$BASE = qw(SQL::Abstract::Classic) unless $sql_abstract;
@@ -40,9 +40,9 @@ allows custom hooks to transform identifiers.
 use strict;
 use warnings;
 
-sub _table	{
+sub _table {
 	my $self = shift;
-	my $tab	 = shift;
+	my $tab  = shift;
 	if (ref $tab eq 'ARRAY') {
 		return join ', ', map { $self->_quote_table($_) } @$tab;
 	} else {
@@ -53,12 +53,12 @@ sub _table	{
 sub _quote {
 	my $self  = shift;
 	my $label = shift;
-	
+
 	return $label if $label eq '*';
-	
+
 	return $self->_quote_field($label)
 		if !defined $self->{name_sep};
-	
+
 	if (defined $self->{transform_all}) {
 		return $self->{transform_all}->($label);
 	} elsif ($label =~ /(.+)\.(.+)/) {
@@ -71,40 +71,38 @@ sub _quote {
 sub _quote_table {
 	my $self  = shift;
 	my $label = shift;
-	
+
 	# if the table name is a scalar reference, leave it alone (but dereference it)
 	return $$label if ref $label eq "SCALAR";
-	
+
 	# call custom transform function
 	$label = $self->{transform_table}->($label)
 		if defined $self->{transform_table};
-	
+
 	return $self->{quote_char} . $label . $self->{quote_char};
 }
 
 sub _quote_field {
 	my $self  = shift;
 	my $label = shift;
-	
+
 	# call custom transform function
 	$label = $self->{transform_field}->($label)
 		if defined $self->{transform_field};
-	
+
 	return $self->{quote_char} . $label . $self->{quote_char};
 }
 
 sub _order_by {
-    my $self = shift;
-    my $ref = ref $_[0];
+	my $self = shift;
+	my $ref  = ref $_[0];
 
-    my @vals = $ref eq 'ARRAY'  ? @{$_[0]} :
-               $ref eq 'SCALAR' ? $_[0]    : # modification: don't dereference scalar refs
-               $ref eq ''       ? $_[0]    :
-			   $self->SUPER::puke("Unsupported data struct $ref for ORDER BY");
+	my @vals = $ref eq 'ARRAY' ? @{ $_[0] } : $ref eq 'SCALAR' ? $_[0] :   # modification: don't dereference scalar refs
+		$ref eq '' ? $_[0] : $self->SUPER::puke("Unsupported data struct $ref for ORDER BY");
 
-    # modification: if an item is a scalar ref, don't quote it, only dereference it
-    my $val = join ', ', map { ref $_ eq "SCALAR" ? $$_ : $self->_quote($_) } @vals;
-    return $val ? $self->_sqlcase(' order by')." $val" : '';
+	# modification: if an item is a scalar ref, don't quote it, only dereference it
+	my $val = join ', ', map { ref $_ eq "SCALAR" ? $$_ : $self->_quote($_) } @vals;
+	return $val ? $self->_sqlcase(' order by') . " $val" : '';
 }
 
 1;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1262,13 +1262,10 @@ sub grade_set {
   #    it invisibly by detecting what the problem types are?
   #    oh well.
 
-  my @problemRecords = $db->getAllMergedUserProblems( $studentName, $setID );
-  my $num_of_problems  = @problemRecords || 0;
-  my $max_problems     = defined($num_of_problems) ? $num_of_problems : 0;
-
-  if ( $setIsVersioned ) {
-    @problemRecords = $db->getAllMergedProblemVersions( $studentName, $setID, $set->version_id );
-  }   # use versioned problems instead (assume that each version has the same number of problems.
+  my @problemRecords =
+    $setIsVersioned
+    ? $db->getAllMergedProblemVersions($studentName, $setID, $set->version_id)
+    : $db->getAllMergedUserProblems($studentName, $setID);
 
   # for jitar sets we only use the top level problems
   if ($set->assignment_type eq 'jitar') {
@@ -1720,30 +1717,23 @@ sub jitar_problem_finished {
 
 # requires a CG object, and a permission type
 # a user may also be submitted, in case we need to filter by section
-# could require the db, course environment and authz separately... why tho?
 
 sub fetchEmailRecipients {
-	my ($self, $permissionType, $sender) = @_; # sender argument is optional
-	my $r = $self->r;
-	my $db = $r->db;
-	my $ce = $r->ce;
+	my ($self, $permissionType, $sender) = @_;    # sender argument is optional
+	my $r     = $self->r;
+	my $db    = $r->db;
+	my $ce    = $r->ce;
 	my $authz = $r->authz;
-	my @recipients;
 
-  return unless $permissionType;
+	return unless $permissionType;
 
-	foreach my $potentialRecipient ($db->listUsers()) {
-		if ($authz->hasPermissions($potentialRecipient, $permissionType)) {
-			my $validRecipient = $db->getUser($potentialRecipient);
-			next if $ce->{feedback_by_section} and defined $sender
-					and defined $validRecipient->section and defined $sender->section
-					and $validRecipient->section ne $sender->section;
-			if ($validRecipient and $validRecipient->email_address) {
-					push @recipients, $validRecipient->rfc822_mailbox;
-			}
-		}
-	}
-	return @recipients;
+	return
+		map { $_->rfc822_mailbox } grep { $authz->hasPermissions($_->user_id, $permissionType) } $db->getUsersWhere({
+			email_address => { '!=', undef },
+			$ce->{feedback_by_section}
+			&& defined $sender
+			&& defined $sender->section ? (section => $sender->section) : (),
+		});
 }
 
 # Requires a CG object.

--- a/lib/WebworkWebservice/SetActions.pm
+++ b/lib/WebworkWebservice/SetActions.pm
@@ -1,6 +1,6 @@
-#!/usr/local/bin/perl -w 
+#!/usr/local/bin/perl -w
 
-# Copyright (C) 2002 Michael Gage 
+# Copyright (C) 2002 Michael Gage
 
 ###############################################################################
 # Web service which fetches, adds, removes and moves WeBWorK problems when working with a Set.
@@ -12,7 +12,7 @@
 
 package WebworkWebservice::SetActions;
 use WebworkWebservice;
-use base qw(WebworkWebservice); 
+use base qw(WebworkWebservice);
 use WeBWorK::Utils qw(readDirectory max sortByName formatDateTime jitar_id_to_seq seq_to_jitar_id);
 use WeBWorK::Utils::Tasks qw(renderProblems);
 
@@ -32,7 +32,7 @@ use Benchmark;
 
 ##############################################
 #   Some of this may have to be moved, to allow for flexability
-#   Obtain basic information about directories, course name and host 
+#   Obtain basic information about directories, course name and host
 ##############################################
 our $WW_DIRECTORY = $WebworkWebservice::WW_DIRECTORY;
 our $PG_DIRECTORY = $WebworkWebservice::PG_DIRECTORY;
@@ -92,7 +92,7 @@ sub listLocalSetProblems{
 		push @problems, $problem;
 
 	}
-	
+
   	my $out = {};
   	$out->{ra_out} = \@problems;
   	$out->{text} = encode_utf8_base64("Loaded Problems for set: " . $setName);
@@ -105,10 +105,10 @@ sub getSets{
   my ($self,$params) = @_;
   my $db = $self->db;
   my @found_sets = $db->listGlobalSets;
-  
+
   my @all_sets = $db->getGlobalSets(@found_sets);
-  
-  # fix the timeDate  
+
+  # fix the timeDate
  foreach my $set (@all_sets){
 	#$set->{due_date} = formatDateTime($set->{due_date},'local');
 	#$set->{open_date} = formatDateTime($set->{open_date},'local');
@@ -117,7 +117,7 @@ sub getSets{
 	my @users = $db->listSetUsers($set->{set_id});
 	$set->{assigned_users} = \@users;
   }
-  
+
   my $out = {};
   $out->{ra_out} = \@all_sets;
   $out->{text} = encode_utf8_base64("Sets for course: ".$self->{courseName});
@@ -131,20 +131,20 @@ sub getSets{
 sub getUserSets{
   my ($self,$params) = @_;
   my $db = $self->db;
-  
+
   my @userSetNames = $db->listUserSets($params->{user});
   debug(@userSetNames);
   my @userSets = $db->getGlobalSets(@userSetNames);
-  
-  # fix the timeDate  
+
+  # fix the timeDate
  # foreach my $set (@userSets){
 	# $set->{due_date} = formatDateTime($set->{due_date},'local');
 	# $set->{open_date} = formatDateTime($set->{open_date},'local');
 	# $set->{answer_date} = formatDateTime($set->{answer_date},'local');
  #  }
-  
-  
-  
+
+
+
   my $out = {};
   $out->{ra_out} = \@userSets;
   $out->{text} = encode_utf8_base64("Sets for course: ".$self->{courseName});
@@ -160,13 +160,13 @@ sub getSet {
   my $db = $self->db;
   my $setName = $params->{set_id};
   my $set = $db->getGlobalSet($setName);
-  
-  # change the date/times to user readable strings.  
-  
+
+  # change the date/times to user readable strings.
+
   $set->{due_date} = formatDateTime($set->{due_date},'local');
   $set->{open_date} = formatDateTime($set->{open_date},'local');
   $set->{answer_date} = formatDateTime($set->{answer_date},'local');
-  
+
   my $out = {};
   $out->{ra_out} = $set;
   $out->{text} = encode_utf8_base64("Sets for course: ".$self->{courseName});
@@ -206,7 +206,7 @@ sub updateSetProperties {
 
 	# Next update the assigned_users list
 
-	# first, get the current list of users. 
+	# first, get the current list of users.
 
 	my @usersForTheSetBefore = $db->listSetUsers($params->{set_id});
 
@@ -218,9 +218,9 @@ sub updateSetProperties {
 
 
 	# The following seems to work if there are only additions or subtractions from the assigned_users field.
-	# Perhaps a better way to do this is to check users that are new or missing and add or delete them. 
+	# Perhaps a better way to do this is to check users that are new or missing and add or delete them.
 
-	# if the number of users have grown, then add them.  
+	# if the number of users have grown, then add them.
 
 	debug(to_json(\@usersForTheSetNow));
 
@@ -235,14 +235,14 @@ sub updateSetProperties {
 		}
 	}
 
-	# delete users that are in the set before but not now. 
+	# delete users that are in the set before but not now.
 
 	foreach my $user (@usersForTheSetBefore){
 		if (! grep(/^$user$/,@usersForTheSetNow)){
 			$db->deleteUserSet($user, $params->{set_id});
 		}
 	}
- 
+
 
 	my $out = {};
 	$out->{ra_out} = $set;
@@ -253,7 +253,7 @@ sub updateSetProperties {
 sub listSetUsers {
 	my ($self,$params) = @_;
 	my $db = $self->db;
-    
+
     my $out = {};
     my @users = $db->listSetUsers($params->{set_id});
     $out->{ra_out} = \@users;
@@ -284,9 +284,6 @@ sub createNewSet{
             $out->{out}=encode_utf8_base64("Failed to create set, you may need to try another name."),
             $out->{ra_out} = {'success' => 'false'};
 		} else {			# Do it!
-			# DBFIXME use $db->newGlobalSet
-			# $newSetRecord = $db->{set}->{record}->new();
-
 			$newSetRecord = $db->newGlobalSet;
 			$newSetRecord->set_id($newSetName);
 			$newSetRecord->set_header("defaultHeader");
@@ -318,7 +315,7 @@ sub createNewSet{
 			$newSetRecord->hide_hint($params->{hide_hint});
 			$newSetRecord->restrict_prob_progression($params->{restrict_prob_progression});
 			$newSetRecord->email_instructor($params->{email_instructor});
-			
+
 			$db->addGlobalSet($newSetRecord);
 			if ($@) {
 				$out->{text} = encode_utf8_base64("Failed to create set, you may need to try another name.");
@@ -342,7 +339,7 @@ sub createNewSet{
 sub assignSetToUsers {
 	my ($self,$params) = @_;
 	my $db = $self->db;
-    
+
     my $setID = $params->{set_id};
     my $GlobalSet = $db->getGlobalSet($params->{set_id});
 
@@ -350,16 +347,16 @@ sub assignSetToUsers {
     my @users = split(',',$params->{users});
     #my @users = decode_json($params->{users});
 
-    my @results; 
+    my @results;
     foreach my $userID (@users) {
 		my $UserSet = $db->newUserSet;
 		$UserSet->user_id($userID);
 		$UserSet->set_id($setID);
-		
-		
-		
+
+
+
 		my $set_assigned = 0;
-		
+
 		eval { $db->addUserSet($UserSet) };
 		if ($@) {
 			if ($@ =~ m/user set exists/) {
@@ -369,12 +366,12 @@ sub assignSetToUsers {
 				die $@;
 			}
 		}
-		
+
 		my @GlobalProblems = grep { defined $_ } $db->getAllGlobalProblems($setID);
 		foreach my $GlobalProblem (@GlobalProblems) {
 			my @result = assignProblemToUser($self,$userID, $GlobalProblem);
 			push @results, @result if @result and not $set_assigned;
-		}   		
+		}
     }
 
 	my $out = {};
@@ -387,13 +384,13 @@ sub assignSetToUsers {
 sub assignProblemToUser {
 	my ($self,$userID,$GlobalProblem,$seed) = @_;
 	my $db = $self->db;
-	
+
 	my $UserProblem = $db->newUserProblem;
 	$UserProblem->user_id($userID);
 	$UserProblem->set_id($GlobalProblem->set_id);
 	$UserProblem->problem_id($GlobalProblem->problem_id);
 	initializeUserProblem($UserProblem, $seed);
-	
+
 	eval { $db->addUserProblem($UserProblem) };
 	if ($@) {
 		if ($@ =~ m/user problem exists/) {
@@ -404,7 +401,7 @@ sub assignProblemToUser {
 			die $@;
 		}
 	}
-	
+
 	return ();
 }
 
@@ -415,7 +412,7 @@ sub deleteProblemSet {
 	my $setID = $params->{set_id};
 	my $result = $db->deleteGlobalSet($setID);
 
-		# check the result 
+		# check the result
 	debug("in deleteProblemSet");
 	debug("deleted set:  $setID");
 	debug($result);
@@ -424,13 +421,13 @@ sub deleteProblemSet {
 
 
 
-	return $out; 
+	return $out;
 
 }
 
 
 sub reorderProblems {
-	my ($self,$params) =  @_; 
+	my ($self,$params) =  @_;
 
 	my $db = $self->db;
 	my $setID = $params->{set_id};
@@ -443,8 +440,8 @@ sub reorderProblems {
 
 	my @probOrder = ();
 
-	foreach my $problem (@allProblems) {		
-		my $recordFound = 0; 
+	foreach my $problem (@allProblems) {
+		my $recordFound = 0;
 
 		for (my $i = 0; $i < scalar(@problemList); $i++){
 			$problemList[$i] =~ s|^$topdir/*||;
@@ -452,7 +449,7 @@ sub reorderProblems {
 			if($problem->{source_file} eq $problemList[$i]){
 				push(@probOrder,$i+1);
 			   	if ($db->existsGlobalProblem($setID,$i+1)){
-			   		$problem->problem_id($i+1);		   			
+			   		$problem->problem_id($i+1);
 			   		$db->putGlobalProblem($problem);
 			   		debug("updating problem " . $problemList[$i] . " and setting the index to " . ($i+1));
 
@@ -465,10 +462,10 @@ sub reorderProblems {
 			   		debug("adding new problem " . $problemList[$i]. " and setting the index to " . ($i+1));
 		   		}
 		 	}
-		 	$recordFound = 1; 
+		 	$recordFound = 1;
 		}
 		die "global " . $problem->{source_file} ." for set $setID not found." unless $recordFound;
-		
+
 
 	}
 
@@ -495,12 +492,12 @@ sub updateProblem{
 		}
 	}
 
-		
+
 	my $out->{text} = encode_utf8_base64("Updated Problem Set " . $setID);
 
 
 
-	return $out; 
+	return $out;
 
 }
 
@@ -516,7 +513,7 @@ sub updateUserSet {
   	debug($params->{open_date});
   	debug($params->{due_date});
   	debug($params->{answer_date});
-  	
+
   	foreach my $userID (@users) {
 		my $set = $db->getUserSet($userID,$params->{set_id});
 		if ($set){
@@ -531,12 +528,12 @@ sub updateUserSet {
 		    $newSet->open_date($params->{open_date});
 		    $newSet->due_date($params->{due_date});
 		    $newSet->answer_date($params->{answer_date});
-					
+
 			$newSet = $db->addUserSet($newSet);
-		} 
+		}
 	}
 
-  
+
   my $out = {};
   #$out->{ra_out} = $set;
   $out->{text} = encode_utf8_base64("Successfully updated set " . $params->{set_id} . " for users " . $params->{users});
@@ -602,7 +599,7 @@ sub unassignSetFromUsers {
   	my ($self, $params) = @_;
   	my $db = $self->db;
   	my @users = split(',',$params->{users});
-    # should we check if the user is assigned before trying to unassign? 
+    # should we check if the user is assigned before trying to unassign?
   	foreach my $user (@users) {
 		my $result = $db->deleteUserSet($user, $params->{set_id});
 	}
@@ -622,30 +619,13 @@ returned.
 sub assignAllSetsToUser {
 	my ($self, $userID) = @_;
 	my $db = $self->db;
-	
-	# assign only sets that are not already assigned
-	#my %userSetIDs = map { $_ => 1 } $db->listUserSets($userID);
-	#my @globalSetIDs = grep { not exists $userSetIDs{$_} } $db->listGlobalSets;
-	#my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
-	# FIXME: i don't think we need to do the above, since asignSetToUser fails
-	# silently if a UserSet already exists. instead we do this:
-	# DBFIXME shouldn't need to get list of set IDs
-	my @globalSetIDs = $db->listGlobalSets;
-	my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
-	
+
 	my @results;
-	
-	my $i = 0;
-	foreach my $GlobalSet (@GlobalSets) {
-		if (not defined $GlobalSet) {
-			warn "record not found for global set $globalSetIDs[$i]";
-		} else {
-			my @result = $self->assignSetToUser($userID, $GlobalSet);
-			push @results, @result if @result;
-		}
-		$i++;
+	for my $GlobalSet (@{ [ $db->getGlobalSetsWhere() ] }) {
+		my @result = $self->assignSetToUser($userID, $GlobalSet);
+		push @results, @result if @result;
 	}
-	
+
 	return @results;
 }
 
@@ -658,8 +638,7 @@ sub addProblem {
 	my $file = $params->{path};
 	my $topdir = $self->ce->{courseDirs}{templates};
 	$file =~ s|^$topdir/*||;
-	
-	# DBFIXME count would work just as well
+
 	my $freeProblemID;
 	my $set = $db->getGlobalSet($setName);
 	warn "record not found for global set $setName" unless $set;
@@ -671,22 +650,22 @@ sub addProblem {
 	  if ($#problemIDs != -1) {
 	    @seq = jitar_id_to_seq($problemIDs[$#problemIDs]);
 	  }
-	    
+
 	  $freeProblemID = seq_to_jitar_id($seq[0]+1);
 	} else {
 	    $freeProblemID = max($db->listGlobalProblems($setName)) + 1;
 	}
 
 	my $value_default = $self->ce->{problemDefaults}->{value};
-	my $max_attempts_default = $self->ce->{problemDefaults}->{max_attempts};	
-	my $showMeAnother_default = $self->ce->{problemDefaults}->{showMeAnother};	
-	my $att_to_open_children_default = $self->ce->{problemDefaults}->{att_to_open_children};	
-	my $counts_parent_grade_default = $self->ce->{problemDefaults}->{counts_parent_grade};	
+	my $max_attempts_default = $self->ce->{problemDefaults}->{max_attempts};
+	my $showMeAnother_default = $self->ce->{problemDefaults}->{showMeAnother};
+	my $att_to_open_children_default = $self->ce->{problemDefaults}->{att_to_open_children};
+	my $counts_parent_grade_default = $self->ce->{problemDefaults}->{counts_parent_grade};
     # showMeAnotherCount is the number of times that showMeAnother has been clicked; initially 0
-	my $showMeAnotherCount = 0;	
-	
+	my $showMeAnotherCount = 0;
+
 	my $prPeriod_default = $self->ce->{problemDefaults}->{prPeriod};
-	
+
 	my $value = $value_default;
 	if (defined($params->{value}) and length($params->{value})){$value = $params->{value};}  # 0 is a valid value for $params{value} but we don't want emptystring
 
@@ -719,13 +698,13 @@ sub addProblem {
 	$problemRecord->prCount(0);
 	$db->addGlobalProblem($problemRecord);
 
-	my @results; 
+	my @results;
 	my @userIDs = $db->listSetUsers($setName);
 	foreach my $userID (@userIDs) {
 		my @result = assignProblemToUser($self, $userID, $problemRecord);
 		push @results, @result if @result;
 	}
-	
+
 
 	#assignProblemToAllSetUsers($self, $problemRecord);
 	my $out->{text} = encode_utf8_base64("Problem added to ".$setName);
@@ -734,19 +713,17 @@ sub addProblem {
 
 sub deleteProblem {
 	my ($self,$params) = @_;
-	
+
 	my $db = $self->db;
 	my $setName = $params->{set_id};
-	
+
 	my $file = $params->{path};
 	my $topdir = $self->ce->{courseDirs}{templates};
 	$file =~ s|^$topdir/*||;
-	# DBFIXME count would work just as well
-	foreach my $problem ($db->listGlobalProblems($setName)) {
-		my $problemRecord = $db->getGlobalProblem($setName, $problem);
-		
+
+	my @setGlobalProblems = $db->getGlobalProblemsWhere({ set_id => $setName });
+	for my $problemRecord (@setGlobalProblems) {
 		if($problemRecord->source_file eq $file){
-			#print "found it";
 			$db->deleteGlobalProblem($setName, $problemRecord->problem_id);
 		}
 	}


### PR DESCRIPTION
Most of the DBFIXME's scattered throughout the code have been dealt with.  In some cases this was accomplished by doing exactly what was said.  In some cases better approaches were used to consolidate calls and cache data.

In other cases the DBFIXME's were just deleted.  The primary case of this is those asking for the usage of database iterators.  Those are really not correct.  The amount of data contained in the database queries is generally not substantial enough to justify their usage.  Furthermore, the correct usage of database iteration (not implemented in webwork) would accumulate data into chunks of a more significant size rather than handle each row separately.

`WHERE` clauses are used to obtain records, rather than listing id's and then filtering on those id's.  `ORDER BY` clauses are used to do sorting in the database, rather than sorting in perl.

This usage has been tested on a course that I have that has more than 40,000 users.  Significant speed improvements are seen particularly on the pages that utilize the data for all users, like the classlist editor, statistics, and student progress pages.

Note that now the set level proctor users are not visible anywhere in the user interface.  Previously they were hidden on the classlist editor page, but showed up many places where they should not have.  There isn't anywhere that they should be shown.

Also note that several invalid `e` flags on regex expressions have been removed in Grades.pm and SendMail.pm.  There was a FIXME in Grades.pm stating that this flag is not needed for variable interpolation, and it isn't.  I have seen also seen errors due to these flags being used.

I recommend using the "Hide Whitespace" option to view this (if you haven't become accustomed to this already).

I also added a .perltidyrc file and ran perltidy on all of the files in the directory lib/WeBWorK/DB.  There are no operational changes to those files, so just ignore them in reviewing this pull request.  The pull request is currently in two commits.  The first has all of the real changes, and the second the perltidy stuff.  (Note that the .perltidyrc file is the same as the webwork3 file except I added the `-xci` option.  We may want to add that to webwork3's file and the pg one also.  That does a much better job of indentation with nested structures.)

This is #1583 again.  @pstaabp be more careful!