### PR TITLE
Allow instructors to use spaces in set names (rework of #1412)

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -85,30 +85,31 @@ sub UserItems {
 # The id, label_text, and values are required parameters.
 sub form_popup_menu_row {
 	my %params = (
-		id => "",
-	   	label_text => "",
-	   	label_attr => {},
-		values => [],
-		menu_attr => {},
+		id                  => '',
+		label_text          => '',
+		label_attr          => {},
+		values              => [],
+		labels              => {},
+		menu_attr           => {},
 		menu_container_attr => {},
-		add_container => 1,
-	   	@_
+		add_container       => 1,
+		@_
 	);
 
-	$params{label_attr}{for} = $params{id};
-	$params{label_attr}{class} = 'col-4 col-form-label' unless defined $params{label_attr}{class};
-	$params{menu_attr}{values} = $params{values};
-	$params{menu_attr}{id} = $params{id};
-	$params{menu_attr}{name} = $params{id};
-	$params{menu_attr}{class} = 'form-select' unless defined $params{menu_attr}{class};
-	$params{menu_container_attr}{class} = 'col-8' unless defined $params{menu_container_attr}{class};
+	$params{label_attr}{for}            = $params{id};
+	$params{label_attr}{class}          = 'col-4 col-form-label' unless defined $params{label_attr}{class};
+	$params{menu_attr}{values}          = $params{values};
+	$params{menu_attr}{labels}          = $params{labels};
+	$params{menu_attr}{id}              = $params{id};
+	$params{menu_attr}{name}            = $params{id};
+	$params{menu_attr}{class}           = 'form-select' unless defined $params{menu_attr}{class};
+	$params{menu_container_attr}{class} = 'col-8'       unless defined $params{menu_container_attr}{class};
 
 	return join('',
 		$params{add_container} ? CGI::start_div({ class => 'row mb-3' }) : '',
 		CGI::label($params{label_attr}, $params{label_text}),
 		CGI::div($params{menu_container_attr}, CGI::popup_menu($params{menu_attr})),
-		$params{add_container} ? CGI::end_div() : ''
-	);
+		$params{add_container} ? CGI::end_div() : '');
 }
 
 #Item to resurrect a homework for 24 hours
@@ -116,7 +117,7 @@ sub form_popup_menu_row {
 package WeBWorK::AchievementItems::ResurrectHW;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -156,10 +157,14 @@ sub print_form {
 	}
     }
 
-	return join("",
-		CGI::p($r->maketext("Choose the set which you would like to resurrect.")),
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set which you would like to resurrect.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'res_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'res_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -215,7 +220,7 @@ sub use_item {
 package WeBWorK::AchievementItems::ExtendDueDate;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -249,10 +254,14 @@ sub print_form {
 	}
     }
 
-	return join("",
-		CGI::p($r->maketext("Choose the set whose close date you would like to extend.")),
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set whose close date you would like to extend.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'ext_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'ext_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -301,7 +310,7 @@ sub use_item {
 package WeBWorK::AchievementItems::SuperExtendDueDate;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -335,10 +344,14 @@ sub print_form {
 	}
     }
 
-    return join("",
-	CGI::p($r->maketext("Choose the set whose close date you would like to extend.")),
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set whose close date you would like to extend.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'ext_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'ext_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -387,7 +400,7 @@ sub use_item {
 package WeBWorK::AchievementItems::ReducedCred;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -425,10 +438,14 @@ sub print_form {
 	}
     }
 
-    return join("",
-	CGI::p($r->maketext("Choose the set which you would like to enable partial credit for.")),
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set which you would like to enable partial credit for.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'red_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'red_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -484,7 +501,7 @@ sub use_item {
 package WeBWorK::AchievementItems::DoubleSet;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -518,10 +535,14 @@ sub print_form {
 	}
     }
 
-    return join("",
-	CGI::p($r->maketext("Choose the set which you would like to be worth twice as much.")),
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set which you would like to be worth twice as much.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'dub_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'dub_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -573,7 +594,7 @@ sub use_item {
 package WeBWorK::AchievementItems::ResetIncorrectAttempts;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -630,16 +651,25 @@ sub print_form {
     $problem_id_script .= "\$('\#ria_problem_id option').slice(max,$maxProblems).hide(); ";
     $problem_id_script .= "\$('\#ria_problem_id option').slice(0,max).show();";
 
-    return join("",
-		CGI::p($r->maketext("Please choose the set name and problem number of the question which should have its incorrect attempt count reset.")),
+	return join(
+		'',
+		CGI::p($r->maketext(
+			'Please choose the set name and problem number of the question which '
+				. 'should have its incorrect attempt count reset.'
+		)),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'ria_set_id', label_text => $r->maketext("Set Name "), values => \@openSets,
-			menu_attr => { onchange => $problem_id_script }
+			id         => 'ria_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { onchange => $problem_id_script }
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'ria_problem_id', label_text => $r->maketext("Problem Number "), values => \@problemIDs,
-			menu_attr => { attributes => \%attributes },
-			menu_container_attr => { class => 'col-3' }
+			id                  => 'ria_problem_id',
+			label_text          => $r->maketext('Problem Number'),
+			values              => \@problemIDs,
+			menu_attr           => { attributes => \%attributes },
+			menu_container_attr => { class      => 'col-3' }
 		)
 	);
 }
@@ -688,7 +718,7 @@ sub use_item {
 package WeBWorK::AchievementItems::DoubleProb;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -745,16 +775,25 @@ sub print_form {
     $problem_id_script .= "\$('\#dbp_problem_id option').slice(max,$maxProblems).hide(); ";
     $problem_id_script .= "\$('\#dbp_problem_id option').slice(0,max).show();";
 
-    return join("",
-		CGI::p($r->maketext("Please choose the set name and problem number of the question which should have its weight doubled.")),
-		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'dbp_set_id', label_text => $r->maketext("Set Name "), values => \@openSets,
-			menu_attr => { onchange => $problem_id_script }
+	return join(
+		'',
+		CGI::p(
+			$r->maketext(
+				'Please choose the set name and problem number of the question which should have its weight doubled.')
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'dbp_problem_id', label_text => $r->maketext("Problem Number "), values => \@problemIDs,
-			menu_attr => { attributes => \%attributes },
-			menu_container_attr => { class => 'col-3' }
+			id         => 'dbp_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { onchange => $problem_id_script }
+		),
+		WeBWorK::AchievementItems::form_popup_menu_row(
+			id                  => 'dbp_problem_id',
+			label_text          => $r->maketext('Problem Number'),
+			values              => \@problemIDs,
+			menu_attr           => { attributes => \%attributes },
+			menu_container_attr => { class      => 'col-3' }
 		)
 	);
 }
@@ -805,7 +844,7 @@ sub use_item {
 package WeBWorK::AchievementItems::HalfCreditProb;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -862,20 +901,27 @@ sub print_form {
     $problem_id_script .= "\$('\#hcp_problem_id option').slice(max,$maxProblems).hide(); ";
     $problem_id_script .= "\$('\#hcp_problem_id option').slice(0,max).show();";
 
-	return join("",
-		CGI::p($r->maketext(
-				"Please choose the set name and problem number of the question which should be given half credit.")),
-		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'hcp_set_id', values => \@openSets, label_text => $r->maketext("Set Name "),
-			menu_attr => { onchange => $problem_id_script }
+	return join(
+		'',
+		CGI::p(
+			$r->maketext(
+				'Please choose the set name and problem number of the question which should be given half credit.')
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'hcp_problem_id', values => \@problemIDs, label_text => $r->maketext("Problem Number "),
-			menu_attr => { attributes => \%attributes },
-			menu_container_attr => { class => 'col-3' }
+			id         => 'hcp_set_id',
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			label_text => $r->maketext('Set Name'),
+			menu_attr  => { onchange => $problem_id_script }
+		),
+		WeBWorK::AchievementItems::form_popup_menu_row(
+			id                  => 'hcp_problem_id',
+			values              => \@problemIDs,
+			label_text          => $r->maketext('Problem Number'),
+			menu_attr           => { attributes => \%attributes },
+			menu_container_attr => { class      => 'col-3' }
 		)
 	);
-
 }
 
 sub use_item {
@@ -927,7 +973,7 @@ sub use_item {
 package WeBWorK::AchievementItems::HalfCreditSet;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -959,11 +1005,15 @@ sub print_form {
     }
 
 
-    #print form with sets
-    return join("",
-		CGI::p($r->maketext("Choose the set which you would like to resurrect.")),
+	# print form with sets
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set which you would like to resurrect.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'hcs_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'hcs_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -1019,7 +1069,7 @@ sub use_item {
 package WeBWorK::AchievementItems::FullCreditProb;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1075,16 +1125,25 @@ sub print_form {
     $problem_id_script .= "\$('\#fcp_problem_id option').slice(max,$maxProblems).hide(); ";
     $problem_id_script .= "\$('\#fcp_problem_id option').slice(0,max).show();";
 
-    return join("",
-	CGI::p($r->maketext("Please choose the set name and problem number of the question which should be given full credit.")),
-		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'fcp_set_id', label_text => $r->maketext("Set Name "), values => \@openSets,
-			menu_attr => { onchange => $problem_id_script }
+	return join(
+		'',
+		CGI::p(
+			$r->maketext(
+				'Please choose the set name and problem number of the question which should be given full credit.')
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'fcp_problem_id', values => \@problemIDs, label_text => $r->maketext("Problem Number "),
-			menu_attr => { attributes => \%attributes },
-			menu_container_attr => { class => 'col-3' }
+			id         => 'fcp_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { onchange => $problem_id_script }
+		),
+		WeBWorK::AchievementItems::form_popup_menu_row(
+			id                  => 'fcp_problem_id',
+			values              => \@problemIDs,
+			label_text          => $r->maketext('Problem Number'),
+			menu_attr           => { attributes => \%attributes },
+			menu_container_attr => { class      => 'col-3' }
 		)
 	);
 }
@@ -1134,7 +1193,7 @@ sub use_item {
 package WeBWorK::AchievementItems::FullCreditSet;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1166,11 +1225,15 @@ sub print_form {
     }
 
 
-    #print form with sets
-    return join("",
-		CGI::p($r->maketext("Choose the set which you would like to resurrect.")),
+	# print form with sets
+	return join(
+		'',
+		CGI::p($r->maketext('Choose the set which you would like to resurrect.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'fcs_set_id', label_text => $r->maketext("Set Name "), values => \@openSets
+			id         => 'fcs_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets }
 		)
 	);
 }
@@ -1221,7 +1284,7 @@ sub use_item {
 package WeBWorK::AchievementItems::DuplicateProb;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1279,24 +1342,36 @@ sub print_form {
     $problem_id_script .= "\$('\#tran_problem_id2 option').slice(max,$maxProblems).hide(); ";
     $problem_id_script .= "\$('\#tran_problem_id2 option').slice(0,max).show();";
 
-	return join("",
-		CGI::p($r->maketext("Please choose the set, the problem you would like to copy, and the problem you would like to copy it to.")),
+	return join(
+		'',
+		CGI::p($r->maketext(
+			'Please choose the set, the problem you would like to copy, '
+				. 'and the problem you would like to copy it to.'
+		)),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'tran_set_id', label_text => $r->maketext("Set Name "), values => \@openSets,
-			menu_attr => { onchange => $problem_id_script }
+			id         => 'tran_set_id',
+			label_text => $r->maketext('Set Name'),
+			values     => \@openSets,
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { onchange => $problem_id_script }
 		),
-		CGI::div({ class => 'row mb-3' },
+		CGI::div(
+			{ class => 'row mb-3' },
 			WeBWorK::AchievementItems::form_popup_menu_row(
-				id => 'tran_problem_id', values => \@problemIDs, label_text => $r->maketext("Copy this Problem"),
-				menu_attr => { attributes => \%attributes },
-				menu_container_attr => { class => 'col-2 ps-0' },
-				add_container => 0
+				id                  => 'tran_problem_id',
+				values              => \@problemIDs,
+				label_text          => $r->maketext('Copy this Problem'),
+				menu_attr           => { attributes => \%attributes },
+				menu_container_attr => { class      => 'col-2 ps-0' },
+				add_container       => 0
 			),
 			WeBWorK::AchievementItems::form_popup_menu_row(
-				id => 'tran_problem_id2', values => \@problemIDs, label_text => $r->maketext("To this Problem"),
-				menu_attr => { attributes => \%attributes },
-				menu_container_attr => { class => 'col-2 ps-0' },
-				add_container => 0
+				id                  => 'tran_problem_id2',
+				values              => \@problemIDs,
+				label_text          => $r->maketext('To this Problem'),
+				menu_attr           => { attributes => \%attributes },
+				menu_container_attr => { class      => 'col-2 ps-0' },
+				add_container       => 0
 			)
 		)
 	);
@@ -1406,7 +1481,7 @@ sub use_item {
 package WeBWorK::AchievementItems::AddNewTestGW;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1457,10 +1532,14 @@ sub print_form {
 
     #print open gateways in a drop down.
 
-    return join("",
-		CGI::p($r->maketext("Add a new test for which Gateway?")),
+	return join(
+		'',
+		CGI::p($r->maketext('Add a new test for which Gateway?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'adtgw_gw_id', label_text => $r->maketext("Gateway Name "), values => \@openGateways
+			id         => 'adtgw_gw_id',
+			label_text => $r->maketext('Gateway Name'),
+			values     => \@openGateways,
+			labels     => { map { $_ => format_set_name_display($_) } @openGateways }
 		)
 	);
 }
@@ -1509,7 +1588,7 @@ sub use_item {
 package WeBWorK::AchievementItems::ExtendDueDateGW;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1558,12 +1637,15 @@ sub print_form {
 	}
     }
 
-    #print open gateways in a drop down.
-
-    return join("",
-		CGI::p($r->maketext("Extend the close date for which Gateway?")),
+    # Print open gateways in a drop down.
+	return join(
+		'',
+		CGI::p($r->maketext('Extend the close date for which Gateway?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'eddgw_gw_id', label_text => $r->maketext("Gateway Name "), values => \@openGateways
+			id         => 'eddgw_gw_id',
+			label_text => $r->maketext('Gateway Name'),
+			values     => \@openGateways,
+			labels     => { map { $_ => format_set_name_display($_) } @openGateways }
 		)
 	);
 }
@@ -1624,7 +1706,7 @@ sub use_item {
 package WeBWorK::AchievementItems::ResurrectGW;
 our @ISA = qw(WeBWorK::AchievementItems);
 
-use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils qw(sortByName before after between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new {
     my $class = shift;
@@ -1663,12 +1745,15 @@ sub print_form {
 	}
     }
 
-    #print gateways in a drop down.
-
-    return join("",
-		CGI::p($r->maketext("Resurrect which Gateway?")),
+    # Print gateways in a drop down.
+	return join(
+		'',
+		CGI::p($r->maketext('Resurrect which Gateway?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
-			id => 'resgw_gw_id', label_text => $r->maketext("Gateway Name "), values => \@sets
+			id         => 'resgw_gw_id',
+			label_text => $r->maketext('Gateway Name'),
+			values     => \@sets,
+			labels     => { map { $_ => format_set_name_display($_) } @sets }
 		)
 	);
 }

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -28,7 +28,8 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(readDirectory list2hash max jitar_id_to_seq jitar_problem_adjusted_status wwRound after);
+use WeBWorK::Utils qw(readDirectory list2hash max jitar_id_to_seq jitar_problem_adjusted_status wwRound after
+format_set_name_display);
 use WeBWorK::Localize;
 sub initialize {
 	my ($self) = @_;
@@ -290,7 +291,7 @@ sub displayStudentStats {
 			next if $setVersionsCount{$setName};
 			push @rows,
 				CGI::Tr(
-					CGI::td(WeBWorK::ContentGenerator::underscore2sp($setID)),
+					CGI::td(format_set_name_display($setID)),
 					CGI::td(
 						{ colspan => ($max_problems + 3) },
 						CGI::em($r->maketext('No versions of this assignment have been taken.'))
@@ -311,7 +312,7 @@ sub displayStudentStats {
 			push(
 				@rows,
 				CGI::Tr(
-					CGI::td(WeBWorK::ContentGenerator::underscore2sp(
+					CGI::td(format_set_name_display(
 						"${setID}_(version_" . $set->version_id . ')')),
 					CGI::td(
 						{ colspan => ($max_problems + 3) },
@@ -444,7 +445,7 @@ sub displayStudentStats {
 		}
 
 		push @rows, CGI::Tr({},
-			CGI::th({scope=>"row"},CGI::a({-href=>$act_as_student_set_url}, WeBWorK::ContentGenerator::underscore2sp($setName))),
+			CGI::th({scope=>"row"},CGI::a({-href=>$act_as_student_set_url}, format_set_name_display($setName))),
 			CGI::td(CGI::span({-class=>$class},$totalRightPercent.'%')),
 			CGI::td(sprintf("%0.2f",$totalRight)), # score
 			CGI::td($total), # out of

--- a/lib/WeBWorK/ContentGenerator/Home.pm
+++ b/lib/WeBWorK/ContentGenerator/Home.pm
@@ -97,7 +97,7 @@ sub body {
 		next if $courseID eq "admin"; # done already above
 		next if -f "$coursesDir/$courseID/hide_directory";
 		my $urlpath = $r->urlpath->newFromModule("WeBWorK::ContentGenerator::ProblemSets", $r, courseID => $courseID);
-		print CGI::li(CGI::a({href=>$self->systemLink($urlpath, authen => 0)}, $courseID));
+		print CGI::li(CGI::a({href=>$self->systemLink($urlpath, authen => 0)}, $courseID =~ s/_/ /gr));
 	}###place to use underscore sub
 
 	print CGI::end_ul();

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -640,12 +640,6 @@ sub read_dir {  # read a directory
 	return sort @files;
 }
 
-sub format_set_name {
-	my $string = shift;
-	$string =~ s/ /_/g;
-	return $string;
-}
-
 =back
 
 =cut

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -640,6 +640,12 @@ sub read_dir {  # read a directory
 	return sort @files;
 }
 
+sub format_set_name {
+	my $string = shift;
+	$string =~ s/ /_/g;
+	return $string;
+}
+
 =back
 
 =cut

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -28,7 +28,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
-#use WeBWorK::Utils::FilterRecords qw/getFiltersForClass/;
+use WeBWorK::Utils qw/format_set_name_internal/;
 
 use constant E_NO_USERS     => "Please do not select any users.";
 use constant E_NO_SETS      => "Please do not select any sets.";
@@ -237,14 +237,13 @@ sub pre_header_initialize {
 	};
 
 	defined param $r "create_set" and do {
-		my $setname = $r->param("new_set_name");
-		if ($setname && $setname ne 'Name for new set here') {
-			if ($setname =~ /^[\w .-]*$/) {
-				$setname = WeBWorK::ContentGenerator::Instructor::format_set_name($setname);
-				$module = "${ipfx}::SetMaker";
+		my $setname = format_set_name_internal($r->param("new_set_name") // '');
+		if ($setname) {
+			if ($setname =~ /^[\w.-]*$/) {
+				$module                = "${ipfx}::SetMaker";
 				$params{new_local_set} = "Create a New Set in this Course";
-				$params{new_set_name} = $setname;
-				$params{selfassign} = 1;
+				$params{new_set_name}  = $setname;
+				$params{selfassign}    = 1;
 			} else {
 				push @error, E_BAD_NAME;
 			}

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -237,19 +237,20 @@ sub pre_header_initialize {
 	};
 
 	defined param $r "create_set" and do {
-	  my $setname = $r->param("new_set_name");
-	  if ($setname) {
-		if ($setname =~ /^[\w.-]*$/) {
-		$module = "${ipfx}::SetMaker";
-		$params{new_local_set} = "Create a New Set in this Course";
-		$params{new_set_name} = $setname;
-		$params{selfassign} = 1;
-		  } else {
-		push @error, E_BAD_NAME;
-		  }
-	  } else {
-		push @error, E_SET_NAME;
-	  }
+		my $setname = $r->param("new_set_name");
+		if ($setname && $setname ne 'Name for new set here') {
+			if ($setname =~ /^[\w .-]*$/) {
+				$setname = WeBWorK::ContentGenerator::Instructor::format_set_name($setname);
+				$module = "${ipfx}::SetMaker";
+				$params{new_local_set} = "Create a New Set in this Course";
+				$params{new_set_name} = $setname;
+				$params{selfassign} = 1;
+			} else {
+				push @error, E_BAD_NAME;
+			}
+		} else {
+			push @error, E_SET_NAME;
+		}
 	};
 
 	defined param $r "add_users" and do {

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -29,7 +29,8 @@ WeBWorK::ContentGenerator::Instructor::PGProblemEditor - Edit a pg file
 use strict;
 use warnings;
 use WeBWorK::CGI;
-use WeBWorK::Utils qw(readFile surePathToFile path_is_subdir jitar_id_to_seq seq_to_jitar_id x getAssetURL);
+use WeBWorK::Utils qw(readFile surePathToFile path_is_subdir jitar_id_to_seq seq_to_jitar_id x getAssetURL
+	format_set_name_display);
 use HTML::Entities;
 use URI::Escape;
 use WeBWorK::Utils qw(has_aux_files not_blank);
@@ -586,19 +587,26 @@ sub body {
 	$prettyProblemNumber = join('.',jitar_id_to_seq($problemNumber))
 		if ($set && $set->assignment_type eq 'jitar');
 
-	my $file_type = $self->{file_type};
 	my %titles = (
-		problem         => CGI::b("set $fullSetName/problem $prettyProblemNumber"),
-		blank_problem   => "blank problem",
-		set_header      => "header file",
-		hardcopy_header => "hardcopy header file",
-		course_info     => "course information",
-		options_info    => "options information",
-		''              => 'Unknown file type',
-		source_path_for_problem_file => " unassigned problem file:  ".CGI::b("set $setName/problem $prettyProblemNumber"),
+		blank_problem                => x('Editing <strong>blank problem</strong> in file "[_1]"'),
+		set_header                   => x('Editing <strong>set header</strong> file "[_1]"'),
+		hardcopy_header              => x('Editing <strong>hardcopy header</strong> file "[_1]"'),
+		course_info                  => x('Editing <strong>course information</strong> file "[_1]"'),
+		options_info                 => x('Editing <strong>options information</strong> file "[_1]"'),
+		''                           => x('Editing <strong>unknown file type</strong> in file "[_1]"'),
+		source_path_for_problem_file => x('Editing <strong>unassigned problem</strong> file "[_1]"')
 	);
-	my $header = CGI::i($r->maketext("Editing [_1] in file '[_2]'",$titles{$file_type}, $self->shortPath($inputFilePath)));
-	$header = ($self->isTempEditFilePath($inputFilePath)  ) ? CGI::div({class=>'temporaryFile'},$header) : $header;  # use colors if temporary file
+	my $header = CGI::i(
+		$self->{file_type} eq 'problem'
+		? $r->maketext(
+			'Editing <strong>problem [_1] of set [_2]</strong> in file "[_3]"', $prettyProblemNumber,
+			format_set_name_display($fullSetName),                              $self->shortPath($inputFilePath)
+			)
+		: $r->maketext($titles{ $self->{file_type} }, $self->shortPath($inputFilePath))
+	);
+	$header = $self->isTempEditFilePath($inputFilePath)
+		? CGI::div({ class => 'temporaryFile' }, $header)    # use colors if temporary file
+		: $header;
 
 	#########################################################################
 	# Format the page

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1378,7 +1378,10 @@ sub initialize {
 				    $param = $self->parseDateTime($param) unless (defined $unlabel || !$param);
 				}
 				if ($field =~ /restricted_release/) {
-				    $self->check_sets($db,$param) if $param;
+					if ($param) {
+						$param = WeBWorK::ContentGenerator::Instructor::format_set_name($param);
+						$self->check_sets($db,$param) if $param;
+					}
 				}
 				if (defined($properties{$field}->{convertby}) && $properties{$field}->{convertby} && $param) {
 					$param = $param*$properties{$field}->{convertby};

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -706,7 +706,10 @@ sub filter_handler {
 		$self->{visibleSetIDs} = $genericParams->{selected_sets};
 	} elsif ($scope eq "match_ids") {
 		$result = $r->maketext("showing matching sets");
-		$self->{visibleSetIDs} = [ split /\s*,\s*/, $actionParams->{"action.filter.set_ids"}[0] ];
+		my @searchTerms = map{WeBWorK::ContentGenerator::Instructor::format_set_name($_)} (split /\s*,\s*/, $actionParams->{"action.filter.set_ids"}->[0]);
+		my $regexTerms = join('|', @searchTerms);
+		my @setIDs = grep { /$regexTerms/i } (@{$self->{allSetIDs}});
+		$self->{visibleSetIDs} = \@setIDs;
 	} elsif ($scope eq "visible") {
 		$result = $r->maketext("showing visible sets");
 		$self->{visibleSetIDs} = [ $db->listGlobalSetsWhere({ visible => 1 }) ];
@@ -1127,7 +1130,7 @@ sub create_handler {
 	my $db     = $r->db;
 	my $ce     = $r->ce;
 
-	my $newSetID = $actionParams->{"action.create.name"}->[0];
+	my $newSetID = WeBWorK::ContentGenerator::Instructor::format_set_name($actionParams->{"action.create.name"}->[0]);
 	return CGI::div({ class => 'alert alert-danger p-1 mb-0' },
 		$r->maketext("Failed to create new set: set name cannot exceed 100 characters."))
 		if (length($newSetID) > 100);
@@ -1349,7 +1352,7 @@ sub import_handler {
 	my $r = $self->r;
 
 	my @fileNames = @{ $actionParams->{"action.import.source"} };
-	my $newSetName = $actionParams->{"action.import.name"}->[0];
+	my $newSetName = WeBWorK::ContentGenerator::Instructor::format_set_name($actionParams->{"action.import.name"}->[0]);
 	$newSetName = "" if $actionParams->{"action.import.number"}->[0] > 1; # cannot assign set names to multiple imports
 	my $assign = $actionParams->{"action.import.assign"}->[0];
 	my $startdate = 0;

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -27,7 +27,8 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(readFile seq_to_jitar_id jitar_id_to_seq jitar_problem_adjusted_status wwRound x);
+use WeBWorK::Utils qw(readFile seq_to_jitar_id jitar_id_to_seq jitar_problem_adjusted_status wwRound x
+	format_set_name_display);
 use WeBWorK::ContentGenerator::Instructor::FileManager;
 
 our @userInfoColumnHeadings = (x("STUDENT ID"), x("login ID"), x("LAST NAME"), x("FIRST NAME"), x("SECTION"), x("RECITATION"));
@@ -888,6 +889,7 @@ sub popup_set_form {
 	return CGI::scrolling_list({
 		name     => 'selectedSet',
 		values   => $self->{ra_set_ids},
+		labels   => { map { $_ => format_set_name_display($_) } @{ $self->{ra_set_ids} } },
 		defaults => [ $self->r->param('selectedSet') ],
 		size     => 10,
 		multiple => 1,

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -1924,7 +1924,7 @@ sub pre_header_initialize {
 		} else {
 			my $newSetName = $r->param('new_set_name');
 			# if we want to munge the input set name, do it here
-			$newSetName =~ s/\s/_/g;
+			$newSetName = WeBWorK::ContentGenerator::Instructor::format_set_name($newSetName);
 			debug("local_sets was ", $r->param('local_sets'));
 			$r->param('local_sets',$newSetName);  ## use of two parameter param
 			debug("new value of local_sets is ", $r->param('local_sets'));

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -31,7 +31,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::Form;
-use WeBWorK::Utils qw(readDirectory max sortByName wwRound x getAssetURL);
+use WeBWorK::Utils qw(readDirectory max sortByName wwRound x getAssetURL format_set_name_internal);
 use WeBWorK::Utils::Tasks qw(renderProblems);
 use WeBWorK::Utils::Tags;
 use WeBWorK::Utils::LibraryStats;
@@ -1920,21 +1920,23 @@ sub pre_header_initialize {
 
 	} elsif ($r->param('new_local_set')) {
 		if ($r->param('new_set_name') !~ /^[\w .-]*$/) {
-			$self->addbadmessage($r->maketext("The name '[_1]' is not a valid set name.  Use only letters, digits, -, _, and .",$r->param('new_set_name')));
+			$self->addbadmessage($r->maketext(
+				'The name "[_1]" is not a valid set name.  '
+					. 'Use only letters, digits, dashes, underscores, periods, and spaces.',
+				$r->param('new_set_name')
+			));
 		} else {
-			my $newSetName = $r->param('new_set_name');
-			# if we want to munge the input set name, do it here
-			$newSetName = WeBWorK::ContentGenerator::Instructor::format_set_name($newSetName);
+			# If we want to munge the input set name, do it here.
+			my $newSetName = format_set_name_internal($r->param('new_set_name'));
 			debug("local_sets was ", $r->param('local_sets'));
 			$r->param('local_sets',$newSetName);  ## use of two parameter param
 			debug("new value of local_sets is ", $r->param('local_sets'));
-			my $newSetRecord	 = $db->getGlobalSet($newSetName);
 			if (! $newSetName) {
 			    $self->addbadmessage($r->maketext("You did not specify a new set name."));
-			} elsif (defined($newSetRecord)) {
+			} elsif (defined $db->getGlobalSet($newSetName)) {
 			    $self->addbadmessage($r->maketext("The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",$newSetName));
 			} else {			# Do it!
-				$newSetRecord = $db->newGlobalSet();
+				my $newSetRecord = $db->newGlobalSet();
 				$newSetRecord->set_id($newSetName);
 				$newSetRecord->set_header("defaultHeader");
 				$newSetRecord->hardcopy_header("defaultHeader");

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -27,7 +27,7 @@ use warnings;
 #use CGI;
 use WeBWorK::CGI;
 use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
-use WeBWorK::Utils qw(sortByName jitar_id_to_seq seq_to_jitar_id getAssetURL);
+use WeBWorK::Utils qw(sortByName jitar_id_to_seq seq_to_jitar_id getAssetURL format_set_name_display);
 use PGcore;
 use Text::CSV;
 
@@ -424,6 +424,7 @@ sub body {
 					name     => 'selected_sets',
 					id       => 'selected_sets',
 					values   => \@expandedGlobalSetIDs,
+					labels   => { map { $_ => format_set_name_display($_) } @expandedGlobalSetIDs },
 					default  => $selectedSets,
 					size     => 23,
 					multiple => 1,
@@ -487,7 +488,7 @@ sub body {
 				my $prettyProblemNumber = $prettyProblemNumbers->{$setName}{$problemNumber};
 				print CGI::h3($r->maketext(
 					"Past Answers for [_1], set [_2], problem [_3]",
-					$studentUser, $setName, $prettyProblemNumber
+					$studentUser, format_set_name_display($setName), $prettyProblemNumber
 				));
 
 				my @row;

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -29,7 +29,8 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::ContentGenerator::Grades;
-use WeBWorK::Utils qw(readDirectory list2hash max sortByName jitar_id_to_seq jitar_problem_adjusted_status);
+use WeBWorK::Utils qw(readDirectory list2hash max sortByName jitar_id_to_seq jitar_problem_adjusted_status
+	format_set_name_display);
 
 # The table format has been borrowed from the Grades.pm module
 sub initialize {
@@ -77,7 +78,7 @@ sub title {
 		return $r->maketext(
 			"Statistics for [_1] set [_2]. Closes [_3]",
 			$self->{ce}->{courseName},
-			$self->{setName}, $self->formatDateTime($self->{set_due_date})
+			format_set_name_display($self->{setName}), $self->formatDateTime($self->{set_due_date})
 		);
 	}
 
@@ -116,7 +117,7 @@ sub siblings {
 			{ class => 'nav-item' },
 			CGI::a(
 				{ href => $self->systemLink($problemPage), class => 'nav-link' },
-				WeBWorK::ContentGenerator::underscore2sp($setID)
+				format_set_name_display($setID)
 			)
 		);
 	}
@@ -196,7 +197,7 @@ sub index {
 			setID    => $set
 		);
 		push @setLinks,
-			CGI::a({ href => $self->systemLink($setStatisticsPage) }, WeBWorK::ContentGenerator::underscore2sp($set));
+			CGI::a({ href => $self->systemLink($setStatisticsPage) }, format_set_name_display($set));
 	}
 
 	# Get a list of students sorted by user_id.

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -28,8 +28,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::ContentGenerator::Grades;
-use WeBWorK::Utils qw(jitar_id_to_seq jitar_problem_adjusted_status wwRound grade_set);
-#use WeBWorK::Utils qw(readDirectory list2hash max sortByName);
+use WeBWorK::Utils qw(jitar_id_to_seq jitar_problem_adjusted_status wwRound grade_set format_set_name_display);
 use WeBWorK::Utils::Grades qw/list_set_versions/;
 use WeBWorK::DB::Record::UserSet;  #FIXME -- this is only used in one spot.
 
@@ -82,7 +81,8 @@ sub title {
 		return $r->maketext(
 			'Student Progress for [_1] set [_2]. Closes [_3]',
 			$self->{ce}->{courseName},
-			$self->{setName}, $self->formatDateTime($self->{set_due_date})
+			format_set_name_display($self->{setName}),
+			$self->formatDateTime($self->{set_due_date})
 		);
 	}
 
@@ -117,9 +117,10 @@ sub siblings {
 			setID    => $setID,
 			statType => 'set',
 		);
-		my $prettySetID = $setID;
-		$prettySetID =~ s/_/ /g;
-		print CGI::li({}, CGI::a({ href => $self->systemLink($problemPage), class => 'nav-link' }, $prettySetID));
+		print CGI::li(CGI::a(
+			{ href => $self->systemLink($problemPage), class => 'nav-link' },
+			format_set_name_display($setID)
+		));
 	}
 
 	print CGI::end_ul();
@@ -218,9 +219,7 @@ sub index {
 			statType => 'set',
 			setID    => $set
 		);
-		my $prettySetID = $set;
-		$prettySetID =~ s/_/ /g;
-		push @setLinks, CGI::a({ -href => $self->systemLink($setStatisticsPage) }, $prettySetID);
+		push @setLinks, CGI::a({ href => $self->systemLink($setStatisticsPage) }, format_set_name_display($set));
 	}
 
 	for my $studentRecord (@studentRecords) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -26,7 +26,7 @@ use strict;
 use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
-use WeBWorK::Utils qw(sortByName x getAssetURL);
+use WeBWorK::Utils qw(sortByName x getAssetURL format_set_name_display);
 use WeBWorK::Debug;
 
 # We use the x function to mark strings for localizaton
@@ -326,7 +326,7 @@ sub outputSetRow {
 				class           => 'form-check-input',
 				labelattributes => { class => 'form-check-label' }
 			}),
-			defined($mergedSet)
+			defined $mergedSet
 			? CGI::b(CGI::a(
 				{
 					href => $self->systemLink(
@@ -343,10 +343,10 @@ sub outputSetRow {
 						}
 					)
 				},
-				$version ? "$setID (version $version)" : $setID
+				format_set_name_display($version ? "$setID (version $version)" : $setID)
 			))
 				. ($version ? CGI::hidden({ name => "set.$setID,v$version.assignment", value => 'delete' }) : '')
-			: CGI::b($setID),
+			: CGI::b(format_set_name_display($setID)),
 			join '',
 			$self->DBFieldTable($set, $userSet, $mergedSet, 'set', $setID, $dateFields, $dateFieldLabels),
 		]

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -27,6 +27,7 @@ use strict;
 use warnings;
 use CGI qw(-nosticky );
 use WeBWorK::Debug;
+use WeBWorK::Utils qw(format_set_name_display);
 
 sub initialize {
 	my ($self)  = @_;
@@ -144,7 +145,7 @@ sub body {
 			"When you unassign by unchecking a student's name, you destroy all of the data for homework set [_1] "
 				. 'for this student. You will then need to reassign the set to these students and they will receive '
 				. 'new versions of the problems. Make sure this is what you want to do before unchecking students.',
-			CGI::b($setID)
+			CGI::b(format_set_name_display($setID))
 		)
 	);
 
@@ -231,7 +232,7 @@ sub body {
 				$r->maketext(
 					'There is NO undo for this function.  Do not use it unless you know what you are doing!  '
 					. 'When you unassign a student using this button, or by unchecking their name, you destroy all '
-					. "of the data for homework set $setID for this student.",
+					. "of the data for homework set [_1] for this student.", format_set_name_display($setID)
 				)
 			),
 			CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -165,7 +165,7 @@ sub body {
 	my $user = $r->param("user") || "";
 	my $key = $r->param("key");
 	my $passwd = $r->param("passwd") || "";
-	my $course = $urlpath->arg("courseID");
+	my $course = $urlpath->arg("courseID") =~ s/_/ /gr;
 	my $practiceUserPrefix = $ce->{practiceUserPrefix};
 
 	# don't fill in the user ID for practice users

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -30,7 +30,8 @@ use WeBWorK::PG;
 use URI::Escape;
 use WeBWorK::Debug;
 use WeBWorK::Utils qw(path_is_subdir is_restricted is_jitar_problem_closed is_jitar_problem_hidden
-	jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id wwRound before between after grade_set);
+	jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id wwRound before between after grade_set
+	format_set_name_display);
 use WeBWorK::Localize;
 
 sub initialize {
@@ -177,14 +178,12 @@ sub siblings {
 	foreach my $setID (@setIDs) {
 		my $setPage = $urlpath->newFromModule("WeBWorK::ContentGenerator::ProblemSet", $r,
 			courseID => $courseID, setID => $setID);
-		my $pretty_set_id = $setID;
-		$pretty_set_id =~ s/_/ /g;
 		print CGI::li({ class => 'nav-item' },
 			CGI::a({
 					href => $self->systemLink($setPage),
 					id => $setID,
 					class => 'nav-link'
-				}, $pretty_set_id)
+				}, format_set_name_display($setID))
 		) ;
 	}
 	debug("End printing sets from listUserSets()");

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -28,7 +28,7 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(after readFile sortByName path_is_subdir is_restricted wwRound);
+use WeBWorK::Utils qw(after readFile sortByName path_is_subdir is_restricted wwRound format_set_name_display);
 use WeBWorK::Localize;
 # what do we consider a "recent" problem set?
 use constant RECENT => 2*7*24*60*60 ; # Two-Weeks in seconds
@@ -312,8 +312,7 @@ sub setListRow {
 
 	my $interactiveURL = $self->systemLink($problemSetPage);
 
-	my $display_name = $set->set_id;
-	$display_name =~ s/_/ /g;
+	my $display_name = format_set_name_display($set->set_id);
 	# add clock icon if timed gateway
 	if ($gwtype && $set->{version_time_limit} > 0 && time < $set->due_date()) {
 		$display_name = CGI::i(
@@ -409,8 +408,8 @@ sub setListRow {
 					{
 						class       => 'icon far fa-arrow-alt-circle-down fa-lg',
 						aria_hidden => 'true',
-						title       => $r->maketext('Download [_1]', $set->set_id =~ s/_/ /gr),
-						data_alt    => $r->maketext('Download [_1]', $set->set_id =~ s/_/ /gr)
+						title       => $r->maketext('Download [_1]', format_set_name_display($set->set_id)),
+						data_alt    => $r->maketext('Download [_1]', format_set_name_display($set->set_id))
 					},
 					''
 				)

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -856,7 +856,7 @@ sub trim_spaces {
 # This is for formatting set names input via text inputs in the user interface for internal use.  Set names are allowed
 # to be input with spaces, but internally spaces are not allowed and are converted to underscores.
 sub format_set_name_internal {
-	return $_[0] =~ s/ /_/gr;
+	return ($_[0] =~ s/^\s*|\s*$//gr) =~ s/ /_/gr;
 }
 
 # This formats set names for display, converting underscores back into spaces.

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -100,6 +100,8 @@ our @EXPORT_OK = qw(
 	textDateTime
 	timeToSec
 	trim_spaces
+	format_set_name_internal
+	format_set_name_display
 	thaw_base64
 	undefstr
 	writeCourseLog
@@ -850,6 +852,18 @@ sub trim_spaces {
 	$in =~ s/^\s*|\s*$//g;
 	return($in);
 }
+
+# This is for formatting set names input via text inputs in the user interface for internal use.  Set names are allowed
+# to be input with spaces, but internally spaces are not allowed and are converted to underscores.
+sub format_set_name_internal {
+	return $_[0] =~ s/ /_/gr;
+}
+
+# This formats set names for display, converting underscores back into spaces.
+sub format_set_name_display {
+	return $_[0] =~ s/_/ /gr;
+}
+
 sub list2hash(@) {
 	map {$_ => "0"} @_;
 }


### PR DESCRIPTION
This updates pull request #1412 to the current develop branch.

Furthermore, this adds two methods in lib/WeBWorK/Utils.pm for formating set names.  `format_set_name_internal` is used to reformat set names when input by an instructor into a text input, and replaces spaces with underscores.  `format_set_name_display` goes the other way, and replaces underscores with spaces anytime a set is displayed in the ui.  The methods are in lib/WeBWorK/Utils.pm instead of in lib/WeBWorK/ContentGenerator/Instructor.pm, because the methods are also used outside of the instructor tools (at least `format_set_name_display` is).  Note that the only place that this is not done is in the Library Browser.  That is because this is done in pull request #1619.  Although it does not use the `format_set_name_display` method as that method is not available in that pull request.  Once either of these pull requests are merged, I will update the other accordingly to do so.

@Alex-Jordan:  I hope you don't mind me continuing your work on this.