### PR TITLE
Add a new permission `change_pg_display_settings`.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -754,6 +754,7 @@ $authen{xmlrpc_module}  = "WeBWorK::Authen::XMLRPC";
 	submit_feedback                => "student",
 	change_password                => "student",
 	change_email_address           => "student",
+	change_pg_display_settings     => "student",
 
 	proctor_quiz_login             => "login_proctor",
 	proctor_quiz_grade             => "grade_proctor",
@@ -1718,6 +1719,11 @@ $ConfigValues = [
 		{ var => 'permissionLevels{change_email_address}',
 		  doc => 'Allowed to change their e-mail address',
 		  doc2 => 'Users at this level and higher are allowed to change their e-mail address. Normally guest users are not allowed to change the e-mail address since it does not make sense to send e-mail to anonymous accounts.',
+		  type => 'permission'
+		},
+		{ var => 'permissionLevels{change_pg_display_settings}',
+		  doc => 'Allowed to change display settings used in pg problems',
+		  doc2 => 'Users at this level and higher are allowed to change display settings used in pg problems.',
 		  type => 'permission'
 		},
 		{ var => 'permissionLevels{view_answers}',

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -795,7 +795,10 @@ sub links {
 
 
 			print CGI::li({ class => 'nav-item' },
-				&$makelink("${pfx}Options", urlpath_args => { %args }, systemlink_args => \%systemlink_args));
+				&$makelink("${pfx}Options", urlpath_args => {%args}, systemlink_args => \%systemlink_args))
+				if ($authz->hasPermissions($userID, 'change_password')
+					|| $authz->hasPermissions($userID, 'change_email_address')
+					|| $authz->hasPermissions($userID, 'change_pg_display_settings'));
 
 			print CGI::li({ class => 'nav-item' },
 				&$makelink("${pfx}Grades", urlpath_args => { %args }, systemlink_args => \%systemlink_args));

--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -24,12 +24,9 @@ WeBWorK::ContentGenerator::Options - Change user options.
 
 use strict;
 use warnings;
-#use CGI qw(-nosticky );
 use WeBWorK::CGI;
-use WeBWorK::Utils qw(cryptPassword dequote);
+use WeBWorK::Utils qw(cryptPassword);
 use WeBWorK::Localize;
-
-
 
 sub body {
 	my ($self) = @_;
@@ -38,7 +35,7 @@ sub body {
 	my $db     = $r->db;
 	my $authz  = $r->authz;
 
-	my $userID = $r->param("user");
+	my $userID = $r->param('user');
 	my $User   = $db->getUser($userID);
 	die "record not found for user '$userID'." unless defined $User;
 
@@ -46,34 +43,32 @@ sub body {
 	my $EUser   = $db->getUser($eUserID);       # checked
 	die "record not found for effective user '$eUserID'." unless defined $EUser;
 
-	my $user_name   = $User->first_name . " " . $User->last_name;
-	my $e_user_name = $EUser->first_name . " " . $EUser->last_name;
+	my $user_name   = $User->first_name . ' ' . $User->last_name;
+	my $e_user_name = $EUser->first_name . ' ' . $EUser->last_name;
 
-	my $changeOptions = $r->param("changeOptions");
-	my $currP         = $r->param("currPassword");
-	my $newP          = $r->param("newPassword");
-	my $confirmP      = $r->param("confirmPassword");
-	my $newA          = $r->param("newAddress");
+	my $changeOptions = $r->param('changeOptions');
+	my $currP         = $r->param('currPassword');
+	my $newP          = $r->param('newPassword');
+	my $confirmP      = $r->param('confirmPassword');
+	my $newA          = $r->param('newAddress');
 
-	print CGI::start_form(-method => "POST", -action => $r->uri);
+	print CGI::start_form(-method => 'POST', -action => $r->uri);
 	print $self->hidden_authen_fields;
 
-	print CGI::h2($r->maketext("Change Password"));
+	if ($authz->hasPermissions($userID, 'change_password')) {
+		print CGI::h2($r->maketext('Change Password'));
 
-	my $Password = eval { $db->getPassword($User->user_id) };   # checked
-																# Its ok if the $Password doesn't exist because students
-																# might be setting it for the first time.
-	warn $r->maketext("Can't get password record for user '[_1]': [_2]", $userID, $@) if $@;
+		my $Password = eval { $db->getPassword($User->user_id) };
 
-	if ($changeOptions and ($currP or $newP or $confirmP)) {
+		# Its ok if the $Password doesn't exist because students might be setting it for the first time.
+		warn $r->maketext("Can't get password record for user '[_1]': [_2]", $userID, $@) if $@;
 
-		if ($authz->hasPermissions($userID, "change_password")) {
+		if ($changeOptions and ($currP or $newP or $confirmP)) {
 
 			my $EPassword = eval { $db->getPassword($EUser->user_id) };    # checked
 			warn $r->maketext("Can't get password record for effective user '[_1]': [_2]", $eUserID, $@) if $@;
 
-			#Check that either password is not defined or if it is
-			#defined then we have the right one.
+			# Check that either password is not defined or if it is defined then we have the right one.
 			if ((not defined $Password) || (crypt($currP // '', $Password->password) eq $Password->password)) {
 				if ($newP or $confirmP) {
 					if ($newP eq $confirmP) {
@@ -87,14 +82,10 @@ sub body {
 								print CGI::div({ class => 'alert alert-danger', tabindex => '-1' },
 									$r->maketext("Couldn't change [_1]'s password: [_2]", $e_user_name, $@));
 							} else {
-								print CGI::div(
-									{ class => 'alert alert-success' },
-									$r->maketext("[_1]'s password has been changed.", $e_user_name),
-								);
+								print CGI::div({ class => 'alert alert-success' },
+									$r->maketext("[_1]'s password has been changed.", $e_user_name));
 							}
-
 						} else {
-
 							$EPassword->password(cryptPassword($newP));
 							eval { $db->putPassword($EPassword) };
 							$Password = $Password // $EPassword;
@@ -102,47 +93,38 @@ sub body {
 								print CGI::div({ class => 'alert alert-danger', tabindex => '-1' },
 									$r->maketext("Couldn't change [_1]'s password: [_2]", $e_user_name, $@));
 							} else {
-								print CGI::div(
-									{ class => 'alert alert-success' },
-									$r->maketext("[_1]'s password has been changed.", $e_user_name),
-								);
+								print CGI::div({ class => 'alert alert-success' },
+									$r->maketext("[_1]'s password has been changed.", $e_user_name));
 							}
-
 						}
 					} else {
 						print CGI::div(
 							{ class => 'alert alert-danger', tabindex => '-1' },
 							$r->maketext(
-								"The passwords you entered in the [_1] and [_2] fields don't match. Please retype your new password and try again.",
+								"The passwords you entered in the [_1] and [_2] fields don't match. "
+									. 'Please retype your new password and try again.',
 								CGI::b($r->maketext("[_1]'s New Password",         $e_user_name)),
 								CGI::b($r->maketext("Confirm [_1]'s New Password", $e_user_name))
 							)
 						);
 					}
 				} else {
-					print CGI::div(
-						{ class => 'alert alert-danger', tabindex => '-1' },
-						$r->maketext("[_1]'s new password cannot be blank.", $e_user_name),
-					);
+					print CGI::div({ class => 'alert alert-danger', tabindex => '-1' },
+						$r->maketext("[_1]'s new password cannot be blank.", $e_user_name));
 				}
 			} else {
 				print CGI::div(
 					{ class => 'alert alert-danger', tabindex => '-1' },
 					$r->maketext(
-						"The password you entered in the [_1] field does not match your current password. Please retype your current password and try again.",
+						'The password you entered in the [_1] field does not match your current password. '
+							. 'Please retype your current password and try again.',
 						CGI::b($r->maketext("[_1]'s Current Password", $user_name))
 					)
 				);
 			}
 
-		} else {
-			print CGI::div({ class => 'alert alert-danger', tabindex => '-1' },
-				$r->maketext("You do not have permission to change your password."))
-				unless $changeOptions and ($currP or $newP or $confirmP);    # avoid double message
 		}
-	}
 
-	if ($authz->hasPermissions($userID, "change_password")) {
 		print CGI::div(
 			{ class => 'row mb-2' },
 			CGI::div(
@@ -156,8 +138,8 @@ sub body {
 					CGI::div(
 						{ class => 'col-sm-6' },
 						CGI::password_field({
-							name => "currPassword",
-							id   => "currPassword",
+							name => 'currPassword',
+							id   => 'currPassword',
 							(defined $Password) ? () : (disabled => 1),
 							class => 'form-control'
 						})
@@ -166,12 +148,12 @@ sub body {
 				CGI::div(
 					{ class => 'row mb-2' },
 					CGI::label(
-						{ 'for' => "newPassword", class => 'col-form-label col-sm-6' },
+						{ 'for' => 'newPassword', class => 'col-form-label col-sm-6' },
 						$r->maketext("[_1]'s New Password", $e_user_name)
 					),
 					CGI::div(
 						{ class => 'col-sm-6' },
-						CGI::password_field({ name => "newPassword", id => "newPassword", class => 'form-control' })
+						CGI::password_field({ name => 'newPassword', id => 'newPassword', class => 'form-control' })
 					)
 				),
 				CGI::div(
@@ -183,23 +165,20 @@ sub body {
 					CGI::div(
 						{ class => 'col-sm-6' },
 						CGI::password_field({
-							name  => "confirmPassword",
-							id    => "confirmPassword",
+							name  => 'confirmPassword',
+							id    => 'confirmPassword',
 							class => 'form-control'
 						})
 					)
 				)
 			)
 		);
-	} else {
-		print CGI::p($r->maketext("You do not have permission to change your password."));
 	}
 
-	print CGI::h2($r->maketext("Change Email Address"));
+	if ($authz->hasPermissions($userID, 'change_email_address')) {
+		print CGI::h2($r->maketext('Change Email Address'));
 
-	if ($changeOptions and $newA) {
-		if ($authz->hasPermissions($userID, "change_email_address")) {
-
+		if ($changeOptions and $newA) {
 			my $oldA = $EUser->email_address;
 			$EUser->email_address($newA);
 			eval { $db->putUser($EUser) };
@@ -207,24 +186,14 @@ sub body {
 				$EUser->email_address($oldA);
 				print CGI::div(
 					{ class => 'alert alert-danger', tabindex => '-1' },
-					$r->maketext("Couldn't change your email address: [_1]", $@),
+					$r->maketext("Couldn't change your email address: [_1]", $@)
 				);
 			} else {
-				print CGI::div(
-					{ class => 'alert alert-success' },
-					$r->maketext("Your email address has been changed."),
-				);
+				print CGI::div({ class => 'alert alert-success' },
+					$r->maketext('Your email address has been changed.'));
 			}
-
-		} else {
-			print CGI::div(
-				{ class => 'alert alert-danger p-1 mb-0', tabindex => '-1' },
-				$r->maketext("You do not have permission to change email addresses."),
-			);
 		}
-	}
 
-	if ($authz->hasPermissions($userID, "change_email_address")) {
 		print CGI::div(
 			{ class => 'row mb-2' },
 			CGI::div(
@@ -239,8 +208,8 @@ sub body {
 						{ class => 'col-sm-6' },
 						CGI::textfield({
 							readonly => undef,
-							id       => "currAddress",
-							name     => "currAddress",
+							id       => 'currAddress',
+							name     => 'currAddress',
 							value    => $EUser->email_address,
 							class    => 'form-control'
 						})
@@ -254,221 +223,189 @@ sub body {
 					),
 					CGI::div(
 						{ class => 'col-sm-6' },
-						CGI::textfield({ name => "newAddress", id => "newAddress", class => 'form-control' })
+						CGI::textfield({ name => 'newAddress', id => 'newAddress', class => 'form-control' })
 					)
 				)
 			)
 		);
-	} else {
-		print CGI::p($r->maketext("You do not have permission to change email addresses."))
-			unless $changeOptions and $newA;    # avoid double message
 	}
 
-	print CGI::h2($r->maketext("Change Display Settings"));
+	if ($authz->hasPermissions($userID, 'change_pg_display_settings')) {
+		print CGI::h2($r->maketext('Change Display Settings'));
 
-	if ($changeOptions) {
+		if ($changeOptions) {
+			if (
+				(defined($r->param('displayMode')) && $EUser->displayMode() ne $r->param('displayMode'))
+				|| (defined($r->param('showOldAnswers')) && $EUser->showOldAnswers() ne $r->param('showOldAnswers'))
+				|| (defined($r->param('useWirisEditor')) && $EUser->useWirisEditor() ne $r->param('useWirisEditor'))
+				|| (defined($r->param('useMathQuill'))   && $EUser->useMathQuill() ne $r->param('useMathQuill'))
+				)
+			{
+				$EUser->displayMode($r->param('displayMode'));
+				$EUser->showOldAnswers($r->param('showOldAnswers'));
+				$EUser->useWirisEditor($r->param('useWirisEditor'));
+				$EUser->useMathQuill($r->param('useMathQuill'));
 
-		if (
-			(defined($r->param('displayMode')) && $EUser->displayMode() ne $r->param('displayMode'))
-			|| (defined($r->param('showOldAnswers'))
-				&& $EUser->showOldAnswers() ne $r->param('showOldAnswers'))
-			|| (defined($r->param('useMathView'))
-				&& $EUser->useMathView() ne $r->param('useMathView'))
-			)
-		{
-
-			$EUser->displayMode($r->param('displayMode'));
-			$EUser->showOldAnswers($r->param('showOldAnswers'));
-			$EUser->useMathView($r->param('useMathView'));
-
-			eval { $db->putUser($EUser) };
-			if ($@) {
-				print CGI::div(
-					{ class => 'alert alert-danger', tabindex => '-1' },
-					$r->maketext("Couldn't save your display options: [_1]", $@),
-				);
-			} else {
-				print CGI::div(
-					{ class => 'alert alert-success' },
-					$r->maketext("Your display options have been saved."),
-				);
+				eval { $db->putUser($EUser) };
+				if ($@) {
+					print CGI::div(
+						{ class => 'alert alert-danger', tabindex => '-1' },
+						$r->maketext("Couldn't save your display options: [_1]", $@)
+					);
+				} else {
+					print CGI::div(
+						{ class => 'alert alert-success p-1 mb-0' },
+						$r->maketext('Your display options have been saved.')
+					);
+				}
 			}
 		}
 
-		if (
-			(defined($r->param('displayMode')) && $EUser->displayMode() ne $r->param('displayMode'))
-			|| (defined($r->param('showOldAnswers'))
-				&& $EUser->showOldAnswers() ne $r->param('showOldAnswers'))
-			|| (defined($r->param('useWirisEditor'))
-				&& $EUser->useWirisEditor() ne $r->param('useWirisEditor'))
-			|| (defined($r->param('useMathQuill'))
-				&& $EUser->useMathQuill() ne $r->param('useMathQuill'))
-			)
-		{
-			$EUser->displayMode($r->param('displayMode'));
-			$EUser->showOldAnswers($r->param('showOldAnswers'));
-			$EUser->useWirisEditor($r->param('useWirisEditor'));
-			$EUser->useMathQuill($r->param('useMathQuill'));
+		my $result = '';
 
-			eval { $db->putUser($EUser) };
-			if ($@) {
-				print CGI::div(
-					{ class => 'alert alert-danger', tabindex => '-1' },
-					$r->maketext("Couldn't save your display options: [_1]", $@),
-				);
-			} else {
-				print CGI::div(
-					{ class => 'alert alert-success p-1 mb-0' },
-					$r->maketext("Your display options have been saved."),
-				);
-			}
+		my $curr_displayMode = $EUser->displayMode || $ce->{pg}{options}{displayMode};
+		my %display_modes    = %{ WeBWorK::PG::DISPLAY_MODES() };
+		my @active_modes     = grep { exists $display_modes{$_} } @{ $ce->{pg}{displayModes} };
+
+		if (@active_modes > 1) {
+			$result .= CGI::div(
+				{ class => 'mb-3' },
+				CGI::p({ class => 'lead mb-2' }, $r->maketext('View equations as') . ':'),
+				map {
+					CGI::div(
+						{ class => 'form-check form-check-inline' },
+						CGI::input({
+							type  => 'radio',
+							name  => 'displayMode',
+							id    => "displayMode-$_",
+							value => $_,
+							$_ eq $curr_displayMode ? (checked => undef) : (),
+							class => 'form-check-input'
+						}),
+						CGI::label({ for => "displayMode-$_", class => 'form-check-label' }, $_)
+					)
+				} @active_modes
+			);
 		}
-	}
 
-	my $result = '';
-
-	my $curr_displayMode = $EUser->displayMode || $ce->{pg}{options}{displayMode};
-	my %display_modes    = %{ WeBWorK::PG::DISPLAY_MODES() };
-	my @active_modes     = grep { exists $display_modes{$_} } @{ $ce->{pg}{displayModes} };
-
-	if (@active_modes > 1) {
-		$result .= CGI::div(
-			{ class => 'mb-3' },
-			CGI::p({ class => 'lead mb-2' }, $r->maketext('View equations as') . ':'),
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::input({
-						type  => 'radio',
-						name  => 'displayMode',
-						id    => "displayMode-$_",
-						value => $_,
-						$_ eq $curr_displayMode ? (checked => undef) : (),
-						class => 'form-check-input'
-					}),
-					CGI::label({ for => "displayMode-$_", class => 'form-check-label' }, $_)
-				)
-			} @active_modes
-		);
-	}
-
-	if ($authz->hasPermissions($userID, "can_show_old_answers")) {
-		my $curr_showOldAnswers =
-			$EUser->showOldAnswers ne '' ? $EUser->showOldAnswers : $ce->{pg}{options}{showOldAnswers};
-		$result .= CGI::div(
-			{ class => 'mb-3' },
-			CGI::p({ class => 'lead mb-2' }, $r->maketext('Show saved answers?')),
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::input({
-						type  => 'radio',
-						name  => 'showOldAnswers',
-						id    => "showOldAnswers$_",
-						value => $_,
-						$_ eq $curr_showOldAnswers ? (checked => undef) : (),
-						class => 'form-check-input'
-					}),
-					CGI::label(
-						{ for => "showOldAnswers$_", class => 'form-check-label' },
-						$_ ? $r->maketext('Yes') : $r->maketext('No')
+		if ($authz->hasPermissions($userID, 'can_show_old_answers')) {
+			my $curr_showOldAnswers =
+				$EUser->showOldAnswers ne '' ? $EUser->showOldAnswers : $ce->{pg}{options}{showOldAnswers};
+			$result .= CGI::div(
+				{ class => 'mb-3' },
+				CGI::p({ class => 'lead mb-2' }, $r->maketext('Show saved answers?')),
+				map {
+					CGI::div(
+						{ class => 'form-check form-check-inline' },
+						CGI::input({
+							type  => 'radio',
+							name  => 'showOldAnswers',
+							id    => "showOldAnswers$_",
+							value => $_,
+							$_ eq $curr_showOldAnswers ? (checked => undef) : (),
+							class => 'form-check-input'
+						}),
+						CGI::label(
+							{ for => "showOldAnswers$_", class => 'form-check-label' },
+							$_ ? $r->maketext('Yes') : $r->maketext('No')
+						)
 					)
-				)
-			} (1, 0)
-		);
-	}
+				} (1, 0)
+			);
+		}
 
-	if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
-		# Note, 0 is a legal value, so we can't use || in setting this
-		my $curr_useMathView = $EUser->useMathView ne '' ? $EUser->useMathView : $ce->{pg}{options}{useMathView};
-		$result .= CGI::div(
-			{ class => 'mb-3' },
-			CGI::p({ class => 'lead mb-2' }, $r->maketext('Use Equation Editor?')),
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::input({
-						type  => 'radio',
-						name  => 'useMathView',
-						id    => "useMathView$_",
-						value => $_,
-						$_ eq $curr_useMathView ? (checked => undef) : (),
-						class => 'form-check-input'
-					}),
-					CGI::label(
-						{ for => "useMathView$_", class => 'form-check-label' },
-						$_ ? $r->maketext('Yes') : $r->maketext('No')
+		if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
+			# Note, 0 is a legal value, so we can't use || in setting this
+			my $curr_useMathView = $EUser->useMathView ne '' ? $EUser->useMathView : $ce->{pg}{options}{useMathView};
+			$result .= CGI::div(
+				{ class => 'mb-3' },
+				CGI::p({ class => 'lead mb-2' }, $r->maketext('Use Equation Editor?')),
+				map {
+					CGI::div(
+						{ class => 'form-check form-check-inline' },
+						CGI::input({
+							type  => 'radio',
+							name  => 'useMathView',
+							id    => "useMathView$_",
+							value => $_,
+							$_ eq $curr_useMathView ? (checked => undef) : (),
+							class => 'form-check-input'
+						}),
+						CGI::label(
+							{ for => "useMathView$_", class => 'form-check-label' },
+							$_ ? $r->maketext('Yes') : $r->maketext('No')
+						)
 					)
-				)
-			} (1, 0)
-		);
-	}
+				} (1, 0)
+			);
+		}
 
-	if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'WIRIS') {
-		# Note, 0 is a legal value, so we can't use || in setting this
-		my $curr_useWirisEditor =
-			$EUser->useWirisEditor ne '' ? $EUser->useWirisEditor : $ce->{pg}{options}{useWirisEditor};
-		$result .= CGI::div(
-			{ class => 'mb-3' },
-			CGI::p({ class => 'lead mb-2' }, $r->maketext('Use Equation Editor?')),
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::input({
-						type  => 'radio',
-						name  => 'useWirisEditor',
-						id    => "useWirisEditor$_",
-						value => $_,
-						$_ eq $curr_useWirisEditor ? (checked => undef) : (),
-						class => 'form-check-input'
-					}),
-					CGI::label(
-						{ for => "useWirisEditor$_", class => 'form-check-label' },
-						$_ ? $r->maketext('Yes') : $r->maketext('No')
+		if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'WIRIS') {
+			# Note, 0 is a legal value, so we can't use || in setting this
+			my $curr_useWirisEditor =
+				$EUser->useWirisEditor ne '' ? $EUser->useWirisEditor : $ce->{pg}{options}{useWirisEditor};
+			$result .= CGI::div(
+				{ class => 'mb-3' },
+				CGI::p({ class => 'lead mb-2' }, $r->maketext('Use Equation Editor?')),
+				map {
+					CGI::div(
+						{ class => 'form-check form-check-inline' },
+						CGI::input({
+							type  => 'radio',
+							name  => 'useWirisEditor',
+							id    => "useWirisEditor$_",
+							value => $_,
+							$_ eq $curr_useWirisEditor ? (checked => undef) : (),
+							class => 'form-check-input'
+						}),
+						CGI::label(
+							{ for => "useWirisEditor$_", class => 'form-check-label' },
+							$_ ? $r->maketext('Yes') : $r->maketext('No')
+						)
 					)
-				)
-			} (1, 0)
-		);
-	}
+				} (1, 0)
+			);
+		}
 
-	if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
-		# Note, 0 is a legal value, so we can't use || in setting this
-		my $curr_useMathQuill =
-			$EUser->useMathQuill ne '' ? $EUser->useMathQuill : $ce->{pg}{options}{useMathQuill};
-		$result .= CGI::div(
-			{ class => 'mb-3' },
-			CGI::p({ class => 'lead mb-2' }, $r->maketext('Use live equation rendering?')),
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::input({
-						type  => 'radio',
-						name  => 'useMathQuill',
-						id    => "useMathQuill$_",
-						value => $_,
-						$_ eq $curr_useMathQuill ? (checked => undef) : (),
-						class => 'form-check-input'
-					}),
-					CGI::label(
-						{ for => "useMathQuill$_", class => 'form-check-label' },
-						$_ ? $r->maketext('Yes') : $r->maketext('No')
+		if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
+			# Note, 0 is a legal value, so we can't use || in setting this
+			my $curr_useMathQuill =
+				$EUser->useMathQuill ne '' ? $EUser->useMathQuill : $ce->{pg}{options}{useMathQuill};
+			$result .= CGI::div(
+				{ class => 'mb-3' },
+				CGI::p({ class => 'lead mb-2' }, $r->maketext('Use live equation rendering?')),
+				map {
+					CGI::div(
+						{ class => 'form-check form-check-inline' },
+						CGI::input({
+							type  => 'radio',
+							name  => 'useMathQuill',
+							id    => "useMathQuill$_",
+							value => $_,
+							$_ eq $curr_useMathQuill ? (checked => undef) : (),
+							class => 'form-check-input'
+						}),
+						CGI::label(
+							{ for => "useMathQuill$_", class => 'form-check-label' },
+							$_ ? $r->maketext('Yes') : $r->maketext('No')
+						)
 					)
-				)
-			} (1, 0)
-		);
-	}
+				} (1, 0)
+			);
+		}
 
-	print CGI::div({ class => 'mb-3' }, $result) if $result;
+		print CGI::div({ class => 'mb-3' }, $result) if $result;
+	}
 
 	print CGI::submit({
-		name  => "changeOptions",
-		value => $r->maketext("Change User Settings"),
+		name  => 'changeOptions',
+		value => $r->maketext('Change User Settings'),
 		class => 'btn btn-primary'
 	});
 
 	print CGI::end_form();
 
-	return "";
+	return '';
 }
 
 1;


### PR DESCRIPTION
If a user does not have this permission, then the user will not be able to change the display settings on the `User Settings` page.

I don't want my students changing these settings.  There really is no need for them to do so.  Also, changing the MathQuill setting from `Yes` to `No` can cause problems.  Basically, if the student has that set to `No`, and the professor has it set to `Yes`, then when the instructor acts as that student and views the problems for that student, no answers appear in the MathQuill answer inputs.  The answers are in the now hidden text inputs only.  Perhaps it should be made so that when an instructor acts as a student, the student's user settings for display are used.

Furthermore, change the display on the `User Settings` page.  If a user does not have a permission to change a setting, don't show "You do not have the permission to change this setting."  Instead just don't show the setting or its header at all.  There are three permissions for this: `change_password`, `change_email_address`, and the new `change_pg_display_settings`.

Additionally, if a user doesn't have any of those permissions, don't even add the `User Settings` link in the site nav (MAIN MENU).