### PR TITLE
Section/recitation filter for the sticky student nav

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -380,6 +380,7 @@ h2.page-title {
 .sticky-nav {
 	display: flex;
 	flex-wrap: wrap;
+	gap: 0.5rem;
 	align-content: space-between;
 	justify-content: space-between;
 	z-index: 1;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1233,94 +1233,134 @@ sub nav {
 		my $maxTestIndex = $minTestIndex + 200 < $#userRecords ? $minTestIndex + 200 : $#userRecords;
 
 		# Set up the student nav.
-		print join(
-			'',
-			CGI::start_div({ class => 'row sticky-nav', role => 'navigation', aria_label => 'user navigation' }),
-			CGI::start_div({ class => 'user-nav' }),
-			$prevTest ? CGI::a(
-				{
-					href => sprintf(
-						$self->systemLink(
-							$setPage,
-							params => {
-								effectiveUser     => $prevTest->user_id,
-								currentPage       => $self->{pageNumber},
-								showProblemGrader => $self->{will}{showProblemGrader},
-								$filter ? (studentNavFilter => $filter) : ()
-							}
-						),
-						$prevTest->{setVersion}
-					),
-					data_bs_toggle    => 'tooltip',
-					data_bs_placement => 'top',
-					title             => "$prevTest->{displayName} (version $prevTest->{setVersion})",
-					class             => 'btn btn-primary student-nav-button'
-				},
-				$r->maketext('Previous Test')
-			) : CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Previous Test')),
-			' ',
-			CGI::start_div({ class => 'btn-group student-nav-selector' }),
-			CGI::a(
-				{
-					href           => '#',
-					id             => 'studentSelector',
-					class          => 'btn btn-primary dropdown-toggle',
-					role           => 'button',
-					data_bs_toggle => 'dropdown',
-					aria_expanded  => 'false',
-					scalar keys %filters ? (style => 'border-top-right-radius:0;border-bottom-right-radius:0') : (),
-				},
-				$userRecords[$currentTestIndex]{displayName}
-					. " (version $userRecords[$currentTestIndex]{setVersion})"
-			),
-			CGI::start_ul({ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelector' }),
-			(
-				map {
-					CGI::li(CGI::a(
+		print CGI::div(
+			{ class => 'row sticky-nav', role => 'navigation', aria_label => 'user navigation' },
+			CGI::div(
+				{ class => 'user-nav' },
+				CGI::div(
+					{ class => 'btn-group', role => 'group', aria_label => 'student selector' },
+					$prevTest
+					? CGI::a(
 						{
-							tabindex => '-1',
-							style    => $_->{currentTest} ? 'background-color: #8F8' : '',
-							class    => 'dropdown-item',
-							href     => sprintf(
+							href => sprintf(
 								$self->systemLink(
 									$setPage,
 									params => {
-										effectiveUser     => $_->user_id,
+										effectiveUser     => $prevTest->user_id,
 										currentPage       => $self->{pageNumber},
 										showProblemGrader => $self->{will}{showProblemGrader},
 										$filter ? (studentNavFilter => $filter) : ()
 									}
 								),
-								$_->{setVersion}
-							)
+								$prevTest->{setVersion}
+							),
+							data_bs_toggle    => 'tooltip',
+							data_bs_placement => 'top',
+							title             => "$prevTest->{displayName} (version $prevTest->{setVersion})",
+							class             => 'btn btn-primary student-nav-button'
 						},
-						"$_->{displayName} (version $_->{setVersion})"
-					))
-				} @userRecords[ $minTestIndex .. $maxTestIndex ]
-			),
-			CGI::end_ul(),
-			(
+						CGI::i({ class => 'fas fa-chevron-left' }, '')
+						)
+					: CGI::span(
+						{ class => 'btn btn-primary disabled' },
+						CGI::i({ class => 'fas fa-chevron-left' }, '')
+					),
+					' ',
+					CGI::div(
+						{ class => 'btn-group student-nav-selector' },
+						CGI::a(
+							{
+								href           => '#',
+								id             => 'studentSelector',
+								class          => 'btn btn-primary dropdown-toggle',
+								role           => 'button',
+								data_bs_toggle => 'dropdown',
+								aria_expanded  => 'false'
+							},
+							$userRecords[$currentTestIndex]{displayName}
+								. " (version $userRecords[$currentTestIndex]{setVersion})"
+						),
+						CGI::ul(
+							{
+								class           => 'dropdown-menu',
+								role            => 'menu',
+								aria_labelledby => 'studentSelector'
+							},
+							(
+								map {
+									CGI::li(CGI::a(
+										{
+											tabindex => '-1',
+											style    => $_->{currentTest} ? 'background-color: #8F8' : '',
+											class    => 'dropdown-item',
+											href     => sprintf(
+												$self->systemLink(
+													$setPage,
+													params => {
+														effectiveUser     => $_->user_id,
+														currentPage       => $self->{pageNumber},
+														showProblemGrader => $self->{will}{showProblemGrader},
+														$filter ? (studentNavFilter => $filter) : ()
+													}
+												),
+												$_->{setVersion}
+											)
+										},
+										"$_->{displayName} (version $_->{setVersion})"
+									))
+								} @userRecords[ $minTestIndex .. $maxTestIndex ]
+							),
+						),
+					),
+					' ',
+					$nextTest
+					? CGI::a(
+						{
+							href => sprintf(
+								$self->systemLink(
+									$setPage,
+									params => {
+										effectiveUser     => $nextTest->user_id,
+										currentPage       => $self->{pageNumber},
+										showProblemGrader => $self->{will}{showProblemGrader},
+										$filter ? (studentNavFilter => $filter) : ()
+									}
+								),
+								$nextTest->{setVersion}
+							),
+							data_bs_toggle    => 'tooltip',
+							data_bs_placement => 'top',
+							title             => "$nextTest->{displayName} (version $nextTest->{setVersion})",
+							class             => 'btn btn-primary student-nav-button'
+						},
+						CGI::i({ class => 'fas fa-chevron-right' }, '')
+						)
+					: CGI::span(
+						{ class => 'btn btn-primary disabled' },
+						CGI::i({ class => 'fas fa-chevron-right' }, '')
+					),
+				),
 				# Create a section/recitation filter by dropdown if there are sections or recitaitons.
 				scalar keys %filters
-				? (
+				? CGI::div(
+					{ class => 'btn-group student-nav-filter-selector' },
 					CGI::a(
 						{
 							href           => '#',
-							id             => 'studentSelectorFilter',
+							id             => 'testSelectorFilter',
 							class          => 'btn btn-primary dropdown-toggle dropdown-toggle-split',
 							role           => 'button',
 							data_bs_toggle => 'dropdown',
 							aria_expanded  => 'false',
 						},
-						CGI::span(
-							{ class => 'visually-hidden' },
-							$r->maketext('Filter tests by section or recitation')
-						)
+						$filter ? $filters{$filter}[0] : $r->maketext('Showing all tests')
 					),
-					CGI::start_ul(
-						{ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelectorFilter' }
-					),
-					(
+					CGI::ul(
+						{
+							class           => 'dropdown-menu',
+							role            => 'menu',
+							aria_labelledby => 'testSelectorFilter'
+						},
 						# If a filter is currently in use, then add an item that will remove that filter.
 						$filter
 						? CGI::li(CGI::a(
@@ -1338,15 +1378,14 @@ sub nav {
 									$setVersion
 								)
 							},
-							$r->maketext('Remove current filter')
+							$r->maketext('Show all tests')
 						))
-						: ''
-					),
-					(
+						: '',
 						map {
 							CGI::li(CGI::a(
 								{
 									class => 'dropdown-item',
+									style => ($filter || '') eq $_ ? 'background-color: #8F8' : '',
 									href  => sprintf(
 										$self->systemLink(
 											$setPage,
@@ -1364,35 +1403,9 @@ sub nav {
 							))
 						} sort keys %filters
 					),
-					CGI::end_ul(),
 					)
 				: ''
-			),
-			CGI::end_div(),
-			' ',
-			$nextTest ? CGI::a(
-				{
-					href => sprintf(
-						$self->systemLink(
-							$setPage,
-							params => {
-								effectiveUser     => $nextTest->user_id,
-								currentPage       => $self->{pageNumber},
-								showProblemGrader => $self->{will}{showProblemGrader},
-								$filter ? (studentNavFilter => $filter) : ()
-							}
-						),
-						$nextTest->{setVersion}
-					),
-					data_bs_toggle    => 'tooltip',
-					data_bs_placement => 'top',
-					title             => "$nextTest->{displayName} (version $nextTest->{setVersion})",
-					class             => 'btn btn-primary student-nav-button'
-				},
-				$r->maketext('Next Test')
-			) : CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Next Test')),
-			CGI::end_div(),
-			CGI::end_div()
+			)
 		);
 	}
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1149,16 +1149,16 @@ sub path {
 
 sub nav {
 	my ($self, $args) = @_;
-	my $r = $self->{r};
-	my $db = $r->db;
-	my $user = $r->param("user");
+	my $r             = $self->{r};
+	my $db            = $r->db;
+	my $user          = $r->param('user');
 	my $effectiveUser = $r->param('effectiveUser');
 
 	# Set up and display a student navigation for those that have permission to act as a student.
-	if ($r->authz->hasPermissions($user, "become_student") && $effectiveUser ne $user) {
+	if ($r->authz->hasPermissions($user, 'become_student') && $effectiveUser ne $user) {
 		my $setName = $self->{set}->set_id;
 
-		return "" if $setName eq "Undefined_Set" || $self->{invalidSet};
+		return '' if $setName eq 'Undefined_Set' || $self->{invalidSet};
 
 		my $setVersion = $self->{set}->version_id;
 		my $courseName = $self->{ce}{courseName};
@@ -1166,108 +1166,237 @@ sub nav {
 		# Find all versions of this set that have been taken (excluding those taken by the current user).
 		my @users =
 			$db->listSetVersionsWhere({ user_id => { not_like => $user }, set_id => { like => "$setName,v\%" } });
-		my @userRecords = $db->getUsers(map { $_->[0] } @users);
+		my @allUserRecords = $db->getUsers(map { $_->[0] } @users);
+
+		my $filter = $r->param('studentNavFilter');
 
 		# Format the student names for display, and associate the users with the test versions.
-		for (0 .. $#userRecords) {
-			$userRecords[$_]{displayName} = ($userRecords[$_]->last_name || $userRecords[$_]->first_name
-				? $userRecords[$_]->last_name . ", " . $userRecords[$_]->first_name
-				: $userRecords[$_]->user_id);
-			$userRecords[$_]{setVersion} = $users[$_][2];
+		my %filters;
+		my @userRecords;
+		for (0 .. $#allUserRecords) {
+			# Add to the sections and recitations if defined.  Also store the first user found in that section or
+			# recitation.  This user will be switched to when the filter is selected.
+			my $section = $allUserRecords[$_]->section;
+			$filters{"section:$section"} =
+				[ $r->maketext('Filter by section [_1]', $section), $allUserRecords[$_]->user_id, $users[$_][2] ]
+				if $section && !$filters{"section:$section"};
+			my $recitation = $allUserRecords[$_]->recitation;
+			$filters{"recitation:$recitation"} =
+				[ $r->maketext('Filter by recitation [_1]', $recitation), $allUserRecords[$_]->user_id, $users[$_][2] ]
+				if $recitation && !$filters{"recitation:$recitation"};
+
+			# Only keep this user if it satisfies the selected filter if a filter was selected.
+			next
+				unless !$filter
+				|| ($filter =~ /^section:(.*)$/    && $allUserRecords[$_]->section eq $1)
+				|| ($filter =~ /^recitation:(.*)$/ && $allUserRecords[$_]->recitation eq $1);
+
+			my $addRecord = $allUserRecords[$_];
+			push @userRecords, $addRecord;
+
+			$addRecord->{displayName} =
+				($addRecord->last_name || $addRecord->first_name
+					? $addRecord->last_name . ', ' . $addRecord->first_name
+					: $addRecord->user_id);
+			$addRecord->{setVersion} = $users[$_][2];
 		}
 
 		# Sort by last name, then first name, then user_id, then set version.
 		@userRecords = sort {
-			lc($a->last_name) cmp lc($b->last_name) ||
-			lc($a->first_name) cmp lc($b->first_name) ||
-			lc($a->user_id) cmp lc($b->user_id) ||
-			lc($a->{setVersion}) <=> lc($b->{setVersion})
+			lc($a->last_name) cmp lc($b->last_name)
+				|| lc($a->first_name) cmp lc($b->first_name)
+				|| lc($a->user_id) cmp lc($b->user_id)
+				|| lc($a->{setVersion}) <=> lc($b->{setVersion})
 		} @userRecords;
 
 		# Find the previous, current, and next test.
 		my $currentTestIndex = 0;
 		for (0 .. $#userRecords) {
 			$currentTestIndex = $_, last
-			if $userRecords[$_]->user_id eq $effectiveUser && $userRecords[$_]->{setVersion} == $setVersion;
+				if $userRecords[$_]->user_id eq $effectiveUser && $userRecords[$_]->{setVersion} == $setVersion;
 		}
-		my $prevTest = $currentTestIndex > 0 ? $userRecords[$currentTestIndex - 1] : 0;
-		my $nextTest = $currentTestIndex < $#userRecords ? $userRecords[$currentTestIndex + 1] : 0;
+		my $prevTest = $currentTestIndex > 0             ? $userRecords[ $currentTestIndex - 1 ] : 0;
+		my $nextTest = $currentTestIndex < $#userRecords ? $userRecords[ $currentTestIndex + 1 ] : 0;
 
 		# Mark the current test.
 		$userRecords[$currentTestIndex]{currentTest} = 1;
 
 		my $setPage = $r->urlpath->newFromModule(__PACKAGE__, $r,
-			courseID => $courseName, setID => "$setName,v%s");
+			courseID => $courseName,
+			setID    => "$setName,v%s"
+		);
 
 		# Cap the number of tests shown to at most 200.
-		my $numAfter = $#userRecords - $currentTestIndex;
-		my $numBefore = 200 - ($numAfter < 100 ? $numAfter : 100);
-		my $minTestIndex = $currentTestIndex < $numBefore ? 0 : $currentTestIndex - $numBefore;
+		my $numAfter     = $#userRecords - $currentTestIndex;
+		my $numBefore    = 200 - ($numAfter < 100 ? $numAfter : 100);
+		my $minTestIndex = $currentTestIndex < $numBefore      ? 0                   : $currentTestIndex - $numBefore;
 		my $maxTestIndex = $minTestIndex + 200 < $#userRecords ? $minTestIndex + 200 : $#userRecords;
 
 		# Set up the student nav.
-		print join("",
-			CGI::start_div({ class => "row sticky-nav", role => "navigation", aria_label => "user navigation"}),
+		print join(
+			'',
+			CGI::start_div({ class => 'row sticky-nav', role => 'navigation', aria_label => 'user navigation' }),
 			CGI::start_div({ class => 'user-nav' }),
-			$prevTest
-			? CGI::a({
-					href => sprintf($self->systemLink($setPage, params => { effectiveUser => $prevTest->user_id,
-								currentPage => $self->{pageNumber},
-								showProblemGrader => $self->{will}{showProblemGrader} }), $prevTest->{setVersion}),
-					data_bs_toggle => "tooltip",
-				   	data_bs_placement => "top",
-					title => "$prevTest->{displayName} (version $prevTest->{setVersion})",
-					class => "btn btn-primary student-nav-button"
-				}, $r->maketext("Previous Test"))
-			: CGI::span({ class => "btn btn-primary disabled" }, $r->maketext("Previous Test")),
-			" ",
-			CGI::start_span({ class => "btn-group student-nav-selector" }),
-			CGI::a({
-				   	class => "btn btn-primary dropdown-toggle",
-				   	role => "button",
-				   	data_bs_toggle => "dropdown",
-					aria_expanded => "false"
-			   	},
-				$userRecords[$currentTestIndex]{displayName} .
-				" (version $userRecords[$currentTestIndex]{setVersion}) " .
-				CGI::span({ class => "caret" }, "")),
-			CGI::start_ul({ class => "dropdown-menu", role => "menu", aria_labelledby => "studentSelector" }),
+			$prevTest ? CGI::a(
+				{
+					href => sprintf(
+						$self->systemLink(
+							$setPage,
+							params => {
+								effectiveUser     => $prevTest->user_id,
+								currentPage       => $self->{pageNumber},
+								showProblemGrader => $self->{will}{showProblemGrader},
+								$filter ? (studentNavFilter => $filter) : ()
+							}
+						),
+						$prevTest->{setVersion}
+					),
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'top',
+					title             => "$prevTest->{displayName} (version $prevTest->{setVersion})",
+					class             => 'btn btn-primary student-nav-button'
+				},
+				$r->maketext('Previous Test')
+			) : CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Previous Test')),
+			' ',
+			CGI::start_div({ class => 'btn-group student-nav-selector' }),
+			CGI::a(
+				{
+					href           => '#',
+					id             => 'studentSelector',
+					class          => 'btn btn-primary dropdown-toggle',
+					role           => 'button',
+					data_bs_toggle => 'dropdown',
+					aria_expanded  => 'false',
+					scalar keys %filters ? (style => 'border-top-right-radius:0;border-bottom-right-radius:0') : (),
+				},
+				$userRecords[$currentTestIndex]{displayName}
+					. " (version $userRecords[$currentTestIndex]{setVersion})"
+			),
+			CGI::start_ul({ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelector' }),
 			(
 				map {
-					CGI::li(
-					CGI::a({
-					   	tabindex => "-1",
-					   	style => $_->{currentTest} ? "background-color: #8F8" : "",
-						class => 'dropdown-item',
-						href => sprintf($self->systemLink($setPage, params => { effectiveUser => $_->user_id,
-									currentPage => $self->{pageNumber},
-									showProblemGrader => $self->{will}{showProblemGrader} }), $_->{setVersion})
-				   	},
-					"$_->{displayName} (version $_->{setVersion})" )
-					)
-				}
-				@userRecords[$minTestIndex ..  $maxTestIndex]
+					CGI::li(CGI::a(
+						{
+							tabindex => '-1',
+							style    => $_->{currentTest} ? 'background-color: #8F8' : '',
+							class    => 'dropdown-item',
+							href     => sprintf(
+								$self->systemLink(
+									$setPage,
+									params => {
+										effectiveUser     => $_->user_id,
+										currentPage       => $self->{pageNumber},
+										showProblemGrader => $self->{will}{showProblemGrader},
+										$filter ? (studentNavFilter => $filter) : ()
+									}
+								),
+								$_->{setVersion}
+							)
+						},
+						"$_->{displayName} (version $_->{setVersion})"
+					))
+				} @userRecords[ $minTestIndex .. $maxTestIndex ]
 			),
 			CGI::end_ul(),
-			CGI::end_span(),
-			" ",
-			$nextTest
-			? CGI::a({
-					href => sprintf($self->systemLink($setPage, params => { effectiveUser => $nextTest->user_id,
-								currentPage => $self->{pageNumber},
-								showProblemGrader => $self->{will}{showProblemGrader} }), $nextTest->{setVersion}),
-					data_bs_toggle => "tooltip",
-				   	data_bs_placement => "top",
-					title => "$nextTest->{displayName} (version $nextTest->{setVersion})",
-					class => "btn btn-primary student-nav-button"
-				}, $r->maketext("Next Test"))
-			: CGI::span({ class => "btn btn-primary disabled" }, $r->maketext("Next Test")),
+			(
+				# Create a section/recitation filter by dropdown if there are sections or recitaitons.
+				scalar keys %filters
+				? (
+					CGI::a(
+						{
+							href           => '#',
+							id             => 'studentSelectorFilter',
+							class          => 'btn btn-primary dropdown-toggle dropdown-toggle-split',
+							role           => 'button',
+							data_bs_toggle => 'dropdown',
+							aria_expanded  => 'false',
+						},
+						CGI::span(
+							{ class => 'visually-hidden' },
+							$r->maketext('Filter tests by section or recitation')
+						)
+					),
+					CGI::start_ul(
+						{ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelectorFilter' }
+					),
+					(
+						# If a filter is currently in use, then add an item that will remove that filter.
+						$filter
+						? CGI::li(CGI::a(
+							{
+								class => 'dropdown-item',
+								href  => sprintf(
+									$self->systemLink(
+										$setPage,
+										params => {
+											effectiveUser     => $effectiveUser,
+											currentPage       => $self->{pageNumber},
+											showProblemGrader => $self->{will}{showProblemGrader}
+										}
+									),
+									$setVersion
+								)
+							},
+							$r->maketext('Remove current filter')
+						))
+						: ''
+					),
+					(
+						map {
+							CGI::li(CGI::a(
+								{
+									class => 'dropdown-item',
+									href  => sprintf(
+										$self->systemLink(
+											$setPage,
+											params => {
+												effectiveUser     => $filters{$_}[1],
+												currentPage       => $self->{pageNumber},
+												showProblemGrader => $self->{will}{showProblemGrader},
+												studentNavFilter  => $_
+											}
+										),
+										$filters{$_}[2]
+									)
+								},
+								$filters{$_}[0]
+							))
+						} sort keys %filters
+					),
+					CGI::end_ul(),
+					)
+				: ''
+			),
+			CGI::end_div(),
+			' ',
+			$nextTest ? CGI::a(
+				{
+					href => sprintf(
+						$self->systemLink(
+							$setPage,
+							params => {
+								effectiveUser     => $nextTest->user_id,
+								currentPage       => $self->{pageNumber},
+								showProblemGrader => $self->{will}{showProblemGrader},
+								$filter ? (studentNavFilter => $filter) : ()
+							}
+						),
+						$nextTest->{setVersion}
+					),
+					data_bs_toggle    => 'tooltip',
+					data_bs_placement => 'top',
+					title             => "$nextTest->{displayName} (version $nextTest->{setVersion})",
+					class             => 'btn btn-primary student-nav-button'
+				},
+				$r->maketext('Next Test')
+			) : CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Next Test')),
 			CGI::end_div(),
 			CGI::end_div()
 		);
 	}
 
-	return "";
+	return '';
 }
 
 sub body {
@@ -2278,6 +2407,10 @@ sub body {
 				-name   => 'problemSeed',
 				-value  =>  $r->param("problemSeed")
 			))  if defined($r->param("problemSeed"));
+
+		# Make sure the student nav filter setting is preserved when the problem form is submitted.
+		my $filter = $r->param('studentNavFilter');
+		print CGI::hidden({ name => 'studentNavFilter', value => $filter }) if $filter;
 
 		print CGI::end_form();
 	}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1127,81 +1127,106 @@ sub nav {
 		# Set up the student nav.
 		$userNav = CGI::div(
 			{ class => 'user-nav d-flex submit-buttons-container' },
-			$prevUser
-			? CGI::a(
-				{
-					href => $self->systemLink(
-						$problemPage,
-						params => {
-							effectiveUser     => $prevUser->user_id,
-							showProblemGrader => $self->{will}{showProblemGrader},
-							$filter ? (studentNavFilter => $filter) : ()
-						}
-					),
-					data_bs_toggle    => 'tooltip',
-					data_bs_placement => 'top',
-					title             => $prevUser->{displayName},
-					class             => 'btn btn-primary student-nav-button'
-				},
-				$r->maketext('Previous Student')
-				)
-			: CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Previous Student')),
-			$args->{separator},
-			CGI::start_div({ class => 'btn-group student-nav-selector' }),
-			CGI::a(
-				{
-					href           => '#',
-					id             => 'studentSelector',
-					class          => 'btn btn-primary dropdown-toggle',
-					role           => 'button',
-					data_bs_toggle => 'dropdown',
-					aria_expanded  => 'false',
-					scalar keys %filters ? (style => 'border-top-right-radius:0;border-bottom-right-radius:0') : (),
-				},
-				$userRecords[$currentUserIndex]{displayName}
-			),
-			CGI::start_ul({ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelector' }),
-			(
-				map {
-					CGI::li(CGI::a(
-						{
-							style => $_->{currentUser} ? 'background-color: #8F8' : '',
-							class => 'dropdown-item',
-							href  => $self->systemLink(
-								$problemPage,
-								params => {
-									effectiveUser     => $_->user_id,
-									showProblemGrader => $self->{will}{showProblemGrader},
-									$filter ? (studentNavFilter => $filter) : ()
-								}
-							)
-						},
-						$_->{displayName}
-					))
-				} @userRecords[ $minStudentIndex .. $maxStudentIndex ]
-			),
-			CGI::end_ul(),
-			(
-				# Create a section/recitation filter by dropdown if there are sections or recitaitons.
-				scalar keys %filters
-				? (
+			CGI::div(
+				{ class => 'btn-group', role => 'group', aria_label => 'student selector' },
+				$prevUser
+				? CGI::a(
+					{
+						href => $self->systemLink(
+							$problemPage,
+							params => {
+								effectiveUser     => $prevUser->user_id,
+								showProblemGrader => $self->{will}{showProblemGrader},
+								$filter ? (studentNavFilter => $filter) : ()
+							}
+						),
+						data_bs_toggle    => 'tooltip',
+						data_bs_placement => 'top',
+						title             => $prevUser->{displayName},
+						class             => 'btn btn-primary student-nav-button'
+					},
+					CGI::i({ class => 'fas fa-chevron-left' }, '')
+					)
+				: CGI::span({ class => 'btn btn-primary disabled' },
+					CGI::i({ class => 'fas fa-chevron-left' }, '')),
+				CGI::div(
+					{ class => 'btn-group student-nav-selector' },
 					CGI::a(
 						{
 							href           => '#',
-							id             => 'studentSelectorFilter',
-							class          => 'btn btn-primary dropdown-toggle dropdown-toggle-split',
+							id             => 'studentSelector',
+							class          => 'btn btn-primary dropdown-toggle',
 							role           => 'button',
 							data_bs_toggle => 'dropdown',
-							aria_expanded  => 'false',
+							aria_expanded  => 'false'
 						},
-						CGI::span(
-							{ class => 'visually-hidden' },
-							$r->maketext('Filter students by section or recitation')
-						)
+						$userRecords[$currentUserIndex]{displayName}
 					),
-					CGI::start_ul(
-						{ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelectorFilter' }
-					),
+					CGI::ul(
+						{ class => 'dropdown-menu', role => 'menu', aria_labelledby => 'studentSelector' },
+						map {
+							CGI::li(CGI::a(
+								{
+									style => $_->{currentUser} ? 'background-color: #8F8' : '',
+									class => 'dropdown-item',
+									href  => $self->systemLink(
+										$problemPage,
+										params => {
+											effectiveUser     => $_->user_id,
+											showProblemGrader => $self->{will}{showProblemGrader},
+											$filter ? (studentNavFilter => $filter) : ()
+										}
+									)
+								},
+								$_->{displayName}
+							))
+						} @userRecords[ $minStudentIndex .. $maxStudentIndex ]
+					)
+				),
+				$nextUser
+				? CGI::a(
+					{
+						href => $self->systemLink(
+							$problemPage,
+							params => {
+								effectiveUser     => $nextUser->user_id,
+								showProblemGrader => $self->{will}{showProblemGrader},
+								$filter ? (studentNavFilter => $filter) : ()
+							}
+						),
+						data_bs_toggle    => 'tooltip',
+						data_bs_placement => 'top',
+						title             => $nextUser->{displayName},
+						class             => 'btn btn-primary student-nav-button'
+					},
+					CGI::i({ class => 'fas fa-chevron-right' }, '')
+					)
+				: CGI::span(
+					{ class => 'btn btn-primary disabled' },
+					CGI::i({ class => 'fas fa-chevron-right' }, '')
+				),
+			),
+			# Create a section/recitation "filter by" dropdown if there are sections or recitations.
+			scalar keys %filters
+			? CGI::div(
+				{ class => 'btn-group student-nav-filter-selector' },
+				CGI::a(
+					{
+						href           => '#',
+						id             => 'studentSelectorFilter',
+						class          => 'btn btn-primary dropdown-toggle',
+						role           => 'button',
+						data_bs_toggle => 'dropdown',
+						aria_expanded  => 'false',
+					},
+					$filter ? $filters{$filter}[0] : $r->maketext('Showing all students')
+				),
+				CGI::ul(
+					{
+						class           => 'dropdown-menu',
+						role            => 'menu',
+						aria_labelledby => 'studentSelectorFilter'
+					},
 					(
 						# If a filter is currently in use, then add an item that will remove that filter.
 						$filter
@@ -1216,7 +1241,7 @@ sub nav {
 									}
 								)
 							},
-							$r->maketext('Remove current filter')
+							$r->maketext('Show all students')
 						))
 						: ''
 					),
@@ -1225,6 +1250,7 @@ sub nav {
 							CGI::li(CGI::a(
 								{
 									class => 'dropdown-item',
+									style => ($filter || '') eq $_ ? 'background-color: #8F8' : '',
 									href  => $self->systemLink(
 										$problemPage,
 										params => {
@@ -1237,32 +1263,10 @@ sub nav {
 								$filters{$_}[0]
 							))
 						} sort keys %filters
-					),
-					CGI::end_ul(),
 					)
-				: ''
-			),
-			CGI::end_div(),
-			$args->{separator},
-			$nextUser
-			? CGI::a(
-				{
-					href => $self->systemLink(
-						$problemPage,
-						params => {
-							effectiveUser     => $nextUser->user_id,
-							showProblemGrader => $self->{will}{showProblemGrader},
-							$filter ? (studentNavFilter => $filter) : ()
-						}
-					),
-					data_bs_toggle    => 'tooltip',
-					data_bs_placement => 'top',
-					title             => $nextUser->{displayName},
-					class             => 'btn btn-primary student-nav-button'
-				},
-				$r->maketext('Next Student')
 				)
-			: CGI::span({ class => 'btn btn-primary disabled' }, $r->maketext('Next Student')),
+				)
+			: ''
 		);
 	}
 


### PR DESCRIPTION
If a course has sections or recitations,  then add a dropdown to the right of the previous dropdown in the student nav that appears when an instructor is acting as another user and is viewing a problem in a problem set or viewing a gateway quiz version.

This dropdown lists all sections and recitations for users assigned to the set on the problem page and for taken test version on a gateway quiz page.  If the section or recitation is clicked on, then only those users/tests will be shown.  There is also an item added in the dropdown when a filter is active that if clicked will remove the filter.  The active filter will be persistent when navigating between problems and students, or when a problem or gateway quiz submit button is pressed.

This is a feature that was requested in #1240.

In addition the order of the things in the sticky nav is changed on the problem page.  Now the "Previous Problem", "Problem List", and "Next Problem" buttons are on the left (or top on narrow screens), and the student nav is on the right (or bottom on narrow screens).  This makes the "Previous Problem", "Problem List", and "Next Problem" buttons appear in the same place that they were before the student nav was added.