### PR TITLE
use best version score for conditional release

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1234,10 +1234,11 @@ sub is_restricted {
 			my $restrictor_set = $db->getGlobalSet($restrictor);
 
 			if ($restrictor_set->assignment_type =~ /gateway/) {
-				my @versions = $db->listSetVersions($studentName, $restrictor);
+				my @versions =
+					$db->getSetVersionsWhere({ user_id => $studentName, set_id => { like => $restrictor . ',v%' } });
 				foreach (@versions) {
-					my $restrictor_set_version = $db->getSetVersion($studentName, $restrictor, $_);
-					my $v_score = grade_set($db, $restrictor_set_version, $restrictor, $studentName,1);
+					my $v_score = grade_set($db, $_, $restrictor, $studentName, 1);
+
 					$r_score = $v_score if ($v_score > $r_score);
 				}
 			} else {

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1212,30 +1212,43 @@ sub has_aux_files ($) { #  determine whether a question has auxiliary files
 }
 
 sub is_restricted {
-        my ($db, $set, $studentName) = @_;
+    my ($db, $set, $studentName) = @_;
 
 	# all sets open after the due date
 	return () if after($set->due_date());
 
-        my $setID = $set->set_id();
+    my $setID = $set->set_id();
 	my @needed;
+
 	if ($set->restricted_release ) {
-	        my @proposed_sets = split(/\s*,\s*/,$set->restricted_release);
-		my $restriction = $set->restricted_status  ||  0;
-		# round to evade machine rounding error
-		$restriction = sprintf("%.2f", $restriction);
+	    my @proposed_sets  = split(/\s*,\s*/,$set->restricted_release);
+		my $required_score = sprintf("%.2f", $set->restricted_status || 0);
+
 		my @good_sets;
 		foreach(@proposed_sets) {
-		  push @good_sets,$_ if $db->existsGlobalSet($_);
+			push @good_sets,$_ if $db->existsGlobalSet($_);
 		}
-		foreach(@good_sets) {
-	  	  my $restrictor =  $db->getGlobalSet($_);
-		  my $r_score = grade_set($db,$restrictor,$_, $studentName,0);
-		  # round to evade machine rounding error
-		  $r_score = sprintf("%.2f", $r_score);
-		  if($r_score < $restriction) {
-	  	    push @needed,$_;
-		  }
+
+		foreach my $restrictor (@good_sets) {
+			my $r_score = 0;
+			my $restrictor_set = $db->getGlobalSet($restrictor);
+
+			if ($restrictor_set->assignment_type =~ /gateway/) {
+				my @versions = $db->listSetVersions($studentName,$restrictor);
+				foreach (@versions) {
+					my $restrictor_set_version = $db->getSetVersion($studentName,$restrictor,$_);
+					my $v_score = grade_set($db,$restrictor_set_version,$restrictor,$studentName,1);
+					$r_score = $v_score if ($v_score > $r_score);
+				}
+			} else {
+				$r_score = grade_set($db,$restrictor_set,$restrictor,$studentName,0);
+			}
+
+			# round to evade machine rounding error
+			$r_score = sprintf("%.2f", $r_score);
+			if($r_score < $required_score) {
+				push @needed, $restrictor;
+			}
 		}
 	}
 	return unless @needed;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1212,16 +1212,16 @@ sub has_aux_files ($) { #  determine whether a question has auxiliary files
 }
 
 sub is_restricted {
-    my ($db, $set, $studentName) = @_;
+	my ($db, $set, $studentName) = @_;
 
 	# all sets open after the due date
 	return () if after($set->due_date());
 
-    my $setID = $set->set_id();
+	my $setID = $set->set_id();
 	my @needed;
 
 	if ($set->restricted_release ) {
-	    my @proposed_sets  = split(/\s*,\s*/,$set->restricted_release);
+		my @proposed_sets  = split(/\s*,\s*/,$set->restricted_release);
 		my $required_score = sprintf("%.2f", $set->restricted_status || 0);
 
 		my @good_sets;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1234,14 +1234,14 @@ sub is_restricted {
 			my $restrictor_set = $db->getGlobalSet($restrictor);
 
 			if ($restrictor_set->assignment_type =~ /gateway/) {
-				my @versions = $db->listSetVersions($studentName,$restrictor);
+				my @versions = $db->listSetVersions($studentName, $restrictor);
 				foreach (@versions) {
-					my $restrictor_set_version = $db->getSetVersion($studentName,$restrictor,$_);
-					my $v_score = grade_set($db,$restrictor_set_version,$restrictor,$studentName,1);
+					my $restrictor_set_version = $db->getSetVersion($studentName, $restrictor, $_);
+					my $v_score = grade_set($db, $restrictor_set_version, $restrictor, $studentName,1);
 					$r_score = $v_score if ($v_score > $r_score);
 				}
 			} else {
-				$r_score = grade_set($db,$restrictor_set,$restrictor,$studentName,0);
+				$r_score = grade_set($db, $restrictor_set, $restrictor, $studentName, 0);
 			}
 
 			# round to evade machine rounding error


### PR DESCRIPTION
When using the conditional release feature, dependencies on _non_-versioned problem sets have not worked as expected.

This PR changes the logic of `is_restricted` in WeBWorK::Utils to loop through all versions of any versioned set dependency in determining whether or not the required score has been attained.

### Replication
1. Create two sets: a gateway set (GW) and a homework (HW) and add 1 'blankProblem.pg' to each.
2. Enable conditional release in Course Configuration
3. Modify HW to require GW as a conditional release dependency, and require 100% score
4. It helps if GW has only one graded attempt per version, with unlimited versions available
5. Assign both sets to a student user (proper dates etc)
6. Score zero points on version 1 of GW, then generate a new version and score 100% for version 2
7. See that HW is (without this PR) locked even though required score is achieved
8. See that HW is (with this PR) available since required score has been achieved

@dlglin I await your feedback ;P 