### PR TITLE
New approach to restricted navigation for use with LTI authentication (alternate new approach).

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -750,6 +750,7 @@ $authen{xmlrpc_module}  = "WeBWorK::Authen::XMLRPC";
 #
 %permissionLevels = (
 	login                          => "guest",
+	navigation_allowed             => "guest",
 	report_bugs                    => "ta",
 	submit_feedback                => "student",
 	change_password                => "student",
@@ -1948,6 +1949,15 @@ $ConfigValues = [
 					. 'guest accounts.'
 			),
 			type => 'permission'
+		},
+		{ var => 'permissionLevels{navigation_allowed}',
+		  doc => 'Allowed to view course home page',
+		  doc2 => 'If a user does not have this permission, then the user will not be allowed to navigate to the '
+			. 'course home page, i.e., the Homework Sets page.  This should only be used for a course when LTI '
+			. 'authentication is used, and is most useful when LTIGradeMode is set to homework.  In this case the '
+			. 'Homework Sets page is not useful and can even be confusing to students.  To use this feature set '
+			. 'this permission to "login_proctor".',
+		  type => 'permission'
 		},
 	],
 	[

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -96,7 +96,7 @@ table caption {
 		max-width: 100%;
 	}
 
-	a {
+	a, span {
 		display: block;
 		margin-left: 0.5rem;
 		margin-right: 0.5rem;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -504,19 +504,29 @@ Create the link to the webwork installation landing page with a logo and alt tex
 =cut
 
 sub webwork_logo {
-	my $self = shift;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $theme = $r->param("theme") || $ce->{defaultTheme};
+	my $self   = shift;
+	my $r      = $self->r;
+	my $ce     = $r->ce;
+	my $theme  = $r->param('theme') || $ce->{defaultTheme};
 	my $htdocs = $ce->{webwork_htdocs_url};
-	print CGI::a(
-		{href => $ce->{webwork_url}},
-		CGI::img({
+
+	if ($r->authen->was_verified && !$r->authz->hasPermissions($r->param('user'), 'navigation_allowed')) {
+		# If navigation is restricted for this user, then the webwork logo is not a link to the courses page.
+		print CGI::span(CGI::img({
 			src => "$htdocs/themes/$theme/images/webwork_logo.svg",
-			alt => $r->maketext("to courses page")
-		})
-	);
-	return "";
+			alt => 'WeBWorK'
+		}));
+	} else {
+		print CGI::a(
+			{ href => $ce->{webwork_url} },
+			CGI::img({
+				src => "$htdocs/themes/$theme/images/webwork_logo.svg",
+				alt => $r->maketext('to courses page')
+			})
+		);
+	}
+
+	return '';
 }
 
 =item institution_logo()
@@ -657,6 +667,13 @@ sub links {
 	my $problemID = $urlpath->arg("problemID");
 	my $achievementID = $urlpath->arg("achievementID");
 
+	# Determine if navigation is restricted for this user.
+	my $restricted_navigation = $authen->was_verified && !$authz->hasPermissions($userID, 'navigation_allowed');
+
+	# If navigation is restricted and the setID was not in the urlpath,
+	# then get the setID this user is restricted to view from the authen cookie.
+	$setID = $authen->get_session_set_id if (!$setID && $restricted_navigation);
+
 	my $prettySetID = format_set_name_display($setID // '');
 	my $prettyAchievementID = $achievementID;
 	$prettyAchievementID =~ s/_/ /g if defined $prettyAchievementID;
@@ -744,33 +761,44 @@ sub links {
 
 	print CGI::h2({ class => 'navbar-brand mb-0' }, $r->maketext('Main Menu'));
 	print CGI::start_ul({ class => 'nav flex-column' });
-	print CGI::start_li({ class => 'nav-item' }); # Courses
-	print &$makelink("${pfx}Home", text=>$r->maketext("Courses"), systemlink_args=>{authen=>0});
-	print CGI::end_li(); # end Courses
+
+	print CGI::li({ class => 'nav-item' },
+		&$makelink("${pfx}Home", text => $r->maketext("Courses"), systemlink_args => { authen => 0 }))
+		unless $restricted_navigation;
 
 	if (defined $courseID) {
 		if ($authen->was_verified) {
-			print CGI::start_li({ class => 'nav-item' }); # Homework Sets
-				my $primaryMenuName = $r->maketext("Homework Sets");
-				$primaryMenuName = $r->maketext("Course Administration") if ($ce->{courseName} eq 'admin');
-			print &$makelink("${pfx}ProblemSets", text=>$primaryMenuName, urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
-			print CGI::end_li();
+			# Homework Sets or Course Administration
+			print CGI::li(
+				{ class => 'nav-item' },
+				$restricted_navigation ? CGI::span({ class => 'nav-link disabled' }, $r->maketext('Homework Sets'))
+				: &$makelink(
+					"${pfx}ProblemSets",
+					text => $ce->{courseName} eq 'admin' ? $r->maketext('Course Administration')
+					: $r->maketext('Homework Sets'),
+					urlpath_args    => {%args},
+					systemlink_args => \%systemlink_args
+				)
+			);
+
 			if (defined $setID) {
-			    print CGI::start_li({ class => 'nav-item' });
+				print CGI::start_li({ class => 'nav-item' });
 				print CGI::start_ul({ class => 'nav flex-column' });
-				print CGI::start_li({ class => 'nav-item' }); # $setID
-				# show a link which depends on if it is a versioned gateway
-				#    assignment or not; to know if it's a gateway
-				#    assignment, we have to get the set record.
-				my ($globalSetID) = ( $setID =~ /(.+?)(,v\d+)?$/ );
-				my $setRecord = $db->getGlobalSet( $globalSetID );
-			    if ($setRecord->assignment_type eq 'jitar'  && defined $problemID) {
-				$prettyProblemID = join('.', jitar_id_to_seq($problemID));
-			    }
+				print CGI::start_li({ class => 'nav-item' });          # $setID
+
+				# Show a link which depends on if it is a versioned gateway
+				# assignment or not; to know if it's a gateway
+				# assignment, we have to get the set record.
+				my ($globalSetID) = ($setID =~ /(.+?)(,v\d+)?$/);
+				my $setRecord = $db->getGlobalSet($globalSetID);
+
+				if ($setRecord->assignment_type eq 'jitar' && defined $problemID) {
+					$prettyProblemID = join('.', jitar_id_to_seq($problemID));
+				}
 				if ($setRecord->assignment_type =~ /proctor/ && $setID =~ /,v(\d)+$/) {
 					print &$makelink(
 						"${pfx}ProctoredGatewayQuiz",
-						text            => $prettySetID,
+						text            => "$prettySetID",
 						urlpath_args    => { %args, setID => $setID },
 						systemlink_args => \%systemlink_args,
 						link_attrs      => { dir => 'ltr' }
@@ -778,7 +806,7 @@ sub links {
 				} elsif ($setRecord->assignment_type =~ /gateway/ && $setID =~ /,v(\d)+$/) {
 					print &$makelink(
 						"${pfx}GatewayQuiz",
-						text            => $prettySetID,
+						text            => "$prettySetID",
 						urlpath_args    => { %args, setID => $setID },
 						systemlink_args => \%systemlink_args,
 						link_attrs      => { dir => 'ltr' }
@@ -786,32 +814,32 @@ sub links {
 				} else {
 					print &$makelink(
 						"${pfx}ProblemSet",
-						text            => $prettySetID,
+						text            => "$prettySetID",
 						urlpath_args    => { %args, setID => $setID },
 						systemlink_args => \%systemlink_args,
 						link_attrs      => { dir => 'ltr' }
 					);
 				}
-			    print CGI::end_li();
+				print CGI::end_li();
 
 				if (defined $problemID) {
-				    print CGI::start_li({ class => 'nav-item' });
+					print CGI::start_li({ class => 'nav-item' });
 					print CGI::start_ul({ class => 'nav flex-column' });
-					print CGI::start_li({ class => 'nav-item' }); # $problemID
+					print CGI::start_li({ class => 'nav-item' });          # $problemID
 					print &$makelink(
 						"${pfx}Problem",
 						text            => $r->maketext("Problem [_1]", $prettyProblemID),
 						urlpath_args    => { %args, setID => $setID, problemID => $problemID },
 						systemlink_args => \%systemlink_args
 					);
-					print CGI::end_li(); # end $problemID
+					print CGI::end_li();                                   # end $problemID
 					print CGI::end_ul();
-				    print CGI::end_li();
+					print CGI::end_li();                                   # end $setID
 				}
-				print CGI::end_ul();
-			    print CGI::end_li(); # end Homework Sets
-			}
 
+				print CGI::end_ul();
+				print CGI::end_li();                                       # end Homework Sets
+			}
 
 			print CGI::li({ class => 'nav-item' },
 				&$makelink("${pfx}Options", urlpath_args => {%args}, systemlink_args => \%systemlink_args))
@@ -820,7 +848,8 @@ sub links {
 					|| $authz->hasPermissions($userID, 'change_pg_display_settings'));
 
 			print CGI::li({ class => 'nav-item' },
-				&$makelink("${pfx}Grades", urlpath_args => { %args }, systemlink_args => \%systemlink_args));
+				&$makelink("${pfx}Grades", urlpath_args => {%args}, systemlink_args => \%systemlink_args))
+				unless $restricted_navigation;
 
 			if ($ce->{achievementsEnabled}) {
 				print CGI::li({ class => 'nav-item' },
@@ -1138,6 +1167,10 @@ sub path {
 	my $r       = $self->r;
 	my $urlpath = $r->urlpath;
 
+	# Determine if navigation is restricted for this user.
+	my $restrict_navigation =
+		$r->authen->was_verified && !$r->authz->hasPermissions($r->param('user'), 'navigation_allowed');
+
 	my @path;
 
 	do {
@@ -1152,10 +1185,14 @@ sub path {
 				}
 			}
 		}
-		unshift @path, $name, $r->location . $urlpath->path;
+
+		# If navigation is restricted for this user and path, then don't provide the link.
+		unshift @path, $name,
+			$restrict_navigation && $urlpath->navigation_restricted ? '' : $r->location . $urlpath->path;
 	} while ($urlpath = $urlpath->parent);
 
-	$path[$#path] = '';    # We don't want the last path element to be a link.
+	# We don't want the last path element to be a link.
+	$path[$#path] = '';
 
 	print $self->pathMacro($args, @path);
 
@@ -1815,14 +1852,13 @@ sub hidden_fields {
 
 	@fields = $r->param unless @fields;
 
-	my $html = "";
+	my $html = '';
 	foreach my $param (@fields) {
-	    my @values = $r->param($param);
-	    foreach my $value (@values) {
-		next unless defined($value);
-#		$html .= CGI::hidden($param, $value); # (can't name these items when using real CGI)
-		$html .= CGI::hidden(-name=>$param, -default=>$value, -id=>"hidden_".$param); # (can't name these items when using real CGI)
-	    }
+		my @values = $r->param($param);
+		foreach my $value (@values) {
+			next unless defined($value);
+			$html .= CGI::hidden({ name => $param, default => $value, id => "hidden_" . $param });
+		}
 	}
 
 	return $html;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1126,10 +1126,12 @@ sub path {
 	my $root       = $ce->{webworkURLs}{root};
 	my $courseName = $ce->{courseName};
 
+	my $navigation_allowed = $r->authz->hasPermissions($r->param('user'), 'navigation_allowed');
+
 	return $self->pathMacro(
 		$args,
-		'Home'      => $root,
-		$courseName => "$root/$courseName",
+		'Home'      => $navigation_allowed ? $root : '',
+		$courseName => $navigation_allowed ? "$root/$courseName" : '',
 		$setName eq "Undefined_Set" || $self->{invalidSet}
 		? ($setName => '')
 		: (

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1372,9 +1372,11 @@ sub path {
 		}
 	}
 
+	my $navigation_allowed = $r->authz->hasPermissions($r->param('user'), 'navigation_allowed');
+
 	my @path = (
-		WeBWorK     => $r->location,
-		$courseName => $r->location . "/$courseName",
+		WeBWorK     => $navigation_allowed ? $r->location                  : '',
+		$courseName => $navigation_allowed ? $r->location . "/$courseName" : '',
 		$setName    => $r->location . "/$courseName/$setName",
 	);
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -73,6 +73,9 @@ sub nav {
 	my ($self, $args) = @_;
 	my $r = $self->r;
 
+	# Don't show the nav if the user does not have unrestricted navigation permissions.
+	return '' unless $r->authz->hasPermissions($r->param('user'), 'navigation_allowed');
+
 	my @links =
 		($r->maketext('Homework Sets'), $r->location . $r->urlpath->parent->path, $r->maketext('Homework Sets'));
 	return CGI::div({ class => 'row sticky-nav', role => 'navigation', aria_label => 'problem navigation' },
@@ -130,10 +133,12 @@ sub siblings {
 	my $authz = $r->authz;
 	my $urlpath = $r->urlpath;
 
-
 	my $courseID = $urlpath->arg("courseID");
 	my $user = $r->param('user');
 	my $eUserID = $r->param("effectiveUser");
+
+	# restrict navigation to other problem sets if not allowed
+	return '' unless $authz->hasPermissions($user, 'navigation_allowed');
 
 	# Note that listUserSets does not list versioned sets, but listUserSetsWhere does.  On the other hand, listUserSets
 	# can not sort in the database, while listUserSetsWhere can.

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -164,7 +164,14 @@ sub body {
 	my $hardcopyPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::Hardcopy",  $r, courseID => $courseName);
 	my $actionURL = $self->systemLink($hardcopyPage, authen => 0); # no authen info for form action
 
-	# we have to get sets and versioned sets separately
+	# If navigation is restricted, then don't show the body and instead display a
+	# message informing the user to access assignments via an LMS.
+	unless ($authz->hasPermissions($r->param('user'), 'navigation_allowed')) {
+		my $LMS = $ce->{LMS_url} ? CGI::a({ href => $ce->{LMS_url} }, $ce->{LMS_name}) : $ce->{LMS_name};
+		print CGI::div({ class => 'alert alert-danger' },
+			$r->maketext('You must access assignments from your Course Management System ([_1]).', $LMS));
+		return '';
+	}
 
 	debug("Begin collecting merged sets");
 	my @sets = $db->getMergedSetsWhere({ user_id => $effectiveUser });

--- a/lib/WeBWorK/DB/Record/Key.pm
+++ b/lib/WeBWorK/DB/Record/Key.pm
@@ -30,6 +30,7 @@ BEGIN {
 		user_id   => { type => "TINYBLOB NOT NULL", key => 1 },
 		key       => { type => "TEXT" },
 		timestamp => { type => "BIGINT" },
+		set_id    => { type => "TINYBLOB" },
 	);
 }
 

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -145,6 +145,7 @@ our %pathTypes = (
 	},
 
 	################################################################################
+
 	html2xml => {
 		name    => 'html2xml',
 		parent  => 'root', #    'set_list',
@@ -177,7 +178,7 @@ our %pathTypes = (
 		parent  => 'root',
 		kids    => [ qw/equation_display feedback gateway_quiz proctored_gateway_quiz answer_log grades hardcopy achievements
 			logout options instructor_tools problem_list
-		/ ],
+			/ ],
 		match   => qr|^([^/]+)/|,
 		capture => [ qw/courseID/ ],
 		produce => '$courseID/',
@@ -203,6 +204,7 @@ our %pathTypes = (
 		capture => [ qw// ],
 		produce => 'feedback/',
 		display => 'WeBWorK::ContentGenerator::Feedback',
+		unrestricted => 1
 	},
 	gateway_quiz => {
 		name    => x('Gateway Quiz [_2]'),
@@ -212,9 +214,10 @@ our %pathTypes = (
 		capture => [ qw/setID/ ],
 		produce => 'quiz_mode/$setID/',
 		display => 'WeBWorK::ContentGenerator::GatewayQuiz',
+		unrestricted => 1
 	},
 
-    	answer_log => {
+	answer_log => {
 		name    => x('Answer Log'),
 		parent  => 'set_list',
 		kids    => [ qw// ],
@@ -232,6 +235,7 @@ our %pathTypes = (
 		capture => [ qw/setID/ ],
 		produce => 'proctored_quiz_mode/$setID/',
 		display => 'WeBWorK::ContentGenerator::ProctoredGatewayQuiz',
+		unrestricted => 1
 	},
 	proctored_gateway_proctor_login => {
 		name    => x('Proctored Gateway Quiz [_2] Proctor Login'),
@@ -241,6 +245,7 @@ our %pathTypes = (
 		capture => [ qw/setID/ ],
 		produce => 'proctored_quiz_mode/$setID/proctor_login',
 		display => 'WeBWorK::ContentGenerator::LoginProctor',
+		unrestricted => 1
 	},
 	grades => {
 		name    => x('Grades'),
@@ -251,15 +256,16 @@ our %pathTypes = (
 		produce => 'grades/',
 		display => 'WeBWorK::ContentGenerator::Grades',
 	},
-        achievements  => {
-	        name    => x('Achievements'),
-                parent  => 'set_list',
-                kids    => [ qw// ],
-                match   => qr|^achievements/|,
-                capture => [ qw// ],
-                produce => 'achievements/',
-                display => 'WeBWorK::ContentGenerator::Achievements',
-        },
+	achievements  => {
+		name    => x('Achievements'),
+		parent  => 'set_list',
+		kids    => [ qw// ],
+		match   => qr|^achievements/|,
+		capture => [ qw// ],
+		produce => 'achievements/',
+		display => 'WeBWorK::ContentGenerator::Achievements',
+		unrestricted => 1
+	},
 	hardcopy => {
 		name    => x('Hardcopy Generator'),
 		parent  => 'set_list',
@@ -277,6 +283,7 @@ our %pathTypes = (
 		capture => [ qw/setID/ ],
 		produce => '$setID/',
 		display => 'WeBWorK::ContentGenerator::Hardcopy',
+		unrestricted => 1
 	},
 	logout => {
 		name    => x('Logout'),
@@ -295,6 +302,7 @@ our %pathTypes = (
 		capture => [ qw// ],
 		produce => 'options/',
 		display => 'WeBWorK::ContentGenerator::Options',
+		unrestricted => 1
 	},
 
 	################################################################################
@@ -382,7 +390,7 @@ our %pathTypes = (
 		display => 'WeBWorK::ContentGenerator::Instructor::UsersAssignedToSet',
 	},
 
-        instructor_problem_grader => {
+	instructor_problem_grader => {
 		name    => x('Manual Grader'),
 		parent  => 'instructor_tools',
 		kids    => [ qw// ],
@@ -391,7 +399,6 @@ our %pathTypes = (
 		produce => 'grader/$setID/$problemID',
 		display => 'WeBWorK::ContentGenerator::Instructor::ProblemGrader',
 	},
-
 
 	################################################################################
 
@@ -527,36 +534,35 @@ our %pathTypes = (
 
 	################################################################################
 
-        instructor_achievement_list => {
-                name    =>  x('Achievement Editor'),
-                parent  =>  'instructor_tools',
-                kids    =>  [ qw/instructor_achievement_editor instructor_achievement_user_editor/ ],
-                match   =>  qr|^achievement_list/|,
-                capture =>  [ qw// ],
-                produce =>  'achievement_list/',
-                display =>  'WeBWorK::ContentGenerator::Instructor::AchievementList',
-        },
+	instructor_achievement_list => {
+		name    =>  x('Achievement Editor'),
+		parent  =>  'instructor_tools',
+		kids    =>  [ qw/instructor_achievement_editor instructor_achievement_user_editor/ ],
+		match   =>  qr|^achievement_list/|,
+		capture =>  [ qw// ],
+		produce =>  'achievement_list/',
+		display =>  'WeBWorK::ContentGenerator::Instructor::AchievementList',
+	},
 
-        instructor_achievement_editor => {
-	        name    => x('Achievement Evaluator Editor'),
-                parent  => 'instructor_achievement_list',
-                kids => [ qw// ],
-                match => qr|^([^/]+)/editor/|,
+	instructor_achievement_editor => {
+		name    => x('Achievement Evaluator Editor'),
+		parent  => 'instructor_achievement_list',
+		kids => [ qw// ],
+		match => qr|^([^/]+)/editor/|,
 		capture => [ qw/achievementID/ ],
-                produce => '$achievementID/editor/',
+		produce => '$achievementID/editor/',
 		display => 'WeBWorK::ContentGenerator::Instructor::AchievementEditor',
 	},
 
-        instructor_achievement_user_editor => {
-	        name    => x('Achievement User Editor'),
-                parent  => 'instructor_achievement_list',
-                kids => [ qw// ],
+	instructor_achievement_user_editor => {
+		name    => x('Achievement User Editor'),
+		parent  => 'instructor_achievement_list',
+		kids => [ qw// ],
 		match   => qr|^([^/]+)/users/|,
 		capture => [ qw/achievementID/ ],
 		produce => '$achievementID/users/',
 		display => 'WeBWorK::ContentGenerator::Instructor::AchievementUserEditor',
 	},
-
 
 	################################################################################
 
@@ -598,6 +604,7 @@ our %pathTypes = (
 		capture => [ qw/setID/ ],
 		produce => '$setID/',
 		display => 'WeBWorK::ContentGenerator::ProblemSet',
+		unrestricted => 1
 	},
 	problem_detail => {
 		name    => '[_3]',
@@ -607,8 +614,9 @@ our %pathTypes = (
 		capture => [ qw/problemID/ ],
 		produce => '$problemID/',
 		display => 'WeBWorK::ContentGenerator::Problem',
-        },
-        show_me_another => {
+		unrestricted => 1
+	},
+	show_me_another => {
 		name    => x('Show Me Another'),
 		parent  => 'problem_detail',
 		kids    => [ qw// ],
@@ -616,9 +624,8 @@ our %pathTypes = (
 		capture => [ qw// ],
 		produce => 'show_me_another/',
 		display => 'WeBWorK::ContentGenerator::ShowMeAnother',
+		unrestricted => 1
 	},
-
-
 );
 
 =for comment
@@ -809,6 +816,19 @@ sub module {
 	my $type = $self->{type};
 
 	return $pathTypes{$type}->{display};
+}
+
+=item navigation_restricted()
+
+Returns 1 if the path is restricted from being viewed by a user that does not
+have the navigation_allowed permission, and 0 otherwise.  The allowed paths for
+restricted users are marked with the unrestricted flag.
+
+=cut
+
+sub navigation_restricted {
+	my $self = shift;
+	return defined $pathTypes{$self->{type}}{unrestricted} ? 0 : 1;
 }
 
 =back


### PR DESCRIPTION
This adds a new permission `navigation_allowed`.  Users that do not have this permission will not be allowed to view the course home page (i.e., the problems sets list page in ProblemSets.pm).  These users will also be restricted to only viewing one assignment set.  That is the set that the user initially signs in to view.

This does not remove the breadcrumb and site navigation elements. Instead the elements in the breadcrumb and site navigation that would normally be links that take the user to these restricted pages are not links for these users.  Furthermore, the set that the user initially signs in to view is always present in the site navigation and is of course a link that the user can use to get back to that set.  So if the user goes to the `User Settings`, `Email Instructor`, `Download Hardcopy`, `Achievements` (if enabled), or any other unrestricted page, the user can still get back to the set the user signed in to view.  Note that the pages that are considered unrestricted are flagged as such in URLPath.pm.  Note that the Grades page is not one of these due to the
links to other problems sets that are provided there.

This works by saving the `setID` in the session so that the `links` method in ContentGenerator.pm can always get this value.  This value is saved in the session key in the database if session_management_via is set to key, and is saved in the session cookie (and actually the session key in the database as well) if session_management_via is set to session_cookie.  **The downside of this approach is that it requires a new column in the database key table.**  The upside of this approach is that it gives a perhaps more reliable method of keeping the setID active for the session.

Also, if a user tries to modify the location address in the browser to get to the ProblemSets.pm page, a message will be displayed telling the user to access assignments from their course management system.

If LTIGradeMode is set to homework and the user modifies the location address in the browser to point to another set for the class that the student has not accessed yet via the learning management system it will give the error `The selected problem set (setID) is not a valid set for user_id.  You must user your LMS to access this set.` (not exact wording).  This of course is already what happens in this case.

Of course only of of #1587 or this pull request should be merged.