### PR TITLE
Allow student access to existing Gateway versions even before the open date.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -52,7 +52,7 @@ sub initialize {
 
 	my $user          = $db->getUser($userName);
 	my $effectiveUser = $db->getUser($effectiveUserName);
-	$self->{set} = $db->getMergedSet($effectiveUserName, $setName);
+	$self->{set} = $authz->{merged_set};
 
 	$self->{displayMode} = $user->displayMode ? $user->displayMode : $r->ce->{pg}->{options}->{displayMode};
 
@@ -203,8 +203,8 @@ sub info {
 	my $userID = $r->param("user");
 	my $eUserID = $r->param("effectiveUser");
 
-	my $effectiveUser = $db->getUser($eUserID); # checked
-	my $set  = $db->getMergedSet($eUserID, $setID); # checked
+	my $effectiveUser = $db->getUser($eUserID);
+	my $set  = $self->{set};
 
 	die "effective user $eUserID not found. One 'acts as' the effective user." unless $effectiveUser;
 	# FIXME: this was already caught in initialize()
@@ -299,7 +299,7 @@ sub body {
 	my $effectiveUser = $r->param('effectiveUser');
 	my $user = $r->param('user');
 
-	my $set = $db->getMergedSet($effectiveUser, $setName);  # checked
+	my $set = $self->{set};
 
 	if ($self->{invalidSet}) {
 		return CGI::div(
@@ -778,7 +778,7 @@ sub body {
 
 		if (@problemNumbers) {
 			# This table contains a summary, a caption, and scope variables for the columns.
-			print CGI::div({ class => 'table-responsive' });
+			print CGI::start_div({ class => 'table-responsive' });
 			print CGI::start_table({
 					class => "problem_set_table table caption-top font-sm",
 					summary => $r->maketext("This table shows the problems that are in this problem set.  " .

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -288,7 +288,6 @@ sub body {
 sub setListRow {
 	my ($self, $set, $multiSet, $preOpenSets, $db) = @_;
 	my $r = $self->r;
-	my $db = $r->db;
 	my $ce = $r->ce;
 	my $authz = $r->authz;
 	my $user = $r->param("user");

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -242,9 +242,7 @@ sub body {
 
 	# Regular sets and gateway template sets are merged, but sorted either by name or urgency.
 	# Versions are not shown here. Instead they are on the ProblemSet page for the gateway quiz.
-	foreach my $set (@sets) {
-		die "set $set not defined" unless $set;
-
+	for my $set (@sets) {
 		if ($set->visible || $authz->hasPermissions($user, "view_hidden_sets")) {
 			print $self->setListRow($set, $authz->hasPermissions($user, "view_multiple_sets"),
 				$authz->hasPermissions($user, "view_unopened_sets"), $db);
@@ -290,6 +288,7 @@ sub body {
 sub setListRow {
 	my ($self, $set, $multiSet, $preOpenSets, $db) = @_;
 	my $r = $self->r;
+	my $db = $r->db;
 	my $ce = $r->ce;
 	my $authz = $r->authz;
 	my $user = $r->param("user");
@@ -351,7 +350,8 @@ sub setListRow {
 			$status .= restricted_progression_msg($r,1,$restriction,@restricted);
 		}
 		$control = "" unless $preOpenSets;
-		$interactive = $display_name unless $preOpenSets;
+		$interactive = $display_name
+			unless $preOpenSets || ($gwtype && $db->countSetVersions($effectiveUser, $set->set_id));
 
 	} elsif (time < $set->due_date) {
 		$status = $self->set_due_msg($set,0);


### PR DESCRIPTION
If a specific version of a gateway quiz is requested, then use its open date rather than the template set's open date to determine if it is open.  Furthermore, if a gateway quiz version already exists then a link is provided on the Homework Sets page to the quiz version list page (in ProblemSet.pm) and student's are allowed to view that page even if it is before the set open date.  That page still shows that the set is closed and no new versions can be opened.

This allows for things like having a gateway quiz that is open for a period of time, then closed for a period, and then subsequetly open again.  With this pull request, students that had taken the quiz during the first period that the quiz was open can still view their past attempts during the period in the middle that the quiz is closed.

This was requested by @glarose for a situation that came up for him.

This also includes a small rework of how conditional release is implemented.  Instead of calling `die` in the content generator sub-modules when those pages are loaded, work the conditional release check into `checkSet` in lib/WeBWorK/Authz.pm.  This is how it should have been done in the first place.  Furthermore, there should never be a `die` call in the content generator.  There are probably still many of these though ... things done wrong.

Also included is the removal of some redundant database calls in ProblemSet.pm and the addition of doing ordering in the database.  The gateway quiz version list versus problem list portion of the code is also reorganized in a much more logical way.