### PR TITLE
Update the javascript for SetMaker (the library browser).

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
@@ -296,124 +296,119 @@
 	// Send a request to the webwork webservice and render a problem.
 	const basicWebserviceURL = '/webwork2/html2xml';
 
-	const render = async (id) => {
-		return new Promise(async (resolve) => {
-			const renderArea = document.getElementById(`psr_render_area_${id}`);
+	const render = (id) => new Promise((resolve) => {
+		const renderArea = document.getElementById(`psr_render_area_${id}`);
 
-			const ro = {
-				userID: document.getElementById('hidden_user')?.value,
-				courseID: document.getElementById('hidden_course_id')?.value,
-				session_key: document.getElementById('hidden_key')?.value
-			};
+		const ro = {
+			userID: document.getElementById('hidden_user')?.value,
+			courseID: document.getElementById('hidden_course_id')?.value,
+			session_key: document.getElementById('hidden_key')?.value
+		};
 
-			if (!(ro.userID && ro.courseID && ro.session_key)) {
-				renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
-					+ 'Missing hidden credentials: user, session_key, courseID</div>';
-				resolve();
-				return;
+		if (!(ro.userID && ro.courseID && ro.session_key)) {
+			renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
+				+ 'Missing hidden credentials: user, session_key, courseID</div>';
+			resolve();
+			return;
+		}
+
+		const problemSeed = document.getElementById(`problem.${id}.problem_seed_id`);
+		ro.problemSeed = problemSeed ? problemSeed.value : 1;
+
+		const sourceFile = document.getElementById(`problem.${id}.source_file_id`);
+		ro.sourceFilePath =
+			sourceFile ? sourceFile.value : document.getElementById(`problem_${id}_default_source_file`)?.value;
+
+		if (ro.sourceFilePath.startsWith('group')) {
+			renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0" style="font-weight:bold">'
+				+ 'Problem source is drawn from a grouping set.</div>';
+			resolve();
+			return;
+		}
+
+		const editForUserInputs = document.querySelector('input[name=editForUser]');
+		if (editForUserInputs) ro.effectiveUser = editForUserInputs.value;
+
+		const versionIDInput = document.getElementById('hidden_version_id');
+		if (versionIDInput) ro.version_id = versionIDInput.value;
+
+		ro.outputformat = 'simple';
+		ro.showAnswerNumbers = 0;
+		ro.set_id = $('#hidden_set_id').val();
+		ro.probNum = id;
+		ro.showHints = 1;
+		ro.showSolutions = 1;
+		ro.permissionLevel = 10;
+		ro.noprepostambles = 1;
+		ro.processAnswers = 0;
+		ro.showFooter = 0;
+		ro.displayMode = $('#problem_displaymode').val();
+		ro.send_pg_flags = 1;
+		ro.extra_header_text = '<style>' +
+			'html{overflow-y:hidden;}body{padding:1px;background:#f5f5f5;}.container-fluid{padding:0px;}' +
+			'</style>';
+		if (window.location.port) ro.forcePortNumber = window.location.port;
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+		fetch(
+			basicWebserviceURL,
+			{
+				method: 'post',
+				mode: 'same-origin',
+				body: new URLSearchParams(ro),
+				signal: controller.signal
 			}
-
-			const problemSeed = document.getElementById(`problem.${id}.problem_seed_id`);
-			ro.problemSeed = problemSeed ? problemSeed.value : 1;
-
-			const sourceFile = document.getElementById(`problem.${id}.source_file_id`);
-			ro.sourceFilePath =
-				sourceFile ? sourceFile.value : document.getElementById(`problem_${id}_default_source_file`)?.value;
-
-			if (ro.sourceFilePath.startsWith('group')) {
-				renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0" style="font-weight:bold">'
-					+ 'Problem source is drawn from a grouping set.</div>';
-				resolve();
-				return;
-			}
-
-			const editForUserInputs = document.querySelector('input[name=editForUser]');
-			if (editForUserInputs) ro.effectiveUser = editForUserInputs.value;
-
-			const versionIDInput = document.getElementById('hidden_version_id');
-			if (versionIDInput) ro.version_id = versionIDInput.value;
-
-			ro.outputformat = 'simple';
-			ro.showAnswerNumbers = 0;
-			ro.set_id = $('#hidden_set_id').val();
-			ro.probNum = id;
-			ro.showHints = 1;
-			ro.showSolutions = 1;
-			ro.permissionLevel = 10;
-			ro.noprepostambles = 1;
-			ro.processAnswers = 0;
-			ro.showFooter = 0;
-			ro.displayMode = $('#problem_displaymode').val();
-			ro.send_pg_flags = 1;
-			ro.extra_header_text = '<style>' +
-				'html{overflow-y:hidden;}body{padding:1px;background:#f5f5f5;}.container-fluid{padding:0px;}' +
-				'</style>';
-			if (window.location.port) ro.forcePortNumber = window.location.port;
-
-			const controller = new AbortController();
-			const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-			const response = await fetch(
-				basicWebserviceURL,
-				{
-					method: 'post',
-					mode: 'same-origin',
-					body: new URLSearchParams(ro),
-					signal: controller.signal
-				}
-			);
-
+		).then((response) => {
 			clearTimeout(timeoutId);
-
-			if (response.ok) {
-				const data = await response.json();
-
-				// Give nicer session timeout error
-				if (!data.html || /Can\'t authenticate -- session may have timed out/i.test(data.html) ||
-					/Webservice.pm: Error when trying to authenticate./i.test(data.html)) {
-					renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
-						+ "Can't authenticate -- session may have timed out.</div>";
-					resolve();
-					return;
-				}
-				// Give nicer file not found error
-				if (/this problem file was empty/i.test(data.html)) {
-					renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
-						+ 'No Such File or Directory!</div>';
-					resolve();
-					return;
-				}
-				// Give nicer problem rendering error
-				if (data.pg_flags && data.pg_flags.error_flag  ||
-					/error caught by translator while processing problem/i.test(data.html) ||
-					/error message for command: renderproblem/i.test(data.html)) {
-					renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
-						+ 'There was an error rendering this problem!</div>';
-					resolve();
-					return;
-				}
-
-				const iframe = document.createElement('iframe');
-				iframe.id = `psr_render_iframe_${id}`;
-				iframe.style.border = 'none';
-				iframe.srcdoc = data.html;
-				renderArea.innerHTML = '';
-				renderArea.append(iframe);
-
-				if (data.pg_flags && data.pg_flags.comment)
-					iframe.insertAdjacentHTML('afterend', data.pg_flags.comment);
-				if (data.warnings)
-					iframe.insertAdjacentHTML('afterend', data.warnings);
-
-				iFrameResize({ checkOrigin: false, warningTimeout: 20000, scrolling: 'omit' }, iframe);
-				iframe.addEventListener('load', () => resolve());
-			} else {
+			return response.json();
+		}).then((data) => {
+			// Give nicer session timeout error
+			if (!data.html || /Can\'t authenticate -- session may have timed out/i.test(data.html) ||
+				/Webservice.pm: Error when trying to authenticate./i.test(data.html)) {
 				renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
-					+ `${basicWebserviceURL}: ${data.statusText}` + '</div>';
+					+ "Can't authenticate -- session may have timed out.</div>";
 				resolve();
+				return;
 			}
+			// Give nicer file not found error
+			if (/this problem file was empty/i.test(data.html)) {
+				renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
+					+ 'No Such File or Directory!</div>';
+				resolve();
+				return;
+			}
+			// Give nicer problem rendering error
+			if (data.pg_flags && data.pg_flags.error_flag  ||
+				/error caught by translator while processing problem/i.test(data.html) ||
+				/error message for command: renderproblem/i.test(data.html)) {
+				renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
+					+ 'There was an error rendering this problem!</div>';
+				resolve();
+				return;
+			}
+
+			const iframe = document.createElement('iframe');
+			iframe.id = `psr_render_iframe_${id}`;
+			iframe.style.border = 'none';
+			iframe.srcdoc = data.html;
+			renderArea.innerHTML = '';
+			renderArea.append(iframe);
+
+			if (data.pg_flags && data.pg_flags.comment)
+				iframe.insertAdjacentHTML('afterend', data.pg_flags.comment);
+			if (data.warnings)
+				iframe.insertAdjacentHTML('afterend', data.warnings);
+
+			iFrameResize({ checkOrigin: false, warningTimeout: 20000, scrolling: 'omit' }, iframe);
+			iframe.addEventListener('load', () => resolve());
+		}).catch((err) => {
+			renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0 fw-bold">'
+				+ `${basicWebserviceURL}: ${err.message}` + '</div>';
+			resolve();
 		});
-	}
+	});
 
 	// Set up the problem render buttons.
 	document.querySelectorAll('.pdr_render').forEach((renderButton) => {

--- a/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
@@ -342,7 +342,8 @@
 		ro.noprepostambles = 1;
 		ro.processAnswers = 0;
 		ro.showFooter = 0;
-		ro.displayMode = $('#problem_displaymode').val();
+		ro.displayMode = document.getElementById('problem_displaymode')?.value ?? 'MathJax';
+		ro.language = document.querySelector('input[name="hidden_language"]')?.value ?? 'en';
 		ro.send_pg_flags = 1;
 		ro.extra_header_text = '<style>' +
 			'html{overflow-y:hidden;}body{padding:1px;background:#f5f5f5;}.container-fluid{padding:0px;}' +

--- a/htdocs/js/apps/SetMaker/setmaker.js
+++ b/htdocs/js/apps/SetMaker/setmaker.js
@@ -455,7 +455,8 @@
 		ro.noprepostambles = 1;
 		ro.processAnswers = 0;
 		ro.showFooter = 0;
-		ro.displayMode = document.querySelector('select[name="mydisplayMode"]').value;
+		ro.displayMode = document.querySelector('select[name="mydisplayMode"]').value ?? 'MathJax';
+		ro.language = document.querySelector('input[name="hidden_language"]')?.value ?? 'en';
 
 		// Abort if the display mode is not set to None
 		if (ro.displayMode === 'None') {

--- a/lib/Apache/WeBWorK.pm
+++ b/lib/Apache/WeBWorK.pm
@@ -240,34 +240,37 @@ sub htmlMessage($$$@) {
 <div style="text-align:left">
  <h1>WeBWorK error</h1>
  <p>An error occured while processing your request.</p>
- <p>For help, please send mail to this site's webmaster $admin, including all of the following information as well as what what you were doing when the error occured.</p>
+ <p>For help, please send mail to this site's webmaster $admin, including all of the following information as well as
+    what what you were doing when the error occured.</p>
  <h2>Error record identifier</h2>
- <p style="margin-left: 5em; color: #dc2a2a"><code>$uuid</code></p>
+ <p style="margin-left: 2em; color: #dc2a2a"><code>$uuid</code></p>
  <h2>Warning messages</h2>
  <ul>$warnings</ul>
  <h2>Error messages</h2>
- <p style="margin-left: 5em; color: #dc2a2a"><code>$exception</code></p>
+ <p style="margin-left: 2em; color: #dc2a2a"><code>$exception</code></p>
  <h2>Call stack</h2>
    <p>The following information can help locate the source of the problem.</p>
    <ul>$backtrace</ul>
  <h2>Request information</h2>
- <div style="margin-left: 5em;">
+ <div>
  <p>The HTTP request information is included in the following table.</p>
- <table border="1" aria-labelledby="req_info_summary1">
+ <div class="table-responsive">
+ <table class="table table-bordered caption-top" border="1" aria-labelledby="req_info_summary1">
   <caption id="req_info_summary1">HTTP request information</caption>
   <tr><th id="outer_item">Item</th><th id="outer_data">Data</th></tr>
   <tr><td headers="outer_item">Method</td><td headers="outer_data">$method</td></tr>
-  <tr><td headers="outer_item">URI</td headers="outer_data"><td headers="outer_data">$uri</td></tr>
-  <tr><td headers="outer_item"">HTTP Headers</td><td headers="outer_data">
-   <table width="90%" aria-labelledby="req_header_summary">
+  <tr><td headers="outer_item">URI</td><td headers="outer_data">$uri</td></tr>
+  <tr><td headers="outer_item">HTTP Headers</td><td headers="outer_data">
+   <table class="table table-bordered caption-top" aria-labelledby="req_header_summary">
     <caption id="req_header_summary">HTTP request headers</caption>
     $headers
    </table>
   </td></tr>
  </table>
  </div>
+ </div>
  <h2>Time generated:</h2>
- <p style="margin-left: 5em;">$time</p>
+ <p style="margin-left: 2em;">$time</p>
 </div>
 </main>
 EOF

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -2271,6 +2271,9 @@ sub body {
 	print CGI::input({type=>"hidden", id=>"hidden_set_id", name=>"setID", value=>$setID});
 	print CGI::input({type=>"hidden", id=>"hidden_version_id", name=>"versionID", value=>$editingSetVersion}) if $editingSetVersion;
 
+	# Add the course language in a hidden input so that the javascript can get this information.
+	print CGI::hidden({ name => 'hidden_language', value => $ce->{language} });
+
 	print CGI::div({ class => 'my-3 submit-buttons-container' },
 		CGI::submit({
 			name => "submit_changes",

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1059,17 +1059,19 @@ sub make_top_row {
 	print CGI::div(
 		{ class => 'd-flex flex-wrap justify-content-center' },
 		CGI::submit({
-			name    => "new_local_set",
-			value   => $r->maketext("Create a New Set in This Course:"),
-			onclick => "document.library_browser_form.selfassign.value=1",
+			name    => 'new_local_set',
+			id      => 'new_local_set',
+			value   => $r->maketext('Create a New Set in This Course:'),
+			onclick => 'document.library_browser_form.selfassign.value=1',
 			class   => 'btn btn-primary btn-sm mb-2 mx-2'
 		}),
 		CGI::textfield({
-			name        => "new_set_name",
-			placeholder => $r->maketext("New set name"),
-			override    => 1,
-			size        => 30,
-			class       => 'form-control form-control-sm d-inline w-auto mb-2'
+			name            => 'new_set_name',
+			aria_labelledby => 'new_local_set',
+			placeholder     => $r->maketext('New set name'),
+			override        => 1,
+			size            => 30,
+			class           => 'form-control form-control-sm d-inline w-auto mb-2'
 		})
 	);
 
@@ -2101,6 +2103,10 @@ sub body {
 	print CGI::start_form({ method => "POST", action => $r->uri, name => 'library_browser_form' }),
 		$self->hidden_authen_fields,
 		CGI::hidden({ id => 'hidden_courseID', name => 'courseID', default => $courseID });
+
+	# Add the course language in a hidden input so that the javascript can get this information.
+	print CGI::hidden({ name => 'hidden_language', value => $ce->{language} });
+
 	print CGI::hidden(-name=>'browse_which', -value=>$browse_which,-override=>1),
 		CGI::hidden(-name=>'problem_seed', -value=>$problem_seed, -override=>1);
 	for ($j = 0 ; $j < scalar(@pg_files) ; $j++) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -31,7 +31,8 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::Form;
-use WeBWorK::Utils qw(readDirectory max sortByName wwRound x getAssetURL format_set_name_internal);
+use WeBWorK::Utils qw(readDirectory max sortByName wwRound x getAssetURL format_set_name_internal
+	format_set_name_display);
 use WeBWorK::Utils::Tasks qw(renderProblems);
 use WeBWorK::Utils::Tags;
 use WeBWorK::Utils::LibraryStats;
@@ -486,7 +487,7 @@ sub browse_mysets_panel {
 	my $r = $self->r;
 	my $library_selected = shift // '';
 	my $list_of_local_sets = shift;
-	my $labels_for_local_sets = { map { $_ => $_ =~ s/_/ /gr } @$list_of_local_sets };
+	my $labels_for_local_sets = { map { $_ => format_set_name_display($_) } @$list_of_local_sets };
 
 	if (@$list_of_local_sets == 0) {
 		$list_of_local_sets = [''];
@@ -507,7 +508,8 @@ sub browse_mysets_panel {
 				values  => $list_of_local_sets,
 				labels  => $labels_for_local_sets,
 				default => $library_selected,
-				class   => 'form-select form-select-sm d-inline w-auto'
+				class   => 'form-select form-select-sm d-inline w-auto',
+				dir     => 'ltr'
 			})
 		),
 		view_problems_line('view_mysets_set', $r->maketext('View Problems'), $self->r)
@@ -1002,7 +1004,7 @@ sub make_top_row {
 	my %data = @_;
 
 	my $list_of_local_sets = $data{all_db_sets};
-	my $labels_for_local_sets = { map { $_ => $_ =~ s/_/ /gr } @$list_of_local_sets };
+	my $labels_for_local_sets = { map { $_ => format_set_name_display($_) } @$list_of_local_sets };
 	my $browse_which = $data{browse_which};
 	my $library_selected = $self->{current_library_set};
 	my $set_selected = $r->param('local_sets') // '';
@@ -1041,6 +1043,7 @@ sub make_top_row {
 				default  => $set_selected,
 				override => 1,
 				class    => 'form-select form-select-sm d-inline w-auto mx-2',
+				dir      => 'ltr',
 				data_no_set_selected => $r->maketext('No Target Set Selected'),
 				data_pick_target_set => $r->maketext('Pick a target set above to add this problem to.'),
 				data_problems_added => $r->maketext('Problems Added'),
@@ -1071,7 +1074,8 @@ sub make_top_row {
 			placeholder     => $r->maketext('New set name'),
 			override        => 1,
 			size            => 30,
-			class           => 'form-control form-control-sm d-inline w-auto mb-2'
+			class           => 'form-control form-control-sm d-inline w-auto mb-2',
+			dir             => 'ltr'
 		})
 	);
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -47,24 +47,18 @@ use constant SHOW_HINTS_DEFAULT => 0;
 use constant SHOW_SOLUTIONS_DEFAULT => 0;
 use constant MAX_SHOW_DEFAULT => 20;
 use constant NO_LOCAL_SET_STRING => x('No sets in this course yet');
-use constant SELECT_SET_STRING => x('Select a Set from this Course');
-use constant SELECT_LOCAL_STRING => x('Select a Problem Collection');
 use constant MY_PROBLEMS => x('My Problems');
 use constant MAIN_PROBLEMS => x('Unclassified Problems');
-use constant ALL_CHAPTERS => 'All Chapters';
-use constant ALL_SUBJECTS => 'All Subjects';
-use constant ALL_SECTIONS => 'All Sections';
-use constant ALL_TEXTBOOKS => 'All Textbooks';
 
 use constant LIB2_DATA => {
-  'dbchapter' => {name => 'library_chapters', all => 'All Chapters'},
-  'dbsection' =>  {name => 'library_sections', all =>'All Sections' },
-  'dbsubject' =>  {name => 'library_subjects', all => 'All Subjects' },
-  'textbook' =>  {name => 'library_textbook', all =>  'All Textbooks'},
-  'textchapter' => {name => 'library_textchapter', all => 'All Chapters'},
-  'textsection' => {name => 'library_textsection', all => 'All Sections'},
-  'keywords' =>  {name => 'library_keywords', all => '' },
-  };
+	'dbchapter'   => { name => 'library_chapters',    all => x('All Chapters') },
+	'dbsection'   => { name => 'library_sections',    all => x('All Sections') },
+	'dbsubject'   => { name => 'library_subjects',    all => x('All Subjects') },
+	'textbook'    => { name => 'library_textbook',    all => x('All Textbooks') },
+	'textchapter' => { name => 'library_textchapter', all => x('All Chapters') },
+	'textsection' => { name => 'library_textsection', all => x('All Sections') },
+	'keywords'    => { name => 'library_keywords',    all => '' },
+};
 
 ## Flags for operations on files
 
@@ -442,44 +436,45 @@ sub view_problems_line {
 # The browsing panel has three versions.
 # Version 1 is local problems
 sub browse_local_panel {
-	my $self = shift;
-	my $r = $self->r;
-	my $library_selected = shift;
-	my $lib = shift || ''; $lib =~ s/^browse_//;
-	my $name = ($lib eq '')? $r->maketext('Local') : Encode::decode("UTF-8",$problib{$lib});
+	my $self             = shift;
+	my $r                = $self->r;
+	my $library_selected = shift // '';
+	my $lib              = (shift || '') =~ s/^browse_//r;
 
-	my $list_of_prob_dirs= get_problem_directories($r,$lib);
-	if(scalar(@$list_of_prob_dirs) == 0) {
-		$library_selected = $r->maketext("Found no directories containing problems");
-		unshift @{$list_of_prob_dirs}, $library_selected;
-	} else {
-		my $default_value = $r->maketext(SELECT_LOCAL_STRING);
-		if (!defined $library_selected or $library_selected eq $default_value) {
-			unshift @{$list_of_prob_dirs},	$default_value;
-			$library_selected = $default_value;
-		}
+	my $list_of_prob_dirs    = get_problem_directories($r, $lib);
+	my $labels_for_prob_dirs = $lib
+		# Make labels without the $lib prefix.  This reduces the width of the popup menu.
+		? { map { $_ => $_ =~ s/^$lib\/(.*)$/$1/r } @$list_of_prob_dirs }
+		: { map { $_ => $_ } @$list_of_prob_dirs };
+
+	if (@$list_of_prob_dirs == 0) {
+		unshift @$list_of_prob_dirs, '';
+		$labels_for_prob_dirs->{''} = $r->maketext("Found no directories containing problems");
+	} elsif ($library_selected eq '') {
+		unshift @$list_of_prob_dirs, '';
+		$labels_for_prob_dirs->{''} = $r->maketext('Select a Problem Collection');
 	}
 	debug("library is $lib and sets are $library_selected");
-
-	my $popup_menu_args = {
-		name    => 'library_sets',
-		id      => 'library_sets',
-		values  => $list_of_prob_dirs,
-		default => $library_selected,
-		class   => 'form-select form-select-sm d-inline w-auto'
-	};
-
-	# Make labels without the $lib prefix.  This reduces the width of the popup menu.
-	if (length($lib)) {
-		$popup_menu_args->{labels} = { map { my ($l) = $_ =~ /^$lib\/(.*)$/; $_ => $l } @$list_of_prob_dirs };
-	}
 
 	print CGI::div(
 		{ class => "InfoPanel" },
 		CGI::div(
 			{ class => 'mb-2' },
-			CGI::label({ for => 'library_sets', class => 'col-form-label-sm' }, $r->maketext("[_1] Problems:", $name)),
-			CGI::popup_menu($popup_menu_args)
+			CGI::label(
+				{ for => 'library_sets', class => 'col-form-label-sm' },
+				$r->maketext(
+					"[_1] Problems:",
+					$lib eq '' ? $r->maketext('Local') : Encode::decode("UTF-8", $problib{$lib})
+				)
+			),
+			CGI::popup_menu({
+				name    => 'library_sets',
+				id      => 'library_sets',
+				values  => $list_of_prob_dirs,
+				labels  => $labels_for_prob_dirs,
+				default => $library_selected,
+				class   => 'form-select form-select-sm d-inline w-auto'
+			})
 		),
 		view_problems_line('view_local_set', $r->maketext('View Problems'), $self->r),
 	);
@@ -489,15 +484,16 @@ sub browse_local_panel {
 sub browse_mysets_panel {
 	my $self = shift;
 	my $r = $self->r;
-	my $library_selected = shift;
+	my $library_selected = shift // '';
 	my $list_of_local_sets = shift;
-	my $default_value = $r->maketext("Select a Homework Set");
+	my $labels_for_local_sets = { map { $_ => $_ =~ s/_/ /gr } @$list_of_local_sets };
 
-	if(scalar(@$list_of_local_sets) == 0) {
-		$list_of_local_sets = [$r->maketext(NO_LOCAL_SET_STRING)];
-	} elsif (!defined $library_selected or $library_selected eq $default_value) {
-		unshift @{$list_of_local_sets},	 $default_value;
-		$library_selected = $default_value;
+	if (@$list_of_local_sets == 0) {
+		$list_of_local_sets = [''];
+		$labels_for_local_sets->{''} = $r->maketext(NO_LOCAL_SET_STRING);
+	} elsif ($library_selected eq '') {
+		unshift @$list_of_local_sets, '';
+		$labels_for_local_sets->{''} = $r->maketext('Select a Homework Set');
 	}
 
 	print CGI::div(
@@ -509,6 +505,7 @@ sub browse_mysets_panel {
 				name    => 'library_sets',
 				id      => 'library_sets',
 				values  => $list_of_local_sets,
+				labels  => $labels_for_local_sets,
 				default => $library_selected,
 				class   => 'form-select form-select-sm d-inline w-auto'
 			})
@@ -553,7 +550,6 @@ HERE
 	# Now check what version we are supposed to use
 	my $libraryVersion = $r->{ce}{problemLibrary}{version} || 2;
 	if ($libraryVersion == 1) {
-		#return $self->browse_library_panel1;
 		print CGI::div(
 			{ class => 'alert alert-danger p-1 mb-2', align => "center" },
 			"Problem library version 1 is no longer supported."
@@ -571,66 +567,24 @@ HERE
 	}
 }
 
-# FIXME:  This needs to be deleted.  The methods called here are commented out in WeBWorK::Utils::ListingDB.
-sub browse_library_panel1 {
-	my $self = shift;
-	my $r = $self->r;
-	my $ce = $r->ce;
-
-	my @chaps = WeBWorK::Utils::ListingDB::getAllChapters($r->{ce});
-	unshift @chaps, LIB2_DATA->{dbchapter}{all};
-	my $chapter_selected = $r->param('library_chapters') || LIB2_DATA->{dbchapter}->{all};
-
-	my @sects=();
-	if ($chapter_selected ne LIB2_DATA->{dbchapter}{all}) {
-		@sects = WeBWorK::Utils::ListingDB::getAllSections($r->{ce}, $chapter_selected);
-	}
-
-	unshift @sects, ALL_SECTIONS;
-	my $section_selected =	$r->param('library_sections') || LIB2_DATA->{dbsection}{all};
-
-	my $view_problem_line = view_problems_line('lib_view', $r->maketext('View Problems'), $self->r);
-
-	print CGI::Tr(CGI::td({-class=>"InfoPanel"},
-		CGI::start_table(),
-			CGI::Tr({},
-				CGI::td([$r->maketext("Chapter:"),
-					CGI::popup_menu(-name=> 'library_chapters',
-					                -values=>\@chaps,
-					                -default=> $chapter_selected
-					),
-					CGI::submit({
-						name => "lib_select_chapter",
-						value => "Update Section List",
-						class => 'btn btn-secondary btn-sm'
-					})
-				])),
-			CGI::Tr({},
-				CGI::td($r->maketext("Section:")),
-				CGI::td({-colspan=>2},
-					CGI::popup_menu(-name=> 'library_sections',
-					                -values=>\@sects,
-					                -default=> $section_selected
-			))),
-
-			CGI::Tr(CGI::td({-colspan=>3}, $view_problem_line)),
-			CGI::end_table(),
-		));
-}
-
 sub browse_library_panel2 {
 	my $self = shift;
 	my $r    = $self->r;
 
-	my @subjs = WeBWorK::Utils::ListingDB::getAllDBsubjects($r);
+	my @subjs       = WeBWorK::Utils::ListingDB::getAllDBsubjects($r);
+	my $subj_labels = { map { $_ => $_ } @subjs };
 	unshift @subjs, LIB2_DATA->{dbsubject}{all};
+	$subj_labels->{ LIB2_DATA->{dbsubject}{all} } = $r->maketext(LIB2_DATA->{dbsubject}{all});
 
-	my @chaps = WeBWorK::Utils::ListingDB::getAllDBchapters($r);
+	my @chaps       = WeBWorK::Utils::ListingDB::getAllDBchapters($r);
+	my $chap_labels = { map { $_ => $_ } @chaps };
 	unshift @chaps, LIB2_DATA->{dbchapter}{all};
+	$chap_labels->{ LIB2_DATA->{dbchapter}{all} } = $r->maketext(LIB2_DATA->{dbchapter}{all});
 
-	my @sects = ();
-	@sects = WeBWorK::Utils::ListingDB::getAllDBsections($r);
+	my @sects       = WeBWorK::Utils::ListingDB::getAllDBsections($r);
+	my $sect_labels = { map { $_ => $_ } @sects };
 	unshift @sects, LIB2_DATA->{dbsection}{all};
+	$sect_labels->{ LIB2_DATA->{dbsection}{all} } = $r->maketext(LIB2_DATA->{dbsection}{all});
 
 	my $count_line = WeBWorK::Utils::ListingDB::countDBListings($r);
 	if ($count_line == 0) {
@@ -658,6 +612,7 @@ sub browse_library_panel2 {
 							name    => 'library_subjects',
 							id      => 'library_subjects',
 							values  => \@subjs,
+							labels  => $subj_labels,
 							default => $r->param('library_subjects') || LIB2_DATA->{dbsubject}{all},
 							class   => 'form-select form-select-sm'
 						})
@@ -675,6 +630,7 @@ sub browse_library_panel2 {
 							name    => 'library_chapters',
 							id      => 'library_chapters',
 							values  => \@chaps,
+							labels  => $chap_labels,
 							default => $r->param('library_chapters') || LIB2_DATA->{dbchapter}{all},
 							class   => 'form-select form-select-sm'
 						})
@@ -692,6 +648,7 @@ sub browse_library_panel2 {
 							name    => 'library_sections',
 							id      => 'library_sections',
 							values  => \@sects,
+							labels  => $sect_labels,
 							default => $r->param('library_sections') || LIB2_DATA->{dbsection}{all},
 							class   => 'form-select form-select-sm'
 						})
@@ -699,7 +656,8 @@ sub browse_library_panel2 {
 				)
 			),
 			CGI::div(
-				{ class =>
+				{
+					class =>
 						'col-md-3 col-sm-4 mb-1 d-flex flex-sm-column justify-content-sm-start justify-content-center'
 				},
 				CGI::submit({
@@ -725,100 +683,66 @@ sub browse_library_panel2adv {
 	my $right_button_style = 'max-width:9rem';
 
 	my @subjs = WeBWorK::Utils::ListingDB::getAllDBsubjects($r);
-	if (!grep { $_ eq $r->param('library_subjects') } @subjs) {
-		$r->param('library_subjects', '');
-	}
+	$r->param('library_subjects', '') if (!grep { $_ eq $r->param('library_subjects') } @subjs);
+	my $subj_labels = { map { $_ => $_ } @subjs };
 	unshift @subjs, LIB2_DATA->{dbsubject}{all};
+	$subj_labels->{ LIB2_DATA->{dbsubject}{all} } = $r->maketext(LIB2_DATA->{dbsubject}{all});
 
 	my @chaps = WeBWorK::Utils::ListingDB::getAllDBchapters($r);
-	if (!grep { $_ eq $r->param('library_chapters') } @chaps) {
-		$r->param('library_chapters', '');
-	}
+	$r->param('library_chapters', '') if (!grep { $_ eq $r->param('library_chapters') } @chaps);
+	my $chap_labels = { map { $_ => $_ } @chaps };
 	unshift @chaps, LIB2_DATA->{dbchapter}{all};
+	$chap_labels->{ LIB2_DATA->{dbchapter}{all} } = $r->maketext(LIB2_DATA->{dbchapter}{all});
 
 	my @sects = WeBWorK::Utils::ListingDB::getAllDBsections($r);
-	if (!grep { $_ eq $r->param('library_sections') } @sects) {
-		$r->param('library_sections', '');
-	}
+	$r->param('library_sections', '') if (!grep { $_ eq $r->param('library_sections') } @sects);
+	my $sect_labels = { map { $_ => $_ } @sects };
 	unshift @sects, LIB2_DATA->{dbsection}{all};
+	$sect_labels->{ LIB2_DATA->{dbsection}{all} } = $r->maketext(LIB2_DATA->{dbsection}{all});
 
 	my $texts      = WeBWorK::Utils::ListingDB::getDBTextbooks($r);
 	my @textarray  = map { $_->[0] } @{$texts};
-	my %textlabels = ();
-	for my $ta (@{$texts}) {
-		$textlabels{ $ta->[0] } = $ta->[1] . " by " . $ta->[2] . " (edition " . $ta->[3] . ")";
-	}
-	if (!grep { $_ eq $r->param('library_textbook') } @textarray) {
-		$r->param('library_textbook', '');
-	}
+	my $textlabels = { map { $_->[0] => $_->[1] . " by " . $_->[2] . " (edition " . $_->[3] . ")" } @$texts };
+	$r->param('library_textbook', '') if (!grep { $_ eq $r->param('library_textbook') } @textarray);
 	unshift @textarray, LIB2_DATA->{textbook}{all};
-	my $atb = LIB2_DATA->{textbook}{all};
-	$textlabels{$atb} = LIB2_DATA->{textbook}{all};
+	$textlabels->{ LIB2_DATA->{textbook}{all} } = $r->maketext(LIB2_DATA->{textbook}{all});
 
-	my $textchap_ref = WeBWorK::Utils::ListingDB::getDBTextbooks($r, 'textchapter');
-	my @textchaps    = map { $_->[0] } @{$textchap_ref};
-	if (!grep { $_ eq $r->param('library_textchapter') } @textchaps) {
-		$r->param('library_textchapter', '');
-	}
+	my $textchap_ref    = WeBWorK::Utils::ListingDB::getDBTextbooks($r, 'textchapter');
+	my @textchaps       = map { $_->[0] } @{$textchap_ref};
+	my $textchap_labels = { map { $_ => $_ } @textchaps };
+	$r->param('library_textchapter', '') if (!grep { $_ eq $r->param('library_textchapter') } @textchaps);
 	unshift @textchaps, LIB2_DATA->{textchapter}{all};
+	$textchap_labels->{ LIB2_DATA->{textchapter}{all} } = $r->maketext(LIB2_DATA->{textchapter}{all});
 
-	my $textsec_ref = WeBWorK::Utils::ListingDB::getDBTextbooks($r, 'textsection');
-	my @textsecs    = map { $_->[0] } @{$textsec_ref};
-	if (!grep { $_ eq $r->param('library_textsection') } @textsecs) {
-		$r->param('library_textsection', '');
-	}
+	my $textsec_ref    = WeBWorK::Utils::ListingDB::getDBTextbooks($r, 'textsection');
+	my @textsecs       = map { $_->[0] } @{$textsec_ref};
+	my $textsec_labels = { map { $_ => $_ } @textsecs };
+	$r->param('library_textsection', '') if (!grep { $_ eq $r->param('library_textsection') } @textsecs);
 	unshift @textsecs, LIB2_DATA->{textsection}{all};
+	$textsec_labels->{ LIB2_DATA->{textsection}{all} } = $r->maketext(LIB2_DATA->{textsection}{all});
 
 	my %selected = ();
 	for my $j (qw( dbsection dbchapter dbsubject textbook textchapter textsection )) {
 		$selected{$j} = $r->param(LIB2_DATA->{$j}{name}) || LIB2_DATA->{$j}{all};
 	}
 
-	my $text_popup = CGI::popup_menu({
-		name     => 'library_textbook',
-		id       => 'library_textbook',
-		values   => \@textarray,
-		labels   => \%textlabels,
-		default  => $selected{textbook},
-		onchange => "submit();return true",
-		class    => 'form-select form-select-sm'
-	});
-
-	my $count_line = WeBWorK::Utils::ListingDB::countDBListings($r);
-	if ($count_line == 0) {
-		$count_line = "There are no matching WeBWorK problems";
-	} else {
-		$count_line = "There are $count_line matching WeBWorK problems";
-	}
+	my $listingsCount = WeBWorK::Utils::ListingDB::countDBListings($r);
+	my $count_line =
+		$listingsCount == 0
+		? 'There are no matching WeBWorK problems'
+		: "There are $listingsCount matching WeBWorK problems";
 
 	# Formatting level checkboxes by hand
 	my %selected_levels = map { $_ => 1 } $r->param('level');
-
-	my $mylevelline = CGI::div(
-		{ class => 'd-flex justify-content-between align-items-center' },
-		(
-			map {
-				CGI::div(
-					{ class => 'form-check form-check-inline' },
-					CGI::checkbox({
-						name            => 'level',
-						value           => $_,
-						label           => $_,
-						class           => 'form-check-input',
-						checked         => defined($selected_levels{$_}),
-						labelattributes => { class => 'form-check-label col-form-label-sm' }
-					})
-				)
-			} 1 .. 6
-		),
-		$self->helpMacro("Levels")
-	);
 
 	print CGI::div(
 		CGI::hidden({ name => "library_is_basic", default => 2, override => 1 }),
 		CGI::div(
 			{ class => 'text-center' },
-			CGI::label({ class => 'col-form-label-sm pt-0' }, $r->maketext('All Selected Constraints Joined by "And"'))
+			CGI::label(
+				{ class => 'col-form-label-sm pt-0' },
+				$r->maketext('All Selected Constraints Joined by "And"')
+			)
 		),
 		CGI::div(
 			{ class => 'row mb-1' },
@@ -837,6 +761,7 @@ sub browse_library_panel2adv {
 							name    => 'library_subjects',
 							id      => 'library_subjects',
 							values  => \@subjs,
+							labels  => $subj_labels,
 							default => $selected{dbsubject},
 							class   => 'form-select form-select-sm',
 						})
@@ -854,6 +779,7 @@ sub browse_library_panel2adv {
 							name    => 'library_chapters',
 							id      => 'library_chapters',
 							values  => \@chaps,
+							labels  => $chap_labels,
 							default => $selected{dbchapter},
 							class   => 'form-select form-select-sm',
 						})
@@ -871,6 +797,7 @@ sub browse_library_panel2adv {
 							name    => 'library_sections',
 							id      => 'library_sections',
 							values  => \@sects,
+							labels  => $sect_labels,
 							default => $selected{dbsection},
 							class   => 'form-select form-select-sm',
 						})
@@ -888,7 +815,7 @@ sub browse_library_panel2adv {
 							name     => 'library_textbook',
 							id       => 'library_textbook',
 							values   => \@textarray,
-							labels   => \%textlabels,
+							labels   => $textlabels,
 							default  => $selected{textbook},
 							onchange => "submit();return true",
 							class    => 'form-select form-select-sm'
@@ -898,17 +825,20 @@ sub browse_library_panel2adv {
 				CGI::div(
 					{ class => 'row mb-1' },
 					CGI::label(
-						{ for => 'library_textchapter', class => 'col-3 col-form-label col-form-label-sm text-nowrap' },
+						{
+							for   => 'library_textchapter',
+							class => 'col-3 col-form-label col-form-label-sm text-nowrap'
+						},
 						$r->maketext('Text chapter:')
 					),
 					CGI::div(
 						{ class => 'col-9' },
 						CGI::popup_menu({
-							name     => 'library_textbook',
-							id       => 'library_textbook',
-							values   => \@textarray,
-							labels   => \%textlabels,
-							default  => $selected{textbook},
+							name     => 'library_textchapter',
+							id       => 'library_textchapter',
+							values   => \@textchaps,
+							labels   => $textchap_labels,
+							default  => $selected{textchapter},
 							onchange => "submit();return true",
 							class    => 'form-select form-select-sm'
 						})
@@ -917,7 +847,10 @@ sub browse_library_panel2adv {
 				CGI::div(
 					{ class => 'row mb-1' },
 					CGI::label(
-						{ for => 'library_textsection', class => 'col-3 col-form-label col-form-label-sm text-nowrap' },
+						{
+							for   => 'library_textsection',
+							class => 'col-3 col-form-label col-form-label-sm text-nowrap'
+						},
 						$r->maketext('Text section:')
 					),
 					CGI::div(
@@ -926,6 +859,7 @@ sub browse_library_panel2adv {
 							name     => 'library_textsection',
 							id       => 'library_textsection',
 							values   => \@textsecs,
+							labels   => $textsec_labels,
 							default  => $selected{textsection},
 							onchange => "submit();return true",
 							class    => 'form-select form-select-sm',
@@ -935,7 +869,28 @@ sub browse_library_panel2adv {
 				CGI::div(
 					{ class => 'row mb-1' },
 					CGI::label({ class => 'col-3 col-form-label col-form-label-sm' }, $r->maketext("Level:")),
-					CGI::div({ class => 'col-9' }, $mylevelline),
+					CGI::div(
+						{ class => 'col-9' },
+						CGI::div(
+							{ class => 'd-flex justify-content-between align-items-center' },
+							(
+								map {
+									CGI::div(
+										{ class => 'form-check form-check-inline' },
+										CGI::checkbox({
+											name            => 'level',
+											value           => $_,
+											label           => $_,
+											class           => 'form-check-input',
+											checked         => defined($selected_levels{$_}),
+											labelattributes => { class => 'form-check-label col-form-label-sm' }
+										})
+									)
+								} 1 .. 6
+							),
+							$self->helpMacro("Levels")
+						)
+					),
 				),
 				CGI::div(
 					{ class => 'row mb-1' },
@@ -956,7 +911,8 @@ sub browse_library_panel2adv {
 				)
 			),
 			CGI::div(
-				{ class =>
+				{
+					class =>
 						'col-md-3 col-sm-4 mb-1 d-flex flex-sm-column justify-content-sm-start justify-content-center'
 				},
 				CGI::submit({
@@ -982,7 +938,12 @@ sub browse_library_panel2adv {
 		view_problems_line('lib_view', $r->maketext('View Problems'), $self->r),
 		CGI::div(
 			{ class => 'text-center', id => 'library_count_line' },
-			CGI::label({ class => 'col-form-label-sm' }, $count_line)
+			CGI::label(
+				{ class => 'col-form-label-sm' },
+				$listingsCount == 0
+				? 'There are no matching WeBWorK problems'
+				: "There are $listingsCount matching WeBWorK problems"
+			)
 		)
 	);
 }
@@ -992,14 +953,14 @@ sub browse_setdef_panel {
 	my $self             = shift;
 	my $r                = $self->r;
 	my $ce               = $r->ce;
-	my $library_selected = shift;
-	my $default_value    = 'Select a Set Definition File';
+	my $library_selected = shift // '';
 
 	# In the following line, the parens after sort are important. If they are
 	# omitted, sort will interpret get_set_defs as the name of the comparison
 	# function, and ($ce->{courseDirs}{templates}) as a single element list to
 	# be sorted.
 	my @list_of_set_defs = sort(get_set_defs($ce->{courseDirs}{templates}));
+	my $labels_for_set_defs = { map { $_ => $_ } @list_of_set_defs };
 
 	if (scalar(@list_of_set_defs) == 0) {
 		print CGI::div(
@@ -1012,9 +973,9 @@ sub browse_setdef_panel {
 		return;
 	}
 
-	if (!defined $library_selected || $library_selected eq $default_value) {
-		unshift @list_of_set_defs, $default_value;
-		$library_selected = $default_value;
+	if ($library_selected eq '') {
+		$labels_for_set_defs->{''} = $r->maketext('Select a Set Definition File');
+		unshift @list_of_set_defs, '';
 	}
 
 	print CGI::div(
@@ -1025,6 +986,7 @@ sub browse_setdef_panel {
 			CGI::popup_menu({
 				name    => 'library_sets',
 				values  => \@list_of_set_defs,
+				labels  => $labels_for_set_defs,
 				default => $library_selected,
 				class => 'form-select form-select-sm d-inline w-auto'
 			})
@@ -1040,10 +1002,10 @@ sub make_top_row {
 	my %data = @_;
 
 	my $list_of_local_sets = $data{all_db_sets};
-	my $have_local_sets = scalar(@$list_of_local_sets);
+	my $labels_for_local_sets = { map { $_ => $_ =~ s/_/ /gr } @$list_of_local_sets };
 	my $browse_which = $data{browse_which};
 	my $library_selected = $self->{current_library_set};
-	my $set_selected = $r->param('local_sets');
+	my $set_selected = $r->param('local_sets') // '';
 	my (@dis1, @dis2, @dis3, @dis4) = ();
 	@dis1 = (disabled => undef) if ($browse_which eq 'browse_npl_library');
 	@dis2 = (disabled => undef) if ($browse_which eq 'browse_local');
@@ -1052,11 +1014,12 @@ sub make_top_row {
 
 	my $these_widths = "width:9.3rem";
 
-	if ($have_local_sets == 0) {
-		$list_of_local_sets = [ $r->maketext(NO_LOCAL_SET_STRING) ];
-	} elsif (!defined $set_selected || $set_selected eq $r->maketext(SELECT_SET_STRING)) {
-		unshift @{$list_of_local_sets}, $r->maketext(SELECT_SET_STRING);
-		$set_selected = $r->maketext(SELECT_SET_STRING);
+	if (@$list_of_local_sets == 0) {
+		$list_of_local_sets = [''];
+		$labels_for_local_sets->{''} = $r->maketext(NO_LOCAL_SET_STRING);
+	} elsif ($set_selected eq '') {
+		unshift @{$list_of_local_sets}, '';
+		$labels_for_local_sets->{''} = $r->maketext('Select a Set from this Course');
 	}
 	my $courseID = $self->r->urlpath->arg("courseID");
 
@@ -1074,9 +1037,15 @@ sub make_top_row {
 				name     => 'local_sets',
 				id       => 'local_sets',
 				values   => $list_of_local_sets,
+				labels   => $labels_for_local_sets,
 				default  => $set_selected,
 				override => 1,
 				class    => 'form-select form-select-sm d-inline w-auto mx-2',
+				data_no_set_selected => $r->maketext('No Target Set Selected'),
+				data_pick_target_set => $r->maketext('Pick a target set above to add this problem to.'),
+				data_problems_added => $r->maketext('Problems Added'),
+				data_added_to_single => $r->maketext('Added one problem to set [_1].', '{set}'),
+				data_added_to_plural => $r->maketext('Added [_1] problems to set [_2].', '{number}', '{set}'),
 			})
 		),
 		CGI::submit({
@@ -1107,9 +1076,7 @@ sub make_top_row {
 	print CGI::hr({ class => 'mt-0 mb-2' });
 
 	# Tidy this list up since it is used in two different places
-	if ($list_of_local_sets->[0] eq $r->maketext(SELECT_SET_STRING)) {
-		shift @{$list_of_local_sets};
-	}
+	shift @$list_of_local_sets if ($list_of_local_sets->[0] eq '');
 
 	print CGI::div(
 		{ class => 'd-flex justify-content-center' },
@@ -1246,17 +1213,10 @@ sub make_data_row {
 	my $urlpath = $self->r->urlpath;
 	my $db      = $self->r->db;
 
-	## to set up edit and try links elegantly we want to know if
-	##    any target set is a gateway assignment or not
-	my $localSet = $self->r->param('local_sets');
-	my $setRecord;
-	if (defined($localSet)
-		&& $localSet ne $r->maketext(SELECT_SET_STRING)
-		&& $localSet ne $r->maketext(NO_LOCAL_SET_STRING))
-	{
-		$setRecord = $db->getGlobalSet($localSet);
-	}
-	my $isGatewaySet = (defined($setRecord) && $setRecord->assignment_type =~ /gateway/);
+	# To set up edit and try links we need to know if the target set is a gateway assignment or not.
+	my $localSet     = $self->r->param('local_sets');
+	my $setRecord    = defined $localSet  && $localSet ne '' ? $db->getGlobalSet($localSet) : undef;
+	my $isGatewaySet = defined $setRecord && $setRecord->assignment_type =~ /gateway/;
 
 	my $problem_seed = $self->{'problem_seed'} || 1234;
 	my $edit_link = CGI::a(
@@ -1587,7 +1547,7 @@ sub make_data_row {
 					$problem_stats),
 				CGI::div(
 					{ class => 'lb-problem-icons mb-1 d-flex align-items-center' },
-					$MOtag, $mlt, $rerand,
+					$mlt, $MOtag, $rerand,
 					$edit_link,
 					$try_link,
 					CGI::span(
@@ -1609,8 +1569,11 @@ sub make_data_row {
 				{ class => 'lb-problem-sub-header d-flex' },
 				CGI::div({ class => 'lb-problem-path font-sm flex-grow-1 flex-shrink-1' }, $sourceFileName),
 				CGI::div(
-					{ class => 'lb-inset text-nowrap', id => "inset$cnt" },
-					$self->{isInSet}{$sourceFileName} ? CGI::i(CGI::b('(in target set)')) : ''
+					{
+						class => 'lb-inset text-nowrap' . ($self->{isInSet}{$sourceFileName} ? '' : ' d-none'),
+						id    => "inset$cnt"
+					},
+					CGI::i(CGI::b($r->maketext('(in target set)')))
 				)
 			),
 			CGI::hidden({ name => "filetrial$cnt", default => $sourceFileName, override => 1 }),
@@ -1857,15 +1820,14 @@ sub pre_header_initialize {
 	} elsif ($r->param('view_local_set')) {
 
 		my $set_to_display = $self->{current_library_set};
-		if (not defined($set_to_display) or $set_to_display eq $r->maketext(SELECT_LOCAL_STRING) or $set_to_display eq "Found no directories containing problems") {
+		if (!defined $set_to_display || $set_to_display eq '') {
 			$self->addbadmessage($r->maketext('You need to select a set to view.'));
 		} else {
-			$set_to_display = '.' if $set_to_display eq $r->maketext(MY_PROBLEMS);
-			$set_to_display = substr($browse_which,7) if $set_to_display eq $r->maketext(MAIN_PROBLEMS);
-			@pg_files = list_pg_files($ce->{courseDirs}->{templates},
-				"$set_to_display");
-			@pg_files = map {{'filepath'=> $_, 'morelt'=>0}} @pg_files;
-			$use_previous_problems=0;
+			$set_to_display        = '.'                      if $set_to_display eq $r->maketext(MY_PROBLEMS);
+			$set_to_display        = substr($browse_which, 7) if $set_to_display eq $r->maketext(MAIN_PROBLEMS);
+			@pg_files              = list_pg_files($ce->{courseDirs}{templates}, "$set_to_display");
+			@pg_files              = map { { 'filepath' => $_, 'morelt' => 0 } } @pg_files;
+			$use_previous_problems = 0;
 		}
 
 		##### View problems selected from the a set in this course
@@ -1874,9 +1836,7 @@ sub pre_header_initialize {
 
 		my $set_to_display = $self->{current_library_set};
 		debug("set_to_display is $set_to_display");
-		if (not defined($set_to_display)
-				or $set_to_display eq "Select a Homework Set"
-				or $set_to_display eq $r->maketext(NO_LOCAL_SET_STRING)) {
+		if (!defined $set_to_display || $set_to_display eq '') {
 			$self->addbadmessage($r->maketext("You need to select a set from this course to view."));
 		} else {
 			@pg_files = map { { 'filepath' => $_->source_file, 'morelt' => 0 } }
@@ -1899,15 +1859,13 @@ sub pre_header_initialize {
 
 		my $set_to_display = $self->{current_library_set};
 		debug("set_to_display is $set_to_display");
-		if (not defined($set_to_display)
-				or $set_to_display eq "Select a Set Definition File"
-				or $set_to_display eq $r->maketext(NO_LOCAL_SET_STRING)) {
+		if (!defined $set_to_display || $set_to_display eq '') {
 			$self->addbadmessage($r->maketext("You need to select a set definition file to view."));
 		} else {
-			@pg_files= $self->read_set_def($set_to_display);
-			@pg_files = map {{'filepath'=> $_, 'morelt'=>0}} @pg_files;
+			@pg_files = $self->read_set_def($set_to_display);
+			@pg_files = map { { 'filepath' => $_, 'morelt' => 0 } } @pg_files;
 		}
-		$use_previous_problems=0;
+		$use_previous_problems = 0;
 
 		##### Edit the current local homework set
 

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -2,12 +2,12 @@
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: webwork2/lib/WeBWorK/Utils/ListingDB.pm,v 1.19 2007/08/13 22:59:59 sh002i Exp $
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -37,14 +37,12 @@ BEGIN
 {
 	require Exporter;
 	use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
-	
+
 	$VERSION		=1.0;
 	@ISA		=qw(Exporter);
-	@EXPORT	=qw(
-	&createListing &updateListing &deleteListing &getAllChapters
-	&getAllSections &searchListings &getAllListings &getSectionListings
-	&getAllDBsubjects &getAllDBchapters &getAllDBsections &getDBTextbooks
-	&getDBListings &countDBListings &getTables &getDBextras
+	@EXPORT = qw(
+		&deleteListing &getSectionListings &getAllDBsubjects &getAllDBchapters &getAllDBsections &getDBTextbooks
+		&getDBListings &countDBListings &getTables &getDBextras
 	);
 	%EXPORT_TAGS		=();
 	@EXPORT_OK		=qw();
@@ -119,7 +117,7 @@ sub getDB {
 
 =item getProblemTags($path) and setProblemTags($path, $subj, $chap, $sect)
 Get and set tags using full path and Tagging module
-                                                                                
+
 =cut
 
 sub getProblemTags {
@@ -162,8 +160,8 @@ sub setProblemTags {
 Both take a string and perform utility functions related to keywords.
 keywordcleaner splits a string, and uses kwtidy to regularize punctuation
 and case for an individual entry.
-                                                                                
-=cut                                                                            
+
+=cut
 
 sub kwtidy {
 	my $s = shift;
@@ -220,9 +218,9 @@ sub getDBextras {
 	return [$mo, $static];
 }
 
-=item getDBTextbooks($r)                                                    
+=item getDBTextbooks($r)
 Returns textbook dependent entries.
-                                                                                
+
 $r is a Apache request object so we can extract whatever parameters we want
 
 $thing is a string of either 'textbook', 'textchapter', or 'textsection' to
@@ -278,15 +276,15 @@ sub getDBTextbooks {
 	}
 
 	my $selectwhat = LIBRARY_STRUCTURE->{$thing}{select};
-	
+
 # 	my $query = "SELECT DISTINCT $selectwhat
-#           FROM `$tables{textbook}` tbk, `$tables{problem}` prob, 
+#           FROM `$tables{textbook}` tbk, `$tables{problem}` prob,
 # 			`$tables{pgfile_problem}` pg, `$tables{pgfile}` pgf,
 #             `$tables{dbsection}` s, `$tables{dbchapter}` c, `$tables{dbsubject}` t,
 # 			`$tables{chapter}` tc, `$tables{section}` ts
-#           WHERE ts.section_id=prob.section_id AND 
+#           WHERE ts.section_id=prob.section_id AND
 #             prob.problem_id=pg.problem_id AND
-#             s.DBchapter_id=c.DBchapter_id AND 
+#             s.DBchapter_id=c.DBchapter_id AND
 #             c.DBsubject_id=t.DBsubject_id AND
 #             pgf.DBsection_id=s.DBsection_id AND
 #             pgf.pgfile_id=pg.pgfile_id AND
@@ -294,13 +292,13 @@ sub getDBTextbooks {
 #             tc.textbook_id=tbk.textbook_id
 #             $extrawhere $textextrawhere ";
 	my $query = "SELECT DISTINCT $selectwhat
-          FROM `$tables{textbook}` tbk, `$tables{problem}` prob, 
+          FROM `$tables{textbook}` tbk, `$tables{problem}` prob,
 			`$tables{pgfile_problem}` pg, `$tables{pgfile}` pgf,
             `$tables{dbsection}` s, `$tables{dbchapter}` c, `$tables{dbsubject}` t,
 			`$tables{chapter}` tc, `$tables{section}` ts
-          WHERE ts.section_id=prob.section_id AND 
+          WHERE ts.section_id=prob.section_id AND
             prob.problem_id=pg.problem_id AND
-            s.DBchapter_id=c.DBchapter_id AND 
+            s.DBchapter_id=c.DBchapter_id AND
             c.DBsubject_id=t.DBsubject_id AND
             pgf.DBsection_id=s.DBsection_id AND
             pgf.pgfile_id=pg.pgfile_id AND
@@ -330,11 +328,11 @@ sub getDBTextbooks {
 }
 
 =item getAllDBsubjects($r)
-Returns an array of DBsubject names                                             
-                                                                                
+Returns an array of DBsubject names
+
 $r is the Apache request object
-                                                                                
-=cut                                                                            
+
+=cut
 
 sub getAllDBsubjects {
 	my $r = shift;
@@ -355,11 +353,11 @@ sub getAllDBsubjects {
 
 
 =item getAllDBchapters($r)
-Returns an array of DBchapter names                                             
-                                                                                
+Returns an array of DBchapter names
+
 $r is the Apache request object
-                                                                                
-=cut                                                                            
+
+=cut
 
 sub getAllDBchapters {
 	my $r = shift;
@@ -367,30 +365,30 @@ sub getAllDBchapters {
 	my $subject = $r->param('library_subjects');
 	return () unless($subject);
 	my $dbh = getDB($r->ce);
-# 	my $query = "SELECT DISTINCT c.name, c.DBchapter_id 
-#                                 FROM `$tables{dbchapter}` c, 
+# 	my $query = "SELECT DISTINCT c.name, c.DBchapter_id
+#                                 FROM `$tables{dbchapter}` c,
 # 				`$tables{dbsubject}` t
 #                  WHERE c.DBsubject_id = t.DBsubject_id AND
 #                  t.name = \"$subject\" ORDER BY c.DBchapter_id";
 # 	my $all_chaps_ref = $dbh->selectall_arrayref($query);
-	my $query = "SELECT DISTINCT c.name, c.DBchapter_id 
-                                FROM `$tables{dbchapter}` c, 
+	my $query = "SELECT DISTINCT c.name, c.DBchapter_id
+                                FROM `$tables{dbchapter}` c,
 				`$tables{dbsubject}` t
                  WHERE c.DBsubject_id = t.DBsubject_id AND
                  t.name = ? ORDER BY c.DBchapter_id";
 	my $all_chaps_ref = $dbh->selectall_arrayref($query, {},$subject);
- 
+
  	my @results = map { $_->[0] } @{$all_chaps_ref};
 	#@results = sortByName(undef, @results);
 	return @results;
 }
 
-=item getAllDBsections($r)                                            
-Returns an array of DBsection names                                             
-                                                                                
+=item getAllDBsections($r)
+Returns an array of DBsection names
+
 $r is the Apache request object
 
-=cut                                                                            
+=cut
 
 sub getAllDBsections {
 	my $r = shift;
@@ -400,14 +398,14 @@ sub getAllDBsections {
 	my $chapter = $r->param('library_chapters');
 	return () unless($chapter);
 	my $dbh = getDB($r->ce);
-# 	my $query = "SELECT DISTINCT s.name, s.DBsection_id 
+# 	my $query = "SELECT DISTINCT s.name, s.DBsection_id
 #                  FROM `$tables{dbsection}` s,
 #                  `$tables{dbchapter}` c, `$tables{dbsubject}` t
 #                  WHERE s.DBchapter_id = c.DBchapter_id AND
 #                  c.DBsubject_id = t.DBsubject_id AND
 #                  t.name = \"$subject\" AND c.name = \"$chapter\" ORDER BY s.DBsection_id";
 # 	my $all_sections_ref = $dbh->selectall_arrayref($query);
-	my $query = "SELECT DISTINCT s.name, s.DBsection_id 
+	my $query = "SELECT DISTINCT s.name, s.DBsection_id
                  FROM `$tables{dbsection}` s,
                  `$tables{dbchapter}` c, `$tables{dbsubject}` t
                  WHERE s.DBchapter_id = c.DBchapter_id AND
@@ -420,13 +418,13 @@ sub getAllDBsections {
 	return @results;
 }
 
-=item getDBListings($r)                             
-Returns an array of hash references with the keys: path, filename.              
-                                                                                
+=item getDBListings($r)
+Returns an array of hash references with the keys: path, filename.
+
 $r is an Apache request object that has all needed data inside of it
 
 Here, we search on all known fields out of r
-                                                                                
+
 =cut
 
 sub getDBListings {
@@ -437,7 +435,7 @@ sub getDBListings {
 	my $subj = $r->param('library_subjects') || "";
 	my $chap = $r->param('library_chapters') || "";
 	my $sec = $r->param('library_sections') || "";
-	
+
 	# Make sure these strings are internally encoded in UTF-8
 	utf8::upgrade($subj);
 	utf8::upgrade($chap);
@@ -457,7 +455,7 @@ sub getDBListings {
 		($keywordstring, @keyword_params) = makeKeywordWhere($keywords) ;
 		$kw1 = ", `$tables{keyword}` kw, `$tables{pgfile_keyword}` pgkey";
 		$kw2 = " AND kw.keyword_id=pgkey.keyword_id AND
-			 pgkey.pgfile_id=pgf.pgfile_id $keywordstring"; 
+			 pgkey.pgfile_id=pgf.pgfile_id $keywordstring";
 #			makeKeywordWhere($keywords) ;
 	}
 
@@ -505,19 +503,19 @@ sub getDBListings {
 	my $selectwhat = 'DISTINCT pgf.pgfile_id';
 	$selectwhat = 'COUNT(' . $selectwhat . ')' if ($amcounter);
 
-# 	my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf, 
+# 	my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf,
 #          `$tables{dbsection}` dbsc, `$tables{dbchapter}` dbc, `$tables{dbsubject}` dbsj $kw1
 #         WHERE dbsj.DBsubject_id = dbc.DBsubject_id AND
 #               dbc.DBchapter_id = dbsc.DBchapter_id AND
-#               dbsc.DBsection_id = pgf.DBsection_id 
-#               \n $extrawhere 
+#               dbsc.DBsection_id = pgf.DBsection_id
+#               \n $extrawhere
 #               $kw2";
 
 	my $pg_id_ref;
-	
+
 	$dbh->do(qq{SET NAMES 'utf8mb4';}) if $ce->{ENABLE_UTF8MB4};
 	if($haveTextInfo) {
-		my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf, 
+		my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf,
 			`$tables{dbsection}` dbsc, `$tables{dbchapter}` dbc, `$tables{dbsubject}` dbsj,
 			`$tables{pgfile_problem}` pgp, `$tables{problem}` prob, `$tables{textbook}` tbk ,
 			`$tables{chapter}` tc, `$tables{section}` ts $kw1
@@ -530,22 +528,22 @@ sub getDBListings {
 				  ts.chapter_id = tc.chapter_id AND
 				  prob.section_id = ts.section_id \n $extrawhere \n $textextrawhere
 				  $kw2";
-				  
+
 		#$query =~ s/\n/ /g;
 		#warn "text info: ", $query;
 		#warn "params: ", join(" | ",@select_parameters, @textInfo_parameters,@keyword_params);
-		
+
 		$pg_id_ref = $dbh->selectall_arrayref($query, {},@select_parameters, @textInfo_parameters, @keyword_params);
 
      } else {
-		my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf, 
+		my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf,
 			 `$tables{dbsection}` dbsc, `$tables{dbchapter}` dbc, `$tables{dbsubject}` dbsj $kw1
 			WHERE dbsj.DBsubject_id = dbc.DBsubject_id AND
 				  dbc.DBchapter_id = dbsc.DBchapter_id AND
-				  dbsc.DBsection_id = pgf.DBsection_id 
-				  \n $extrawhere 
+				  dbsc.DBsection_id = pgf.DBsection_id
+				  \n $extrawhere
 				  $kw2";
-				  
+
 		#$query =~ s/\n/ /g;
 		#warn "no text info: ", $query;
 		#warn "params: ", join(" | ",@select_parameters,@keyword_params);
@@ -561,15 +559,15 @@ sub getDBListings {
 	}
 	my @results=();
 	for my $pgid (@pg_ids) {
-# 		$query = "SELECT path, filename, morelt_id, pgfile_id, static, MO FROM `$tables{pgfile}` pgf, `$tables{path}` p 
+# 		$query = "SELECT path, filename, morelt_id, pgfile_id, static, MO FROM `$tables{pgfile}` pgf, `$tables{path}` p
 #           WHERE p.path_id = pgf.path_id AND pgf.pgfile_id=\"$pgid\"";
 # 		my $row = $dbh->selectrow_arrayref($query);
-		my $query = "SELECT path, filename, morelt_id, pgfile_id, static, MO FROM `$tables{pgfile}` pgf, `$tables{path}` p 
+		my $query = "SELECT path, filename, morelt_id, pgfile_id, static, MO FROM `$tables{pgfile}` pgf, `$tables{path}` p
           WHERE p.path_id = pgf.path_id AND pgf.pgfile_id= ? ";
 		my $row = $dbh->selectrow_arrayref($query,{},$pgid);
 
 		push @results, {'path' => $row->[0], 'filename' => $row->[1], 'morelt' => $row->[2], 'pgid'=> $row->[3], 'static' => $row->[4], 'MO' => $row->[5] };
-		
+
 	}
 	return @results;
 }
@@ -588,203 +586,6 @@ sub getMLTleader {
 	my $row = $dbh->selectrow_arrayref($query);
 	return $row->[0];
 }
-
-##############################################################################
-# input expected: keywords,<keywords>,chapter,<chapter>,section,<section>,path,<path>,filename,<filename>,author,<author>,instituition,<instituition>,history,<history>
-#
-#
-# Warning - this function is out of date (but currently unused)
-#
-
-# sub createListing {
-# 	my $ce = shift;
-# 	my %tables = getTables($ce);
-# 	my %listing_data = @_; 
-# 	my $classify_id;
-# 	my $dbh = getDB($ce);
-# 	#	my $dbh = WeBWorK::ProblemLibrary::DB::getDB();
-# 	my $query = "INSERT INTO classify
-# 		(filename,chapter,section,keywords)
-# 		VALUES
-# 		($listing_data{filename},$listing_data{chapter},$listing_data{section},$listing_data{keywords})";
-# 	$dbh->do($query);	 #TODO: watch out for comma delimited keywords, sections, chapters!
-# 
-# 	$query = "SELECT id FROM classify WHERE filename = $listing_data{filename}";
-# 	my $sth = $dbh->prepare($query);
-# 	$sth->execute();
-# 	if ($sth->rows())
-# 	{
-# 		($classify_id) = $sth->fetchrow_array;
-# 	}
-# 	else
-# 	{
-# 		#print STDERR "ListingDB::createListingPGfiles: $listing_data{filename} failed insert into classify table";
-# 		return 0;
-# 	};
-# 
-# 	$query = "INSERT INTO pgfiles
-#    (
-#    classify_id,
-#    path,
-#    author,
-#    institution,
-#    history
-#    )
-#    VALUES
-#   (
-#    $classify_id,
-#    $listing_data{path},
-#    $listing_data{author},
-#    $listing_data{institution},
-#    $listing_data{history}
-#    )";
-# 	
-# 	$dbh->do($query);
-# 	return 1;
-# }
-
-##############################################################################
-# input expected any pair of: keywords,<keywords data>,chapter,<chapter data>,section,<section data>,filename,<filename data>,author,<author data>,instituition,<instituition data>
-# returns an array of hash references
-#
-# Warning - out of date (and unusued)
-#
-
-# sub searchListings {
-# 	my $ce = shift;
-# 	my %tables = getTables($ce);
-# 	my %searchterms = @_;
-# 	#print STDERR "ListingDB::searchListings  input array @_\n";
-# 	my @results;
-# 	my ($row,$key);
-# 	my $dbh = getDB($ce);
-# 	my $query = "SELECT c.filename, p.path
-# 		FROM classify c, pgfiles p
-# 		WHERE c.id = p.classify_id";
-# 	foreach $key (keys %searchterms) {
-# 		$query .= " AND c.$key = $searchterms{$key}";
-# 	};
-# 	my $sth = $dbh->prepare($query);
-# 	$sth->execute();
-# 	if ($sth->rows())
-# 	{
-# 		while (1)
-# 		{
-# 			$row = $sth->fetchrow_hashref();
-# 			if (!defined($row))
-# 			{
-# 				last;
-# 			}
-# 			else
-# 			{
-# 				#print STDERR "ListingDB::searchListings(): found $row->{id}\n";
-# 				my $listing = $row;
-# 				push @results, $listing;
-# 			}
-# 		}
-# 	}
-# 	return @results;
-# }
-##############################################################################
-# returns a list of chapters
-#
-# Warning - out of date
-#
-
-# sub getAllChapters {
-# 	#print STDERR "ListingDB::getAllChapters\n";
-# 	my $ce = shift;
-# 	my %tables = getTables($ce);
-# 	my @results=();
-# 	my ($row,$listing);
-# 	my $query = "SELECT DISTINCT chapter FROM classify";
-# 	my $dbh = getDB($ce);
-# 	my $sth = $dbh->prepare($query);
-# 	$sth->execute();
-# 	while (1)
-# 	{
-# 		$row = $sth->fetchrow_array;
-# 		if (!defined($row))
-# 		{
-# 			last;
-# 		}
-# 		else
-# 		{
-# 			my $listing = $row;
-# 			push @results, $listing;
-# 			#print STDERR "ListingDB::getAllChapters $listing\n";
-# 		}
-# 	}
-# 	return @results;
-# }
-##############################################################################
-# input chapter
-# returns a list of sections
-#
-# Warning - out of date (and unused)
-#
-
-# sub getAllSections {
-# 	#print STDERR "ListingDB::getAllSections\n";
-# 	my $ce = shift;
-# 	my %tables = getTables($ce);
-# 	my $chapter = shift;
-# 	my @results=();
-# 	my ($row,$listing);
-# # 	my $query = "SELECT DISTINCT section FROM classify
-# # 				WHERE chapter = \'$chapter\'";
-# 	my $query = "SELECT DISTINCT section FROM classify
-# 				WHERE chapter = ? ";
-# 	my $dbh = getDB($ce);
-# #	my $sth = $dbh->prepare($query);
-# 	my $sth = $dbh->prepare($query, $chapter);
-# 
-# 	$sth->execute();
-# 	while (1)
-# 	{
-# 		$row = $sth->fetchrow_array;
-# 		if (!defined($row))
-# 		{
-# 			last;
-# 		}
-# 		else
-# 		{
-# 			my $listing = $row;
-# 			push @results, $listing;
-# 			#print STDERR "ListingDB::getAllSections $listing\n";
-# 		}
-# 	}
-# 	return @results;
-# }
-
-##############################################################################
-# returns an array of hash references
-#
-# Warning - out of date (and unused)
-#
-
-# sub getAllListings {
-# 	#print STDERR "ListingDB::getAllListings\n";
-# 	my $ce = shift;
-# 	my @results;
-# 	my ($row,$key);
-# 	my $dbh = getDB($ce);
-# 	my %tables = getTables($ce);
-# 	my $query = "SELECT c.*, p.path
-# 			FROM classify c, pgfiles p
-# 			WHERE c.pgfiles_id = p.pgfiles_id";
-# 	my $sth = $dbh->prepare($query);
-# 	$sth->execute();
-# 	while (1)
-# 	{
-# 		$row = $sth->fetchrow_hashref();
-# 		last if (!defined($row));
-# 		my $listing = $row;
-# 		push @results, $listing;
-# 		#print STDERR "ListingDB::getAllListings $listing\n";
-# 	}
-# 	return @results;
-# }
 
 ##############################################################################
 # input chapter, section
@@ -818,7 +619,7 @@ sub getSectionListings	{
 # 	my $dbh = getDB($ce);
 # 	my %tables = getTables($ce);
 # 	my $sth = $dbh->prepare($query);
-# 	
+#
 # 	$sth->execute();
     my $query = "SELECT c.*, p.path
 	FROM classify c, pgfiles p
@@ -826,7 +627,7 @@ sub getSectionListings	{
 	my $dbh = getDB($ce);
 	my %tables = getTables($ce);
 	my $sth = $dbh->prepare($query);
-	
+
 	$sth->execute($chapstring,$secstring);
 
 	while (1)
@@ -895,27 +696,9 @@ This module provides access to the database of classify in the
 system. This includes the filenames, along with the table of
 search terms.
 
-=head1 FUNCTION REFERENCE
-
-=over 4
-
-=item $result = createListing( %listing_data );
-
-Creates a new listing populated with data from %listing_data. On
-success, 1 is returned, 0 is returned on failure. The %listing_data
-hash has the following format:
-=cut
-
-=back
-
 =head1 AUTHOR
 
 Written by Bill Ziemer.
 Modified by John Jones.
 
 =cut
-
-
-##############################################################################
-# end of ListingDB.pm
-##############################################################################


### PR DESCRIPTION
In addition to modernizing the setmaker.js file, this fixes several bugs.

One issue is one that I caused when I switched from using the `onclick` attributes and inline javascript to using `addEventListener` and external javascript.  I missed a case where the "More/Less like this" handling changed the `onclick` attribute.  That has now been converted to change the appropriate data attribute instead.

Another issue was that the "Target Set" select was directly using its values for labels.  In particular it was using the "Select a Set from this Course" value which is translated.  The javascript looks for that value, and if it is translated it fails.  So now proper labels and values are used.  Furthermore the labels for sets have the underscore translated to spaces.  In addition, all of the "All ..." options for the subjects, chapters, sections, etc., are now translated in labels.  Of course the values are not translated.

There was also an instance of a jquery-ui dialog in setmaker.js.  Of course that is a problem as jquery-ui is no longer loaded on that page.  That was replaced with a bootstrap modal.  Since the contents of that modal are webwork errors, the styles of those errors were tweaked a bit to make them appear well both on a regular page and in those dialogs.  Also, all native alerts were replaced with bootstrap toasts.

In problemsetdetail.js there is a minor issue fixed in that the executor of a promise should not be an async function.

Translations are also added for some of the dialogs on the library browser page (the ones that will typically appear in day-to-day use). These are passed to the javascript via data attributes.

Some obsolete and already commented out code in lib/WeBWorK/Utils/ListingsDB.pm was deleted.  This is to make it clearer as to why some code was also deleted in SetMaker.pm.