### PR TITLE
Fix docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ ENV WEBWORK_ROOT=$APP_ROOT/webwork2 \
 # Phase 3 - Ubuntu 20.04 base image + required packages
 
 # Packages changes/added for ubuntu 20.04:
-#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl
+#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl, libemail-stuffer-perl
 
 # Do NOT include "apt-get -y upgrade"
 # see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
@@ -182,6 +182,7 @@ RUN apt-get update \
 	libjson-maybexs-perl \
 	libcpanel-json-xs-perl \
 	libyaml-libyaml-perl \
+	libemail-stuffer-perl \
 	make \
 	netpbm \
 	patch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,9 +97,6 @@ ENV WEBWORK_ROOT=$APP_ROOT/webwork2 \
 
 # Phase 3 - Ubuntu 20.04 base image + required packages
 
-# Packages changes/added for ubuntu 20.04:
-#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl, libemail-stuffer-perl
-
 # Do NOT include "apt-get -y upgrade"
 # see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -17,7 +17,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Phase 2 - Ubuntu 20.04 base image + required packages
 
 # Packages changes/added for ubuntu 20.04:
-#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl
+#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl, libemail-stuffer-perl
 
 # Do NOT include "apt-get -y upgrade"
 # see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
@@ -101,6 +101,7 @@ RUN apt-get update \
 	libjson-maybexs-perl \
 	libcpanel-json-xs-perl \
 	libyaml-libyaml-perl \
+	libemail-stuffer-perl \
 	make \
 	netpbm \
 	patch \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -16,9 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # Phase 2 - Ubuntu 20.04 base image + required packages
 
-# Packages changes/added for ubuntu 20.04:
-#       libcgi-pm-perl (for CGI::Cookie), libdbd-mariadb-perl, libemail-stuffer-perl
-
 # Do NOT include "apt-get -y upgrade"
 # see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -100,7 +100,7 @@ if [ "$1" = 'apache2' ]; then
 
     echo "check admin course and admin tables"
     wait_for_db
-    ADMIN_TABLE_EXISTS=`mysql -u $WEBWORK_DB_USER  -p$WEBWORK_DB_PASSWORD -B -N -h $WEBWORK_DB_HOST -e "select count(*) from information_schema.tables where table_schema='webwork' and table_name = 'admin_user';" 
+    ADMIN_TABLE_EXISTS=`mysql -u $WEBWORK_DB_USER  -p$WEBWORK_DB_PASSWORD -B -N -h $WEBWORK_DB_HOST -e "select count(*) from information_schema.tables where table_schema='webwork' and table_name = 'admin_user';"`
     if [ ! -d "$APP_ROOT/courses/admin" ]; then
         newgrp www-data
         umask 2


### PR DESCRIPTION
There seem to be two issues that come up with the current `docker-compose` routine, i.e. when creating the container via:
```bash
sudo docker build --tag webwork-base:forWW217 -f DockerfileStage1 . && sudo docker-compose build && sudo docker-compose up
```
* Syntax: Missing backtick in `docker-entrypoint.sh`
```
app_1  | /usr/local/bin/docker-entrypoint.sh: line 180: unexpected EOF while looking for matching ``'
```
* Dependencies: `docker-compose` complains about `Email::Stuffer` missing
```
app_1  | AH00526: Syntax error on line 60 of /etc/apache2/conf-enabled/webwork.conf:
app_1  | Can't locate Email/Stuffer.pm in @INC (you may need to install the Email::Stuffer module) (@INC contains: /opt/webwork/pg/lib /opt/webwork/webwork2/lib /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /etc/apache2) at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm line 47.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm line 47.\nCompilation failed in require at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm line 19.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm line 19.\nCompilation failed in require at /usr/share/perl/5.30/base.pm line 137.\n\t...propagated at /usr/share/perl/5.30/base.pm line 159.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm line 18.\nCompilation failed in require at (eval 420) line 1.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/WeBWorK.pm line 88.\nCompilation failed in require at /opt/webwork/webwork2/lib/Apache/WeBWorK.pm line 37.\nBEGIN failed--compilation aborted at /opt/webwork/webwork2/lib/Apache/WeBWorK.pm line 37.\n
```
