### PR TITLE
add height and width to CGI::img command for pi.svg

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1392,7 +1392,9 @@ sub make_data_row {
 			},
 			CGI::img({
 				src => $r->ce->{webworkURLs}{htdocs} . '/images/pi.svg',
-				alt => $r->maketext('Uses Math Objects')
+				alt => $r->maketext('Uses Math Objects'),
+                                width => '10',
+                                height => '10'
 			})
 		)
 		: ''


### PR DESCRIPTION
if not added, the pi svg spans as much space as allowed by the sourrounding container. Not sure if this is the best approach in terms of responsiveness.

Bases of the changes introduced in commit 8a9e3e3cf594c2376c8985a046805fe39956edb1

Makes the symbol bar in the library browser look like

![image](https://user-images.githubusercontent.com/3385756/156063433-690d18c7-da6b-4254-9f9e-337986d8c8ce.png)

instead of

![image](https://user-images.githubusercontent.com/3385756/156063627-25f19c48-6dcf-42ed-8d3a-379b10bfd64a.png)

