### PR TITLE
Add permission for ignoring feedback.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -770,6 +770,7 @@ $authen{xmlrpc_module}  = "WeBWorK::Authen::XMLRPC";
 	score_sets                     => "professor",
 	send_mail                      => "professor",
 	receive_feedback               => "ta",
+	ignore_feedback                => "nobody",
 
 	create_and_delete_problem_sets => "professor",
 	assign_problem_sets            => "professor",
@@ -1832,6 +1833,11 @@ $ConfigValues = [
 		{ var => 'permissionLevels{receive_feedback}',
 		  doc => 'E-mail feedback from students automatically sent to this permission level and higher:',
 		  doc2 => 'Users with this permssion level or greater will automatically be sent feedback from students (generated when they use the "Contact instructor" button on any problem page).  In addition the feedback message will be sent to addresses listed below.  To send ONLY to addresses listed below set permission level to "nobody".',
+		  type => 'permission'
+		},
+		{ var => 'permissionLevels{ignore_feedback}',
+		  doc => 'Ignore feedback if this permission level and higher:',
+		  doc2 => 'Users with this permission level or greater will be excluded from receiving feedback from students (generated when they use the "Contact instructor" button on any problem page).',
 		  type => 'permission'
 		},
 		{ var => 'mail{feedbackRecipients}',

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -367,9 +367,14 @@ sub getFeedbackRecipients {
 
 	my @recipients;
 
-	# send to all users with permission to receive_feedback and an email address
+	# send to all users that meet the following criteria:
+	#     * has an email address
+	#     * has permission to receive_feedback
+	#     * does not have permission to ignore_feedback
+	#     * (if sending feedback by section) is in the same section as the sender
 	foreach my $rcptName ($db->listUsers()) {
-		if ($authz->hasPermissions($rcptName, "receive_feedback")) {
+		if ($authz->hasPermissions($rcptName, "receive_feedback")
+			&& !($authz->hasPermissions($rcptName, "ignore_feedback"))) {
 			my $rcpt = $db->getUser($rcptName); # checked
 			next if $ce->{feedback_by_section} and defined $user
 				and defined $rcpt->section and defined $user->section

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -437,6 +437,11 @@ my $ConfigStrings = [
 		  doc2 => x('Users with this permssion level or greater will automatically be sent feedback from students (generated when they use the "Contact instructor" button on any problem page).  In addition the feedback message will be sent to addresses listed below.  To send ONLY to addresses listed below set permission level to "nobody".'),
 		  type => 'permission'
 		},
+		{ var => 'permissionLevels{ignore_feedback}',
+		  doc => x('Ignore feedback if this permission level and higher:'),
+		  doc2 => x('Users with this permission level or greater will be excluded from receiving feedback from students (generated when they use the "Contact instructor" button on any problem page).'),
+		  type => 'permission'
+		},
 		{ var => 'mail{feedbackRecipients}',
 		  doc => x('Additional addresses for receiving feedback e-mail.'),
 		  doc2 => x('By default, feeback is sent to all users above who have permission to receive feedback. Feedback is also sent to any addresses specified in this blank. Separate email address entries by commas.'),


### PR DESCRIPTION
Users with this permission will be excluded from receiving feedback emails that they would otherwise get by having the `receive_feedback` permission.

Our use case for this permission is allowing our system administrators to assist faculty with their WeBWorK courses without receiving feedback emails. This pull request does not modify the current behavior by default, but by changing the `ignore_feedback` permission to `admin` in `conf/defaults.config`, it works as desired for this use case.