### PR TITLE
Add right-to-left language support to the bootstrap update.

### DIFF
--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -24,7 +24,9 @@
     "devDependencies": {
         "autoprefixer": "^10.4.1",
         "chokidar": "^3.5.3",
+        "cssnano": "^5.1.4",
         "postcss": "^8.4.5",
+        "rtlcss": "^3.5.0",
         "sass": "^1.45.2",
         "terser": "^5.10.0",
         "yargs": "^16.2.0"


### PR DESCRIPTION
Bootstrap does not use the same css for right-to-left languages that it uses for left-to-right languages.  Furthermore, some of our local css does not work correctly for right-to-left languages (at least since the bootstrap update).

This adds generation of right-to-left css to the build system.  When scss and css files are processed by generate-assets.js, in addition to generating a minimized and prefixed css file it also generates a rtl variant.  When the lib/WeBWorK/Utils.pm method is called to get a static asset location, it now also checks for a rtl variant when a right-to-left language is enabled.

To make this work css minification is no longer done by sass.  For the right-to-left css we first need to run rtlcss, then autoprefixer, and then minification is done by cssnano.  All of that is done with postcss. Of course for rtl css the rtlcss step is skipped.

openwebwork/pg#663 adds rtl styles for problems.