### PR TITLE
Fix errors when processing unassigned quizzes.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -414,6 +414,9 @@ sub get_instructor_comment {
 sub pre_header_initialize {
 	my ($self)     = @_;
 
+	# if authz->checkSet has failed, this set is invalid, and no need to proceeded.
+	return if $self->{invalidSet};
+
 	my $r = $self->r;
 	my $ce = $r->ce;
 	my $db = $r->db;
@@ -1290,7 +1293,7 @@ sub body {
 
 	if ($self->{invalidSet} || $self->{invalidProblem}) {
 		# delete any proctor keys that are floating around
-		if ($self->{'assignment_type'} eq 'proctored_gateway') {
+		if (defined($self->{'assignment_type'}) && $self->{'assignment_type'} eq 'proctored_gateway') {
 			my $proctorID = $r->param('proctor_user');
 			if ($proctorID) {
 				eval{ $db->deleteKey("$effectiveUser,$proctorID"); };


### PR DESCRIPTION
When linking directly to a gateway quiz from an LMS (or typing in the url with quiz_mode), GatewayQuiz.pm would error out if the quiz was not assigned to the user. This provides a fix to avoid trying to access undefined variables in the case authz->checkSet has failed, and updates the class for the alert div that returns the message about trying to access an invalid set to match what is done in ProblemSet.pm.