### PR TITLE
UI improvements and html validation fixes.

### DIFF
--- a/htdocs/js/apps/UserList/userlist.js
+++ b/htdocs/js/apps/UserList/userlist.js
@@ -1,23 +1,28 @@
 (() => {
-	const filter_select = document.getElementById('filter_select')
-	const classlist_add_filter_elements = () => {
-		const filter_elements = document.getElementById('filter_elements');
+	const filter_select = document.getElementById('filter_select');
+	if (filter_select) {
+		const classlist_add_filter_elements = () => {
+			const filter_elements = document.getElementById('filter_elements');
 
-		if (filter_select?.selectedIndex === 3) filter_elements.style.display = 'block';
-		else filter_elements.style.display = 'none';
-	};
+			if (filter_select.selectedIndex === 3) filter_elements.style.display = 'block';
+			else filter_elements.style.display = 'none';
+		};
 
-	filter_select?.addEventListener('change', classlist_add_filter_elements);
-	classlist_add_filter_elements();
+		filter_select.addEventListener('change', classlist_add_filter_elements);
+		classlist_add_filter_elements();
+	}
 
 	const export_select_target = document.getElementById('export_select_target');
-	const classlist_add_export_elements = () => {
-		const export_elements = document.getElementById('export_elements');
+	if (export_select_target) {
+		const classlist_add_export_elements = () => {
+			const export_elements = document.getElementById('export_elements');
+			if (!export_elements) return;
 
-		if (export_select_target?.selectedIndex === 0) export_elements.style.display = 'block';
-		else export_elements.style.display = 'none';
-	};
+			if (export_select_target.selectedIndex === 0) export_elements.style.display = 'block';
+			else export_elements.style.display = 'none';
+		};
 
-	export_select_target?.addEventListener('change', classlist_add_export_elements);
-	classlist_add_export_elements();
+		export_select_target.addEventListener('change', classlist_add_export_elements);
+		classlist_add_export_elements();
+	}
 })();

--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -6,8 +6,6 @@
 <head>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- This encourages IE to *not* use compatibility view, which breaks math4 -->
-<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 
 <!--
 ################################################################################
@@ -73,7 +71,7 @@
 <!-- Breadcrumb -->
 <div id="breadcrumb-row" class="row my-2">
 	<div class="col-12 d-flex align-items-center">
-		<nav id="breadcrumb-navigation" role="navigation" aria-label="breadcrumb navigation" class="w-100">
+		<nav id="breadcrumb-navigation" aria-label="breadcrumb navigation" class="w-100">
 			<ol class="breadcrumb">
 				<!--#path style="bootstrap" text=""-->
 			</ol>

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -708,7 +708,7 @@ input.changed[type=text] { /* orange */
 /* Text colors for Auditing, Current, and Dropped students */
 .Audit { font-style: normal; color: purple; background-color: inherit; }
 .Enrolled { font-weight: normal; color: black; background-color: inherit; }
-.Drop { font-style: italic; color: gray; background-color: inherit; }
+.Drop { font-style: italic; color: #555; background-color: inherit; }
 
 /* Styles for the PGProblemEditor Page */
 
@@ -877,7 +877,7 @@ span {
 
 /* Course Configuration */
 .config-tabs {
-	a {
+	a, span {
 		&.nav-link {
 			font-weight: bold;
 			color: inherit;

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -6,8 +6,6 @@
 <head>
 <meta charset='utf-8'>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- This encourages IE to *not* use compatibility view, which breaks math4 -->
-<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 
 <!--
 ################################################################################
@@ -88,7 +86,7 @@
 			</span>
 		</button>
 		<!--#endif-->
-		<nav id="breadcrumb-navigation" role="navigation" aria-label="breadcrumb navigation" class="w-100">
+		<nav id="breadcrumb-navigation" aria-label="breadcrumb navigation" class="w-100">
 			<ol class="breadcrumb">
 				<!--#path style="bootstrap" text=""-->
 			</ol>
@@ -168,7 +166,7 @@
 	<!--#if can="output_problem_body"-->
 		<!-- ==== in this case print body parts ELSE print entire body -->
 		<div class="row">
-			<div id="problem_body" class="Body col-12">
+			<div class="Body col-12">
 
 			<!--#if can="output_custom_edit_message"-->
 			<div id="custom_edit_message" class="row"><div class="col-lg-10">

--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -187,9 +187,9 @@ sub body {
 			$levelpercentage = $levelpercentage <= 100 ? $levelpercentage : 100;
 
 			print CGI::start_div({
-				class     => 'levelouterbar',
-				title     => $r->maketext("[_1]% Complete", $levelpercentage),
-				aria_labe => $r->maketext("[_1]% Complete", $levelpercentage)
+				class      => 'levelouterbar',
+				title      => $r->maketext("[_1]% Complete", $levelpercentage),
+				aria_label => $r->maketext("[_1]% Complete", $levelpercentage)
 			});
 			print CGI::div({ class => 'levelinnerbar', style => "width:$levelpercentage\%" }, '');
 			print CGI::end_div();
@@ -273,7 +273,7 @@ sub body {
 				# Note: we provide the item with some information about the current sets to help set up the form fields.
 				print $item->print_form(\@sets, \@setProblemCount, $r);
 				print CGI::hidden({ name => "useditem", value => $itemnumber });
-				print $self->hidden_authen_fields;
+				print $self->hidden_authen_fields =~ s/id=\"hidden_/id=\"achievement_hidden_/gr;
 				print CGI::end_div();
 				print CGI::start_div({ class => "modal-footer" });
 				print CGI::submit({ value => $r->maketext("Submit"), class => 'btn btn-primary' });

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -622,12 +622,17 @@ sub add_course_form {
 
 	print CGI::div(
 		{ class => 'row mb-3' },
-		CGI::label({ class => 'col-auto col-form-label fw-bold' }, $r->maketext('Copy templates from:')),
+		CGI::label(
+			{ for => 'add_templates_course', class => 'col-auto col-form-label fw-bold' },
+			$r->maketext('Copy templates from:')
+		),
 		CGI::div(
 			{ class => 'col-auto' },
 			CGI::popup_menu({
 				name    => 'add_templates_course',
+				id      => 'add_templates_course',
 				values  => [ '', @existingCourses ],
+				labels  => { '' => $r->maketext('No Course'), map { $_ => $_ } @existingCourses },
 				default => trim_spaces($r->param('add_templates_course')) || '',
 				class   => 'form-select'
 			})
@@ -842,7 +847,7 @@ sub do_add_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p("An error occured while creating the course $add_courseID:"),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 		# get rid of any partially built courses
 		# FIXME  -- this is too fragile
@@ -946,11 +951,15 @@ sub rename_course_form {
 		{ class => 'col-lg-7 col-md-8' },
 		CGI::div(
 			{ class => 'row mb-2' },
-			CGI::label({ class => 'col-sm-6 col-form-label fw-bold' }, $r->maketext('Course ID:')),
+			CGI::label(
+				{ for => 'rename_oldCourseID', class => 'col-sm-6 col-form-label fw-bold' },
+				$r->maketext('Course ID:')
+				),
 			CGI::div(
 				{ class => 'col-sm-6' },
 				CGI::scrolling_list({
 					name     => 'rename_oldCourseID',
+					id       => 'rename_oldCourseID',
 					values   => \@courseIDs,
 					default  => $r->param('rename_oldCourseID') || '',
 					size     => 10,
@@ -1036,8 +1045,6 @@ sub rename_course_form {
 			)
 		)
 	);
-
-	print CGI::end_table();
 
 	print CGI::submit({ name => 'rename_course', label => $r->maketext('Rename Course'), class => 'btn btn-primary' });
 
@@ -1391,7 +1398,7 @@ sub do_retitle_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p($r->maketext("An error occured while changing the title of the course [_1].", $rename_oldCourseID)),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 	} else {
 		print CGI::div(
@@ -1475,7 +1482,7 @@ sub do_rename_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p( $r->maketext("An error occured while renaming the course [_1] to [_2]:", $rename_oldCourseID, $rename_newCourseID)),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 	} else {
 		print CGI::div(
@@ -1615,11 +1622,15 @@ sub delete_course_form {
 	print CGI::div({ class => 'mb-2' }, $r->maketext('Select a course to delete.'));
 	print CGI::div(
 		{ class => 'row mb-2' },
-		CGI::label({ class => 'col-auto col-form-label fw-bold' }, $r->maketext('Course Name:')),
+		CGI::label(
+			{ for => 'delete_courseID', class => 'col-auto col-form-label fw-bold' },
+			$r->maketext('Course Name:')
+		),
 		CGI::div(
 			{ class => 'col-auto' },
 			CGI::scrolling_list({
 				name     => 'delete_courseID',
+				id       => 'delete_courseID',
 				values   => \@courseIDs,
 				default  => $r->param('delete_courseID') || '',
 				size     => 15,
@@ -1745,7 +1756,7 @@ sub do_delete_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p($r->maketext("An error occured while deleting the course [_1]:", $delete_courseID)),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 	} else {
 	    # mark the contact person in the admin course as dropped.
@@ -1908,11 +1919,15 @@ sub archive_course_form {
 	print CGI::div({ class => 'mb-2' }, $r->maketext('Select course(s) to archive.'));
 	print CGI::div(
 		{ class => 'row mb-2' },
-		CGI::label({ class => 'col-auto col-form-label fw-bold' }, $r->maketext('Course Name:')),
+		CGI::label(
+			{ for => 'archive_courseIDs', class => 'col-auto col-form-label fw-bold' },
+			$r->maketext('Course Name:')
+		),
 		CGI::div(
 			{ class => 'col-auto' },
 			CGI::scrolling_list({
 				name     => 'archive_courseIDs',
+				id       => 'archive_courseIDs',
 				values   => \@courseIDs,
 				default  => $r->param('archive_courseID') || '',
 				size     => 15,
@@ -2254,7 +2269,7 @@ sub do_archive_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p($r->maketext("An error occured while archiving the course [_1]:", $archive_courseID)),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 	} else {
 		print CGI::div(
@@ -2282,7 +2297,7 @@ sub do_archive_course {
 				print CGI::div(
 					{ class => 'alert alert-danger p-1 mb-2' },
 					CGI::p($r->maketext("An error occured while deleting the course [_1]:", $archive_courseID)),
-					CGI::tt(CGI::escapeHTML($error)),
+					CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 				);
 			} else {
 				# mark the contact person in the admin course as dropped.
@@ -2384,11 +2399,15 @@ sub unarchive_course_form {
 		{ class => 'col-lg-7 col-md-8' },
 		CGI::div(
 			{ class => 'row mb-2' },
-			CGI::label({ class => 'col-sm-4 col-form-label' }, $r->maketext('Course Name:')),
+			CGI::label(
+				{ for => 'unarchive_courseID', class => 'col-sm-4 col-form-label' },
+				$r->maketext('Course Name:')
+			),
 			CGI::div(
 				{ class => 'col-sm-8' },
 				CGI::scrolling_list({
 					name     => 'unarchive_courseID',
+					id       => 'unarchive_courseID',
 					values   => \@courseIDs,
 					default  => $r->param('unarchive_courseID') || '',
 					size     => 10,
@@ -2397,7 +2416,7 @@ sub unarchive_course_form {
 					class    => 'form-select'
 				})
 			)
-		),
+			),
 		CGI::div(
 			{ class => 'row mb-2 align-items-center' },
 			CGI::div(
@@ -2406,7 +2425,6 @@ sub unarchive_course_form {
 					{ class => 'form-check' },
 					CGI::checkbox({
 						name            => 'create_newCourseID',
-						default         => '',
 						value           => 1,
 						label           => $r->maketext('New Name:'),
 						class           => 'form-check-input',
@@ -2547,7 +2565,7 @@ sub do_unarchive_course {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
 			CGI::p($r->maketext("An error occured while archiving the course [_1]:", $unarchive_courseID)),
-			CGI::tt(CGI::escapeHTML($error)),
+			CGI::div({ class => 'font-monospace' }, CGI::escapeHTML($error)),
 		);
 	} else {
 		print CGI::div(
@@ -2979,11 +2997,15 @@ sub manage_location_form {
 
 	print CGI::div(
 		{ class => 'row ms-sm-3 mb-2' },
-		CGI::label({ class => 'col-sm-4 col-form-label' }, $r->maketext('Location name:')),
+		CGI::label(
+			{ for => 'new_location_name', class => 'col-sm-4 col-form-label' },
+			$r->maketext('Location name:')
+		),
 		CGI::div(
 			{ class => 'col-sm-8' },
 			CGI::textfield({
 				name  => 'new_location_name',
+				id    => 'new_location_name',
 				value => $r->param('new_location_name') // '',
 				class => 'form-control'
 			})
@@ -2992,11 +3014,15 @@ sub manage_location_form {
 
 	print CGI::div(
 		{ class => 'row ms-sm-3 mb-2' },
-		CGI::label({ class => 'col-sm-4 col-form-label' }, $r->maketext('Location description:')),
+		CGI::label(
+			{ for => 'new_location_description', class => 'col-sm-4 col-form-label' },
+			$r->maketext('Location description:')
+		),
 		CGI::div(
 			{ class => 'col-sm-8' },
 			CGI::textfield({
 				name  => 'new_location_description',
+				id    => 'new_location_description',
 				value => $r->param('new_location_description') // '',
 				class => 'form-control'
 			})
@@ -3007,9 +3033,12 @@ sub manage_location_form {
 		{ class => 'row ms-sm-3 mb-2' },
 		CGI::div(
 			{ class => 'col' },
-			$r->maketext(
-				'Addresses for new location.  Enter one per line, as single IP addresses (e.g., 192.168.1.101), '
-					. 'address masks (e.g., 192.168.1.0/24), or IP ranges (e.g., 192.168.1.101-192.168.1.150):'
+			CGI::label(
+				{ for => 'new_location_addresses' },
+				$r->maketext(
+					'Addresses for new location.  Enter one per line, as single IP addresses (e.g., 192.168.1.101), '
+						. 'address masks (e.g., 192.168.1.0/24), or IP ranges (e.g., 192.168.1.101-192.168.1.150):'
+				)
 			)
 		)
 	);
@@ -3020,6 +3049,7 @@ sub manage_location_form {
 			{ class => 'col-auto' },
 			CGI::textarea({
 				name    => 'new_location_addresses',
+				id      => 'new_location_addresses',
 				columns => 28,
 				value   => $r->param('new_location_addresses') ? $r->param('new_location_addresses') : '',
 				class   => 'form-control'
@@ -3108,11 +3138,12 @@ sub manage_location_form {
 		print CGI::Tr(CGI::td([
 			CGI::checkbox({
 				name  => 'delete_selected',
+				id    => $loc->location_id . '_id',
 				value => $loc->location_id,
 				label => '',
 				class => 'form-check-input'
 			}),
-			CGI::a({ href => $editAddr }, $loc->location_id),
+			CGI::label({ for => $loc->location_id . '_id' }, CGI::a({ href => $editAddr }, $loc->location_id)),
 			$loc->description,
 			join(', ', @{ $locAddr{ $loc->location_id } })
 		]));
@@ -3286,11 +3317,15 @@ sub edit_location_form {
 
 		print CGI::div(
 			{ class => 'row mb-2' },
-			CGI::label({ class => 'col-auto col-form-label' }, $r->maketext('Location description:')),
+			CGI::label(
+				{ for => 'location_description', class => 'col-auto col-form-label' },
+				$r->maketext('Location description:')
+			),
 			CGI::div(
 				{ class => 'col-auto' },
 				CGI::textfield({
 					name    => 'location_description',
+					id      => 'location_description',
 					size    => '50',
 					default => $location->description,
 					class   => 'form-control'
@@ -3304,16 +3339,20 @@ sub edit_location_form {
 				{ class => 'col-md-6' },
 				CGI::div(
 					{ class => 'mb-2' },
-					$r->maketext(
-						'Addresses to add to the location.  Enter one per line, as single IP addresses '
-							. '(e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges '
-							. '(e.g., 192.168.1.101-192.168.1.150):'
+					CGI::label(
+						{ for => 'new_location_addresses' },
+						$r->maketext(
+							'Addresses to add to the location.  Enter one per line, as single IP addresses '
+								. '(e.g., 192.168.1.101), address masks (e.g., 192.168.1.0/24), or IP ranges '
+								. '(e.g., 192.168.1.101-192.168.1.150):'
+						)
 					)
 				),
 				CGI::div(
 					{ class => 'mb-2' },
 					CGI::textarea({
 						name    => 'new_location_addresses',
+						id      => 'new_location_addresses',
 						rows    => 5,
 						columns => 28,
 						class   => 'form-control'
@@ -3324,15 +3363,19 @@ sub edit_location_form {
 				{ class => 'col-md-6' },
 				CGI::div(
 					{ class => 'mb-2' },
-					$r->maketext(
-						'Existing addresses for the location are given in the scrolling list below.  '
-							. 'Select addresses from the list to delete them:'
+					CGI::label(
+						{ for => 'delete_location_addresses' },
+						$r->maketext(
+							'Existing addresses for the location are given in the scrolling list below.  '
+								. 'Select addresses from the list to delete them:'
+						)
 					)
 				),
 				CGI::div(
 					{ class => 'mb-2' },
 					CGI::scrolling_list({
 						name     => 'delete_location_addresses',
+						id       => 'delete_location_addresses',
 						values   => [@locAddresses],
 						size     => 8,
 						multiple => 'multiple',
@@ -3360,6 +3403,8 @@ sub edit_location_form {
 			value => $r->maketext('Take Action!'),
 			class => 'btn btn-primary'
 		}));
+
+		print CGI::end_form();
 	} else {
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2' },
@@ -3599,11 +3644,15 @@ sub hide_inactive_course_form {
 	print CGI::div({ class => 'mb-2' }, $r->maketext('Select course(s) to hide or unhide.'));
 	print CGI::div(
 		{ class => 'row mb-2' },
-		CGI::label({ class => 'col-auto col-form-label fw-bold' }, $r->maketext('Course Name:')),
+		CGI::label(
+			{ for => 'hide_courseIDs', class => 'col-auto col-form-label fw-bold' },
+			$r->maketext('Course Name:')
+		),
 		CGI::div(
 			{ class => 'col-auto' },
 			CGI::scrolling_list({
 				name     => 'hide_courseIDs',
+				id       => 'hide_courseIDs',
 				values   => \@hideCourseIDs,
 				size     => 15,
 				multiple => 1,

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -374,13 +374,14 @@ sub feedbackForm {
 
 	print CGI::div(
 		{ class => 'row mb-3' },
-		CGI::label({ class => 'col-form-label col-auto' }, CGI::b($r->maketext('From:'))),
+		CGI::label({ for => 'from', class => 'col-form-label col-auto' }, CGI::b($r->maketext('From:'))),
 		CGI::div(
 			{ class => 'col-auto' },
 			CGI::textfield({
 				class => 'form-control',
 				size  => 40,
 				name  => 'from',
+				id    => 'from',
 				$user && $user->email_address
 				? (disabled => undef, readonly => undef, value => $user->email_address)
 				: (required => undef, value => $r->param('from') // '')

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -276,7 +276,7 @@ sub displayStudentStats {
 	my $numGatewayVersions = 0;
 	my $bestGatewayScore = 0;
 
-	foreach my $setName (@allSetIDs)   {
+	foreach my $setName (@allSetIDs) {
 		my $act_as_student_set_url = "$root/$courseName/$setName/?user=".$r->param("user").
 			"&effectiveUser=$effectiveUser&key=".$r->param("key");
 		my $set = $setsByID{ $setName };
@@ -292,20 +292,33 @@ sub displayStudentStats {
 				CGI::Tr(
 					CGI::td(WeBWorK::ContentGenerator::underscore2sp($setID)),
 					CGI::td(
-						{ colspan => ($max_problems + 2) },
-						CGI::em($r->maketext("No versions of this assignment have been taken."))
+						{ colspan => ($max_problems + 3) },
+						CGI::em($r->maketext('No versions of this assignment have been taken.'))
 					)
 				);
 			next;
 		}
 		# if the set has hide_score set, then we need to skip printing
 		#    the score as well
-		if ( defined( $set->hide_score ) &&
-		     ( ! $authz->hasPermissions($r->param("user"), "view_hidden_work") &&
-		       ( $set->hide_score eq 'Y' ||
-			 ($set->hide_score eq 'BeforeAnswerDate' && time < $set->answer_date) ) ) ) {
-			push( @rows, CGI::Tr({}, CGI::td(WeBWorK::ContentGenerator::underscore2sp("${setID}_(version_" . $set->version_id . ")")),
-					     CGI::td({colspan=>($max_problems+2)}, CGI::em($r->maketext("Display of scores for this set is not allowed.")))) );
+		if (
+			defined($set->hide_score)
+			&& (
+				!$authz->hasPermissions($r->param('user'), 'view_hidden_work')
+				&& ($set->hide_score eq 'Y' || ($set->hide_score eq 'BeforeAnswerDate' && time < $set->answer_date))
+			)
+			)
+		{
+			push(
+				@rows,
+				CGI::Tr(
+					CGI::td(WeBWorK::ContentGenerator::underscore2sp(
+						"${setID}_(version_" . $set->version_id . ')')),
+					CGI::td(
+						{ colspan => ($max_problems + 3) },
+						CGI::em($r->maketext('Display of scores for this set is not allowed.'))
+					)
+				)
+			);
 			next;
 		}
 

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -240,7 +240,7 @@ sub displayStudentStats {
 	my $act_as_student_url = "$root/$courseName/?user=".$r->param("user").
 			"&effectiveUser=$effectiveUser&key=".$r->param("key");
 
-	print CGI::h3($fullName);
+	print CGI::h2($fullName);
 
 	###############################################################
 	#  Print table

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -430,14 +430,18 @@ sub display_form {
 			{ class => 'row gx-3' },
 			CGI::div(
 				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Users")),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_users' }, $r->maketext('Users'))
+				),
 				scrollingRecordList(
 					{
-						name            => "selected_users",
+						name            => 'selected_users',
+						id              => 'selected_users',
 						request         => $r,
-						default_sort    => "lnfn",
-						default_format  => "lnfn_uid",
-						default_filters => ["all"],
+						default_sort    => 'lnfn',
+						default_format  => 'lnfn_uid',
+						default_filters => ['all'],
 						size            => 20,
 						multiple        => $perm_multiuser,
 					},
@@ -446,14 +450,18 @@ sub display_form {
 			),
 			CGI::div(
 				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Sets")),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_sets' }, $r->maketext('Sets'))
+				),
 				scrollingRecordList(
 					{
-						name            => "selected_sets",
+						name            => 'selected_sets',
+						id              => 'selected_sets',
 						request         => $r,
-						default_sort    => "set_id",
-						default_format  => "sid",
-						default_filters => ["all"],
+						default_sort    => 'set_id',
+						default_format  => 'sid',
+						default_filters => ['all'],
 						size            => 20,
 						multiple        => $perm_multiset,
 					},

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -272,7 +272,7 @@ sub body {
 					class => 'tab-pane pg_editor_action_div fade mb-2' . ($active ? " show$active" : ""),
 					id => $actionID,
 					role => 'tabpanel',
-					aria_labelled_by => "$actionID-tab"
+					aria_labelledby => "$actionID-tab"
 				}, $line_contents));
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -225,6 +225,7 @@ sub addStudentForm {
 		CGI::start_form({ method => "post", action => $r->uri(), name => "new-users-form", id => "new-users-form" }),
 		$self->hidden_authen_fields(),
 		CGI::input({ type => 'hidden', name => "number_of_students", value => $numberOfStudents }),
+		CGI::start_div({ class => 'table-responsive' }),
 		CGI::start_table({ class => 'table table-sm table-bordered' }),
 		CGI::Tr(CGI::th([
 			$r->maketext('Last Name'),
@@ -238,6 +239,7 @@ sub addStudentForm {
 		])),
 		@entryLines,
 		CGI::end_table(),
+		CGI::end_div(),
 
 		CGI::p($r->maketext("Select sets below to assign them to the newly-created users.")),
 		CGI::scrolling_list({

--- a/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
@@ -121,10 +121,14 @@ sub body {
 			{ class => 'row gx-3' },
 			CGI::div(
 				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext('Users')),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_users' }, $r->maketext('Users'))
+				),
 				scrollingRecordList(
 					{
 						name            => 'selected_users',
+						id              => 'selected_users',
 						request         => $r,
 						default_sort    => 'lnfn',
 						default_format  => 'lnfn_uid',
@@ -137,10 +141,14 @@ sub body {
 			),
 			CGI::div(
 				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext('Sets')),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_sets' }, $r->maketext('Sets'))
+				),
 				scrollingRecordList(
 					{
 						name            => 'selected_sets',
+						id              => 'selected_sets',
 						request         => $r,
 						default_sort    => 'set_id',
 						default_format  => 'set_id',

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -328,39 +328,45 @@ sub body {
 	print $self->hidden_authen_fields();
 
 	print CGI::div(
-			{ class => 'row gx-3' },
+		{ class => 'row gx-3' },
+		CGI::div(
+			{ class => 'col-xl-5 col-md-6 mb-2' },
 			CGI::div(
-				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Users")),
-				scrollingRecordList(
-					{
-						name            => "selected_users",
-						request         => $r,
-						default_sort    => "lnfn",
-						default_format  => "lnfn_uid",
-						default_filters => ["all"],
-						size            => 10,
-						multiple        => 1,
-					},
-					@Users
-				)
+				{ class => 'fw-bold text-center' },
+				CGI::label({ for => 'selected_users' }, $r->maketext('Users'))
 			),
-			CGI::div(
-				{ class => 'col-xl-5 col-md-6 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Sets")),
-				scrollingRecordList(
-					{
-						name            => "selected_sets",
-						request         => $r,
-						default_sort    => "set_id",
-						default_format  => "sid",
-						default_filters => ["all"],
-						size            => 10,
-						multiple        => 1,
-					},
-					@GlobalSets
-				)
+			scrollingRecordList(
+				{
+					name            => 'selected_users',
+					request         => $r,
+					default_sort    => 'lnfn',
+					default_format  => 'lnfn_uid',
+					default_filters => ['all'],
+					size            => 10,
+					multiple        => 1,
+				},
+				@Users
 			)
+		),
+		CGI::div(
+			{ class => 'col-xl-5 col-md-6 mb-2' },
+			CGI::div(
+				{ class => 'fw-bold text-center' },
+				CGI::label({ for => 'selected_sets' }, $r->maketext('Sets'))
+			),
+			scrollingRecordList(
+				{
+					name            => 'selected_sets',
+					request         => $r,
+					default_sort    => 'set_id',
+					default_format  => 'sid',
+					default_filters => ['all'],
+					size            => 10,
+					multiple        => 1,
+				},
+				@GlobalSets
+			)
+		)
 		),
 		CGI::div(
 			{ class => 'row gx-3' },
@@ -433,7 +439,7 @@ sub body {
 					)
 				),
 			),
-		   	CGI::div(
+			CGI::div(
 				{ class => 'col-xl-5 col-md-6 mb-2 font-sm' },
 				CGI::div(
 					{ class => 'input-group input-group-sm mb-2' },
@@ -506,9 +512,10 @@ sub body {
 						label => $r->maketext("Create"),
 						class => 'btn btn-sm btn-secondary'
 					}),
-					CGI::span({ class => 'input-group-text' }, $r->maketext("new set:")),
+					CGI::label({ for => 'new_set_name', class => 'input-group-text' }, $r->maketext('new set:')),
 					CGI::textfield({
-						name        => "new_set_name",
+						name        => 'new_set_name',
+						id          => 'new_set_name',
 						placeholder => $r->maketext("Name for new set here"),
 						size        => 20,
 						class       => 'form-control form-control-sm'

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -627,7 +627,7 @@ sub body {
 		$self->hidden_authen_fields,
 		$force_field,
 		CGI::hidden(-name=>'file_type',-default=>$self->{file_type}),
-		CGI::div({}, @PG_Editor_References),
+		CGI::div({ class => 'mb-2' }, @PG_Editor_References),
 		CGI::p(
 			CGI::textarea( -id => "problemContents",
 				-name => 'problemContents', -default => $problemContents, -class => 'latexentryfield',
@@ -678,7 +678,7 @@ sub body {
 						class            => "tab-pane pg_editor_action_div fade" . ($active ? " show$active" : ''),
 						id               => $actionID,
 						role             => 'tabpanel',
-						aria_labelled_by => "$actionID-tab"
+						aria_labelledby => "$actionID-tab"
 					},
 					$line_contents
 				)
@@ -711,7 +711,6 @@ sub body {
 	print CGI::end_div();
 	print CGI::start_div({ class => 'modal-footer' });
 	print CGI::button({
-		type            => 'button',
 		value           => $r->maketext('Close'),
 		data_bs_dismiss => 'modal',
 		class           => 'btn btn-primary'
@@ -938,9 +937,9 @@ sub getFilePaths {
 		($file_type eq 'set_header' or $file_type eq 'hardcopy_header') and do {
 			# first try getting the merged set for the effective user
 			# FIXME merged set is overwritten immediately with global value... WTF? --sam
-			my $set_record = $db->getMergedSet($effectiveUserName, $setName); # checked
+			my $set_record = $db->getMergedSet($effectiveUserName, $setName);
 			# if that doesn't work (the set is not yet assigned), get the global record
-			$set_record = $db->getGlobalSet($setName); # checked
+			$set_record = $db->getGlobalSet($setName);
 			# bail if no set is found
 			die "Cannot find a set record for set $setName" unless defined($set_record);
 
@@ -965,13 +964,13 @@ sub getFilePaths {
 			# first try getting the merged problem for the effective user
 			my $problem_record;
 			if ( $editSetVersion ) {
-				$problem_record = $db->getMergedProblemVersion($effectiveUserName, $setName, $editSetVersion, $problemNumber); # checked
+				$problem_record = $db->getMergedProblemVersion($effectiveUserName, $setName, $editSetVersion, $problemNumber);
 			} else {
-				$problem_record = $db->getMergedProblem($effectiveUserName, $setName, $problemNumber); # checked
+				$problem_record = $db->getMergedProblem($effectiveUserName, $setName, $problemNumber);
 			}
 
 			# if that doesn't work (the problem is not yet assigned), get the global record
-			$problem_record = $db->getGlobalProblem($setName, $problemNumber) unless defined($problem_record); # checked
+			$problem_record = $db->getGlobalProblem($setName, $problemNumber) unless defined($problem_record);
 			# bail if no source path for the problem is found ;
 			die "Cannot find a problem record for set $setName / problem $problemNumber" unless defined($problem_record);
 			$editFilePath .= '/' . $problem_record->source_file;
@@ -1797,7 +1796,7 @@ sub save_as_form {
 					id      => 'action_save_as_saveMode_rename_id',
 					name    => 'action.save_as.saveMode',
 					value   => 'rename',
-					checked => 1,
+					checked => undef,
 					class   => 'form-check-input',
 				}),
 				CGI::label(
@@ -1830,7 +1829,7 @@ sub save_as_form {
 				name  => 'action.save_as.saveMode',
 				value => 'new_independent_problem',
 				class => 'form-check-input',
-				$can_add_problem_to_set ? () : (checked => 1)
+				$can_add_problem_to_set ? () : (checked => undef)
 			}),
 			CGI::label(
 				{ for => 'action_save_as_saveMode_independent_problem_id', class => 'form-check-label' },

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1274,7 +1274,7 @@ sub import_form {
 					class => 'form-select form-select-sm',
 					size  => $actionParams{'action.import.number'}[0] || '1',
 					defined($actionParams{'action.import.number'}[0])
-						&& $actionParams{'action.import.number'}[0] == 8 ? (multiple => 'multiple') : ()
+						&& $actionParams{'action.import.number'}[0] ne '1' ? (multiple => undef) : ()
 				})
 			)
 		),

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -110,7 +110,7 @@ sub initialize {
 		$self->writeCSV("$scoringDir/$scoringFileName", @totals);
 
 	} else {
-		if (!@selected) {  # nothing selected for scoring
+		if ($r->param('score-sets') && !@selected) {  # nothing selected for scoring
 			$self->addbadmessage($r->maketext("You must select one or more sets for scoring!"));
 		}
 		if (!$scoringFileNameOK) { # fileName is not properly formed
@@ -166,7 +166,7 @@ sub body {
 						name            => 'includeIndex',
 						value           => 1,
 						label           => $r->maketext('Include Success Index'),
-						checked         => 0,
+						checked         => $r->param('includeIndex') // 0,
 						class           => 'form-check-input',
 						labelattributes => { class => 'form-check-label' }
 					})
@@ -177,7 +177,7 @@ sub body {
 						name            => 'recordSingleSetScores',
 						value           => 1,
 						label           => $r->maketext('Record Scores for Single Sets'),
-						checked         => 0,
+						checked         => $r->param('recordSingleSetScores') // 0,
 						class           => 'form-check-input',
 						labelattributes => { class => 'form-check-label' }
 					})
@@ -188,7 +188,7 @@ sub body {
 						name            => 'padFields',
 						value           => 1,
 						label           => $r->maketext('Pad Fields'),
-						checked         => 1,
+						checked         => $r->param('padFields') // 1,
 						class           => 'form-check-input',
 						labelattributes => { class => 'form-check-label' }
 					})
@@ -199,7 +199,7 @@ sub body {
 						name            => 'includePercentEachSet',
 						value           => 1,
 						label           => $r->maketext('Include percentage grades columns for all sets'),
-						checked         => 1,
+						checked         => $r->param('includePercentEachSet') // 1,
 						class           => 'form-check-input',
 						labelattributes => { class => 'form-check-label' }
 					})
@@ -888,6 +888,7 @@ sub popup_set_form {
 	return CGI::scrolling_list({
 		name     => 'selectedSet',
 		values   => $self->{ra_set_ids},
+		defaults => [ $self->r->param('selectedSet') ],
 		size     => 10,
 		multiple => 1,
 		class    => 'form-select'

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -613,7 +613,10 @@ sub print_form {
 					{ class => 'col-md-6 mb-2' },
 					CGI::div(
 						{ class => 'input-group input-group-sm mb-2' },
-						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext("Message file:"))),
+						CGI::label(
+							{ for => 'openfilename', class => 'input-group-text' },
+							CGI::strong($r->maketext('Message file:'))
+						),
 						CGI::span({ class => 'input-group-text' }, $input_file)
 					),
 					CGI::div(
@@ -625,6 +628,7 @@ sub print_form {
 						}),
 						CGI::popup_menu({
 							name    => 'openfilename',
+							id      => 'openfilename',
 							values  => \@sorted_messages,
 							default => $input_file,
 							class   => 'form-select form-select-sm'
@@ -632,16 +636,20 @@ sub print_form {
 					),
 					CGI::div(
 						{ class => 'input-group input-group-sm mb-2' },
-						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext("Save file to:"))),
+						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext('Save file to:'))),
 						CGI::span({ class => 'input-group-text' }, $output_file)
 					),
 					CGI::div(
 						{ class => 'input-group input-group-sm mb-2' },
-						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext('Merge file:'))),
+						CGI::label(
+							{ for => 'merge_file', class => 'input-group-text' },
+							CGI::strong($r->maketext('Merge file:'))
+						),
 						CGI::span({ class => 'input-group-text' }, $merge_file)
 					),
 					CGI::popup_menu({
 						name    => 'merge_file',
+						id      => 'merge_file',
 						values  => \@sorted_merge_files,
 						default => $merge_file,
 						class   => 'form-select form-select-sm mb-2'
@@ -655,8 +663,8 @@ sub print_form {
 						CGI::div(
 							{ class => 'col-sm-9' },
 							CGI::textfield({
-								name      => "from",
-								id        => "from",
+								name      => 'from',
+								id        => 'from',
 								value     => $from,
 								class     => 'form-control form-control-sm'
 							})
@@ -671,8 +679,8 @@ sub print_form {
 						CGI::div(
 							{ class => 'col-sm-9' },
 							CGI::textfield({
-								name      => "replyTo",
-								id        => "replyTo",
+								name      => 'replyTo',
+								id        => 'replyTo',
 								value     => $replyTo,
 								class     => 'form-control form-control-sm'
 							})
@@ -697,13 +705,14 @@ sub print_form {
 					CGI::div(
 						{ class => 'row mb-2' },
 						CGI::label(
-							{ for => 'subject', class => 'col-3 col-form-label col-form-label-sm' },
+							{ for => 'rows', class => 'col-3 col-form-label col-form-label-sm' },
 							$r->maketext('Editor rows:')
 						),
 						CGI::div(
 							{ class => 'col-9' },
 							CGI::textfield({
 								name  => 'rows',
+								id    => 'rows',
 								size  => 3,
 								value => $rows,
 								class => 'form-control form-control-sm d-inline w-auto'
@@ -712,7 +721,7 @@ sub print_form {
 					),
 					CGI::submit({
 						name  => 'updateSettings',
-						value => $r->maketext("Update settings and refresh page"),
+						value => $r->maketext('Update settings and refresh page'),
 						class => 'btn btn-secondary btn-sm'
 					}),
 				),
@@ -720,7 +729,7 @@ sub print_form {
 					{ class => 'col-md-6 mb-2' },
 					CGI::div(
 						{ class => 'input-group input-group-sm mb-2' },
-						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext("Send to:"))),
+						CGI::span({ class => 'input-group-text' }, CGI::strong($r->maketext('Send to:'))),
 						CGI::div(
 							{ class => 'input-group-text' },
 							CGI::radio_group({
@@ -736,17 +745,17 @@ sub print_form {
 								labelattributes => { class => 'form-check-label mx-1' }
 							})
 						),
-						CGI::span({ class => 'input-group-text' }, $r->maketext('students')),
+						CGI::label({ for => 'classList', class => 'input-group-text' }, $r->maketext('students')),
 					),
 					CGI::div(
 						{ class => 'mb-2' },
 						scrollingRecordList(
 							{
-								name                => "classList",
+								name                => 'classList',
 								request             => $r,
-								default_sort        => "lnfn",
-								default_format      => "lnfn_uid",
-								default_filters     => ["all"],
+								default_sort        => 'lnfn',
+								default_format      => 'lnfn_uid',
+								default_filters     => ['all'],
 								size                => 5,
 								multiple            => 1,
 								refresh_button_name => $r->maketext('Update settings and refresh page'),
@@ -763,7 +772,7 @@ sub print_form {
 						}),
 						CGI::span(
 							{ class => 'input-group-text', style => 'white-space:pre;' },
-							CGI::strong($r->maketext("for")) . ' '
+							CGI::strong($r->maketext('for')) . ' '
 								. $preview_record->last_name . ', '
 								. $preview_record->first_name . ' ('
 								. $preview_record->user_id . ')'
@@ -775,7 +784,7 @@ sub print_form {
 			CGI::div(
 				{ class => 'd-flex justify-content-center' },
 				CGI::span(
-					{ dir => "ltr" },    # Put the popup in a LTR span
+					{ dir => 'ltr' },    # Put the popup in a LTR span
 					CGI::popup_menu({
 						name   => 'dummyName',
 						values => [

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1045,10 +1045,10 @@ sub make_top_row {
 	my $library_selected = $self->{current_library_set};
 	my $set_selected = $r->param('local_sets');
 	my (@dis1, @dis2, @dis3, @dis4) = ();
-	@dis1 =	 (-disabled=>1) if($browse_which eq 'browse_npl_library');
-	@dis2 =	 (-disabled=>1) if($browse_which eq 'browse_local');
-	@dis3 =	 (-disabled=>1) if($browse_which eq 'browse_mysets');
-	@dis4 =	 (-disabled=>1) if($browse_which eq 'browse_setdefs');
+	@dis1 = (disabled => undef) if ($browse_which eq 'browse_npl_library');
+	@dis2 = (disabled => undef) if ($browse_which eq 'browse_local');
+	@dis3 = (disabled => undef) if ($browse_which eq 'browse_mysets');
+	@dis4 = (disabled => undef) if ($browse_which eq 'browse_setdefs');
 
 	my $these_widths = "width:9.3rem";
 
@@ -1096,11 +1096,11 @@ sub make_top_row {
 			class   => 'btn btn-primary btn-sm mb-2 mx-2'
 		}),
 		CGI::textfield({
-			name     => "new_set_name",
-			example  => $r->maketext("Name for new set here"),
-			override => 1,
-			size     => 30,
-			class    => 'form-control form-control-sm d-inline w-auto mb-2'
+			name        => "new_set_name",
+			placeholder => $r->maketext("New set name"),
+			override    => 1,
+			size        => 30,
+			class       => 'form-control form-control-sm d-inline w-auto mb-2'
 		})
 	);
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -377,15 +377,17 @@ sub body {
 		########## print site identifying information
 
 		print CGI::input({
-			type  => "button",
-			id    => "show_hide",
-			value => $r->maketext("Show/Hide Site Description"),
-			class => "btn btn-info mb-2"
+			type  => 'button',
+			id    => 'show_hide',
+			value => $r->maketext('Show/Hide Site Description'),
+			class => 'btn btn-info mb-2'
 		});
-		print CGI::p({ -id => "site_description", -style => "display:none" },
-			CGI::em($r->maketext("_ANSWER_LOG_DESCRIPTION")));
+		print CGI::p(
+			{ id => 'site_description', style => 'display:none' },
+			CGI::em($r->maketext('_ANSWER_LOG_DESCRIPTION'))
+		);
 
-		print CGI::p(), CGI::hr();
+		print CGI::hr();
 
 		print CGI::start_form({ -target => 'WW_Info', -id => 'past-answer-form' }, "POST", $showAnswersURL);
 		print $self->hidden_authen_fields();
@@ -394,10 +396,14 @@ sub body {
 			{ class => 'row gx-3' },
 			CGI::div(
 				{ class => 'col-sm-5 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext('Users')),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_users' }, $r->maketext('Users'))
+				),
 				scrollingRecordList(
 					{
 						name            => 'selected_users',
+						id              => 'selected_users',
 						request         => $r,
 						default_sort    => 'lnfn',
 						default_format  => 'lnfn_uid',
@@ -410,9 +416,13 @@ sub body {
 			),
 			CGI::div(
 				{ class => 'col-sm-4 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Sets")),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_sets' }, $r->maketext('Sets'))
+				),
 				CGI::scrolling_list({
-					name     => "selected_sets",
+					name     => 'selected_sets',
+					id       => 'selected_sets',
 					values   => \@expandedGlobalSetIDs,
 					default  => $selectedSets,
 					size     => 23,
@@ -422,9 +432,13 @@ sub body {
 			),
 			CGI::div(
 				{ class => 'col-sm-2 mb-2' },
-				CGI::div({ class => 'fw-bold text-center' }, $r->maketext("Problems")),
+				CGI::div(
+					{ class => 'fw-bold text-center' },
+					CGI::label({ for => 'selected_problems' }, $r->maketext('Problems'))
+				),
 				CGI::scrolling_list({
-					name     => "selected_problems",
+					name     => 'selected_problems',
+					id       => 'selected_problems',
 					values   => \@globalProblemIDs,
 					default  => $selectedProblems,
 					size     => 23,
@@ -517,18 +531,19 @@ sub body {
 						$rowOptions->{'class'} = '';
 					}
 
-					@row = (CGI::td({ width => 10 }), CGI::td({ style => "color:#808080" }, CGI::small($time)));
+					@row = (CGI::td({ width => 10 }), CGI::td(CGI::small($time)));
 
 					for (my $i = 0; $i <= $upper_limit; $i++) {
-						my $td;
+						my $tdParams;
 						my $answer     = $answers[$i] // '';
 						my $answerType = defined($answerTypes[$i]) ? $answerTypes[$i] : '';
 						my $score      = shift(@scores);
-						#Only color answer if its an instructor
-						if ($instructor) {
-							$td->{style} = $score ? "color:#006600" : "color:#660000";
+
+						# Only color the answer if the user is an instructor and there is an answer, score, and its not
+						# an essay question.
+						if ($instructor && $answer ne '' && defined $score && $answerType ne 'essay') {
+							$tdParams->{style} = $score ? "color:#006600" : "color:#660000";
 						}
-						delete($td->{style}) unless $answer ne "" && defined($score) && $answerType ne 'essay';
 
 						my $answerstring;
 						if ($answer eq '') {
@@ -537,12 +552,12 @@ sub body {
 							$answerstring = PGcore::encode_pg_and_html($answer);
 						} elsif ($answerType eq 'essay') {
 							$answerstring = PGcore::encode_pg_and_html($answer);
-							$td->{class} = 'essay';
+							$tdParams->{class} = 'essay';
 						} else {
 							$answerstring = PGcore::encode_pg_and_html($answer);
 						}
 
-						push(@row, CGI::td({ width => 20 }), CGI::td($td, $answerstring));
+						push(@row, CGI::td({ width => 20 }), CGI::td($tdParams, $answerstring));
 					}
 
 					if ($record{comment}) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -64,21 +64,24 @@ sub initialize {
 
 sub title {
 	my ($self) = @_;
-	my $r = $self->r;
-	my $authz = $r->authz;
-	my $user = $r->param('user');
+	my $r      = $self->r;
+	my $authz  = $r->authz;
+	my $user   = $r->param('user');
 
-	return "" unless $authz->hasPermissions($user, "access_instructor_tools");
+	return '' unless $authz->hasPermissions($user, 'access_instructor_tools');
 
-	my $type                = $self->{type};
-	my $string = '';
+	my $type   = $self->{type};
 	if ($type eq 'student') {
-	  $string = $r->maketext("Statistics for [_1] student [_2]", $self->{ce}->{courseName}, $self->{studentName});
-	} elsif ($type eq 'set' ) {
-	  $string = $r->maketext("Statistics for [_1] set [_2]. Closes [_3]", $self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date}));
+		return $r->maketext("Statistics for [_1] student [_2]", $self->{ce}->{courseName}, $self->{studentName});
+	} elsif ($type eq 'set') {
+		return $r->maketext(
+			"Statistics for [_1] set [_2]. Closes [_3]",
+			$self->{ce}->{courseName},
+			$self->{setName}, $self->formatDateTime($self->{set_due_date})
+		);
 	}
 
-	return $string;
+	return $r->maketext('Statistics');
 }
 
 sub siblings {
@@ -233,12 +236,12 @@ sub index {
 		{ class => 'row g-0' },
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
-			CGI::h3({ -align => 'center' }, $r->maketext('View statistics by set')),
+			CGI::h3({ class => 'text-center' }, $r->maketext('View statistics by set')),
 			CGI::ul(CGI::li([@setLinks])),
 		),
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
-			CGI::h3({ -align => 'center' }, $r->maketext('View statistics by student')),
+			CGI::h3({ class => 'text-center' }, $r->maketext('View statistics by student')),
 			CGI::ul(CGI::li([@studentLinks])),
 		)
 	);

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -68,22 +68,25 @@ sub initialize {
 
 sub title {
 	my ($self) = @_;
-	my $r = $self->r;
-	my $authz = $r->authz;
-	my $user = $r->param('user');
+	my $r      = $self->r;
+	my $authz  = $r->authz;
+	my $user   = $r->param('user');
 
 	# Check permissions
-	return "" unless $authz->hasPermissions($user, "access_instructor_tools");
+	return '' unless $authz->hasPermissions($user, 'access_instructor_tools');
 
-	my $type                = $self->{type};
-	my $string = '';
+	my $type   = $self->{type};
 	if ($type eq 'student') {
-	  $string = $r->maketext("Student Progress for [_1] student [_2]", $self->{ce}->{courseName}, $self->{studentName});
-	} elsif ($type eq 'set' ) {
-	  $string = $r->maketext("Student Progress for [_1] set [_2]. Closes [_3]", $self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date}));
+		return $r->maketext('Student Progress for [_1] student [_2]', $self->{ce}->{courseName}, $self->{studentName});
+	} elsif ($type eq 'set') {
+		return $r->maketext(
+			'Student Progress for [_1] set [_2]. Closes [_3]',
+			$self->{ce}->{courseName},
+			$self->{setName}, $self->formatDateTime($self->{set_due_date})
+		);
 	}
 
-	return $string;
+	return $r->maketext('Student Progress');
 }
 
 sub siblings {
@@ -239,12 +242,12 @@ sub index {
 		{ class => 'row g-0' },
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
-			CGI::h3({ align => 'center' }, $r->maketext('View student progress by set')),
+			CGI::h3({ class => 'text-center' }, $r->maketext('View student progress by set')),
 			CGI::ul(CGI::li([@setLinks]))
 		),
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
-			CGI::h3({ align => 'center' }, $r->maketext('View student progress by student')),
+			CGI::h3({ class => 'text-center' }, $r->maketext('View student progress by student')),
 			CGI::ul(CGI::li([@studentLinks]))
 		)
 	);

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -256,7 +256,7 @@ sub body {
 		})
 	);
 
-	print CGI::div({ class => 'table-responsive' });
+	print CGI::start_div({ class => 'table-responsive' });
 	print CGI::start_table({ class => 'table table-bordered table-sm font-sm align-middle' });
 	print CGI::Tr(CGI::th({ class => 'text-center', colspan => 3 }, "Sets assigned to $userName ($editForUserID)"));
 	print CGI::Tr(CGI::th({ class => 'text-center' }, [ 'Assigned', "Edit set for $editForUserID", 'Dates', ]));
@@ -316,10 +316,9 @@ sub outputSetRow {
 	my $dateFieldLabels = DATE_FIELDS();
 
 	print CGI::Tr(CGI::td(
-		{ align => 'center' },
+		{ class => 'text-center' },
 		[
 			CGI::checkbox({
-				type            => 'checkbox',
 				name            => $version ? "set.$setID,v$version.assignment" : "set.$setID.assignment",
 				label           => '',
 				value           => 'assigned',
@@ -465,7 +464,6 @@ sub DBFieldTable {
 				$r->maketext($rh_fieldLabels->{$field}) . ' ',
 				defined $UserRecord
 				? CGI::checkbox({
-					type    => 'checkbox',
 					name    => "$recordType.$recordID.$field.override",
 					id      => "$recordType.$recordID.$field.override_id",
 					label   => '',

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -568,7 +568,7 @@ sub body {
 					class            => 'tab-pane fade mb-2' . ($active ? " show$active" : ''),
 					id               => $actionID,
 					role             => 'tabpanel',
-					aria_labelled_by => "$actionID-tab"
+					aria_labelledby => "$actionID-tab"
 				},
 				$self->$actionForm($self->getActionParams($actionID))
 			)
@@ -721,7 +721,6 @@ sub filter_form {
 						id            => 'filter_text',
 						name          => 'action.filter.user_ids',
 						value         => $actionParams{'action.filter.user_ids'}[0] || '',
-						width         => '50',
 						aria_required => 'true',
 						class         => 'form-control form-control-sm'
 					})
@@ -1086,7 +1085,7 @@ sub add_form {
 	return CGI::div(
 		{ class => 'row mb-2' },
 		CGI::label(
-			{ for => 'edit_select', class => 'col-form-label col-form-label-sm col-auto' },
+			{ for => 'add_entry', class => 'col-form-label col-form-label-sm col-auto' },
 			$r->maketext('Add how many users?') . CGI::span({ class => 'required-field' }, '*')
 		),
 		CGI::div(
@@ -1124,6 +1123,7 @@ sub import_form {
 				{ class => 'col-auto' },
 				CGI::popup_menu({
 					name    => 'action.import.source',
+					id      => 'import_select_source',
 					values  => [ $self->getCSVList() ],
 					default => $actionParams{'action.import.source'}[0] || '',
 					class   => 'form-select form-select-sm',
@@ -1274,11 +1274,10 @@ sub export_form {
 						id            => 'export_filename',
 						name          => 'action.export.new',
 						value         => $actionParams{'action.export.new'}[0] || '',
-						width         => '50',
 						aria_required => 'true',
 						class         => 'form-control form-control-sm'
 					}),
-					CGI::span({ class => 'input-group-text' }, CGI::tt('.lst'))
+					CGI::span({ class => 'input-group-text font-monospace' }, '.lst')
 				)
 			)
 		)
@@ -1772,23 +1771,25 @@ sub recordEditHTML {
 	} else {
 		# selection checkbox
 		push @tableCells,
-			CGI::checkbox({
-				id      => $User->user_id . "_checkbox",
-				label   => '',
+			CGI::input({
+				type    => 'checkbox',
+				id      => $User->user_id . '_checkbox',
 				name    => "selected_users",
 				value   => $User->user_id,
 				class   => "form-check-input",
-				checked => $userSelected,
+				$userSelected ? (checked => undef) : (),
 			});
 
-		my $label = "";
+		my $label = '';
 		if (FIELD_PERMS()->{act_as} and not $authz->hasPermissions($user, FIELD_PERMS()->{act_as})) {
-			$label = $User->user_id . " " . $imageLink;
+			$label = $User->user_id . ' ' . $imageLink;
 		} else {
-			$label = CGI::a({ href => $changeEUserURL }, $User->user_id) . " " . $imageLink;
+			$label = CGI::a({ href => $changeEUserURL }, $User->user_id) . ' ' . $imageLink;
 		}
 
-		push @tableCells, CGI::div({ class => 'label-with-edit-icon' }, $label);
+		# Make the user id the label for the select user checkbox.
+		push @tableCells,
+			CGI::div({ class => 'label-with-edit-icon' }, CGI::label({ for => $User->user_id . '_checkbox' }, $label));
 	}
 
 	# Login Status
@@ -1944,11 +1945,11 @@ sub printTableHTML {
 			);
 		}
 
-		my $selectBox = CGI::checkbox({
+		my $selectBox = CGI::input({
+			type              => 'checkbox',
 			id                => 'select-all',
 			data_select_group => 'selected_users',
-			label             => '',
-			class             => 'form-check-input'
+			class             => 'form-check-input',
 		});
 		@tableHeadings = (
 			$editMode or $passwordMode ? '' : $selectBox,

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -155,7 +155,7 @@ sub body {
 		CGI::th([
 			$r->maketext('Login Name'), $r->maketext('Student Name'),
 			$r->maketext('Section'),    $r->maketext('Close Date'),
-			''
+			$r->maketext('Edit Data')
 		])
 	));
 
@@ -177,18 +177,17 @@ sub body {
 		print CGI::Tr(
 			CGI::td(
 				{ class => 'text-center' },
-				CGI::checkbox({
+				CGI::input({
 					type            => 'checkbox',
 					name            => 'selected',
-					checked         => defined($userSetRecord),
+					id              => "selected_$user",
 					value           => $user,
-					label           => '',
 					class           => 'form-check-input',
-					labelattributes => { class => 'form-check-label' }
+					defined($userSetRecord) ? (checked => undef) : ()
 				})
 			),
 			CGI::td([
-				CGI::div({ class => $statusClass }, $user),
+				CGI::div({ class => $statusClass }, CGI::label({ for => "selected_$user" }, $user)),
 				$prettyName,
 				$userRecord->section,
 				(
@@ -222,6 +221,8 @@ sub body {
 		value => $r->maketext('Save'),
 		class => 'btn btn-primary'
 	});
+
+	print CGI::end_form();
 
 	print CGI::hr()
 		. CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -891,9 +891,8 @@ sub siblings {
 	my $progressBarEnabled = $r->ce->{pg}->{options}->{enableProgressBar};
 
 
-	print CGI::start_div({class=>"info-box", id=>"fisheye"});
-	print CGI::h2($r->maketext("Problems"));
-	print CGI::start_ul({ class => 'nav flex-column problem-list' });
+	print CGI::start_div({ class => 'info-box', id => 'fisheye' });
+	print CGI::h2($r->maketext('Problems'));
 
 	my @items;
 
@@ -974,57 +973,64 @@ sub siblings {
 		my $progress_bar_inprogress_width  = $total_inprogress * 100 / $num_of_problems;
 		my $progress_bar_unattempted_width = $unattempted * 100 / $num_of_problems;
 
-		# construct the progress bar
-		#     CORRECT | IN PROGRESS | INCORRECT | UNATTEMPTED
+		# Construct the progress bar.
+		# CORRECT | IN PROGRESS | INCORRECT | UNATTEMPTED
 		my $progress_bar = CGI::start_div({
 			class      => 'progress set-id-tooltip',
 			aria_label => 'progress bar for current problem set',
 		});
 		if ($total_correct > 0) {
-			$progress_bar .= CGI::div({
-				class             => 'progress-bar correct-progress set-id-tooltip',
-				style             => "width:$progress_bar_correct_width%",
-				aria_label        => 'correct progress bar for current problem set',
-				data_bs_toggle    => 'tooltip',
-				data_bs_placement => 'bottom',
-				data_bs_title     => $r->maketext('Correct: [_1]/[_2]', $total_correct, $num_of_problems)
-			});
-			# perfect scores deserve some stars (&#9733;)
-			$progress_bar .= ($total_correct == $num_of_problems) ? '&#9733;Perfect&#9733;' : '';
-			$progress_bar .= CGI::end_div();
+			$progress_bar .= CGI::div(
+				{
+					class             => 'progress-bar correct-progress set-id-tooltip',
+					style             => "width:$progress_bar_correct_width%",
+					aria_label        => 'correct progress bar for current problem set',
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'bottom',
+					data_bs_title     => $r->maketext('Correct: [_1]/[_2]', $total_correct, $num_of_problems)
+				},
+				# perfect scores deserve some stars (&#9733;)
+				$total_correct == $num_of_problems ? '&#9733;Perfect&#9733;' : ''
+			);
 		}
 		if ($total_inprogress > 0) {
-			$progress_bar .= CGI::div({
-				class             => 'progress-bar inprogress-progress set-id-tooltip',
-				style             => "width:$progress_bar_inprogress_width%",
-				aria_label        => 'in progress bar for current problem set',
-				data_bs_toggle    => 'tooltip',
-				data_bs_placement => 'bottom',
-				data_bs_title     => $r->maketext('In progress: [_1]/[_2]', $total_inprogress, $num_of_problems)
-			});
-			$progress_bar .= CGI::end_div();
+			$progress_bar .= CGI::div(
+				{
+					class             => 'progress-bar inprogress-progress set-id-tooltip',
+					style             => "width:$progress_bar_inprogress_width%",
+					aria_label        => 'in progress bar for current problem set',
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'bottom',
+					data_bs_title     => $r->maketext('In progress: [_1]/[_2]', $total_inprogress, $num_of_problems)
+				},
+				''
+			);
 		}
 		if ($total_incorrect > 0) {
-			$progress_bar .= CGI::div({
-				class             => 'progress-bar incorrect-progress set-id-tooltip',
-				style             => "width:$progress_bar_incorrect_width%",
-				aria_label        => 'incorrect progress bar for current problem set',
-				data_bs_toggle    => 'tooltip',
-				data_bs_placement => 'bottom',
-				data_bs_title     => $r->maketext('Incorrect: [_1]/[_2]', $total_incorrect, $num_of_problems)
-			});
-			$progress_bar .= CGI::end_div();
+			$progress_bar .= CGI::div(
+				{
+					class             => 'progress-bar incorrect-progress set-id-tooltip',
+					style             => "width:$progress_bar_incorrect_width%",
+					aria_label        => 'incorrect progress bar for current problem set',
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'bottom',
+					data_bs_title     => $r->maketext('Incorrect: [_1]/[_2]', $total_incorrect, $num_of_problems)
+				},
+				''
+			);
 		}
 		if ($unattempted > 0) {
-			$progress_bar .= CGI::div({
-				class             => 'progress-bar unattempted-progress set-id-tooltip',
-				style             => "width:$progress_bar_unattempted_width%",
-				aria_label        => 'unattempted progress bar for current problem set',
-				data_bs_toggle    => 'tooltip',
-				data_bs_placement => 'bottom',
-				data_bs_title     => $r->maketext('Unattempted: [_1]/[_2]', $unattempted, $num_of_problems)
-			});
-			$progress_bar .= CGI::end_div();
+			$progress_bar .= CGI::div(
+				{
+					class             => 'progress-bar unattempted-progress set-id-tooltip',
+					style             => "width:$progress_bar_unattempted_width%",
+					aria_label        => 'unattempted progress bar for current problem set',
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'bottom',
+					data_bs_title     => $r->maketext('Unattempted: [_1]/[_2]', $unattempted, $num_of_problems)
+				},
+				''
+			);
 		}
 		# close the progress bar div
 		$progress_bar .= CGI::end_div();
@@ -1033,12 +1039,11 @@ sub siblings {
 		print $progress_bar;
 	}
 
-	print @items;
+	print CGI::ul({ class => 'nav flex-column problem-list' }, @items);
 
-	print CGI::end_ul();
 	print CGI::end_div();
 
-	return "";
+	return '';
 }
 
 sub nav {
@@ -1394,7 +1399,7 @@ sub title {
 	my $ce = $r->ce;
 	my $problem = $self->{problem};
 
-	$out .= CGI::start_div({ class => "problem-sub-header" });
+	$out .= CGI::start_span({ class => "problem-sub-header d-block" });
 
 	my $problemValue = $problem->value;
 	if (defined($problemValue) && $problemValue ne "") {
@@ -1410,7 +1415,7 @@ sub title {
 		$out .= " " . $problem->source_file;
 	}
 
-	$out .= CGI::end_div();
+	$out .= CGI::end_span();
 
 	return $out;
 }
@@ -1854,7 +1859,7 @@ sub output_submit_buttons {
 				data_bs_toggle    => 'tooltip',
 				data_bs_placement => 'right',
 				id                => 'SMA_button',
-				target            => '_wwsma',
+				target            => 'WW_Show_Me_Another',
 				data_bs_title     => $r->maketext(
 					'You can use this feature [quant,_1,more time,more times,as many times as you want] on this problem',
 					$showMeAnother{MaxReps} >= $showMeAnother{Count}

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -190,7 +190,7 @@ sub siblings {
 		print CGI::li({ class => 'nav-item' },
 			CGI::a({
 					href => $self->systemLink($setPage),
-					id => $pretty_set_id,
+					id => $setID,
 					class => 'nav-link'
 				}, $pretty_set_id)
 		) ;

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -69,7 +69,7 @@ sub scrollingRecordList {
 
 	if (@Records) {
 		my $class = ref $Records[0];
-        $class = $1 if $class =~ /(.*)Version$/;
+		$class = $1 if $class =~ /(.*)Version$/;
 
 		($filters, $filter_labels) = getFiltersForClass(@Records);
 		if (defined $r->param("$name!filter")) {
@@ -111,13 +111,14 @@ sub scrollingRecordList {
 		CGI::div(
 			{ class => 'row mb-2' },
 			CGI::label(
-				{ class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
+				{ for => "$name!sort", class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
 				$r->maketext('Sort:')
 			),
 			CGI::div(
 				{ class => 'col-10' },
 				CGI::popup_menu({
 					name    => "$name!sort",
+					id      => "$name!sort",
 					values  => $sorts,
 					default => $selected_sort,
 					labels  => $sort_labels,
@@ -128,13 +129,14 @@ sub scrollingRecordList {
 		CGI::div(
 			{ class => 'row mb-2' },
 			CGI::label(
-				{ class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
+				{ for => "$name!format", class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
 				$r->maketext('Format:')
 			),
 			CGI::div(
 				{ class => 'col-10' },
 				CGI::popup_menu({
 					name    => "$name!format",
+					id      => "$name!format",
 					values  => $formats,
 					default => $selected_format,
 					labels  => $format_labels,
@@ -145,13 +147,14 @@ sub scrollingRecordList {
 		CGI::div(
 			{ class => 'row mb-2' },
 			CGI::label(
-				{ class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
+				{ for => "$name!filter", class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' },
 				$r->maketext("Filter:")
 			),
 			CGI::div(
 				{ class => 'col-10' },
 				CGI::scrolling_list({
 					name     => "$name!filter",
+					id       => "$name!filter",
 					values   => $filters,
 					default  => \@selected_filters,
 					labels   => $filter_labels,
@@ -165,7 +168,8 @@ sub scrollingRecordList {
 			{ name => "$name!refresh", label => $refresh_button_name, class => 'btn btn-secondary btn-sm mb-2' }
 		)),
 		CGI::scrolling_list({
-			name    => "$name",
+			name    => $name,
+			id      => $name,
 			values  => \@ids,
 			default => \@selected_records,
 			labels  => \%labels,


### PR DESCRIPTION
Here is a detailed list of the changes made:

Add the table-responsive wrapper to the table on the add users page.

Fix the comparison of the request parameter that determines if the "Import from where?" select on the homework sets editor page is multiple or not on page load.  That needs to be a string comparison.  Also, change that to checking that the value is `ne '1'` instead of `eq '8'` in case that in the future the multiple size is changed.  The single size probably won't.

Make the state of the checkboxes and set id select on `Scoring Tools` page (Scoring.pm) persistent when the form is submitted.  Also make it so that the "You must select one or more sets for scoring!" message is only displayed after clicking on the "Score selected set(s) and save to:" button, and not when the page initially loads.

Fix a typo in Achievements.pm.  aria_labe -> aria_label.  Also prefix the id's of the hidden authen inputs in the forms for using achievement items inside the modal dialogs that are embedded in the page when a user has such items available for use.  Really, these hidden forms shouldn't even have id's.  However, at this point some javascript uses that to find these forms.  That can be fixed by searching by name instead, but will take care to make sure all case where these id's are used are found.

Remove the duplicate id "problem_body" in the system.template file.

Remove the `role="navigation"` attribute from the breadcrumb `nav` in the system.template and gateway.template files.  `nav` tags should not have that role.

Remove the `<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>` tag from the system.template and gateway.template files.  Those tags are neither valid nor needed anymore.

Use the `$setID` with underscores for the html id of the set siblings on the ProblemSet page.  The `$pretty_set_id` has spaces which is invalid for an html id.  Do these anchors even need an id?

Move the progress bar out of the siblings `ul` in Problem.pm.  It is invalid html to have that in the list.  Also correct the html markup for the divs that make up the progress bar.  Several were self closing, and then also followed by an end div tag.

Make the `problem-sub-header` `div` in the page title of Problem.pm a `span` instead (but give it the css style display block).  It is invalid html for a `div` to be inside an `h1`.

Remove the underscore from the target attribute for the show me another link in Problem.pm.  Targets should not have the underscore prefix unless they are reserved word targets like `_self` or `_blank`.  Also change that target name to be more consistent with the other target names used by webwork.

Fix the number of columns for the gateway quiz rows that have no versions, or that do not allow the display of scores for the set in Grades.pm.