### PR TITLE
Hebrew translations updates - from WW 2.16 in the Technion

### DIFF
--- a/lib/WeBWorK/Localize/heb.po
+++ b/lib/WeBWorK/Localize/heb.po
@@ -23,7 +23,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:683
 msgid "# of active students"
-msgstr "מספר תלמידים פעילים"
+msgstr "מספר סטודנטים פעילים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:498
 msgid "#corr"
@@ -35,7 +35,7 @@ msgstr "#שגוי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2032
 msgid "% Score:"
-msgstr ""
+msgstr "% ציון:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:667
 msgid "% correct"
@@ -49,7 +49,7 @@ msgstr "% נכון עם ביקורת"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:723
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:760
 msgid "% students"
-msgstr "% תלמידים"
+msgstr "% הסטודנטים"
 
 #. ($achievement->{points})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:319
@@ -64,12 +64,12 @@ msgstr "%1 שאלות:"
 #. ($itemCounts{$item->id()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:241
 msgid "%1 remaining"
-msgstr ""
+msgstr "%1 נשארים"
 
 #. ($numAdded, $numSkipped, join(", ", @$skipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1322
 msgid "%1 sets added, %2 sets skipped. Skipped sets: (%3)"
-msgstr "%1 גליונות נוספו, %2 גליונות שעליהם דילגו. הגליונות שעליהם דילגו: (%3)"
+msgstr "נוספו %1 גליונות, דילגו על %2 גליונות. הגליונות שעליהן דילגו: (%3)"
 
 #. ($numExported, $numSkipped, (($numSkipped)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1428
@@ -79,7 +79,7 @@ msgstr "%1 גליונות יוצאו, %2 גליונות שעליהם דילגו.
 #. ($count, $numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:626
 msgid "%1 students out of %2"
-msgstr "%1 תלמידים מתוך %2"
+msgstr "%1 סטודנטים מתוך %2"
 
 #. ($rename_oldCourseID, $rename_oldCourseTitle, $rename_newCourseTitle, $rename_oldCourseInstitution, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1316
@@ -187,7 +187,7 @@ msgstr "(כל שינויים שלא נשמרו ימחקו)"
 msgid ""
 "(Instructor hint preview: show the student hint after the following number "
 "of attempts:"
-msgstr "(צפייה ברמז למדריך: הראה לתלמיד את הרמז לאחר מספר זה של נסיונות:"
+msgstr "(צפייה ברמז למורה: הראה לסטודנט את הרמז לאחר מספר זה של נסיונות:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1805
 msgid "(This problem will not count towards your grade.)"
@@ -202,13 +202,13 @@ msgstr "(מבחן זה הוגש באיחור מכיוון שהוא לא הוגש
 #. ($testNoun, $self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1821
 msgid "(Your score on this %1 is not available until %2.)"
-msgstr "(הניקוד שלך על זה %1 לא זמין עד %2.)"
+msgstr "(הציון שלך על %1 זה לא זמין עד %2.)"
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1823
 msgid "(Your score on this %1 is not available.)"
-msgstr "(הניקוד שלך על זה  %1 לא זמין.)"
+msgstr "הציון שלך על %1 זה לא זמין.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1364
 msgid "(correct)"
@@ -216,7 +216,7 @@ msgstr "(נכון)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:200
 msgid "(gw/quiz) After version answer date"
-msgstr "(מחסום/בוחן) אחרי תאריך התשובות של הגירסה"
+msgstr "(מבחן מחסום) אחרי תאריך התשובות של הגרסה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1366
 msgid "(incorrect)"
@@ -225,25 +225,26 @@ msgstr "(לא נכון)"
 #. ($recScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1368
 msgid "(score %1)"
-msgstr "(ניקוד %1)"
+msgstr "(ציון %1)"
 
 #. ($vnum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:488
 msgid "(version&nbsp;%1)"
-msgstr ""
+msgstr "(גרסה&nbsp;%1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1179
 msgid ". If this is a class roster, rename it to have extension '.lst'"
 msgstr ""
+". אם זה קובץ רשימת סטודנטים, יש לשנות את שם הקובץ כדי לססים בסיומת '.lst'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:622
 msgid "1 student"
-msgstr "1 תלמיד"
+msgstr "סטודנט 1"
 
 #. (wwRound(2, $weights[$part] * 100)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SingleProblemGrader.pm:124
 msgid "<b>Weight:</b> %1%"
-msgstr ""
+msgstr "<b>משקל:</b> %1%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:240
 msgid ""
@@ -259,12 +260,12 @@ msgid ""
 "std_problem_grader (the all or nothing grader). It will work with custom "
 "graders if they are written appropriately.</p>"
 msgstr ""
-"<p>לאחר תאריך התלחת תקןפת הניקוד המופחת כל ,תשובות נוספות של התלמיד יקבלו "
+"<p>לאחר תאריך התלחת תקופת הניקוד המופחת כל ,תשובות נוספות של הסטודנט יקבלו "
 "ערך מופחת. כאן ניתן למלא את הערך המופת באחוזים. לדוגמה, אם הערך הוא 50% "
-"ותלמיד צופה בשאלה בזמן תקופת הניקוד המופחת, הוא יראה את ההודעה \"אתה בתקופת "
+"וסטודנט צופה בשאלה בזמן תקופת הניקוד המופחת, הוא יראה את ההודעה \"אתה בתקופת "
 "ניקוד מופחת: כל הגשה נוספת תחשב כ-50% מהניקוד המקורי.\"</p><p>כדי להשתמש "
 "אפשרות זאת, יש גם לאפשר ניקוד מופחת ולבחור תאריך ניקוד מופחת לכל מטלה בנפרד, "
-"על-ידי עריכתו של הנתונים של הגליון בעזרת עורך אוספי שיעורי הבית.</p><p>זה "
+"על-ידי עריכתו של הנתונים של הגליון בעזרת עורך גליונות שיעורי הבית.</p><p>זה "
 "עובד עם avg_problem_grader (שהוא המנקד לפי ברירת המחדל) ועם "
 "std_problem_grader ( מנקד לפי הכל או כלום). זה יעבוד גם עם מנקדים שנכתבו על-"
 "ידי המשתמשים, אם הם נכתבו כנדרש.</p>"
@@ -316,7 +317,7 @@ msgstr ""
 "\" נלחץ; שים לב שיש להפעיל את <b>תלע\"א-בדוק תשובות</b> באותו הזמן</"
 "li><li><b>תלע\"א-תראה רמזים</b>: מראה רמזים <i>עבור השאלה החדשה</i>(בהנחה "
 "שקיימים)</li></ul> שים לב: אין ממש סיבה להפעיל את הכפתור אלא עם כן מופעלות "
-"לפחות אחת מאפשרויות אלו - התלמידים פשוט יראו גרסה חדשה שהם לא יכולים לפתור "
+"לפחות אחת מאפשרויות אלו - הסטודנטים פשוט יראו גרסה חדשה שהם לא יכולים לפתור "
 "או ללמוד ממנה.</p>"
 
 #. ($add_courseID)
@@ -359,8 +360,8 @@ msgid ""
 "check that no problems are missing and that they are all legible. If not, "
 "please inform your instructor."
 msgstr ""
-"הוכן קובץ להדפסה, אבל הוא עשוי להיות חלקי או שגוי. אנא בדוק ששום שאלות אינן "
-"חסרות וכולן קריאות. אם לא, אנא פנה למדריך שלך."
+"הוכן קובץ להדפסה, אבל הוא עשוי להיות חלקי או שגוי. אנא בדוק שאין שאלות חסרות "
+"ושכולן קריאות. אם לא, אנא פנה למורה שלך או לצוות התמיכה."
 
 #. ($locationID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2739
@@ -375,8 +376,8 @@ msgid ""
 "A message with the subject line \"%1\" has been sent to %quant(%2,recipient) "
 "in the class %3.  There were %4 message(s) that could not be sent."
 msgstr ""
-"הודעה עם הנושא \"%1\" נשלחה ל-%quant(%2, נמען) בכיתה %3.  לא היה נתן לשלוח "
-"%4 הודעה/ות."
+"הודעה עם הנושא \"%1\" נשלחה ל-%quant(%2, נמען, נמענים) בכיתה %3.  לא היה ניתן "
+"לשלוח %4 הודעה/ות."
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:609
@@ -396,7 +397,7 @@ msgid ""
 "to 100 indicates the grade earned. The number on the second line gives the "
 "number of incorrect attempts."
 msgstr ""
-"נוקדה (.) מסמל שהשאלה לא נוסתה, והמספר מ-0 ל-100 מראה את הניקוד. המספר בשורה "
+"נוקדה (.) מסמל שהשאלה לא נוסתה, והמספר מ-0 ל-100 מראה את הציון. המספר בשורה "
 "השנייה הוא מספר הניסיונות הלא נכונים."
 
 # Leave symbol codes in place
@@ -407,8 +408,8 @@ msgid ""
 "and whether it is correct (&#x2713;), in progress (&hellip;), incorrect "
 "(&#x2717;), or unattempted (no symbol)."
 msgstr ""
-"מתג ששולט בשימוש במד ההתקדמות עבור התלמיד; המתג גם מפעיל/מכבה את הדגשת השעלה "
-"הנוכחית בסרגל הצד, והאם היא נכונה (&#x2713;), מתבצעת (&hellip;), שגויה "
+"מתג ששולט בשימוש במד ההתקדמות עבור הסטודנט; המתג גם מפעיל/מכבה את הדגשת "
+"השעלה הנוכחית בסרגל הצד, והאם היא נכונה (&#x2713;), מתבצעת (&hellip;), שגויה "
 "(&#x2717;), או לא נוסתה כלל (ללא סימון)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:108
@@ -427,19 +428,20 @@ msgid ""
 "to a page where you can view and reassign the sets for the selected user."
 msgstr ""
 "טבלה שמראה את כל המשתמשים העשיויים ובנוסף מס' נתונים על המשתמשים. הנתונים "
-"מימין לשמאל: שם משתמש, מצב התחברות, אוספים שהוקצאו, שם פרטי, שם משפחה, כתובת "
-"דוא\"ל, מס' תלמיד, מצב לימודים, קבוצה, תרגול, תגובות, והרשאות. לחיצה על "
-"הקישורים בראש העמוד תמhין את הטבלה לפי הנתון המתאים. תאי שם המשתמשים מכילים "
-"ריבועים לסימון בחירת המשתמש. לחיצה על הקישור שבשם עצמו יאפשר פהתחזות לאותו "
-"משתמש. יהיה גם תמונת קישור לאחר השם שיוביל לעמוד בו ניתן את פרטי אותו "
-"המשתמש. לחיצה על דוא\"ל תאפשר שליחת דוא\"ל לאותו המשתמש. הקישורים בעמודת "
-"האוספים שהוקצאו מובילים לעמוד בו ניתן לראות ולהקצות אוספים עבור אותו משתשמש."
+"מימין לשמאל: שם משתמש, מצב התחברות, גליונות שהוקצאו, שם פרטי, שם משפחה, "
+"כתובת דוא\"ל, מס' סטודנט, מצב לימודים, קבוצה, קבוצת תרגול, תגובות, והרשאות. "
+"לחיצה על הקישורים בראש העמוד תמיין את הטבלה לפי הנתון המתאים. תאי שם "
+"המשתמשים מכילים ריבועים לסימון בחירת המשתמש. לחיצה על הקישור שבשם עצמו יאפשר "
+"פהתחזות לאותו משתמש. יהיה גם תמונת קישור לאחר השם שיוביל לעמוד בו ניתן את "
+"פרטי אותו המשתמש. לחיצה על דוא\"ל תאפשר שליחת דוא\"ל לאותו המשתמש. הקישורים "
+"בעמודת הגליונות שהוקצאו מובילים לעמוד בו ניתן לראות ולהקצות גליונות עבור "
+"אותו משתשמש."
 
 # Short for ADJUSTED STATUS
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:492
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:704
 msgid "ADJ STATUS"
-msgstr "סטטוס מותאם"
+msgstr "ציון מותאם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2069
 msgid "ANSWERS NOT RECORDED"
@@ -455,13 +457,15 @@ msgstr "התשובות נבדקו בלבד --"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2058
 msgid "ANSWERS ONLY CHECKED -- ANSWERS NOT RECORDED"
-msgstr "התשובות נבדקו בלבד --  תשובות לא נשמרו"
+msgstr "התשובות נבדקו אך לא נשמרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2080
 msgid ""
 "ATTEMPT NOT ACCEPTED -- Please submit answers again (or request new version "
 "if neccessary)."
 msgstr ""
+"ההגשה לא נקלטה עקב תקלה טכנית. יש להגיש שוב את התשובות, או לפי הצורך לבקש "
+"גרסה חדשה של השאלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1007
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1435
@@ -473,14 +477,15 @@ msgstr "בטל שינויים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:934
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1374
 msgid "Abandon export"
-msgstr "בטל יצוא"
+msgstr "בטל ייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:508
-#, fuzzy
 msgid ""
 "Account creation is currently disabled in this course.  Please speak to your "
 "instructor or system administrator."
-msgstr "הייתה שגיאה בתהליך ההתחברות. אנא פנה למדריך או למנהל מערכת."
+msgstr ""
+"נחסמה האפשרות ליצור חשבונות חדשים בקורס זה. אנא פנה למורה הקורס או למנהל "
+"מערכת לקבלת סיוע."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:155
 msgid "Achievement"
@@ -498,7 +503,7 @@ msgstr "הישג %1 קיים. לא נוצר הישג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:586
 msgid "Achievement Editor"
-msgstr "עורך הישגים"
+msgstr "עורך ההישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:596
 msgid "Achievement Evaluator Editor"
@@ -578,8 +583,7 @@ msgid ""
 "Activiating this will enable Mathchievements for webwork.  Mathchievements "
 "can be managed by using the Achievement Editor link."
 msgstr ""
-"מאפשר הישגי מתמטיקה עבור webwork. הישגי מתמטיקה ניתנים לשינוי בעזרת הקישור "
-"לעורך היעדים. "
+"מפעיל הישגים עבור הקורס. ניהול ההישגים מתבצע בעורך ההישגים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:225
 msgid ""
@@ -587,7 +591,7 @@ msgid ""
 "students who earn achievements with items that allow them to affect their "
 "homework in a limited way."
 msgstr ""
-"מאפשר חפצי הישגים. כלי זה מזכה תלמידים שזכו בהישגים בחפצים שיאפשרו להם "
+"מפעיל חפצי הישגים. כלי זה מזכה סטודנטים שזכו בהישגים בחפצים שיאפשרו להם "
 "להשפיע על שיעורי הבית שלהם באופן מוגבל."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:395
@@ -609,7 +613,7 @@ msgstr "הוסף קורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:197
 msgid "Add Students"
-msgstr "הוסף תלמידים"
+msgstr "הוסף סטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:417
 msgid "Add Users"
@@ -617,11 +621,11 @@ msgstr "הוסף משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:520
 msgid "Add WeBWorK administrators to new course"
-msgstr "הוסף מנהלי WeBWorK לקורס חדש"
+msgstr "הוסף מנהלי ווב-וורק לקורס החדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1392
 msgid "Add a new test for which Gateway?"
-msgstr "הוסף מבחן חדש לאיזה בוחן מחסום?"
+msgstr "הוסף מבחן חדש לאיזה מבחן מחסום?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1323
 msgid "Add as what filetype?"
@@ -629,7 +633,7 @@ msgstr "איזה סוג קובץ להוסיף?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1011
 msgid "Add how many users?"
-msgstr ""
+msgstr "כמה משתמשים להוסיף?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:848
 msgid "Add problems to"
@@ -744,7 +748,7 @@ msgstr "הוסף 48 שעות לתאריך סגירת שיעורי הבית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:419
 msgid "Adjusted Status"
-msgstr "סטטוס מותאם"
+msgstr "ציון מותאם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:65
 msgid "Adobe PDF"
@@ -762,12 +766,12 @@ msgstr "לאחר תאריך התשובות של הגליון"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:362
 msgid ""
 "After the reduced scoring period begins all work counts for %1% of its value."
-msgstr "לאחר תחילת תקופת הניקוד המופחת, כל ניקוד נספר כ-%1% מערכו."
+msgstr "לאחר תחילת תקופת הניקוד המופחת, כל ציון נספר כ-%1% מערכו המלא."
 
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:758
 msgid "Afterward reduced credit can be earned until %1."
-msgstr ""
+msgstr "לאחר מכן ניתן לקבל ניקוד מופחת עד %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:711
 msgid "All Selected Constraints Joined by \"And\""
@@ -779,11 +783,11 @@ msgstr "כל המטלות בוצעו בהצלחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:416
 msgid "All of the answers above are correct."
-msgstr "כל התשובות לעיל הן נכונות."
+msgstr "כל התשובות נכונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:414
 msgid "All of the gradeable answers above are correct."
-msgstr "כל התשבות לעיל שניתנות לניקוד הן נכונות."
+msgstr "כל התשבות שניתנות לבדיקה הן נכונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:238
 msgid "All of these files will also be made available for mail merge."
@@ -791,27 +795,27 @@ msgstr "כל הקבצים הללו יהיו נגשים לאיחוד דואר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:958
 msgid "All selected sets hidden from all students"
-msgstr "כל האוספים שנבחרו הם מוחבאים מכל התלמידים"
+msgstr "כל הגליונות שנבחרו הוחבאו מכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:957
 msgid "All selected sets made visible for all students"
-msgstr "כל האוספים שנבחרו הם ניתנים לצפייה לכל התלמידים"
+msgstr "כל הגליונות שנבחרו נהפכו לזמינים לכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:948
 msgid "All sets hidden from all students"
-msgstr "כל האוספים הם מוחבאים מכל התלמדים"
+msgstr "כל הגליונות הוחבאו מכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:947
 msgid "All sets made visible for all students"
-msgstr "כל האוספים הם ניתנים לצפייה לכל התלמידים"
+msgstr "כל הגליונות נהפכו לזמינים לכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1357
 msgid "All sets were selected for export."
-msgstr ""
+msgstr "כל הגליונות נבחרו לייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 msgid "All students in course"
-msgstr "כל התלמידים בקורס"
+msgstr "כל הסטודנטים בקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:57
 msgid "All unassignments were made successfully."
@@ -819,15 +823,15 @@ msgstr "כל ביטולי ההקצאות בוצעו בהצלחה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:953
 msgid "All visible hidden from all students"
-msgstr "כל הנראים כאן הם מוחבאים מכל התלמידים"
+msgstr "כל הגליונות שהיו ברישמה הוגדרו כלא זמינים לכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:952
 msgid "All visible sets made visible for all students"
-msgstr "כל האוספים הנראים כאן הם ניתנים לצפייה לכל התלמידים"
+msgstr "כל הגליונות שהיו ברשימה הוגדרו כזמינים לכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:397
 msgid "Allow Unicode alternatives in student answers"
-msgstr ""
+msgstr "אפשר חלופות Unicode בתשובות של הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:184
@@ -869,7 +873,7 @@ msgstr "מורשה לראות תשובות מהעבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:342
 msgid "Allowed to view problems in sets which are not open yet"
-msgstr "מורש לצפות בשאלו באוספים שעדיין לא נפתחו"
+msgstr "מורשה לצפות בשאלות בגליונות שעדיין לא נפתחו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1449
 msgid "Amulet of Extension"
@@ -902,7 +906,7 @@ msgstr "שגיאה ארעה בזמן שינוי השם של הקורס %1 ל-%2:
 #. ($part + 1)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SingleProblemGrader.pm:103
 msgid "Answer %1 Score (%):"
-msgstr ""
+msgstr "תשובה %1 ציון (%):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:490
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:795
@@ -917,7 +921,7 @@ msgstr "רשימת תשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:316
 msgid "Answer Preview"
-msgstr "תצוגה מקדימה של תשובות"
+msgstr "תצוגה מקדימה של התשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1371
 msgid "Answer(s) submitted:"
@@ -956,22 +960,22 @@ msgstr "תשובות לא יכולות להפוך לזמינות עד זמן א�
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:300
 msgid ""
 "Any changes made below will be reflected in the achievement for ALL students."
-msgstr "כל שינוי שנעשה למטה יוחל על ההישגים עבור כל התלמידים."
+msgstr "כל שינוי שנעשה למטה יוחל על ההישגים עבור כל הסטודנטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2141
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:576
 msgid "Any changes made below will be reflected in the set for ALL students."
-msgstr "כל שינוי שנעשה למטה יוחל על הגליון עבור כל התלמידים."
+msgstr "כל שינוי שנעשה למטה יוחל על הגליון עבור כל הסטודנטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2139
 msgid ""
 "Any changes made below will be reflected in the set for ONLY the student(s) "
 "listed above."
-msgstr "כל שינוי שנעשה למטה יופיע בגליון רק עבור התלמיד/ים למעלה."
+msgstr "כל שינוי שנעשה למטה יופיע בגליון רק עבור הסטודנט/ים למעלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:128
 msgid "Append"
-msgstr "צרף"
+msgstr "צרף לגליון"
 
 #. (CGI::strong("$fullSetID")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1639
@@ -1050,11 +1054,11 @@ msgstr "הקצה %1 לכל המשתמשים, צור מידע גלובלי, ו %2
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:264
 msgid "Assign All Sets to Current User"
-msgstr "הקצה את כל האוספים למשתמש הנוכחי"
+msgstr "הקצה את כל הגליונות למשתמש הנוכחי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:167
 msgid "Assign selected sets to selected users"
-msgstr "הקצה את האוספים שנבחרו לתלמידים שנבחרו"
+msgstr "הקצה את הגליונות שנבחרו לסטודנטים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1283
 msgid "Assign this set to which users?"
@@ -1072,7 +1076,7 @@ msgstr "הוקצה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1866
 msgid "Assigned Sets"
-msgstr "אוספים שהוקצו"
+msgstr "גליונות שהוקצו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:520
 msgid "Assigned achievements to users"
@@ -1080,7 +1084,7 @@ msgstr "הקצה הישגים למשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2068
 msgid "Assigned to"
-msgstr "הקצה ל-"
+msgstr "הוקצה ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:205
 msgid "Assignment type"
@@ -1092,7 +1096,7 @@ msgstr "רק מטלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:421
 msgid "At least one of the answers above is NOT correct."
-msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
+msgstr "לפחות אחת מהתשובות איננה נכונה."
 
 # Short for "Attempts to Open Children"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:416
@@ -1112,16 +1116,16 @@ msgstr "בוצע נסיון"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1061
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:414
 msgid "Attempts"
-msgstr "ניסיונות"
+msgstr "מספר ניסיונות שכבר הוגשו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:118
 msgid "Audit"
-msgstr "צופה"
+msgstr "שומע חופשי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:348
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:354
 msgid "Authentication failed.  Please speak to your instructor."
-msgstr "האימות נכשל. אנא פנה למדריך."
+msgstr "האימות נכשל. אנא פנה למורה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:520
 msgid "Author Info"
@@ -1139,7 +1143,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2540
 msgid "Automatically render problems on page load"
-msgstr "הצג שאלות ישירוצ לאחר טעינת העמוד"
+msgstr "הצג את השאלות ישירות לאחר טעינת העמוד"
 
 #. ($emailDirectory,$old_default_msg_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:415
@@ -1176,7 +1180,7 @@ msgid ""
 msgstr ""
 "כברירת מחדל, המשוב תמיד נשלח לכל המשתמשים שנבחרו לקבלת משוב. משתנה זה גורם "
 "למערכת לשלוח דוא\"ל משוב רק למשתמשים חברי אותה הקבוצה כמו המשתמש ששולח את "
-"המשוב. ז\"א משוב ישלח רק למנהיגי הקבוצה."
+"המשוב. כלומר, משוב ישלח רק למורי הקבוצה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:442
 msgid ""
@@ -1201,7 +1205,7 @@ msgstr "עוגת התפיחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:317
 msgid "Can e-mail instructor"
-msgstr "יכול לשלוח דוא\"ל למדריך"
+msgstr "יכול לשלוח דוא\"ל למורה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:327
 msgid "Can report bugs"
@@ -1213,7 +1217,7 @@ msgstr "יכול לראות תשובות מהעבר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:322
 msgid "Can submit answers for a student"
-msgstr "יכול לשלוח תשבות בשם תלמיד"
+msgstr "יכול לשלוח תשבות בשם סטודנט"
 
 #. ($!)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:626
@@ -1311,18 +1315,16 @@ msgstr "ביטול דוא\"ל"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:101
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:83
 msgid "Cancel Edit"
-msgstr ""
+msgstr "בטל עריכה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:80
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:112
-#, fuzzy
 msgid "Cancel Export"
-msgstr "ביטול"
+msgstr "בטל ייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:93
-#, fuzzy
 msgid "Cancel Password"
-msgstr "שנה סיסמה"
+msgstr "בטל הגדרת סיסמה"
 
 #. ($filePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:293
@@ -1423,11 +1425,11 @@ msgstr "פרק:"
 #: /opt/webwork/webwork2/lib/FormatRenderedProblem.pm:282
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1679
 msgid "Check Answers"
-msgstr "בדוק תשובות"
+msgstr "בדיקת התשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2186
 msgid "Check Test"
-msgstr "בדוק מבחן"
+msgstr "בדיקת המבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:219
 msgid "Check that it's permissions are set correctly."
@@ -1450,7 +1452,7 @@ msgstr "בחר את הגליון שתרצה שיחשב פי-2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:394
 msgid "Choose the set which you would like to enable partial credit for."
-msgstr "בחר את הגליון עבורו תרצה להפעיל ניקוד חלקי."
+msgstr "בחר את הגליון עבורו תרצה להפעיל ניקוד מופחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1112
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:131
@@ -1465,11 +1467,11 @@ msgstr "בחר את הגליון שתרצה להאריך את תאריך הסג�
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:912
 msgid "Choose visibility of the sets to be affected"
-msgstr "בחר את האופן בו האוספים שנבחרו יהיו ניתנים לצפייה"
+msgstr "איך לשנות את הזמנינות של הגליונות? הפוך אותן אל "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:896
 msgid "Choose which sets to be affected"
-msgstr "בחר אילו אוספים יושפעו"
+msgstr "בחר אילו גליונות יושפעו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:499
 msgid "Class values"
@@ -1481,7 +1483,7 @@ msgstr "עורך רשימות כיתה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:349
 msgid "Clear"
-msgstr "רוקן"
+msgstr "בטל את הבחירה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:926
 msgid "Clear Problem Display"
@@ -1492,7 +1494,7 @@ msgid ""
 "Click on a student's name to see the student's version of the homework set. "
 "Click heading to sort table."
 msgstr ""
-"לחץ על שמו של תלמיד על מנת לראות את גירסתו של גליון שיעורי הבית. לחץ על "
+"לחץ על שמו של סטודנט על מנת לראות את גירסתו של גליון שיעורי הבית. לחץ על "
 "הכותרות כדי למיין את הטבלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:574
@@ -1500,8 +1502,8 @@ msgid ""
 "Click on the login name to edit individual problem set data, (e.g. due "
 "dates) for these students."
 msgstr ""
-"לחץ על שם המשתמש כדי לערוך מידע של גליון שאלות ספציפי, (למשל תאריך הגשה) "
-"עבור תלמידים אלו."
+"לחץ על שם המשתמש כדי לערוך נתוני הגליון עבור סטודנט מסוים, (למשל תאריך "
+"הגשה, מספר נסיונות מותרים) עבור הסטודנט הנבחר."
 
 #. ($clientIP->ip()
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:553
@@ -1580,16 +1582,16 @@ msgstr "הערה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SingleProblemGrader.pm:158
 msgid "Comment:"
-msgstr ""
+msgstr "הערה:"
 
 #. ($self->formatDateTime($set->answer_date)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1965
 msgid "Completed results for this assignment are not available until %1"
-msgstr "תוצאות עבור מטלה זו אינן זמינות עד %1"
+msgstr "התוצאות עבור מטלה זו אינן זמינות עד %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1967
 msgid "Completed results for this assignment are not available."
-msgstr "תוצאות עבור מטלה זו אינן זמינות."
+msgstr "התוצאות עבור מטלה זו אינן זמינות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:468
 msgid "Completed."
@@ -1611,7 +1613,7 @@ msgstr "אשר סיסמה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1398
 msgid "Confirm which sets to export."
-msgstr ""
+msgstr "אשר אילו גליונות לייצא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementEvaluator.pm:285
 msgid "Congratulations, you earned a new level!"
@@ -1639,7 +1641,7 @@ msgstr "העתק קובץ בשם:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:525
 msgid "Copy simple configuration file to new course"
-msgstr ""
+msgstr "העתק את הקובץ simple.conf לקורס החדש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:571
 msgid "Copy templates from:"
@@ -1656,7 +1658,7 @@ msgstr "נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:644
 msgid "Correct Adjusted Status"
-msgstr "תקן סטטוס מותאם"
+msgstr "ציון מותאם נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:318
 msgid "Correct Answer"
@@ -1668,7 +1670,7 @@ msgstr "תשובות נכונות:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:640
 msgid "Correct Status"
-msgstr "תקן סטטוס"
+msgstr "ציון נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:594
 msgid "Correct answers"
@@ -1751,19 +1753,20 @@ msgstr "ניהול הקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:435
 msgid "Course Configuration"
-msgstr "תצורת קורס"
+msgstr "הגדרות הקורס"
 
 #. ($ce->{maxCourseIdLength})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1236
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2176
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:657
 msgid "Course ID cannot exceed %1 characters."
-msgstr ""
+msgstr "מזהה הקורס Course ID איינו יכול להכיל יותר מ- %1 תווים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1239
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:651
 msgid "Course ID may only contain letters, numbers, hyphens, and underscores."
-msgstr "מזהה הקורס יכול להכיל רק אותיות, מספרים, מקפים, וקוים תחתונים."
+msgstr ""
+"מזהה הקורס Course ID יכול להכיל רק אותיות, מספרים, מקפים, וקוים תחתונים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:500
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:932
@@ -1839,7 +1842,7 @@ msgstr "איזה סוג של גליון ליצור?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1649
 msgid "Create unattached problem"
-msgstr "צור שאלה ללא שיכות"
+msgstr "צור שאלה ללא שייכות כרגע לגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1691
 msgid ""
@@ -1964,7 +1967,7 @@ msgstr "מחק מיקום:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:953
 msgid "Delete which users?"
-msgstr ""
+msgstr "אילו משתמשים יש למחוק?"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:698
@@ -1990,11 +1993,13 @@ msgstr "מוחק קובץ זמני ב%1"
 msgid ""
 "Deletion deletes all location data and related addresses, and is not "
 "undoable!"
-msgstr "המחיקה תמחוק את כל מידע המיקום וכתובות שקשורות עליו, והיא בלתי הפיך!"
+msgstr ""
+"המחיקה תמחוק את כל הנתונים על מקומות מוגדרים וכתובות שקשורות אל המקומות האלו. "
+"הפעולה בלתי הפיכה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:661
 msgid "Deletion destroys all achievement-related data and is not undoable!"
-msgstr "מחיקה הורסת את כל המידע שקשור להישג והיא בלתי הפיכה!"
+msgstr "המחיקה מוחקת לחלוטין את כל ההתונים שקשור להישגים והיא פעולה בלתי הפיכה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:188
 msgid "Deny From"
@@ -2026,7 +2031,7 @@ msgstr "התיקייה '%1' הוסרה (פריטים שנמחקו: %2)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:401
 msgid "Directory permission errors "
-msgstr "שגיאות התרי תיקייה"
+msgstr "קיימות שגיאות בהרשאות של תיקיות חשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1912
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2434
@@ -2060,7 +2065,7 @@ msgstr "יש לתקן את מבנה התיקייה באופן ידני לפני 
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2341
 msgid "Directory structure or permissions need to be repaired. "
-msgstr "יש לתקן את מבנה התיקייה או את ההיתרים. "
+msgstr "יש לתקן את מבנה התיקייה או את ההרשאות. "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2330
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:380
@@ -2069,12 +2074,12 @@ msgstr "מצב תצוגה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:434
 msgid "Display Past Answers"
-msgstr "הראה תשובות מהעבר"
+msgstr "צפייה בתשובות קודמות"
 
 # $testNoun is either "test" or "submission"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:315
 msgid "Display of scores for this set is not allowed."
-msgstr "הצגת הצינים למטלה זו אסורה."
+msgstr "הצגת הציונים למטלה זו אסורה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:778
 msgid "Display options: Show"
@@ -2082,11 +2087,11 @@ msgstr "אפשריות תצוגה: הראה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:381
 msgid "Display the evaluated student answer"
-msgstr "הצג את התשובה הבדוקה של התלמיד"
+msgstr "הצג את התשובה של הסטודנט לאחר פיענוח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:175
 msgid "Do not unassign students unless you know what you are doing."
-msgstr "אל תבטל את ההקצאה של תלמידים אלא אם אתה יודע מה אתה עושה."
+msgstr "אל תבטל את ההקצאה של סטודנטים אלא אם אתה יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:273
 msgid "Do not uncheck a set unless you know what you are doing."
@@ -2095,7 +2100,7 @@ msgstr "אל תבטל גליון אם אתה לא יודע מה אתה עושה.
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:151
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:126
 msgid "Do not uncheck students, unless you know what you are doing."
-msgstr "אל תבטל הקצאת תלמידים אם אתה לא יודע מה אתה עושה."
+msgstr "אל תבטל את הסימון של סטודנטים ברשימה אם אתה לא יודע מה אתה עושה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1951
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1959
@@ -2156,7 +2161,7 @@ msgstr "הורד קובץ להדפסה"
 #. ($pl)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:342
 msgid "Download Hardcopy for Selected %plural(%1,Set,Sets)"
-msgstr "הורד קובץ להדפסה עבור האוספים שנבחרו"
+msgstr "הורד קובץ להדפסה עבור הגליונות שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:456
 msgid "Download PDF or TeX Hardcopy for Current Set"
@@ -2173,17 +2178,17 @@ msgstr "הורדה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:118
 msgid "Drop"
-msgstr "עזוב"
+msgstr "פרש מהקורס"
 
 #. ($self->formatDateTime($set->reduced_scoring_date, undef,					$r->ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:137
 msgid "Due %1, after which reduced scoring is available until %2"
-msgstr ""
+msgstr "להגשה עד %1, לאחר מכן ניתן להגיש לניקוד מופחת עד %2"
 
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:768
 msgid "Due date %1 has passed."
-msgstr ""
+msgstr "מועד ההגשה %1 כבר עבר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1557
 msgid "Duplicate this set and name it"
@@ -2201,7 +2206,7 @@ msgid ""
 "checkers will be used by default."
 msgstr ""
 "במהלך קיץ 2005, גרסה חדשה יותר של בודקי התשובות הוספה עבור תשובות שהן "
-"פונקציות או מספרים. הבודקים החדשים מאפשרים יותר פוונקציות בתשובות התלמידים, "
+"פונקציות או מספרים. הבודקים החדשים מאפשרים יותר פוונקציות בתשובות הסטודנטים, "
 "ומתפקדות טוב יותר במקרים מסויימים. חלק מהשאלות בנויות במיוחד עבור בודקי "
 "התשובות החדשים (או הישנים). אבל עבור רוב השאלות, אתה יכול לבחור מה תהיה "
 "ברירת המחדל. <p> בחירת <i> לא נכון</i> כאן אומר שהבודקים החדשים יהיו ברירת "
@@ -2213,7 +2218,7 @@ msgstr "דוא\"ל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:344
 msgid "E-mail Instructor"
-msgstr "שלח דוא\"ל למדריך"
+msgstr "שלח דוא\"ל למורה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:431
 msgid "E-mail addresses which can receive e-mail from a pg problem"
@@ -2223,7 +2228,7 @@ msgstr "כתובות דוא\"ל שיכולות לקבל הודעה משאלת PG
 msgid ""
 "E-mail feedback from students automatically sent to this permission level "
 "and higher:"
-msgstr "דוא\"ל משוב מתלמידים נשלח אוטומטית לדרגת היתרים זו ומעלה:"
+msgstr "דוא\"ל משוב מסטודנטים נשלח אוטומטית לחשבונות בעלי רמת הרשאה זו ומעלה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:421
 msgid "E-mail verbosity level"
@@ -2304,7 +2309,7 @@ msgstr "ערוך את המידע של %1"
 #. (CGI::strong($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2095
 msgid "Edit set %1 data for ALL students assigned to this set."
-msgstr "ערוך את המידע של הגליון %1 עבור כל התלמידים שלהם שהוקצעו לגליון הזה."
+msgstr "ערוך את המידע של הגליון %1 עבור כל הסטודנטים שלהם שהוקצעו לגליון הזה."
 
 #. (CGI::a({href=>$editSetLink},$setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2080
@@ -2319,16 +2324,16 @@ msgid ""
 "changes and return to the Manage Locations page."
 msgstr ""
 "ערוך את הערך הנוכחי של תיאור המיקום, אם אתה רוצה, ואז תוסיף כתובות למחיקה, "
-"ואז לחץ על כפתור \"בצע פעולה\" כדי לבצע את כל השינויים. או, לחץ \"נהל מיקומים"
+"ואז לחץ על כפתור \"בצע את הפעולה!\" כדי לבצע את כל השינויים. או, לחץ \"נהל מיקומים"
 "\" למעלה כדי לא לבצע שינויים ולחזור למנהל המיקומים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:851
 msgid "Edit which sets?"
-msgstr "איזה אוספים לערוך?"
+msgstr "אילו גליונות לערוך?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:861
 msgid "Edit which users?"
-msgstr ""
+msgstr "אילו משתמשים לערוך?"
 
 #. ($titles{$file_type}, $self->shortPath($inputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:592
@@ -2348,7 +2353,7 @@ msgstr "עורך את המיקום %1"
 #. (CGI::strong($setID . $vermsg)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2094
 msgid "Editing problem set %1 data for these individual students: %2"
-msgstr "עורך את המידע של גליון השאלות %1 עבור התלמידים הספציפים האלה: %2"
+msgstr "עורך את המידע של גליון השאלות %1 עבור הסטודנטים הספציפים האלה: %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:406
 msgid "Editor"
@@ -2376,7 +2381,7 @@ msgstr "גוף הדוא\"ל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:299
 msgid "Email Instructor On Failed Attempt"
-msgstr "שלח דוא\"ל למדריך בכל נסיון כושל"
+msgstr "שלח דוא\"ל למורה בכל נסיון כושל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1869
 msgid "Email Link"
@@ -2390,7 +2395,7 @@ msgstr "כתובת דוא\"ל"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1728
 msgid "Email instructor"
-msgstr "שלח דוא\"ל למדריך"
+msgstr "שלח דוא\"ל למורה"
 
 #. (scalar(@{$self->{ra_send_to}})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:527
@@ -2440,8 +2445,8 @@ msgid ""
 "Enable reduced scoring for a homework set.  This will allow you to submit "
 "answers for partial credit for 24 hours after the close date."
 msgstr ""
-"אפשר ניקוד מופחת עבור מחבן שיעורי בית. יאפשר לשלוח תשובות עבור ניקוד חלקי 24 "
-"שעות לאחר תאריך הסגירה."
+"אפשר ניקוד מופחת עבור גליון שיעורי בית. יאפשר לשלוח תשובות עבור ניקוד חלקי "
+"למשך 24 שעות לאחר תאריך הסגירה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1348
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1358
@@ -2454,9 +2459,8 @@ msgid ""
 "attempts. Student would have to click Request New Version to obtain new "
 "version of the problem and to continue working on the problem"
 msgstr ""
-"הפעל רנדומיזציה מחדש של שאלות מדי לסרוגין לאחר מספר מסויים של נסיונות. "
-"התלמידילחץ על \"בקש גרסה חדשה\" כדי לקבל גרסה חדשה של השאלה ולהמשיך לעבוד על "
-"השאלה "
+"מפעיל רנדומיזציה תקופתית מחדש של שאלות לאחר מספר מסויים של נסיונות. הסטודנט "
+"ילחץ על \"בקש גרסה חדשה\" כדי לקבל גרסה חדשה של השאלה ולהמשיך לעבוד על השאלה "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:230
 msgid ""
@@ -2466,16 +2470,16 @@ msgid ""
 "homework set until they have achieved the minimum score on all of the listed "
 "sets."
 msgstr ""
-"הפעל את השימוש במערכת הפרסום המותנה. כדי להשתמש בפרסום מותנה צריך לפרט רשימה "
-"של שמות בדף פרטי גליון השאלות, ולפרט ציון מינימלי. לתלמידים לא יהיה גישה "
-"לגליון הזה עד שהגיעו לציון המינימלי בכל האוספים שנרשמו."
+"מפעיל מערכת הפרסום המותנה. כדי להשתמש בפרסום מותנה צריך לפרט רשימה של שמות "
+"בדף פרטי גליון השאלות, ולפרט ציון מינימלי. לסטודנטים לא יהיה גישה לגליון "
+"הנתון עד שהגיעו לציון המינימלי בכל הגליונות שנרשמו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:179
 msgid ""
 "Enables the use of the date picker on the Homework Sets Editor 2 page and "
 "the Problem Set Detail page"
 msgstr ""
-"מפעיל את השימוש בבורר התאריך על אוספי שיעורי הבית דף עורך 2 ודף פרטי גליון "
+"מפעיל את השימוש בבורר התאריך על גליונות שיעורי הבית דף עורך 2 ודף פרטי גליון "
 "השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:270
@@ -2484,8 +2488,8 @@ msgid ""
 "seeded version of the current problem, complete with solution (if it exists "
 "for that problem)."
 msgstr ""
-"הפעל את השימוש בכפתור \"תראה לי עוד אחת\", שנותן לתלמיד גרסה עם מספרים שונים "
-"של אותה השאלה, ביחד עם פתרון מתאים (אם קיים לשאלה)."
+"מפעיל את השימוש בכפתור \"תראה לי עוד אחת\", שנותן לסטודנט גרסה עם מספרים "
+"שונים של אותה השאלה, ביחד עם פתרון מתאים (אם קיים לשאלה)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:118
 msgid "Enrolled"
@@ -2493,7 +2497,7 @@ msgstr "רשום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:743
 msgid "Enrolled, Drop, etc."
-msgstr "רשום, פרש, וכו'."
+msgstr "רשום, פרש מהקורס, וכו'."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:771
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:793
@@ -2515,16 +2519,16 @@ msgid ""
 "Enter information below for students you wish to add. Each student's "
 "password will initially be set to their student ID."
 msgstr ""
-"הכנס מידע כאן לגבי התלמידים שאתה רוצה להוסיף כל סיסמה של תלמיד תהיה מזהה "
-"התלמיד שלו בהתחלה."
+"הכנס מידע כאן לגבי הסטודנטים שאתה רוצה להוסיף כל סיסמה של סטודנט תהיה מזהה "
+"הסטודנט שלו בהתחלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:315
 msgid "Entered"
-msgstr "הוכנס"
+msgstr "הוזן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:88
 msgid "Entered student:"
-msgstr "תלמיד שהוכנס:"
+msgstr "סטודנט שהוכנס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:198
 msgid "Equation Display"
@@ -2587,7 +2591,7 @@ msgstr "שיגאה: תאריך סגירה לא יכול להיות יותר מ-1
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:551
 msgid "Error: no file data was submitted!"
-msgstr ""
+msgstr "שגיאה: לא הגיעו נתונים לשמור בקובץ!"
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1151
@@ -2610,8 +2614,9 @@ msgid ""
 "create the file hide_directory in the course's directory. Check the "
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
-"אירעו שגיאות זמן החבאת הקורסים שנרשמו למטה בזמן הנסיון ליצור את הקובץ  "
-"hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרים של תיקיית הקורס, %1"
+"אירעו שגיאות בזמן החבאת הקורסים שנרשמו למטה בזמן הנסיון ליצור את הקובץ  "
+"hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההרשאות של תיקיות הקורסים. "
+"למשל בקורס %1"
 
 #. ("$coursesDir/$failed_courses[0]/")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3241
@@ -2621,8 +2626,8 @@ msgid ""
 "ownership and permissions of the course's directory, e.g %1"
 msgstr ""
 "שגיאות אירעו בזמן הפיכת הקורסים שנרשמו למטה לגלויים בזמן הניסיון למחוק את "
-"הקובץ hide_directory בתיקיית הקורס. בדוק את הבעלות ואת ההיתרית של תיקיית "
-"הקורס, %11"
+"הקובץ hide_directory בתיקיות הקורסים. בדוק את הבעלות ואת ההרשאות של תיקיות "
+"הקורסים. למשל בקורס %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1364
 msgid "Evaluator"
@@ -2670,19 +2675,19 @@ msgstr "פתח הכל"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:107
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:89
 msgid "Export"
-msgstr "יצא"
+msgstr "ייצא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:949
 msgid "Export selected achievements."
-msgstr "יצא הישגים שנבחרו."
+msgstr "ייצא הישגים שנבחרו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1131
 msgid "Export to what kind of file?"
-msgstr "איזה סוג קובץ ליצא?"
+msgstr "איזה סוג קובץ לייצא?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1115
 msgid "Export which users?"
-msgstr "איזה משתמשים ליצא?"
+msgstr "איזה משתמשים לייצא?"
 
 #. ($FileName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1000
@@ -2691,14 +2696,14 @@ msgstr "הישגים יוצאו ל-%1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1493
 msgid "Extend the close date for which Gateway?"
-msgstr "הארך את תאריך הסגירה של איזה בוחן מחסום?"
+msgstr "הארך את תאריך הסגירה של איזה מבחן מחסום?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1450
 msgid ""
 "Extends the close date of a gateway test by 24 hours. Note: The test must "
 "still be open for this to work."
 msgstr ""
-"מאריך את תאריך הסגירה של בוחן מחסום ב-24 שעות. שים לב: הבוחן חייב להיות פתוח "
+"מאריך את תאריך הסגירה של מבחן מחסום ב-24 שעות. שים לב: המבחן חייב להיות פתוח "
 "כדי שזה יעבוד."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
@@ -2725,7 +2730,7 @@ msgstr "יצירת גליון חדש נכשלה: לא הוכנס שם לגליו
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1132
 msgid "Failed to create new set: set name cannot exceed 100 characters."
-msgstr ""
+msgstr "תהליך ייצור הגליון החדש נכשל: שם הגליון מוגבל ל- 100 תווים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:752
 msgid ""
@@ -2753,7 +2758,7 @@ msgstr "שכפול הגליון נכשל: גליון %1 כבר קיים!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:77
 msgid "Failed to enter student:"
-msgstr "הוספת תלמיד נכשלה:"
+msgstr "נכשלה הוספת הסטודנט:"
 
 #. ($scoreFilePath)
 #. ($filePath)
@@ -2836,7 +2841,7 @@ msgstr "הקובץ '%1' הוסר בהצלחה"
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:949
 msgid "File '%1' uploaded successfully"
-msgstr ""
+msgstr "הקובץ '%1' הועלה בהצלחה"
 
 #. ($name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:909
@@ -2875,7 +2880,7 @@ msgstr "קבצים עם הסיומת '.%1' בדרכ כלל שייכים ל-'%2"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:102
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:84
 msgid "Filter"
-msgstr ""
+msgstr "סנן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:682
 msgid "Filter by what text?"
@@ -2927,7 +2932,7 @@ msgstr "פורמט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:415
 msgid "Format for the subject line in feedback e-mails"
-msgstr "פורמט עבור נשורת נושא בדוא\"ל משוב."
+msgstr "פורמט עבור שורת הנושא בדוא\"ל משוב."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/DropdownList.pm:173
 #: /opt/webwork/webwork2/lib/WeBWorK/HTML/ScrollingRecordList.pm:164
@@ -2959,15 +2964,15 @@ msgstr "שימוש גלובאלי"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1494
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1597
 msgid "Gateway Name "
-msgstr "שם בוחן מחסום"
+msgstr "שם מבחן מחסום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:216
 msgid "Gateway Quiz %2"
-msgstr "בוחן מחסום %2"
+msgstr "מבחן מחסום %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:795
 msgid "Gateway parameters"
-msgstr "הפאראמטרים של בוחן המחסום"
+msgstr "הגדרות של מבחן המחסום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:129
 msgid "General"
@@ -2983,15 +2988,15 @@ msgstr "מידע כללי"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:279
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:280
 msgid "Generate Hardcopy"
-msgstr "תיצור קובץ להדפסה"
+msgstr "צור קובץ להדפסה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:350
 msgid "Generate Hardcopy for Select Sets"
-msgstr ""
+msgstr "צור קבצי הדפסה לגליונות שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:477
 msgid "Generate hardcopy for selected sets and selected users"
-msgstr "צור קובץ להדפסה עבור האוספים והמשתמשים שנבחרו."
+msgstr "צור קבצי הדפסה עבור הגליונות והמשתמשים שנבחרו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:472
 msgid "Get Library Set Problems"
@@ -3012,19 +3017,22 @@ msgstr "לאיזה משתמשים לתת סיסמה חדשה?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:976
 msgid "Gives full credit on a single homework problem."
-msgstr "תן ניקוד מלא על שאלת שיעורי בית אחת."
+msgstr "נותן ציון מלא על שאלה בודדת בגליון שיעורי בית."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1087
 msgid "Gives full credit on every problem in a set."
-msgstr "תן ניקוד מלא על כל שאלה בגליון."
+msgstr "נותן ציון מלא על כל השאלות בגליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:770
 msgid "Gives half credit on a single homework problem."
-msgstr "תן חצי ניקוד על שאלה אחת משעורי הבית."
+msgstr ""
+"מעלה ציון של שאלה אחת בגליון שיעורי בית ב- 50 נקודות (אך לכל היותר לציון "
+"100)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:886
 msgid "Gives half credit on every problem in a set."
-msgstr "תן חצי ניקוד על כל שאלה מגליון."
+msgstr ""
+"מעלה את הציונים של כל השאלות בגליון ב- 50 נקודות (אך לכל היותר לציון 100)."
 
 #. ($problemID, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1476
@@ -3041,13 +3049,13 @@ msgstr "התחל"
 
 #: /opt/webwork/pg/macros/compoundProblem.pl:470
 msgid "Go back to Part 1"
-msgstr ""
+msgstr "חזור לחקל 1"
 
 #: /opt/webwork/pg/macros/compoundProblem.pl:291
 #: /opt/webwork/pg/macros/compoundProblem.pl:480
 #: /opt/webwork/pg/macros/compoundProblem.pl:491
 msgid "Go on to next part"
-msgstr ""
+msgstr "המשך לחלק הבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2429
 msgid "Grade"
@@ -3061,7 +3069,7 @@ msgstr "נקד שאלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2184
 msgid "Grade Test"
-msgstr "נקד מבחן"
+msgstr "הגש את המבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:424
 msgid "Grader"
@@ -3102,13 +3110,13 @@ msgstr "פורמט קובץ להדפסה:"
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:272
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:281
 msgid "Hardcopy Generator"
-msgstr "יוצר הקבצים להדפסה"
+msgstr "יוצר קבצים להדפסה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:99
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:486
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:792
 msgid "Hardcopy Header"
-msgstr "קידומת גירסת הדפסה"
+msgstr "קידומת לגירסת הדפסה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:636
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:170
@@ -3117,7 +3125,7 @@ msgstr "עיצוב גרסת הדפסה"
 
 #: /opt/webwork/pg/macros/problemRandomize.pl:409
 msgid "Hardcopy will always print the original version of the problem."
-msgstr ""
+msgstr "בקבצי הדפסה תמיד יודפס הגרסה המקורית של השאלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2217
 msgid "Headers"
@@ -3133,7 +3141,7 @@ msgstr "הנה גרסה חדשה של השאלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:918
 msgid "Hidden"
-msgstr "מוחבא"
+msgstr "מוחבא/לא זמין לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2327
 msgid "Hide All"
@@ -3150,7 +3158,7 @@ msgstr "החבא רמזים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:406
 msgid "Hide Hints from Students"
-msgstr "החבא רמזים מהתלמידים"
+msgstr "החבא רמזים מהסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3044
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:375
@@ -3163,7 +3171,7 @@ msgstr "רמז:"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1558
 msgid "Hint: "
-msgstr ""
+msgstr "רמז: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:600
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:391
@@ -3201,7 +3209,7 @@ msgstr "קוץ אייקון"
 msgid ""
 "If a password field is left blank, the student's current password will be "
 "maintained."
-msgstr "אם משארים את שדה הסיסמה ריק, סיסמת התלמיד לא תשתנה."
+msgstr "אם משארים את שדה הסיסמה ריק, סיסמת הסטודנט לא תשתנה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:433
 msgid ""
@@ -3210,9 +3218,9 @@ msgid ""
 "of the problem's status and the weighted average of the status of its child "
 "problems which have this flag enabled."
 msgstr ""
-"כשזה נבחר, שאלה זו תחשב לניקוד השאלה המכילה. בכללי הסטאטוס המותאם של שאלה "
-"הוא הסטאטוס הגדול יותר מסטאטוס השאלה והממוצע המותאם של הסטאטוס של השאלות "
-"המוכלות שעבורם אפשרות זו נבחרה."
+"כשזה נבחר, שאלה זו תחשב לציון של השאלה המכילה. באופן כללי הציון המותאם של "
+"שאלה הוא הציון הגדול יותר מבין ציון השאלה עצמה והממוצע המשורלל של ציוני "
+"השאלות המוכלות שעבורם אפשרות זו הופעלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:305
 msgid ""
@@ -3220,8 +3228,8 @@ msgid ""
 "emails will be notified whenever a student runs out of attempts on a problem "
 "and its children without receiving an adjusted status of 100%."
 msgstr ""
-"אם זה מופעל אז מדריכים שיכולים לקבל משוב יקבלו הודעה בכל פעם שלתלמיד נגמר "
-"הנסיונות על שאלה והשאלות המוכלות בלי לקבל סטאטוס מותאם של 100%"
+"אם זה מופעל אז מורים שיכולים לקבל משוב יקבלו הודעה בכל פעם שלסטודנט נגמר "
+"הנסיונות על שאלה והשאלות המוכלות בלי לקבל ציון מותאם של 100%"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:295
 msgid ""
@@ -3229,8 +3237,8 @@ msgid ""
 "they have completed all of the previous problems, and their child problems "
 "if necessary."
 msgstr ""
-"אם זה מופעל אז תלמידים לא יוכלו לנסות שאלה עד שהשלימו את כל השאלות הקודמות, "
-"והאשלות המוכלות במידת הצורך."
+"אם זה מופעל אז סטודנטים לא יוכלו לנסות שאלה נתונה עד שהשלימו את כל השאלות "
+"הקודמות, והאשלות המוכלות (צאצאים בעץ השאלות) במידת הצורך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:94
 msgid ""
@@ -3247,7 +3255,7 @@ msgstr ""
 
 #: /opt/webwork/pg/macros/problemRandomize.pl:408
 msgid "If you come back to it later, it may revert to its original version."
-msgstr ""
+msgstr "אם תחזור לשאלה בהמשל, ייתכן שהשאלה תחזור לגרסה המקורית."
 
 #. ($file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:689
@@ -3262,29 +3270,29 @@ msgstr "שם קובץ לא חוקי, מכיל '..'"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:106
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:88
 msgid "Import"
-msgstr "יבא"
+msgstr "ייבא"
 
 # Context is "Import achievements from ____ assigning the achievements to ___"
 #. (CGI::popup_menu(			-name => "action.import.source",			-values => [ "", $self->getAxpList()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:785
 msgid "Import achievements from %1 assigning the achievements to %2."
-msgstr "יבא הישגים מ- %1 והקצב את ההישגים ל- %2-"
+msgstr "ייבא הישגים מ- %1 והקצב את ההישגים ל- %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1243
 msgid "Import from where?"
-msgstr "מאיפה ליבא?"
+msgstr "מאיפה לייבא?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1228
 msgid "Import how many sets?"
-msgstr "כמה אוספים ליבא?"
+msgstr "כמה גליונות לייבא?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1259
 msgid "Import sets with names"
-msgstr "יבא אוספים עם שמות"
+msgstr "ייבא גליונות עם שמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1028
 msgid "Import users from what file?"
-msgstr "מאיזה קובץ ליבא משתמשים?"
+msgstr "מאיזה קובץ לייבא משתמשים?"
 
 #. ($count)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:889
@@ -3329,15 +3337,15 @@ msgstr "מוסד:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2108
 msgid "Instructor Comment:"
-msgstr ""
+msgstr "הערת המורה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:320
 msgid "Instructor Tools"
-msgstr "כלי מדריך"
+msgstr "כלי מורה"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1226
 msgid "Instructor solution preview: show the student solution after due date."
-msgstr "הצגת פתרון למדריך: הראה לתלמיד פתרון לאחר מועד ההגשה."
+msgstr "הצגת פתרון למורה: התפרון מוצג לסטודנט רק לאחר מועד ההגשה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:442
 msgid "Invalid Reply-to address."
@@ -3365,7 +3373,7 @@ msgstr "מזהה משתמש או סיסמה לא תקינים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:85
 msgid "Item Used Successfully!"
-msgstr ""
+msgstr "החפץ הופעל בהצלחה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:233
 msgid "Items"
@@ -3457,7 +3465,7 @@ msgstr "דפדפן ספרייה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:361
 msgid "List of display modes made available to students"
-msgstr "רשימת מצבי התצוגה המופיעים לתלמידים"
+msgstr "רשימת מצבי התצוגה המוצגים לסטודנטים כאפשרויות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:432
 msgid ""
@@ -3636,7 +3644,7 @@ msgstr "קובץ איחוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:319
 msgid "Message"
-msgstr "הודעה"
+msgstr "הודעות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:671
 msgid "Message file:"
@@ -3669,11 +3677,11 @@ msgstr "הזז"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2026
 msgid "Move to Page:"
-msgstr ""
+msgstr "עבור אל דף:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2024
 msgid "Move to Problem:"
-msgstr ""
+msgstr "עבור אל שאלה:"
 
 # Msg is short for message
 #. ($recipient, $ur->email_address)
@@ -3752,7 +3760,7 @@ msgstr "סיסמה חדשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:130
 msgid "New Version"
-msgstr ""
+msgstr "גרסה חדשה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:835
 msgid "New file name:"
@@ -3769,17 +3777,17 @@ msgstr "סיסמאות חדשות נשמרו"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1199
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1201
 msgid "Next Problem"
-msgstr "שאלה הבאה"
+msgstr "השאלה הבאה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1137
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1138
 msgid "Next Student"
-msgstr ""
+msgstr "הסטדונט הבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1259
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1260
 msgid "Next Test"
-msgstr ""
+msgstr "המבחן הבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1686
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:915
@@ -3826,7 +3834,7 @@ msgid ""
 "No authentication method found for your request.  If this recurs, please "
 "speak with your instructor."
 msgstr ""
-"לא נמצאה שיטת אימות לבקשה שלך. אם בעיה זו חוזרת על עצמה, אנא פנה למדריך שלך."
+"לא נמצאה שיטת אימות לבקשה שלך. אם בעיה זו חוזרת על עצמה, אנא פנה למורה שלך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:943
 msgid "No change made to any set"
@@ -3910,23 +3918,23 @@ msgstr "לא נמצא רישום."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1136
 msgid "No set created."
-msgstr ""
+msgstr "לא נוצר גליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:49
 msgid "No sets in this course yet"
-msgstr "עדיין לא קיימים אוספים בקורס זה"
+msgstr "עדיין לא קיימים גליונות בקורס זה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1008
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:294
 msgid "No sets selected for scoring"
-msgstr "לא נבחרו אוספים לנקד"
+msgstr "לא נבחרו גליונות לנקד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2757
 msgid ""
 "No sets shown.  Choose one of the options above to list the sets in the "
 "course."
 msgstr ""
-"לא מוצגים אוספים. בחר את אחת האפשרויות לעיל כדי להציג את האוספים בקורס."
+"לא מוצגים גליונות. בחר את אחת האפשרויות למעלה כדי להציג את הגליונות בקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1916
 msgid "No source filePath specified"
@@ -3941,7 +3949,7 @@ msgid ""
 "No students shown.  Choose one of the options above to list the students in "
 "the course."
 msgstr ""
-"לא מוצגים תלמידים. אנא בחר את אחד  מהאפשרויות לעיל כדי לראות את התלמידים "
+"לא מוצגים סטודנטים. אנא בחר את אחד מהאפשרויות למעלה כדי לראות את הסטודנטים "
 "בקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:955
@@ -4036,7 +4044,7 @@ msgstr "רק לאחר תאריך התשובות של הגליון"
 msgid ""
 "Only this permission level and higher get buttons for sending e-mail to the "
 "instructor."
-msgstr "רק רמת ההיתר הזאת ומעלה מקבלים גישה לכפתור לשליחת דוא\"ל למדריך."
+msgstr "רק רמת הרשאה זאת ומעלה מקבלים גישה לכפתור לשליחת דוא\"ל למורה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:672
 msgid "Open"
@@ -4076,15 +4084,15 @@ msgstr "פתוח, מועד הגשה אחרון: %1."
 #. ($beginReducedScoringPeriod)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:758
 msgid "Open, due %1."
-msgstr ""
+msgstr "פתוח, מועד הגשה אחרון: %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:34
 msgid "Open:"
-msgstr "פתח:"
+msgstr "מועד פתיחה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:113
 msgid "Opens"
-msgstr "פותח"
+msgstr "מועד פתיחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:99
 msgid "Opens any homework set for 24 hours."
@@ -4092,7 +4100,7 @@ msgstr "פותח גליון שיעורי בית ל-24 שעות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:212
 msgid "Optional Modules"
-msgstr "מערכות אפשריות"
+msgstr "מודולים אופציונאליים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:259
 msgid "Order Problems Randomly"
@@ -4166,12 +4174,12 @@ msgstr "תצוגה מקדימה בלבד -- התשובות לא נשמרות"
 # Problem Number
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:378
 msgid "PROB NUMBER"
-msgstr "מספר שאלה"
+msgstr "מספר השאלה"
 
 # Problem Value
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:381
 msgid "PROB VALUE"
-msgstr "ערך שאלה"
+msgstr "ערך השאלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:210
 msgid "Pad Fields"
@@ -4206,15 +4214,15 @@ msgstr "אחוז"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:574
 msgid "Percentage of Active Students with Correct Answers"
-msgstr "אחוז התלמידים הפעילים עם תשובות נכונות"
+msgstr "אחוז הסטודנטים הפעילים עם תשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:757
 msgid ""
 "Percentile cutoffs for number of attempts. The 50% column shows the median "
 "number of attempts."
 msgstr ""
-"אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. עמודת ה-50% מראה את "
-"החציון של מספר הניסיונות"
+"חסם באחוזים לכמות נסיונות הגשה שנוצלו. עמודת ה-50% מראה את החציון של מספר "
+"ניסיונות ההגשה שנוצלו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1875
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:301
@@ -4227,7 +4235,7 @@ msgstr "רמת הרשאה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:302
 msgid "Permissions"
-msgstr "היתרים"
+msgstr "הרשאות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3128
 msgid ""
@@ -4242,20 +4250,23 @@ msgstr ""
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given full credit."
-msgstr "אנא בחר שם גליון ומספר מספר שאלה של השאלה שיש לתת לה ניקוד מלא."
+msgstr "אנא בחר שם גליון ומספר שאלה של השאלה שיש לתת לה ניקוד מלא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:819
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "be given half credit."
-msgstr "אנא בחר שם גליון ומספר מספר שאלה של השאלה שיש לתת לה חצי ניקוד."
+msgstr ""
+"אנא בחר שם גליון ומספר שאלה של השאלה שיש להוסיף לציון שלה 50 נקושות (השינוי "
+"לא יגדיל את הציון מעל 100)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:595
 msgid ""
 "Please choose the set name and problem number of the question which should "
 "have its incorrect attempt count reset."
 msgstr ""
-"אנא בחר שם גליון ומספר מספר שאלה של השאלה שלה יש לאפס את ספירת הניסיונות."
+"אנא בחר שם גליון ומספר שאלה של השאלה שיש לאפס לה את מונה הניסיונות הלא "
+"נכונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:706
 msgid ""
@@ -4319,47 +4330,47 @@ msgstr "פרטי בדיקה מקדימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1333
 msgid "Prepare which sets for export?"
-msgstr ""
+msgstr "הכן אילו גליונות לייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SingleProblemGrader.pm:164
 msgid "Preview Comment"
-msgstr ""
+msgstr "תצוגה מקדימה של ההערה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "Preview Message"
-msgstr "צפייה מוקדמת בהודעה"
+msgstr "תצוגה מקדימה של ההודעה"
 
 #: /opt/webwork/webwork2/lib/FormatRenderedProblem.pm:279
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1677
 msgid "Preview My Answers"
-msgstr "צפייה מוקדמת בתשובות שלי"
+msgstr "תצוגה מקדימה של התשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2182
 msgid "Preview Test"
-msgstr "צפייה מוקדמת במבחן"
+msgstr "תצוגה מקדימה של התשובות למבחן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:722
 msgid "Preview message"
-msgstr "צפייה מוקדמת בהודעה"
+msgstr "תצוגה מקדימה של ההודעה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:721
 msgid "Preview set to:"
-msgstr "הצג גליון עבור:"
+msgstr "תצוגה מקדימה עבור:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1185
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1187
 msgid "Previous Problem"
-msgstr "שאלה קודמת"
+msgstr "השאלה הקודמת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1109
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1110
 msgid "Previous Student"
-msgstr ""
+msgstr "הסטודנט הקודם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1228
 msgid "Previous Test"
-msgstr ""
+msgstr "המבחן הקודם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1682
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:910
@@ -4406,7 +4417,7 @@ msgstr "שאלה %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:359
 msgid "Problem Display/Answer Checking"
-msgstr ""
+msgstr "הצגת שאלות/בדיקת תשובות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:490
 msgid "Problem Editor"
@@ -4431,7 +4442,7 @@ msgstr "מספר שאלה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SingleProblemGrader.pm:132
 msgid "Problem Score (%):"
-msgstr ""
+msgstr "ציון השאלה (%):"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:490
 msgid "Problem Techniques"
@@ -4447,7 +4458,7 @@ msgstr "השאלה נבחרת באופן אקראי מתוך קבוצת שאלו
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1507
 msgid "ProblemGrader"
-msgstr ""
+msgstr "עורך ידני של הציון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2323
@@ -4461,11 +4472,11 @@ msgstr "שאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:62
 msgid "Problems for all students have been unassigned."
-msgstr "הוקצאו שאלות לכל התלמידים"
+msgstr "בוטלו הקצאות השאלות לכל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:65
 msgid "Problems for selected students have been reassigned."
-msgstr "הוקצאו שאלות לתלמידים הנבחרים"
+msgstr "הוקצאו מחדש שאלות לסטודנטים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:57
 msgid "Problems have been assigned to all current users."
@@ -4489,11 +4500,11 @@ msgstr "שם משתמש משגיח:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:236
 msgid "Proctored Gateway Quiz %2"
-msgstr "השגיח על בוחן מחסום %2"
+msgstr "מבחן מחסום מושגח %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:245
 msgid "Proctored Gateway Quiz %2 Proctor Login"
-msgstr "השגיח על מבחן מחסום %2 התחברות משגיח"
+msgstr "מבחן מחסום מושגח %2 התחברות המשגיח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:828
 msgid ""
@@ -4501,8 +4512,8 @@ msgid ""
 "Provide a password to have a single password for all students to start a "
 "proctored test."
 msgstr ""
-"כדי להתחיל ולנקד מבחן עם משגיח צריך הרשאת משגיח. תן סיסמה כדי שיהיה סיסמה "
-"אחת שכל התלמידים יוכלו להתחיל בעזרתה מבחן עם משגיח."
+"נדרש אישור של משגיח כדי לפתוח ולהגיש מבחן עם השגחה. ניתן לספק כאן סיסמה "
+"בודדת איתה כל הסטודנטים יוכלו להתחיל את המבחן המושגח."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:105
 msgid "Publish"
@@ -4510,15 +4521,15 @@ msgstr "פרסם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:495
 msgid "Quiz with time limit"
-msgstr ""
+msgstr "מבחן עם הגבלת זמן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:496
 msgid "Quiz with time limit."
-msgstr ""
+msgstr "מבחן עם הגבלת זמן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "RECITATION"
-msgstr "תרגול"
+msgstr "קבוצת תרגול"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:227
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:215
@@ -4542,11 +4553,11 @@ msgstr "אתה באמת רוצה למחוק את הפריטים לעיל?"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:817
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:845
 msgid "Recitation"
-msgstr "תרגול"
+msgstr "קבוצת תרגול"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:202
 msgid "Record Scores for Single Sets"
-msgstr "שמור ניקוד לאוספים בודדים"
+msgstr "שמור ציונים לגליונות בודדים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:492
 msgid "Reduced Scoring"
@@ -4569,7 +4580,7 @@ msgstr "הפעלת ניקוד מופחת"
 #. ($self->formatDateTime($set->due_date()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:768
 msgid "Reduced credit can still be earned until %1."
-msgstr ""
+msgstr "ניתן לקבל ניקוד מופחת עד %1."
 
 # Short for "Reduced Scoring:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:35
@@ -4592,12 +4603,12 @@ msgstr "רענן רשימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:193
 msgid "Relax IP restrictions when?"
-msgstr "הרגע הגבלות IP מתי?"
+msgstr "ממתי לשחרר את מגבלות כתובת IP?"
 
 # Context is "Attempts Remaining"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:415
 msgid "Remaining"
-msgstr "נותר"
+msgstr "נסיונות נותרים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:267
 msgid "Remember Me"
@@ -4619,17 +4630,17 @@ msgstr "שנה שם"
 #. ($rename_oldCourseID, $rename_newCourseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1188
 msgid "Rename %1 to %2"
-msgstr "שנה את שם %1 ל-%2"
+msgstr "שנה את שם %1 ל- %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:363
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:921
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:981
 msgid "Rename Course"
-msgstr "שנה שם לקורס"
+msgstr "שנה שם של קורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:655
 msgid "Rename file as:"
-msgstr "שנה שם קובץ ל-:"
+msgstr "שנה שם הקובץ אל:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2463
 msgid "Render"
@@ -4653,13 +4664,13 @@ msgid ""
 "a test even if the close date has past. This item does not allow you to take "
 "additional versions of the test."
 msgstr ""
-"פותח מחדש בוחן מחסום ל-24 שעות נוספות. דבר זה מאפשר לך לבצע אותו אפילו עם "
-"עבר תאריך הסגירה. חפץ זה לא מאפשר לך לבצע גרסאות אחרות של הבוחן הזה."
+"פותח מחדש מבחן מחסום ל-24 שעות נוספות. החפץ מאפשר לך לבצע אותו אפילו עם עבר "
+"מועד הסגירה. חפץ זה לא מאפשר לך לבצע גירסאות נוספות של המבחן."
 
 #. (CGI::strong("$fullSetID/$prettyProbNum")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1633
 msgid "Replace current problem: %1"
-msgstr "החלףשאלה נוכחית: %1"
+msgstr "החלף את השאלה הנוכחית: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1039
 msgid "Replace which users?"
@@ -4671,11 +4682,11 @@ msgstr "השב ל-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:525
 msgid "Report Bugs in this Problem"
-msgstr "דווח על באגים בשאלה הזו"
+msgstr "דווח על שגיאה בשאלה זו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:959
 msgid "Report bugs"
-msgstr "דווח על באגים"
+msgstr "דווח על שגיאות"
 
 #. ($upgrade_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2414
@@ -4688,7 +4699,7 @@ msgstr "דווח עבור קורס %1:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1092
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1848
 msgid "Report on database structure for course %1:"
-msgstr "דווח מבנה מסד נתונים עבור קורס %1:"
+msgstr "דו\"ח על מבנה מסד הנתונים עבור הקורס %1:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1673
 msgid "Request New Version"
@@ -4717,15 +4728,17 @@ msgid ""
 "generator %2 was called.  Try re-entering the set from the problem sets "
 "listing page."
 msgstr ""
-"הגליון שבוקש '%1' הוא מטלת שיעורי בית אבל יוצר התכנים של בוחן המחסום/בוחן %2 "
-"נקרא.  נסה  להכניס מחדש את הגליון מעמוד רישום אוספי השאלות."
+"הגליון שבוקש '%1' הוא גליון שיעורי בית רגיל, אבל המערכת קיבלה פנייה להציג את "
+"התוכן כמבחן: %2. יש להכניס מחדש אל הגליון מדף רשימת הגליונות."
 
 #. ($setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:474
 msgid ""
 "Requested set '%1' is a proctored test/quiz assignment, but no valid proctor "
 "authorization has been obtained."
-msgstr "הגליון שבוקש '%1' הוא מטלת בבוחן מוגנת, אבל לא הושג אימות משגיח תקין."
+msgstr ""
+"הגליון שבוקש '%1' הוא מבחן מושגח, אבל לא התקבל אישור תקין ממשגיח להתחיל את "
+"המבחן."
 
 #. ($setName,$node_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:459
@@ -4734,8 +4747,8 @@ msgid ""
 "assignment content generator %2 was called.  Try re-entering the set from "
 "the problem sets listing page."
 msgstr ""
-"הגליון שבוקש '%1' הוא מטלת בוחן/מבחן אבל יוצר התכנים של מטלות שיעורי הבית %2 "
-"נקרא. נסה להכניס מחדש את הגליון מעמוד רישום אוספי השאלות."
+"הגליון שבוקש '%1' הוא מבחן, אבל המערכת קיבלה פנייה להציג את התוכן כגליון "
+"שיעורי בית רגיל %2. יש להכניס מחדש אל הגליון מדף רשימת הגליונות."
 
 #. ($setName,$effectiveUserName)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authz.pm:426
@@ -4787,15 +4800,15 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:181
 msgid "Restrict Access by IP"
-msgstr "הגבל גישה לפי  IP"
+msgstr "הגבל גישה לפי כתובת IP"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:878
 msgid "Restrict Locations"
-msgstr "הגבל מיקומים"
+msgstr "הגבלות לפי מיקום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:289
 msgid "Restrict Problem Progression"
-msgstr "הגבל התקדמות שאלות"
+msgstr "הגבל התקדמות בשאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:187
 msgid "Restrict To"
@@ -4803,7 +4816,7 @@ msgstr "הגבל ל-"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:157
 msgid "Restrict release by set(s)"
-msgstr "הגבל פרסום לפי אוספים"
+msgstr "הגבל פרסום לפי גליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1896
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:317
@@ -4817,7 +4830,7 @@ msgstr "התוצאה של הפעולה האחרונה שבוצעה: %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:330
 msgid "Results for this submission"
-msgstr "תוצאות של הגשה זו"
+msgstr "משוב עבור הגשה זו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:418
 msgid "Results of last action performed"
@@ -4829,7 +4842,7 @@ msgstr "התוצאות של הפעולה האחרונה שבוצעה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1596
 msgid "Resurrect which Gateway?"
-msgstr "החזר איזה בוחן מחסום?"
+msgstr "החזר איזה מבחן מחסום?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1313
 msgid "Retitled"
@@ -4848,7 +4861,7 @@ msgstr "שחזר"
 #. ($self->shortPath($editFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1856
 msgid "Revert to %1"
-msgstr "שחזר ל-%1"
+msgstr "שחזר ל- %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:363
 msgid "Ring of Reduction"
@@ -4864,15 +4877,15 @@ msgstr "קבוצה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:377
 msgid "SET NAME"
-msgstr "שם גליון"
+msgstr "שם הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:488
 msgid "STATUS"
-msgstr "סטאטוס"
+msgstr "ציון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:34
 msgid "STUDENT ID"
-msgstr "מזהה תלמיד"
+msgstr "מזהה סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:43
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:219
@@ -4906,18 +4919,16 @@ msgstr "שמור שינויים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:100
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:82
 msgid "Save Edit"
-msgstr ""
+msgstr "שמור את שינווי העריכה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:111
-#, fuzzy
 msgid "Save Export"
-msgstr "יצא"
+msgstr "שמור את קובץ הייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:92
-#, fuzzy
 msgid "Save Password"
-msgstr "סיסמה חדשה"
+msgstr "שמור את שינויי הסיסמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:782
 msgid "Save as"
@@ -4939,7 +4950,7 @@ msgstr "שמור שינויים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1653
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:678
 msgid "Save file to:"
-msgstr "שמור קובץ ב-:"
+msgstr "שמור קובץ בשם:"
 
 #. (CGI::b($self->shortPath($self->{editFilePath})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1466
@@ -4950,7 +4961,7 @@ msgstr "שמור ל-%1 וצפה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:394
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1121
 msgid "Saved to file '%1'"
-msgstr "שמור לקובץ '%1'"
+msgstr "נשמר בקובץ '%1'"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1087
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1843
@@ -4982,19 +4993,19 @@ msgstr "ציון (%)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:164
 msgid "Score required for release"
-msgstr "ציון שנדרש עבור פרסום"
+msgstr "ציון שנדרש עבור שחרור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:226
 msgid "Score selected set(s) and save to:"
-msgstr "נקד את האוספים שנבחרו ושמור ב-:"
+msgstr "נקד את הגליונות שנבחרו ושמור ב-:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1892
 msgid "Score summary for last submit:"
-msgstr "סיכום ניקוד עבור שליחה אחרונה:"
+msgstr "סיכום הציון עבור ההגשה האחרונה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:978
 msgid "Score which sets?"
-msgstr "איזה אוספים לנקד?"
+msgstr "לאיזה גליונות לאסוף ציונים?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:222
 msgid "Scores"
@@ -5010,14 +5021,15 @@ msgstr "הודעת ציון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:517
 msgid "Scoring Tools"
-msgstr "כלי ניקוד"
+msgstr "ציונים/כלי ניקוד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2283
 msgid ""
 "Screen and Hardcopy set header information can not be overridden for "
 "individual students."
 msgstr ""
-"מידע קידומת גרסת הדפסה או מסך של גליון לא יכול להשתנות עבור תלמיד ספציפי."
+"אין אפשרות לשנות לסטודנטים מסוימים את קבצי הקידומויות - "
+"Screen and Hardcopy set header information"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:98
 msgid "Scroll of Resurrection"
@@ -5083,7 +5095,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2121
 msgid "Select a course to unarchive."
-msgstr "בחר קורס להוציא מהארכיון"
+msgstr "בחר קורס לחלץ מקובץ ארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:591
 msgid "Select a database layout below."
@@ -5093,11 +5105,11 @@ msgstr "בחר מתכונת מסד נתונים למטה."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1704
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3061
 msgid "Select a listing format:"
-msgstr "בחר פורמט רשימה"
+msgstr "בחר פורמט לרשימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:273
 msgid "Select above then:"
-msgstr "אז בחר לעיל:"
+msgstr "בחר פעולה למעלה ואז:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2290
 msgid "Select all eligible courses"
@@ -5111,11 +5123,11 @@ msgstr "בחר בפעולה לבצע"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2609
 msgid "Select an action to perform:"
-msgstr "בחר פעולה שתרצה לבצע:"
+msgstr "בחר פעולה לבצע:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1717
 msgid "Select course(s) to archive."
-msgstr "בחור קורס/ים להוסיף לארכיון."
+msgstr "בחר קורס/ים להעביר לקבצי ארכיון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3074
 msgid "Select course(s) to hide or unhide."
@@ -5126,12 +5138,12 @@ msgid ""
 "Select one or more sets and one or more users below to assign/unassign each "
 "selected set to/from all selected users."
 msgstr ""
-"בחר גליון אחד או יותר ומשתמש אחד או יותר כדי להקצות/לבטל הקצאת כל גליון "
-"שנבחר לכל המשתמש שנבחר."
+"בחר גליון אחד או יותר ומשתמש אחד או יותר כדי להקצות/לבטל הקצאות של הגליונות "
+"שנבחרו לכל המשתמשים שנבחרו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:189
 msgid "Select sets below to assign them to the newly-created users."
-msgstr "בחר אוספים למטה כדי להקצות אותם למשתמשים החדשים."
+msgstr "בחר גליונות למטה כדי להקצות אותם למשתמשים החדשים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3046
 msgid ""
@@ -5146,7 +5158,7 @@ msgstr ""
 "בחר קורס/ים שתרצה להחביא (או להפוך לגלוי/ים) ולחץ על \"החבא קורסים\" (או "
 "\"הפוך קורסים לגלויים\"). החבאת קורס שהוא כבר חבוי לא עושה כלום. באותו אופן "
 "הפיכת קורס גלוי לגלוי גם לא עושה כלום. קורסים מוחבאים הם עדיין פעילים אבל לא "
-"רשומים ברשימת הקורסים של WeBWorK בדף השער. כדי לגשת לקורס, מדריך או תלמיד "
+"רשומים ברשימת הקורסים של WeBWorK בדף השער. כדי לגשת לקורס, מורה או סטודנט "
 "חייבים לדעת את כתובת ה-URL המלאה של הקורס."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:494
@@ -5155,8 +5167,9 @@ msgid ""
 "also select multiple users from the users list. You will receive hardcopy "
 "for each (set, user) pair."
 msgstr ""
-"בחר גליון שיעורי בית עבורו תרצה ליצור גרסת הדפסה. אתה גם יכול לבחור מספר "
-"משתמשים מרשימת המשתמשים. אתה תקבל גרסת הדפסה עבור כל זוג (גליון, תלמיד)."
+"בחר את הגליונות עבורן תרצה ליצור גרסת הדפסה. אתה גם יכול לבחור "
+"מספר משתמשים מרשימת המשתמשים. אתה תקבל גרסת הדפסה עבור כל זוג (גליון, "
+"סטודנט)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:303
 msgid ""
@@ -5166,7 +5179,7 @@ msgstr "בחר משתמש/ים ו/או גליון/ים ולחץ על כפתור 
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:718
 msgid "Selected students"
-msgstr "תלמידים שנבחרו"
+msgstr "סטודנטים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:367
 msgid "Send E-mail"
@@ -5196,7 +5209,7 @@ msgstr "גליון %1 הוקצה ל%2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:426
 msgid "Set Assigner"
-msgstr "מקצה האוספים"
+msgstr "מקצה הגליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:483
 msgid "Set Definition Filename"
@@ -5219,7 +5232,7 @@ msgstr "פרטי גליון עבור גליון %2"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:485
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:791
 msgid "Set Header"
-msgstr "קידומת גליון"
+msgstr "קידומת לגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:219
 msgid "Set ID"
@@ -5232,13 +5245,13 @@ msgstr "נתוני גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2735
 msgid "Set List"
-msgstr "רשימת אוספים"
+msgstr "רשימת הגליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:790
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:810
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:832
 msgid "Set Name"
-msgstr "שם גליון"
+msgstr "שם הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1025
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1113
@@ -5253,11 +5266,11 @@ msgstr "שם גליון"
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:820
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:912
 msgid "Set Name "
-msgstr "שם גליון"
+msgstr "שם הגליון "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2260
 msgid "Set headers are not used in display of gateway tests."
-msgstr "קידומות אוספים  לא משומשות בהצגת בחני מחסום."
+msgstr "קידומות גליונות אינן בשימוש בהצגת מבחני מחסום."
 
 #: /opt/webwork/pg/macros/problemRandomize.pl:187
 msgid "Set random seed to:"
@@ -5294,9 +5307,9 @@ msgid ""
 "version of their answer."
 msgstr ""
 "בחר \"נכון\" כדי להציג את עמודת \"הוכנס\" שמציגה את התשובה המוערכת של "
-"התלמיד, לדוגמה 1 אם התלמיד כתב sin(pi/2). אם בחרת \"לא נכון\", לדוגמה כדי "
-"לשמור מקום באיזור התגובה, התלמיד עדיין יכול לראות את התשובה המוערכת שלו על "
-"ידי להניח את הסמן על התשובה שהכניס."
+"הסטודנט, לדוגמה 1 אם הסטודנט כתב sin(pi/2). אם בחרת \"לא נכון\", לדוגמה כדי "
+"לשמור מקום באיזור התגובה, הסטודנט עדיין יכול לראות את התשובה המוערכת שלו על "
+"ידי הנחת הסמן על התשובה במוצגת בצורה LATEX מפורמטת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:403
 msgid ""
@@ -5311,19 +5324,19 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:425
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:196
 msgid "Sets"
-msgstr "אוספים"
+msgstr "גליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:362
 msgid "Sets Assigned to User"
-msgstr "האוספים שהוקצאו למשתמש"
+msgstr "הגליונות שהוקצאו למשתמש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:353
 msgid "Sets assigned to %1"
-msgstr "האוספים שהוקצאו ל-%1"
+msgstr "הגליונות שהוקצאו ל-%1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1363
 msgid "Sets were selected for export."
-msgstr ""
+msgstr "נבחרו גליונות לייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:683
 msgid "Setting"
@@ -5339,7 +5352,7 @@ msgstr "הצג מקורות מישניים"
 
 #: /opt/webwork/webwork2/lib/FormatRenderedProblem.pm:285
 msgid "Show Correct Answers"
-msgstr ""
+msgstr "הצג תשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:326
 msgid "Show Date & Size"
@@ -5356,11 +5369,11 @@ msgstr "תראה לי עוד אחת"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2222
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:2245
 msgid "Show Past Answers"
-msgstr "הראה תשובות מהעבר"
+msgstr "צפייה בתשובות קודמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:624
 msgid "Show Problem Source File:"
-msgstr ""
+msgstr "הצג שם קובץ השאלה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:281
 msgid "Show Problems on Finished Tests"
@@ -5377,11 +5390,11 @@ msgstr "הראה פתרונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:183
 msgid "Show Total Homework Grade on Grades Page"
-msgstr "הראה ציון בסך כל שיעורי הבית בעמוד הציונים"
+msgstr "הראה ציון כולל (ממוצע) בעמוד הציונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2163
 msgid "Show correct answers"
-msgstr "הראה תשובות נכונות"
+msgstr "הצג תשובות נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:340
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1712
@@ -5403,11 +5416,11 @@ msgstr "הראה תשובות שנשמרו?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:687
 msgid "Show which sets?"
-msgstr "איזה אוספים להציג?"
+msgstr "איזה גליונות להציג?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:651
 msgid "Show which users?"
-msgstr ""
+msgstr "איזה משתמשים להציג?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:281
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:542
@@ -5424,12 +5437,12 @@ msgstr "הראה:"
 #. (scalar @visibleSetIDs, scalar @allSetIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:627
 msgid "Showing %1 out of %2 sets."
-msgstr "מראה %1 מתוך %2 אוספים."
+msgstr "מראה %1 מתוך %2 גליונות."
 
 #. (scalar @Users, scalar @allUserIDs)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:568
 msgid "Showing %1 out of %2 users"
-msgstr "מראה %1 מתוך %2 אוספים"
+msgstr "מראה %1 מתוך %2 משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:423
 msgid "Simple"
@@ -5454,7 +5467,7 @@ msgstr "פתרון:"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:1553
 msgid "Solution: "
-msgstr ""
+msgstr "פתרון: "
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:606
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:393
@@ -5505,7 +5518,7 @@ msgid ""
 "with your instructor"
 msgstr ""
 "משהו לא כשורה עם הפאראמטרים של ה-LTI שלך. אם בעיה זו חוזרת על עצמה, אנא פנה "
-"למדריך שלך"
+"למורה שלך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:103
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:85
@@ -5546,6 +5559,8 @@ msgid ""
 "contain only letters, numbers, hyphens, and underscores, and may have at "
 "most %1 characters."
 msgstr ""
+"פרט מזהה, כותרת, ומוסד עבור הקורס החדש. מזהה הקורס יכול להכיל רק אותיות "
+"באנגלית, מספרים, מקפים, וקוים תחתונים. המזהה יכול להכיל עד %1 תווים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:424
 msgid "Standard"
@@ -5553,7 +5568,7 @@ msgstr "סטנדרטי"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:275
 msgid "Start Date"
-msgstr ""
+msgstr "תאריך שחרור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:385
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:387
@@ -5574,6 +5589,7 @@ msgstr "סטטיסטיקה עבור %1 גליון %2.  נסגר ב-%3"
 msgid "Statistics for %1 student %2"
 msgstr "סטטיסטיקה עבור %1 סטודנט %2"
 
+# Sometimes this is a grade, sometimes open/closed, etc.
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1895
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:371
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1049
@@ -5592,11 +5608,11 @@ msgstr "עצור התחזות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1944
 msgid "Stop Archiving"
-msgstr "הפסק להוסיף לארכיון"
+msgstr "הפסק העברת קורסים לקבצי ארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2076
 msgid "Stop archiving courses"
-msgstr "הפסק להוסיף קורסים לארכיון"
+msgstr "הפסק העברת קורסים לקבצי ארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:181
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:738
@@ -5607,33 +5623,33 @@ msgstr "הפסק להוסיף קורסים לארכיון"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:814
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:842
 msgid "Student ID"
-msgstr "מזהה תלמיד"
+msgstr "מזהה סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:158
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:132
 msgid "Student Name"
-msgstr "שם תלמיד"
+msgstr "שם סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:109
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:619
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:628
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:637
 msgid "Student Progress"
-msgstr "התקדמות תלמיד"
+msgstr "התקדמות הסטודנטים"
 
 #. ($self->{ce}->{courseName}, $self->{setName}, $self->formatDateTime($self->{set_due_date})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:85
 msgid "Student Progress for %1 set %2. Closes %3"
-msgstr "התקדמות התלמיד עבור %1 גליון %2.  נסגר ב-%3"
+msgstr "התקדמות הסטודנטים עבור %1 גליון %2.  נסגר ב-%3"
 
 #. ($self->{ce}->{courseName}, $self->{studentName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:83
 msgid "Student Progress for %1 student %2"
-msgstr "התקדמות התלמיד עבור %1 תלמיד %2"
+msgstr "התקדמות הסטודנט עבור %1 סטודנט %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:588
 msgid "Student answers"
-msgstr "תשובות התלמידים"
+msgstr "תשובות הסטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:586
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:713
@@ -5654,12 +5670,12 @@ msgstr "שלח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1688
 msgid "Submit Answers"
-msgstr "שלח תשובות"
+msgstr "הגשת התרגיל"
 
 #. ($effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1685
 msgid "Submit Answers for %1"
-msgstr "שלח תשובות עבור %1"
+msgstr "הגשת התרגיל עבור %1"
 
 #: /opt/webwork/pg/macros/compoundProblem.pl:502
 msgid "Submit your answers again to go on to the next part."
@@ -5667,7 +5683,7 @@ msgstr "שלח את התשובות שוב כדי להתקדם לחלק הבא."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1594
 msgid "Success"
-msgstr "הצלחה"
+msgstr "הפעולה הסתיימה בהצלחה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:740
 msgid "Success Index"
@@ -5708,19 +5724,19 @@ msgstr "שם הקורס שונה בהצלחה מ-%1 ל-%2"
 #. ($unarchive_courseID, $new_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2253
 msgid "Successfully unarchived %1 to the course %2"
-msgstr "%1 הוסר בהצלחה מהארכיון עבור קורס %2"
+msgstr "%1 חולץ בהצלחה מהארכיון אל הקורס %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1080
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1836
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3560
 msgid "Table defined in database but missing in schema"
-msgstr "טבלה מוגדרת במסד הנתונים אך חסרה בסכמה"
+msgstr "הטבלה מוגדרת במסד הנתונים אך חסרה בסכמה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1079
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1835
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3559
 msgid "Table defined in schema but missing in database"
-msgstr "טבלה מוגדרת בסכמה אך חסרה במסד הנתונים"
+msgstr "הטבלה מוגדרת בסכמה אך חסרה במסד הנתונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1081
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1837
@@ -5736,11 +5752,11 @@ msgstr "הטבלה תקינה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:618
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:563
 msgid "Take Action!"
-msgstr "בצע פעולה!"
+msgstr "בצע את הפעולה!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:849
 msgid "Target Set:"
-msgstr "הגליון שנבחר:"
+msgstr "גליון היעד:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:64
 msgid "TeX Source"
@@ -5760,11 +5776,11 @@ msgstr "טקסט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:745
 msgid "Text chapter:"
-msgstr "פרק טקסט:"
+msgstr "פרק בספר הלימוד:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:753
 msgid "Text section:"
-msgstr "קטע טקסט:"
+msgstr "סעיף בספר הלימוד:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:742
 msgid "Textbook:"
@@ -5776,8 +5792,8 @@ msgid ""
 "student. If set to -1 then there is no limit to the number of times that "
 "Show Me Another can be used."
 msgstr ""
-"המספר המקסימלי של הפעמים שתלמיד יכול להשתמש ב-\"תראה לי עוד אחת\" עבור כל "
-"שאלה. אם הוכנס -1 אז אין גבול למספר הפעמים."
+"המספר המקסימלי של הפעמים שסטודנט יכול להשתמש ב-\"תראה לי עוד אחת\" עבור כל "
+"שאלה. אם מוגדר -1 (מינוס 1) אז אין מגבלה למספר הפעמים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:265
 msgid ""
@@ -5791,17 +5807,17 @@ msgid ""
 "the due date, 11/10/2009 at 06:17pm EST. During this period all additional "
 "work done counts 50% of the original.\" will be displayed."
 msgstr ""
-"תקופת הניקוד המופחת היא התקופה בברירת המחדל לפני תאריך ההגשה בה כל התקדמות "
-"שמבצע התלמיד נספרת בערך ניקו מופחת. כשנבחרת אפשרות הניקוד מופחת עבור גליון "
+"תקופת הניקוד המופחת היא התקופה ברירת המחדל לפני תאריך ההגשה בה כל התקדמות "
+"שמבצע הסטודנט נספרת בערך ניקוד מופחת. כשנבחרת אפשרות הניקוד מופחת עבור גליון "
 "תאריך הניקוד המופחת יהיה תאריך ההגשה פחות המספר הזה בתור ברירת מחדל. לאחר "
 "מכן, ניתן לשנות את תאריך הניקוד המופחת. אם אפשרות זו נבחרת ואם תאריך הניקוד "
 "זה עבר, אבל לא עבר תאריך ההגשה, תופיעה הודעה כגון \"למטלה זו יש תקופת ניקוד "
 "מופחת שמתחילה ב-08/11/2009 בשעה 18:17 ונגמרת בתאריך ההגשה, 10/11/2009 בשעה "
-"18:17. בתקופה זו כל עבודה תשובות נוספות נספרות כ-50% מערכם המקורי\"."
+"18:17. בתקופה זו כל ההגשות הנוספות מקנות 50% מהניקוד המקורי\"."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:1134
 msgid "The WeBWorK Project"
-msgstr "פרוייקט WeBWorK"
+msgstr "פרוייקט ה-WeBWorK"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:408
 msgid ""
@@ -5818,7 +5834,7 @@ msgid ""
 "available to student to view.  You can change this for individual homework, "
 "but WeBWorK will use this value when a set is created."
 msgstr ""
-"כמה זמן (בדקות) אחרי תאריך ההגשה שהתשובות יהיו זמינות לתלמיד לצפייה. אתה "
+"כמה זמן (בדקות) אחרי תאריך ההגשה שהתשובות יהיו זמינות לסטודנט לצפייה. אתה "
 "יכול לשנות את זה עבור גליון שיעורי בית ספציפי, אבל WeBWorK ישתמש בערך זה "
 "כשהגליון נוצר."
 
@@ -5833,11 +5849,11 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:409
 msgid "The answer above is NOT correct."
-msgstr "התשובה לעיל היא לא נכונה."
+msgstr "התשובה איננה נכונה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Utils/AttemptsTable.pm:405
 msgid "The answer above is correct."
-msgstr "התשובה למעלה נכונה."
+msgstr "התשובה נכונה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:424
 msgid ""
@@ -5847,7 +5863,7 @@ msgid ""
 "here then child problems will only be available after a student runs out of "
 "attempts."
 msgstr ""
-"השאלות המוכלות עבור שאלה זו יהפכו לגלויות עבור התלמיד כשהם ביצעו יותר "
+"השאלות המוכלות עבור שאלה זו יהפכו לגלויות עבור הסטודנט כשהם ביצעו יותר "
 "ניסיונות שגויים מאשר מפורט כאן, או כשנגמר להם הניסיונות, הקודום מבינהם. אם "
 "נבחר כאן \"מקסימום\"  אז שאלות מוכלות יהיו זמינות רק לאחר שלתמיד נגמרו "
 "הניסיונות."
@@ -5865,7 +5881,7 @@ msgstr ""
 msgid ""
 "The course %1 uses an external authentication system (%2). Please go there "
 "to log in again."
-msgstr ""
+msgstr "הקורס %1 משתמש במערכת אימות/הזדהות חיצונית (%2). נא לחזור לשם כדי להיכנס שוב."
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:210
@@ -5873,6 +5889,7 @@ msgid ""
 "The course %1 uses an external authentication system (%2). Please return to "
 "that system to access this course."
 msgstr ""
+"הקורס %1 משתמש במערכת אימות/הזדהות חיצונית (%2). נא לחזור לשם כדי להיכנס לקורס הזה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:104
 msgid ""
@@ -5880,6 +5897,8 @@ msgid ""
 "authenticated through that system, but aren't allowed to log in to this "
 "course."
 msgstr ""
+"הקורס %1 משתמש במערכת אימות/הזדהות חיצונית (%2). אומתת במערכת החיצונית, אבל אתה לא "
+"מורשה להתחבר לקורס הזה."
 
 #. ($archive_courseID, $archive_path)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1940
@@ -5891,7 +5910,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:369
 msgid "The default display mode"
-msgstr "ברירי ת המחדל של מצב התצוגה"
+msgstr "ברירת המחדל של מצב התצוגה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:293
 msgid ""
@@ -5987,12 +6006,12 @@ msgstr "הקובץ שאת/ה מנסה להוריד אינו קיים"
 #. (CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3166
 msgid "The following courses were successfully hidden:"
-msgstr ""
+msgstr "הקורסים הבאים הוחבאו בהצלחה:"
 
 #. (CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3232
 msgid "The following courses were successfully unhidden:"
-msgstr ""
+msgstr "הקורסים הבאים נהפכו לגלויים בהצלחה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3463
 msgid "The following upgrades are available for your WeBWorK system:"
@@ -6040,7 +6059,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1309
 msgid ""
 "The institution associated with the course %1 has been changed from %2 to %3"
-msgstr "המוסד שמיחס לקורס %1 שונה מ-%2 ל-%3"
+msgstr "המוסד שאליו קורס %1 מיוחס שונה מ-%2 ל-%3"
 
 #. ($rename_newCourseID, $rename_newCourseInstitution)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1362
@@ -6053,8 +6072,8 @@ msgid ""
 "The instructor account with user id %1 does not exist.  Please create the "
 "account manually via WeBWorK."
 msgstr ""
-"לא קיים חשבון מדריך בעל מהה המשתמש %1. אנא צור את החשבון באופן ידני דרך "
-"WeBWorK."
+"לא קיים חשבון מורה בעל מזהה המשתמש %1. אנא צור את החשבון באופן ידני בתוך "
+"בקורס במערכת ה- WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3455
 msgid ""
@@ -6073,8 +6092,8 @@ msgid ""
 "Its contents are displayed in the right panel next to the list of homework "
 "sets."
 msgstr ""
-"קובץ מידע שם הקורס (נמצא בתיקיית התבניות). התוכן שלו מופיע בפאנל הימני לייד "
-"הרשימה של אוספי שיעורי הבית."
+"שם קובץ במידע של הקורס (נמצא בתיקיית templates). תוכן הקובץ מוצג בפאנל הימני "
+"ליד רשימת הגליונות."
 
 #. ($openDate, $dueDate, $answerDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1955
@@ -6087,7 +6106,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:668
 msgid "The password and password confirmation for the instructor must match."
-msgstr "הסיסמה ואימות הסיסמה של המדריך חייבות להתאים."
+msgstr "הסיסמה ואימות הסיסמה של המורה חייבות להתאים."
 
 #. (CGI::b($r->maketext("[_1]'s Current Password",$user_name)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:126
@@ -6123,17 +6142,17 @@ msgstr "אחוז הסטודנטים עם ניקוד כזה לפחות. הציו�
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1727
 msgid "The problem set is not yet open"
-msgstr ""
+msgstr "הגליון טרם נפתח לשימוש"
 
 #. ($recScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1844
 msgid "The recorded score for this version is  %1/%2."
-msgstr ""
+msgstr "הציון שנשמר לגרסה זו של המבחן הוא %1 מתוך %2."
 
 #. ($recScore, $totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1854
 msgid "The recorded score for this version is %1/%2."
-msgstr ""
+msgstr "הציון שנשמר לגרסה זו של המבחן הוא %1 מתוך %2."
 
 #. ($origReducedScoringDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1968
@@ -6141,6 +6160,8 @@ msgid ""
 "The reduced credit date %1 in the file probably was generated from the Unix "
 "epoch 0 value and is being treated as if it was Unix epoch 0."
 msgstr ""
+"תאריך ניקוד המופחת %1 בקובץ כנראה נוצר מזמן 0 של יונקס וכך התיחסה המערכת אל "
+"הערך שהופיע."
 
 #. ($openDate, $dueDate)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1979
@@ -6156,7 +6177,7 @@ msgstr "תאריך הניקוד המופחת צריך להיות בין תארי
 #. (join('.',@seq)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1887
 msgid "The score for this problem can count towards score of problem %1."
-msgstr "הניקוד לשאלה זו יכול להספר לניקוד של שאלה %1."
+msgstr "הציון על שאלה זו יכול להחשב כחלק מהציון של שאלה %1."
 
 #. ($setName, $effectiveUser)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:339
@@ -6201,7 +6222,7 @@ msgstr "קוד המקור ל'גליון %1 / שאלה %2' שונה מ-'%3' ל-'%
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1932
 msgid "The test (which is version %1) may  no longer be submitted for a grade."
-msgstr ""
+msgstr "כבר לא ניתן להגיש את המבחן (גרסה %1) לניקוד ולקבלת ציון."
 
 #
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1716
@@ -6309,7 +6330,7 @@ msgstr "ואז לפי"
 #. ($count_line)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:578
 msgid "There are %1 matching WeBWorK problems"
-msgstr "יש %1 בעיות WeBWorK מתאימות"
+msgstr "יש %1 שאלות מתאימות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:171
 msgid ""
@@ -6352,7 +6373,7 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:576
 msgid "There are no matching WeBWorK problems"
-msgstr "אין בעיות WeBWorK מתאימות."
+msgstr "אין שאלות מתאימות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1902
 msgid ""
@@ -6389,8 +6410,8 @@ msgid ""
 "their name, you destroy all of the data for achievement %1 for this student."
 msgstr ""
 "פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
-"הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
-"הנתונים של הישג %1 של תלמיד זה."
+"הקצאה של סטודנט בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
+"הנתונים של הישג %1 של סטודנט זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:212
 msgid ""
@@ -6400,8 +6421,8 @@ msgid ""
 "student."
 msgstr ""
 "פעולה זו בלתי הפיכה. אל תבצע אותה אם אתה לא יודע מה אתה עושה! כשאתה מבטל "
-"הקצאה של תלמיד בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
-"הנתונים של גליון שיעורי הבית $setID של תלמיד זה."
+"הקצאה של סטודנט בעזרת כפתור זה, או על ידי בחירת השם שלו, אתה מוחק את כל "
+"הנתונים של גליון שיעורי הבית $setID של סטודנט זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:275
 msgid "There is NO undo for unassigning a set."
@@ -6411,7 +6432,7 @@ msgstr "אי אפשר לחזור בך מביטול הקצאה של גליון."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:127
 msgid "There is NO undo for unassigning students."
-msgstr "אי אפשר לחזור בך מביטול הקצאת תלמידים."
+msgstr "אי אפשר לחזור בך מביטול הקצאת סטודנטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:3390
 msgid "There is a new version of PG available."
@@ -6423,7 +6444,7 @@ msgstr "יש גרסה חדשה של WeBWorK."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:500
 msgid "There is a written solution available."
-msgstr ""
+msgstr "יש פתרון זמין לשאלה."
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:101
@@ -6448,15 +6469,14 @@ msgid "There is no undo for deleting files or directories!"
 msgstr "אי אפשר לחזור בך ממחיקת קבצים או תיקייות!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:502
-#, fuzzy
 msgid ""
 "There is no written solution available for this problem, but you can still "
 "view the correct answers."
-msgstr "לא קיים פתרון כתוב לשאלה זו, אבל עדיין ניתן לצפות בתשובות נכונות"
+msgstr "לא קיים פתרון לשאלה זו, אבל עדיין ניתן לצפות בתשובות הנכונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:504
 msgid "There is no written solution available for this problem."
-msgstr "לא קיים פתרון כתוב לשאלה זו"
+msgstr "לא קיים פתרון לשאלה זו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:138
 msgid ""
@@ -6470,15 +6490,15 @@ msgid ""
 "There may be something wrong with this question. Please inform your "
 "instructor including the warning messages below."
 msgstr ""
-"ייתכן שישנה בעיה בשאלה. אנא עדכן את המדריך שלך, לרבות בהודעות השגיאה שלהלן."
+"ייתכן שישנה בעיה בשאלה. אנא עדכן את המורה שלך, לרבות בהודעות השגיאה שלהלן."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:429
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator if this recurs."
 msgstr ""
-"הייתה שגיאה בתהליך ההתחברות. אנה פנה למדריך שלך או עם מנהל מערכת במידה "
-"והבעיה הזאת נמשכת."
+"אירעה שגיאה בתהליך ההתחברות. אנה פנה למורה שלך או למנהל מערכת במידה והתקלה "
+"הזאת נמשכת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:182
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIAdvanced.pm:290
@@ -6494,17 +6514,19 @@ msgstr ""
 msgid ""
 "There was an error during the login process.  Please speak to your "
 "instructor or system administrator."
-msgstr "הייתה שגיאה בתהליך ההתחברות. אנא פנה למדריך או למנהל מערכת."
+msgstr "אירעה שגיאה בתהליך ההתחברות. אנא פנה למורה או למנהל מערכת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:338
 msgid ""
 "These users and higher get the \"Show Past Answers\" button on the problem "
 "page."
-msgstr "משתמשים אלו והלאה מקבלים את כפתור \"הראה תשובות מהעבר\" בעמוד הבעיות."
+msgstr ""
+"משתמשים מרמת הרשאה זו ומעלה מקבלים את כפתור \"צפייה בתשובות קודמות\" בדף "
+"השאלות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:124
 msgid "This action can take a long time if there are many students."
-msgstr "הפעולה יכולה להמשך זמן רב אם ישנם תלמידים רבים."
+msgstr "הפעולה יכולה להמשך זמן רב אם ישנם סטודנטים רבים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:149
 msgid "This action will not overwrite existing users."
@@ -6553,12 +6575,12 @@ msgid ""
 "in the edit assigned users field contains links which take you to a page "
 "where you can edit what students the set is assigned to."
 msgstr ""
-"טבלה זו מראה את אוספי שיעורי הבית הנוכחיים של כיתה זו. השדות משמאל לימין הם: "
-"ערוך נתוני גליון, ערוך שאלות, ערוך הקצאות משתמשים, ראות לתלמידים, מופעל "
+"טבלה זו מראה את גליונות שיעורי הבית הנוכחיים של כיתה זו. השדות משמאל לימין "
+"הם: ערוך נתוני גליון, ערוך שאלות, ערוך הקצאות משתמשים, ראות לסטודנטים, מופעל "
 "ניקוד מופחת, תאריך פתיחה, תאריך הגשה, והתאריך בו התשובות מוצגות. שדה ה-"
 "\"ערוך נתוני גליון\" מכיל ריבועים לסימון בחירה וקישור לדף עריכת נתוני גליון. "
 "התאים בשדת \"ערוך שאלות\" מכילים קישורים שמפנים לדף שבו ניתן לערוך לאיזה "
-"תלמידים מוקצה הקורס/"
+"סטודנטים מוקצה הגליון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:100
 msgid ""
@@ -6569,13 +6591,12 @@ msgid ""
 "are earned.  The \"level\" category is used for the achievements associated "
 "to a users level."
 msgstr ""
-"זהו עורך ההישגים.  הוא משמש לערוך את ההישגים שזמינים לתלמידים. אנא זכור את "
+"זהו עורך ההישגים.  הוא משמש לערוך את ההישגים שזמינים לסטודנטים. אנא זכור את "
 "העובדות הבאות: הישגים הם מוצגים, ומוערכים, בסדר שהם רשומים. הקטגוריה ה-"
-"\"סודית\" יוצרת הישגים שמוחבאים מהתלמידים עד שהם הרוויחו אותם. הקטגורית ה-"
+"\"סודית\" יוצרת הישגים שמוחבאים מהסטודנטים עד שהם הרוויחו אותם. הקטגורית ה-"
 "\"שלב\" משמשת להישגים שמקושרים לשלב המשתמש."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:98
-#, fuzzy
 msgid ""
 "This is the classlist editor page, where you can view and edit the records "
 "of all the students currently enrolled in this course.  The top of the page "
@@ -6587,15 +6608,14 @@ msgid ""
 "\"Take Action!\" button at the bottom of the form.  The bottom of the page "
 "contains a table containing the student usernames and their information."
 msgstr ""
-"זהו דף רשימת הכיתה, בו ניתן לצפות ולערוך את הנתונים של כל התלמידים שרשומים "
-"בקורס. החלק העליון של דף זה מכיל טפסים שמאפשרים לסנן את התלמדים, לסדר אותם "
-"לפי סדר מסויים, לערוך נתוני תלמידים, לתת להם סיסמ חדש, ליבא/ליצא נתוני "
-"תלמידים לקבצים חיצוניים, או להוסיף/למחוק תלמידים. לביצוע פעולה אנא בחר את "
-"הפעולה הרצוייה והחנס את המידע הדרוש בשדות למטה, ולחץ על כפתור \\\"בצע פעולה!"
-"\"\\ בתחתית הטופס. תחתית הדף כוללת טבלה שמכילה את שמות התלמידים ואת נתוניהם."
+"זהו דף רשימת הכיתה, בו ניתן לצפות ולערוך את הנתונים של כל הסטודנטים שרשומים "
+"בקורס. החלק העליון של דף זה מכיל טפסים שמאפשרים לסנן את הסטודנטים, לסדר אותם "
+"לפי סדר מסויים, לערוך נתוני סטודנטים, לתת להם סיסמ חדש, ליבא/ליצא נתוני "
+"סטודנטים לקבצים חיצוניים, או להוסיף/למחוק סטודנטים. לביצוע פעולה אנא בחר את "
+"הפעולה הרצוייה והחנס את המידע הדרוש בשדות למטה, ולחץ על כפתור \"בצע את הפעולה!\" "
+"בתחתית הטופס. תחתית הדף כוללת טבלה שמכילה את שמות הסטודנטים ואת נתוניהם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:96
-#, fuzzy
 msgid ""
 "This is the homework sets editor page where you can view and edit the "
 "homework sets that exist in this course and the problems that they contain. "
@@ -6608,13 +6628,13 @@ msgid ""
 "the page contains a table displaying the sets and several pieces of relevant "
 "information."
 msgstr ""
-"זהו דף עורך אוספי שיעורי הבית, שבו ניתן לצפות ולערוך אוספי שיעורי בית "
+"זהו דף עורך גליונות שיעורי הבית, שבו ניתן לצפות ולערוך גליונות שיעורי בית "
 "שקיימים בקורס ואת השאלות שהם מכילים. החל העליון של דף זה מכיל טפסים שמאפשרים "
-"סינון של האוספים, לסדר אותם בסדר מסויים, לערוך אוספי שיעורי בית, לפרסם אוספי "
-"שיעורי בית, ליבא/ליצא אוספים לקובץ חיצוני, לנקד אוספים, או ליצור/למחוק "
-"אוספים. ליצוע פעולה אנא בחר בעולה לביצוע, מלא את המידע הדרוש בשדות למטה, "
-"ולחץ על כפתור \\\"בצע פעולה!\"\\ בתחתית הטופס. תחתית הדף מכילה טבלה שמציגה "
-"את האוספים וכמה נתונים רלוונטים."
+"סינון של הגליונות, לסדר אותם בסדר מסויים, לערוך גליונות שיעורי בית, לפרסם "
+"גליונות שיעורי בית, ליבא/ליצא גליונות לקובץ חיצוני, לנקד גליונות, או "
+"ליצור/למחוק גליונות. ליצוע פעולה אנא בחר בעולה לביצוע, מלא את המידע הדרוש "
+"בשדות למטה, ולחץ על כפתור \"בצע את הפעולה!\" בתחתית הטופס. תחתית הדף מכילה טבלה "
+"שמציגה את הגליונות וכמה נתונים רלוונטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:220
 msgid ""
@@ -6662,7 +6682,7 @@ msgstr "שאלה זו משתמשת באותו קובץ מקור כמו שאלה 
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:552
 msgid "This problem will not count towards your grade."
-msgstr "שאלה זו לא תיחשב לציון שלך."
+msgstr "שאלה זו לא תחשב בציון שלך."
 
 #. ($EMAIL)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:1046
@@ -6674,7 +6694,7 @@ msgstr "דוא\"ל דוגמה זה ישלח ל-%1"
 msgid ""
 "This score for this problem does not count for the score of problem %1 or "
 "for the set."
-msgstr "הניקוד לשאלה זו לא יחשב לניקוד בשאלה %1 או בגליון. "
+msgstr "הציון על שאלה זו איננה תורמת לציון של שאלה %1 או לציון הגליון. "
 
 #. ($message_file, $merge_file)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Grades.pm:164
@@ -6683,7 +6703,7 @@ msgid ""
 "the file [Scoring]/%2. These files can be edited using the \"Email\" link "
 "and the \"File Manager\" link in the left margin."
 msgstr ""
-"הודעת הניקוד מיוצרת מ-[TMPL]/email/%1. היר מאוחדת באמצעות בקובץ  [Scoring]/"
+"הודעת הציונים מיוצרת מ-[TMPL]/email/%1. היא ממוזגת באמצעות הקובץ [Scoring]/"
 "%2. קבצים אלה ניתנים לעריכה בעזרת קישור ה-\"דוא\"ל\" וה-\"עורך הקבצים\" בצד "
 "שמאל."
 
@@ -6740,9 +6760,9 @@ msgid ""
 "comma separated list.  The minimum score required on the sets is specified "
 "in the following field."
 msgstr ""
-"הגליון לא יהיה זמין לסטודנטים עד אשר הם ירוויחו ניקוד מסויים באוספים שצוינו "
-"בשדה זה. האוספים צריך להכתב כרשימה מופרדת בפסיקים. הניקוד המינימלי הנדרש "
-"בגליון יצויין בשדה שלאחר מכן."
+"הגליון לא יהיה זמין לסטודנטים עד אשר הם ירוויחו ציון מסויים בגליונות שצוינו "
+"בשדה זה. הגליונות צריך להכתב כרשימה מופרדת בפסיקים. הציון המינימלי הנדרש "
+"בגליונות יצויין בשדה העוקבת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:235
 msgid ""
@@ -6799,6 +6819,11 @@ msgid ""
 "at the end of the table. There is also a clear button and an Email "
 "Instructor button at the end of the table."
 msgstr ""
+"הטבלה מציגה את גליונות שיעורי הבית הזמינים בקורס, ביחד עם המצב הנוכחי של כל "
+"גליון. השם של גליון הוא קישורית הפותחת את רשימת השאלות של הגליון. ניתן לסמן "
+"גליונות להורדה בפורמט PDF או TeX בעזרת תיבות הסימון בשורה המתאימה, ואז ללחוץ "
+"על כפתור \"הורד גרסת הדפסה של הגליונות שנבחרו\" שמופיע מתחת הטבלה. קיים גם "
+"כפתור לביטול הבחירות מתחת הטבלה וכן כפתור לפתוח קריאה לצוות התמיכה/למורים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:402
 msgid ""
@@ -6815,7 +6840,7 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2156
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2231
 msgid "Time"
-msgstr "זמן"
+msgstr "מועד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:240
 msgid "Time Interval for New Test Versions (min; 0=infty)"
@@ -6832,7 +6857,7 @@ msgstr "חותמת זמן"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:163
 msgid "Timezone for the course"
-msgstr "איזור זמנים של הקורס"
+msgstr "איזור זמן של הקורס"
 
 #. (sprintf("%.0f",$restriction)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:784
@@ -6843,7 +6868,7 @@ msgstr "על מנת לגשת לגליון זה, עליך לצבור ניקוד �
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:786
 msgid ""
 "To access this set you must score at least %1% on the following sets: %2."
-msgstr "כדי לגשת לגליון זה עליך לצבור ניקוד של לפחות %1%באוספים הבאים: %2."
+msgstr "כדי לגשת לגליון זה עליך לצבור ניקוד של לפחות %1% בגליונות הבאים: %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:528
 msgid ""
@@ -6851,7 +6876,7 @@ msgid ""
 "below. The user ID may contain only numbers, letters, hyphens, periods "
 "(dots), commas,and underscores.\n"
 msgstr ""
-"כדי להוסיף מדריך נוסף לקורס חדש, מלא את פרטי המשתמש למטה. מזהה המשתמש יכול "
+"כדי להוסיף מורה נוסף לקורס חדש, מלא את פרטי המשתמש למטה. מזהה המשתמש יכול "
 "להכיל רק מספרים, אותיות, מקפים, נקודות, פסיקים, וקווים תחתונים.\n"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:516
@@ -6879,7 +6904,7 @@ msgid ""
 "To edit a specific student version of this set, edit (all of) her/his "
 "assigned sets."
 msgstr ""
-"על מנת לערוך גרסה מסוימת של סטודנט לגליון הנ\"ל, ערוך (את כל) האוספים "
+"על מנת לערוך גרסה מסוימת של סטודנט לגליון הנ\"ל, ערוך (את כל) הגליונות "
 "המוקצים לו/ה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:375
@@ -6925,7 +6950,7 @@ msgstr "נכון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:195
 msgid "Tunic of Extension"
-msgstr "טוניקת ההארכה"
+msgstr "כתונת ההארכה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:114
 msgid "Two Columns"
@@ -6956,23 +6981,23 @@ msgstr "לא ניתן לרשום ל'%1': %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2217
 msgid "Unarchive"
-msgstr "הסר מהארכיון"
+msgstr "חלץ מקבצי ארכיון"
 
 #. ($unarchive_courseID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2206
 msgid "Unarchive %1 to course:"
-msgstr "הוצא מהארכיון את %1 לקורס:"
+msgstr "חלץ %1 מהארכיון אל הקורס:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2112
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2144
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2191
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:369
 msgid "Unarchive Course"
-msgstr "הסר קורס מהארכיון"
+msgstr "חלץ את הקורס מקובץ הארכיון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2273
 msgid "Unarchive Next Course"
-msgstr "הסר את הקורס הבא מהארכיון"
+msgstr "חלץ מקובץ ארכיון את הקורס הבא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm:226
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:214
@@ -6981,7 +7006,7 @@ msgstr "בטל הקצאה מכל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:181
 msgid "Unassign selected sets from selected users"
-msgstr "בטל הקצאה של האוספים הנבחרים מהמשתמשים הנבחרים"
+msgstr "בטל הקצאה של הגליונות הנבחרים מהמשתמשים הנבחרים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm:59
 msgid ""
@@ -7045,7 +7070,7 @@ msgstr "עדכן תפריטים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:631
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:706
 msgid "Update settings and refresh page"
-msgstr "עדכן הגדרות ורענן עמוד"
+msgstr "עדכן הגדרות ורענן את הדף"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2308
 msgid "Update the checked directories?"
@@ -7074,7 +7099,7 @@ msgstr "עדכן קורסים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2559
 msgid "Upgrade process completed"
-msgstr "עדכן תהליכים שהושלמו"
+msgstr "תהליך העדכון הושלם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:168
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:373
@@ -7096,7 +7121,7 @@ msgstr "השתמש בעורך המשוואות?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:249
 msgid "Use Item"
-msgstr "השתמש בפריט"
+msgstr "הפעל את הפריט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2712
 msgid "Use System Default"
@@ -7117,7 +7142,7 @@ msgstr "השתמש בהישג חדש:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:326
 msgid "Use live equation rendering?"
-msgstr ""
+msgstr "הפעל תצוגת נוסחאות בזמן אמת?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:386
 msgid "Use log base 10 instead of base <i>e</i>"
@@ -7125,14 +7150,14 @@ msgstr "השתמש בלוגריתם בבסיס 10 במקום בבסיס <i>e</i>
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:392
 msgid "Use older answer checkers"
-msgstr "השתמש בבודקי תשובות ישנים יותר"
+msgstr "השתמש בבודקי תשובות הישנים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:302
 msgid ""
 "Use the interface below to quickly access commonly-used instructor tools, or "
 "select a tool from the list to the left."
 msgstr ""
-"השתמש בממשק שלהלן על מנת לגשת בקלות לכלי מדריך נפוצים בשימוש, או בחר כלי "
+"השתמש בממשק שלהלן על מנת לגשת בקלות לכלי מורה נפוצים בשימוש, או בחר כלי "
 "מהרשימה שמשמאל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Feedback.pm:361
@@ -7149,7 +7174,7 @@ msgstr ""
 msgid ""
 "User '%1' will not be copied from admin course as it is the initial "
 "instructor."
-msgstr "משתמש '%1' לא יועתק מקורס המנהל שכן זהו המדריך הראשוני."
+msgstr "משתמש '%1' לא יועתק מקורס הניהול שכן זהו המורה שביקשת להוסיף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:535
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:218
@@ -7194,7 +7219,7 @@ msgstr "משתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/URLPath.pm:394
 msgid "Users Assigned to Set %2"
-msgstr "משתמש מוקצה לגליון %2"
+msgstr "משתמשים אליהם הוקצה גליון %2"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1889
 msgid "Users List"
@@ -7239,8 +7264,8 @@ msgid ""
 "to addresses listed below.  To send ONLY to addresses listed below set "
 "permission level to \"nobody\"."
 msgstr ""
-"משתמשים עם רמת הרשאות זו או גבוהה יותר יקבלו משוב מתלמידים באופן אוטומטי "
-"(נוצר כשהתלמידים לוחצים על כפתור \"צור קשר עם המדריך\" שנמצא בכל דף שאלה). "
+"משתמשים עם רמת הרשאות זו או גבוהה יותר יקבלו משוב מסטודנטים באופן אוטומטי "
+"(נוצר כשהסטודנטים לוחצים על כפתור \"צור קשר עם המורה\" שנמצא בכל דף שאלה). "
 "בנוסף, הודעת המשוב תישלח לכתובות למטה. כדי לשלוח רק לכתובות למטה, בחר את רמת "
 "ההרשאות \"אף אחד\"."
 
@@ -7259,7 +7284,7 @@ msgstr "להשתמש באיזה זרע?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:239
 msgid "Value of work done in Reduced Scoring Period"
-msgstr "ערך העבודה נעשה בתקופת ניקוד מופחת."
+msgstr "ערך יחסית של ההגשות בתקופת הניקוד המופחת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:646
 msgid "Variable Documentation:"
@@ -7284,7 +7309,7 @@ msgstr "הצג"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:681
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:797
 msgid "View Problems"
-msgstr "בעיות תצוגה"
+msgstr "הצג את השאלות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:265
 msgid "View equations as"
@@ -7296,15 +7321,15 @@ msgstr "הצג סטטיסטיקה לפי גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm:214
 msgid "View statistics by student"
-msgstr "הצג סטטיסטיקה לפי תלמיד"
+msgstr "הצג סטטיסטיקה לפי סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:252
 msgid "View student progress by set"
-msgstr "הצג התקדמיות תלמיד לפיי גליון"
+msgstr "הצג את ההתקדמות של כל הסטודנטים עבור גליון מסוים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:256
 msgid "View student progress by student"
-msgstr "הצג התקדמות תלמיד לפי תלמיד"
+msgstr "הצג את ההתקדמות של סטודנט מסוים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
@@ -7321,20 +7346,20 @@ msgstr "מציג קובץ זמני:"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:814
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:836
 msgid "Visibility"
-msgstr "ראות"
+msgstr "זמינים לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:491
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:919
 msgid "Visible"
-msgstr "ניתן לצפייה"
+msgstr "זמין לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1360
 msgid "Visible sets were selected for export."
-msgstr ""
+msgstr "הגליונות שהופיעו ברשימה נבחרו לייצוא"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:131
 msgid "Visible to Students"
-msgstr "גלוי לסטודנטים"
+msgstr "זמין לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2177
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:735
@@ -7348,7 +7373,9 @@ msgstr "הודעות אזהרה"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1035
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:949
 msgid "Warning: Deletion destroys all user-related data and is not undoable!"
-msgstr "זהירות: מחיקה הורסת את כל המידע שנוגע למשתמשים והיא בלתי הפיכה!"
+msgstr ""
+"זהירות: מחיקה מוחקת לחלוטין את כל המידע בנוגע למשתמשים והמשימות שלהם והיא "
+"פעולה בלתי הפיכה!"
 
 #. ($problem_desc , CGI::br()
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1314
@@ -7385,7 +7412,7 @@ msgid ""
 "more information."
 msgstr ""
 "WeBWorK נתקלה שגיאת תוכנה בזמן הניסיון לעבד את שאלה זו. סביר להניח שיש שגיאה "
-"בשאלה עצמה. אם אתה תלמיד, דווח על הודעת שגיאה זו למרצה שלך כדי שיתקן את "
+"בשאלה עצמה. אם אתה סטודנט, דווח על הודעת שגיאה זו למרצה שלך כדי שיתקן את "
 "השאלה. אם אתה המרצה, אנא פנה לפלט השגיאה למטה למידע נוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2226
@@ -7399,7 +7426,7 @@ msgid ""
 msgstr ""
 "WeBWorK נתקלה בהזהרות בזמן עיבוד הבקשה שלך. אם זה קרה בזמן צפייה בשאלה, זה "
 "כנראה נגרם בגלל שגיאה או דו-משמעות בשאלה. אם לא, זה עשוי להעיד על בעיה "
-"במערכת ה-WeBWorK עצמה. אם אתה תלמיד, דווח על הודעת שגיאה זו למרצה שלך כדי "
+"במערכת ה-WeBWorK עצמה. אם אתה סטודנט, דווח על הודעת שגיאה זו למרצה שלך כדי "
 "שיתקן את השאלה. אם אתה המרצה, אנא פנה לפלט השגיאה למטה למידע נוסף."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:519
@@ -7416,7 +7443,7 @@ msgid ""
 "inform your instructor. "
 msgstr ""
 "WeBWorK לא הצליחה ליצור גרסת הדפסה גליון שיעורי הבית הזה. אנא דווח על כך "
-"למדריך שלך."
+"למורה שלך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:323
 msgid "Weight"
@@ -7424,15 +7451,15 @@ msgstr "משקל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Home.pm:88
 msgid "Welcome to WeBWorK!"
-msgstr "!WebWork ברוכים הבאים ל-"
+msgstr "ברוכים הבאים ל- WeBWorK!"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/AchievementItems.pm:1297
 msgid "What could be inside?"
-msgstr "מה יכל להיות בפנים?"
+msgstr "מה יכול להיות בפנים?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:670
 msgid "What field should filtered users match on?"
-msgstr "באיזה שדה תלמידים צריכים להתאים?"
+msgstr "לפי איזה שדה לבדוק את תיאום המשתמשים?"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:349
 msgid ""
@@ -7441,15 +7468,15 @@ msgid ""
 "and if set to -2 the course default is used."
 msgstr ""
 "כאשר לסטודנט יש יותר נסיונות משמצויין כאן, הם יוכלו לראות גרסה אחרת של "
-"השאלה. אם מוזן -1 האופציה מבוטלת, ואם מוזן -2 ייעשה שימוש בברירת המחדל של "
-"הקורס"
+"השאלה. אם מוזן מינוס אחד -1 האופציה מבוטלת, ואם מוזן מינוס שתיים -2 ייעשה "
+"שימוש בברירת המחדל של הקורס"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:323
 msgid ""
 "When acting as a student, this permission level and higher can submit "
 "answers for that student."
 msgstr ""
-"רמת ההרשאה הזאת וגבוהות ממנה רשאים להגיש תשובות עבור תלמיד כאשר הם פועלים "
+"רמת ההרשאה הזאת וגבוהות ממנה רשאים להגיש תשובות עבור סטודנט כאשר הם מתחזים "
 "בשמו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:416
@@ -7461,11 +7488,11 @@ msgid ""
 "ID<li> %p = problem ID<li> %x = section<li> %r = recitation<li> %% = literal "
 "percent sign</ul>"
 msgstr ""
-"כשתלמידים לוחצים על כפתור <em>של דוא\"ל למדריך</em> כדי לשלוח משוב, WeBWorK "
+"כשסטודנטים לוחצים על כפתור <em>של דוא\"ל למורה</em> כדי לשלוח משוב, WeBWorK "
 "ממלא את שורת הנושא. כאן אתה יכול לכתוב את שורת הנושא. ניתן לשים בה מספר "
 "נתונים שממולאים בעזרת סדרות הבריחה הבאות. <p><ul><li>%c = מזהה קורס <li>%u = "
-"מזהה משתמש <li>%p = מזהה שאלה <li>%x = קבוצה <li> %r = תרגול <li>%% = סימן "
-"אחוז</ul>"
+"מזהה משתמש <li>%p = מזהה שאלה <li>%x = קבוצה <li> %r = קבוצת תרגול <li>%% = "
+"סימן אחוז</ul>"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:184
 msgid ""
@@ -7474,7 +7501,7 @@ msgid ""
 "the student."
 msgstr ""
 "כאשר אפשרות זו נבחרת, הסטודנט יראה שורה בעמוד הציונים עם הציון הכולל שלהם "
-"בשיעורי הבית. הניקוד יכלול את כל האוספים שמוקצים לסטודנט."
+"בשיעורי הבית. הציון יכלול את כל הגליונות שמוקצים לסטודנט."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:355
 msgid ""
@@ -7494,7 +7521,7 @@ msgid ""
 "do."
 msgstr ""
 "כשאתה מבטל הקצאה על ידי ביטול הבחירה של השם שלו, אתה הורס את כל המידע עבור "
-"הישג %1 של תלמיד זה. תוודא שזה אכן כוונתך."
+"הישג %1 של סטודנט זה. תוודא שזה אכן כוונתך."
 
 #. (CGI::b($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm:128
@@ -7505,7 +7532,7 @@ msgid ""
 "problems. Make sure this is what you want to do before unchecking students."
 msgstr ""
 "כשאתה מבטל הקצאה על ידי ביטול הבחירה של השם שלו,  אתה הורס את כל מידע של "
-"גליון שיעורי בית %1 עבור תלמיד זה. לאחר מכן תצטרך להקצות להם את הגליון מחדש "
+"גליון שיעורי בית %1 עבור סטודנט זה. לאחר מכן תצטרך להקצות להם את הגליון מחדש "
 "והם יקבלו גרסאות חדשות של השאלות. תוודא שזה אכן מה שאתה רוצה לעשות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:279
@@ -7515,9 +7542,10 @@ msgid ""
 "student will receive a new version of each problem. Make sure this is what "
 "you want to do before unchecking sets."
 msgstr ""
-"כשאתה מבטל בחירה של גליון שיעורי בית (ושומר את השינויים), אתה הורס את כל "
-"המידע של גליון זה עבור תלמיד זה. אם אתה מקצה אותו מחדש, התלמיד יקבל גרסה "
-"חדשה של כל שאלה. ודא שזה מה שאתה רוצה לעשות לפני ביטול הבחירה."
+"כשאתה מבטל סימון ההקצאה של גליון (ושומר את השינויים), אתה מוחק "
+"לחלוטין את כל הנתונים של הגליון עבור הסטודנט ממסד הנתונים. אם אתה מקצה אותו "
+"מחדש, הסטודנט יקבל גרסה חדשה של כל שאלה. וודא שזה מה שאתה רוצה לעשות לפני "
+"ביטול סימון ההקצאה."
 
 #. ($self->formatDateTime($set->open_date,undef,$ce->{studentDateDisplayFormat})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:500
@@ -7527,7 +7555,7 @@ msgstr "ייפתח ב-%1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:416
 msgid "Worth"
-msgstr "ערך"
+msgstr "משקל"
 
 #. ($self->shortPath($outputFilePath)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:380
@@ -7549,7 +7577,7 @@ msgstr ""
 msgid ""
 "Write permissions have not been enabled in the templates directory.  No "
 "changes can be made."
-msgstr "הרשאות כתיבה לא הופעלו בתיקיית התבניות. לא ניתן לבצע שינויים"
+msgstr "הרשאות כתיבה לא הופעלו בתיקיית templates. לא ניתן לבצע שינויים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:629
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1289
@@ -7590,51 +7618,51 @@ msgstr ""
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:258
 msgid ""
 "You are not allowed to generate a hardcopy for %1 from your IP address, %2."
-msgstr "אתה לא רשאי ליצר גרסת הדפסה של %1 מכתובת ה-IP שלך, %2."
+msgstr "אתה לא מורשה ליצר גרסת הדפסה של %1 מכתובת ה-IP שלך, %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:633
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1977
 msgid "You are not authorized to access the Instructor tools."
-msgstr "אתה לא רשאי להשתמש בכלי המדריך."
+msgstr "אתה לא מורשה להשתמש בכלי המורה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:336
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:450
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:272
 msgid "You are not authorized to access the instructor tools."
-msgstr "אתה לא רשאי לגשת לכלי המדריך"
+msgstr "אתה לא מורשה לגשת לכלי המורה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:370
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:453
 msgid "You are not authorized to modify homework sets."
-msgstr "אתה לא רשאי לשנות אוספי שיעורי בית"
+msgstr "אתה לא מורשה לבצע שינויים בגליונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1980
 msgid "You are not authorized to modify problems."
-msgstr "אתה לא רשאי לשנות שאלות."
+msgstr "אתה לא מורשה לשנות שאלות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:376
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:456
 msgid "You are not authorized to modify set definition files."
-msgstr "אתה לא רשאי לשנות קבצי הגדרה."
+msgstr "אתה לא מורשה לשנות קבצי הגדרת גליונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:339
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:345
 msgid "You are not authorized to modify student data"
-msgstr "אתה לא רשאי לשנות פרטי תלמיד."
+msgstr "אתה לא מורשה לשנות נתוני סטודנטים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:421
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:390
 msgid "You are not authorized to perform this action."
-msgstr "אתה לא רשאי לבצע פעולה זו."
+msgstr "אתה לא מורשה לבצע את הפעולה הזו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:251
 msgid ""
 "You are not permitted to generate a hardcopy for a set with hidden work."
-msgstr "אתה לא רשאי ליצר גרסת הדפסה של גליון עם עבודה מוחבאת."
+msgstr "אתה לא מורשה ליצר גרסת הדפסה של גליון עם עבודה מוחבאת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:239
 msgid "You are not permitted to generate a hardcopy for an unopened set."
-msgstr "אתה לא רשאי ליצר גרסת הדפסה של אוף שלא נפתח."
+msgstr "אתה לא מורשה ליצר גרסת הדפסה של מטלה שטרם נפתחה."
 
 #. ($showMeAnother{MaxReps},$solutionShown)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm:512
@@ -7730,29 +7758,29 @@ msgstr "לא מלאת את תוכן ההודעה."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:179
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:197
 msgid "You do not have permission to change email addresses."
-msgstr "אין לך את ההרשאות לשנות כתובות דוא\"ל"
+msgstr "אין לך הרשאה לשנות כתובות דוא\"ל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:168
 msgid "You do not have permission to change the hardcopy theme."
-msgstr "אין לך את ההרשאות הדרושות כדי לשנות את עיצוב גרסת ההדפסה."
+msgstr "אין לך הרשאה לשנות את עיצוב גרסת ההדפסה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:133
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Options.pm:155
 msgid "You do not have permission to change your password."
-msgstr "אין לך את ההרשאות לשנות את "
+msgstr "אין לך הרשאה לשנות את הסיסמה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:499
 msgid "You do not have permission to edit this file."
-msgstr "אין לך הרשאות לערוך את הקובץ הזה."
+msgstr "אין לך הרשאה לערוך את הקובץ הזה."
 
 #. ($hardcopy_format)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:161
 msgid "You do not have permission to generate hardcopy in %1 format."
-msgstr "אין לך את ההרשאות הדרושות כדי ליצור גרסת הדפסה בפורמט %1."
+msgstr "אין לך הרשאה ליצר גרסת הדפסה בפורמט %1."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1457
 msgid "You do not have permission to view the details of this error."
-msgstr "אין לך את ההרשאות לצפות בפרטים של השגיאה זו."
+msgstr "אין לך הרשאה לצפות בפרטים על השגיאה הזו."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:158
 msgid "You don't have any Achievement data associated to you!"
@@ -7774,7 +7802,7 @@ msgstr "נשארו לך %1 ניסיון/ות למבחן זה."
 #. ($attemptsLeft)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1814
 msgid "You have %negquant(%1,unlimited attempts,attempt,attempts) remaining."
-msgstr "נותר לך %negquant(%1,נסיונות לא מוגבלים,נסיון,ניסיונות)."
+msgstr "נותרו לך %negquant(%1,נסיונות לא מוגבלים,נסיון,ניסיונות)."
 
 #. ($attempts_before_rr)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1771
@@ -7841,7 +7869,7 @@ msgstr "לא ניתן לשנות את הסיסמה שלך כאן!"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1014
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:436
 msgid "You may not follow symbolic links"
-msgstr ""
+msgstr "לא ניתן לעקוב אחרי קישוריות סימבוליות symbolic links"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1933
 msgid "You may still check your answers."
@@ -7865,13 +7893,13 @@ msgstr "יש לנסות את שאלה זו %quant(%1,פעם,פעמים) לפני
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:665
 msgid "You must confirm the password for the initial instructor."
-msgstr "אתה חייב לאשר את הסיסמה למדריך הראשוני."
+msgstr "אתה חייב לאשר את הסיסמה למורה הראשוני."
 
 #. ($ce->{LMS_name})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:531
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSets.pm:611
 msgid "You must log into this set via your Learning Management System (%1)."
-msgstr ""
+msgstr "אתה חייב להתחבר לגליון הזה דרך מערכת ניהול הלמידה שלך (%1)."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:76
 msgid "You must provide a student ID, a set ID, and a problem number."
@@ -7917,11 +7945,11 @@ msgstr "אתה חיב למלא שם קובץ"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:671
 msgid "You must specify a first name for the initial instructor."
-msgstr "אתה חייב למלא שם פרטי למדריך הראשוני."
+msgstr "אתה חייב למלא שם פרטי למורה הראשוני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:674
 msgid "You must specify a last name for the initial instructor."
-msgstr "אתה חייב למלא שם משפחה למדריך הראשוני."
+msgstr "אתה חייב למלא שם משפחה למורה הראשוני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1248
 msgid "You must specify a new institution for the course."
@@ -7937,7 +7965,7 @@ msgstr "אתה חייב למלא כותרת חדשה לקורס זה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:662
 msgid "You must specify a password for the initial instructor."
-msgstr "אתה חייב למלא סיסמה למדריך הראשוני."
+msgstr "אתה חייב למלא סיסמה למורה הראשוני."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:461
 msgid "You must specify a user ID."
@@ -7945,7 +7973,7 @@ msgstr "אתה חייב למלא מזהה משתמש."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:677
 msgid "You must specify an email address for the initial instructor."
-msgstr "אתה חייב למלא כתובת דוא\"ל של במדריך הראשוני."
+msgstr "אתה חייב למלא כתובת דוא\"ל של המורה הראשון."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm:329
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm:1007
@@ -7958,6 +7986,8 @@ msgid ""
 "You must use your Learning Managment System (%1) to access this set.  Try "
 "logging in to the Learning Managment System and visiting the set from there."
 msgstr ""
+"אתה חייב להשתמש במערכת ניהול הלמידה שלך (%1) כדי לגשת לגליון הזה. נסה להתחבר "
+"למערכת ניהול הלמידה ולגשת לגליון משם."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1230
 msgid "You need to select a \"Target Set\" before you can edit it."
@@ -7985,7 +8015,7 @@ msgstr "אתה צריך לבחור גליון לצפייה"
 #: /opt/webwork/webwork2/lib/FormatRenderedProblem.pm:256
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1809
 msgid "You received a score of %1 for this attempt."
-msgstr "קיבלת ציון %1 עבור ניסיון זה"
+msgstr "קיבלת ציון %1 עבור הגשה זו."
 
 #. (join('.',@{$problemSeqs[$next_id]})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1877
@@ -8006,7 +8036,7 @@ msgstr "לא תוכל להמשיך לשאלה %1 עד שהשלמת, או שנג�
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1225
 msgid "Your %1 name contains illegal characters"
-msgstr "שם ה-%1 שלך מכיל תוים לא חוקיים."
+msgstr "שם ה-%1 שנתת מכיל תווים שאסורים לשימוש כאן."
 
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1226
@@ -8016,14 +8046,14 @@ msgstr "שם ה-%1 לא יכול להתחיל בנקודה"
 #. ($object)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1227
 msgid "Your %1 name may not contain a path component"
-msgstr "שם ה-%1 לא יכול להכיל מרכיב מסלול"
+msgstr "שם ה-%1 לא יכול להכיל מרכיב מסלול (path)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:549
 msgid ""
 "Your LTI OAuth verification failed.  If this recurs, please speak with your "
 "instructor"
 msgstr ""
-"אימות ה-LTI OAuth שלך נכשל. אם בעיה זו חוזרת על עצמה, אנא פנה למדריך שלך"
+"אימות ה-LTI OAuth שלך נכשל. אם בעיה זו חוזרת על עצמה, אנא פנה למורה שלך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:537
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:548
@@ -8034,7 +8064,7 @@ msgstr "האימות שלך נכשל. אנא חזור ל-Oncourse והתחבר �
 msgid ""
 "Your authentication failed.  Please try again. Please speak with your "
 "instructor if you need help."
-msgstr "האימות שלך נכשל. אנא נסה שוב. אנא פנה למדריך שלך אם אתה צריך עזרה."
+msgstr "האימות שלך נכשל. אנא נסה שוב. אנא פנה למורה שלך אם אתה צריך עזרה."
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:3102
 msgid "Your browser does not support the video tag."
@@ -8067,7 +8097,7 @@ msgstr "כתובת הדוא\"ל שלך שונתה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:1251
 msgid "Your file name contains illegal characters"
-msgstr "שם הקובץ מכיל תוים לא חוקיים."
+msgstr "שם הקובץ מכיל תווים לא חוקיים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:124
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
@@ -8081,67 +8111,67 @@ msgstr "ההודעה שלך נשלח בהצלחה."
 #. ($lastScore,$notCountedMessage)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1812
 msgid "Your overall recorded score is %1.  %2"
-msgstr "סה\"כ הניקוד שלך הוא %1. %2"
+msgstr "הציון שנשמר עבורך במערכת הוא %1. %2"
 
 #. ($versionNumber, wwRound(2,$recordedScore)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1912
 msgid "Your recorded score on this test (version %1) is %2/%3."
-msgstr ""
+msgstr "הציון שנשמר עבורך למבחן זה (גרסה %1) הוא %2 מתוך %3."
 
 #: /opt/webwork/pg/macros/compoundProblem.pl:603
 msgid "Your score for this attempt is for this part only;"
-msgstr ""
+msgstr "הציון שקבלת בהגשה זו הוא רק לחקל זה;"
 
 # $testNounNum is either "test (#)" or "submission (#)"
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1812
 msgid "Your score on this %1 WAS recorded."
-msgstr "הציון שלך ב-%1 הזה נשמרה."
+msgstr "הציון שלך ב-%1 הזה נשמר."
 
 # $testNoun is either "test" or "submission"
 #. ($testNoun,$attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1817
 msgid "Your score on this %1 is %2/%3."
-msgstr "הציון שלך ב-%1 זה הוא %2/%3."
+msgstr "הציון שלך ב-%1 זה הוא %2 מתוך %3."
 
 # $testNounNum is either "test (#)" or "submission (#)
 #. ($testNounNum)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1808
 msgid "Your score on this %1 was NOT recorded."
-msgstr "הניקוד שלך ב-%1 זה לא נשמרה."
+msgstr "הציון שלך ב-%1 זה לא נשמר."
 
 #. ($attemptScore,$totPossible)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1852
 msgid "Your score on this (checked, not recorded) submission is %1/%2."
-msgstr "הניקוד שלך על הגשה זו (נבדקה, לא נשמרה) הוא %1/%2."
+msgstr "הציון שלך על הגשה זו (שנבדקה, ולא נשמרה) הוא %1 מתוך %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1467
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1798
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2055
 msgid "Your score on this problem was recorded."
-msgstr "הניקוד שלך בשאלה זו נשמר."
+msgstr "הציון שלך בשאלה זו נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1469
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:171
 msgid ""
 "Your score was not recorded because there was a failure in storing the "
 "problem record to the database."
-msgstr "הניקוד שלך לא נשמר בגלל שהיה כישלון בשמירת נתוני השאלה במסד הנתונים"
+msgstr "הציון שלך לא נשמר בגלל שאירעה תקלה בשמירת נתוני השאלה במסד הנתונים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:272
 msgid "Your score was not recorded because this homework set is closed."
-msgstr "הניקוד שלך לא נשמר בגלל שגליון שיעורי בית זה הוא סגור."
+msgstr "הציון שלך לא נשמר בגלל שגליון שיעורי בית זה הוא סגור."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:278
 msgid ""
 "Your score was not recorded because this problem has not been assigned to "
 "you."
-msgstr "הניקוד שלך לא נשמר בגלל ששאלה זו לא הוקצאה אליך."
+msgstr "הציון שלך לא נשמר בגלל ששאלה זו לא הוקצאה אליך."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1493
 msgid ""
 "Your score was not recorded because this problem set version is not open."
-msgstr "הניקוד שלך לא נשמר בגלל שגירסת גליון השאלות הזאת לא פתוחה."
+msgstr "הציון שלך לא נשמר בגלל שגירסת הגליון הזאת לא פתוחה."
 
 #. ($elapsed, $allowed)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1508
@@ -8149,36 +8179,36 @@ msgid ""
 "Your score was not recorded because you have exceeded the time limit for "
 "this test. (Time taken: %1 min; allowed: %2 min.)"
 msgstr ""
-"הציון שלך לא נשמר כי עברת את הגבלת הזמן של מבחן זה. (זמן שעבר: %1 דק', הגבלת "
-"זמן: %2 דק'.)"
+"הציון שלך לא נשמר כי עברת את מגבלת הזמן של מבחן זה. (זמן שעבר: %1 דקות, "
+"מגבלת הזמן: %2 דקות.)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1496
 msgid ""
 "Your score was not recorded because you have no attempts remaining on this "
 "set version."
-msgstr "הניקוד שלך לא נשמר כי אין לך עוד ניסיונות לגרסת הגליון הזאת."
+msgstr "הציון שלך לא נשמר כי אין לך עוד ניסיונות לגרסת הגליון הזאת."
 
 #: /opt/webwork/webwork2/lib/FormatRenderedProblem.pm:259
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1511
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:274
 msgid "Your score was not recorded."
-msgstr "הניקוד שלך לא נשמר."
+msgstr "הציון שלך לא נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1833
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:259
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:265
 msgid "Your score was not successfully sent to the LMS."
-msgstr "הניקוד שלך לא נשלח בהצלחה ל-LMS."
+msgstr "נכשלה שליחת הציון שלך אל מערכת ה-LMS."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:169
 msgid "Your score was recorded."
-msgstr "הניקוד שלך נשמר."
+msgstr "הציון שלך נשמר."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1832
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:257
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm:263
 msgid "Your score was successfully sent to the LMS."
-msgstr "הניקוד לך נשלח בהצלחה ל-LMS."
+msgstr "הציון שלך נשלח בהצלחה אל מערכת ה-LMS."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen.pm:561
 msgid "Your session has timed out due to inactivity. Please log in again."
@@ -8197,48 +8227,67 @@ msgstr "[ערוך]"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:282
 msgid "_ACHIEVEMENTS_EDITOR_DESCRIPTION"
-msgstr "_תיאור_עורך_הישגים"
+msgstr ""
+"כלי לעריכת הישגים: משמש לערוך אלו הישגים פעילים בקורס וזמינים לסטודנטים. נא "
+"לזכור: ההישגים מופעים ונבדקים לפי הסדר בהם הם רשומים. הקטגוריה הסודי secret "
+"מייצר הישגים שאינם גלויים לסטודנטים עד אשר זכו בהם. הקטגוריה level משמש "
+"להישגים הקשורים לרמת level המשתשמש. מומלץ לרוא את התיעוד על הישגים במערכת."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm:415
 msgid "_ANSWER_LOG_DESCRIPTION"
-msgstr "_תיאור_רשימת_תשובות"
+msgstr ""
+"רשימת התשובות: סטודנטים זכאים רק לראות הת התשובות של עצמם ומבלי סימון אלו "
+"תשובות נכונות/לא נכונות. סגל ההוראה יכולים לבחור לראות תשובות של רשימת "
+"הסטודנטים שיסמנו בטופס, והמערכת תסמן בצבע אילו תשובות נכונות/לא נכונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:488
 msgid "_CLASSLIST_EDITOR_DESCRIPTION"
-msgstr "_תיאור_עורך_רשימת_כיתה"
+msgstr "כלי לעריכת רשימת המשתמים"
 
 #. (CGI::strong($course)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:212
 msgid "_EXTERNAL_AUTH_MESSAGE"
-msgstr "_הודעת_אימות_חיצונית"
+msgstr ""
+"הקורס %1 משתמש במערכת אימות/הזדהות חיצונת (%2). ההזדות בעזרת המערכת החיצונית "
+"הצליחה, אך אינך רשאי להיכנס לקורס זה."
 
 #. (CGI::b($r->maketext("Guest Login")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:295
 msgid "_GUEST_LOGIN_MESSAGE"
-msgstr "_הודעת_התחברות_אורח"
+msgstr "קורס זה מאפשר להתחבר כאורח. לחץ %1 כדי להתחבר כאורח."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:543
 msgid "_HMWKSETS_EDITOR_DESCRIPTION"
-msgstr "_תיאור_עורך_שיעורי_הבית"
+msgstr ""
+"עורך הגליונות: שים לב לבורר הפעולות מעל הטבלה, ולקישוריות בשורות הטבלה."
 
 #. (CGI::b($r->maketext("Remember Me")
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Login.pm:217
 msgid "_LOGIN_MESSAGE"
-msgstr "_הודעת_היתחברות"
+msgstr ""
+"ניתן לסמן %1 כדי שהדפדפן ישמור את פרטי ההזדהות שלך, ובכך לאפשר התחברות מהירה "
+"למשך התקופה המותרת להתחברות ממושכת. אין לאפשר את זה במחשב ציבורי או בכל מחשב "
+"אחר בו יש גישה למשתמשים נוספים."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2730
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:2732
 msgid "_PROBLEM_SET_SUMMARY"
-msgstr "_תקציר_גליון_שאלות"
+msgstr ""
+"טבלה של הגליונות המוגדרות בקורס. ניתן לגלוש לעורכי הגליון / התאריכים / רשימת "
+"הסטודנטים אליהם הוקצה הגליון בעזרת הקישוריות בטבלה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:2141
 msgid "_REQUEST_ERROR"
-msgstr "_שגיאת_בקשה"
+msgstr ""
+"אירעה תקלה בזמן עיבוד הפנייה שלך. לפי הצורך דווח על התקלה לסגל הקורס / צוות "
+"התמיכה."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1884
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1886
 msgid "_USER_TABLE_SUMMARY"
-msgstr "_תקציר_טבלת_משתמשים"
+msgstr ""
+"טבלת המשתמשים: יש מספר קישוריות פעילות בשורות הטבלה, וניתן למיין בעזרת שורת "
+"הכותרות."
 
 # Context is "Create set ______ as a duplicate of the first selected set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:720
@@ -8275,7 +8324,7 @@ msgstr "הוסף גליון גלובלי %1 ברשימת שאלות ??? האוס
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:471
 msgid "added missing permission level for user"
-msgstr "נוספה רמת ההרשאות החסרה למשתמש"
+msgstr "נוספה רמת הרשאה שהייתה חסרה למשתמש"
 
 # #short for administrator
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:116
@@ -8292,7 +8341,7 @@ msgstr "כל ההישגים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:794
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1289
 msgid "all current users"
-msgstr "כל המשתמשים העכשיויים"
+msgstr "כל המשתמשים שקיימים כרגע"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:376
 msgid "all set dates for one <b>user</b>"
@@ -8305,11 +8354,11 @@ msgstr "כל תאריכי האוסופים של <b>משתמש</b> אחד"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:903
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:985
 msgid "all sets"
-msgstr "כל האוספים"
+msgstr "כל הגליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:620
 msgid "all students"
-msgstr "כל התלמדים"
+msgstr "כל הסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1121
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:657
@@ -8320,7 +8369,7 @@ msgstr "כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:377
 msgid "all users for one <b>set</b>"
-msgstr "כל המשתמשים של <b>גליון</b> אחד"
+msgstr "כל המשתמשים עבור <b>גליון</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1465
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1698
@@ -8331,12 +8380,12 @@ msgstr "בסדר אלפבתי"
 #. ($count,$numSets)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:644
 msgid "an impossible number of sets: %1 out of %2"
-msgstr ""
+msgstr "מספר בלתי סביר של גליונות: %1 מתוך %2"
 
 #. ($count,$numUsers)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:624
 msgid "an impossible number of users: %1 out of %2"
-msgstr ""
+msgstr "מספר בלתי סביר של משתמשים: %1 מתוך %2"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:645
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:656
@@ -8360,7 +8409,7 @@ msgstr "ממוצע ניסיונות"
 # Context is "Append ____ blank problem template(s) to end of homework set"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:2561
 msgid "blank problem template(s) to end of homework set"
-msgstr "תבנית שאלה ריקה לסיום גליון שיעורי הבית"
+msgstr "תבניות שאלות ריקות בסוף הגליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1466
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1699
@@ -8371,20 +8420,20 @@ msgstr "לפי תאריך ההתחברות האחרון"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1016
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1453
 msgid "changes abandoned"
-msgstr "שינויים לא נשמרו"
+msgstr "השינויים לא נשמרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:1066
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1542
 msgid "changes saved"
-msgstr "שינויים נשמרו"
+msgstr "השינויים נשמרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:221
 msgid "class list data"
-msgstr "נתוני רשימת כיתה"
+msgstr "נתוני רשימת המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:380
 msgid "class list data for selected <b>users</b>"
-msgstr "נתוני רשימת כיתה של <b>המשתמשים</b> שנבחרו"
+msgstr "נתוני רשימת המשתמשים של <b>המשתמשים</b> שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:252
 msgid "close"
@@ -8409,7 +8458,7 @@ msgstr "קבצי קורס"
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1085
 msgid "deleted %1 sets"
-msgstr "נמחקו %1 אוספים"
+msgstr "נמחקו %1 גליונות"
 
 #. ($num)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1005
@@ -8422,7 +8471,7 @@ msgstr "עורך את כל ההישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:874
 msgid "editing all sets"
-msgstr "עורך את כל האוספים"
+msgstr "עורך את כל הגליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:884
 msgid "editing all users"
@@ -8434,7 +8483,7 @@ msgstr "עורך את ההישגים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:880
 msgid "editing selected sets"
-msgstr "עורך את האוספים שנבחרו"
+msgstr "עורך את הגליונות שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:890
 msgid "editing selected users"
@@ -8442,11 +8491,11 @@ msgstr "עורך את המשתמשים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:877
 msgid "editing visible sets"
-msgstr "עורך את האוספים שניתנים לצפייה"
+msgstr "עורך את הגליונות שמופיעים כרגע ברשימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:887
 msgid "editing visible users"
-msgstr "עורך את המשתמשים שניתנים לצפייה"
+msgstr "עורך את המשתמשים שמופיעים כרגע ברשימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:79
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:90
@@ -8459,7 +8508,7 @@ msgstr "ריק"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:698
 msgid "enter matching set IDs below"
-msgstr "הכנס את מזהי האוספים המתאימים למטה"
+msgstr "הכנס את מזהי הגליונות הרצויות למטה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm:171
 msgid "entry rows."
@@ -8468,25 +8517,25 @@ msgstr "שורות קליטה"
 #. ($restrictLoc, $setName, $@)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1756
 msgid "error adding set location %1 for set %2: %3"
-msgstr "שגיאה בהוספת מיקום %1 עבור גליון %2:%3"
+msgstr "אירעה שגיאה בהוספת מיקום %1 עבור גליון %2: %3"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:943
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1392
 msgid "export abandoned"
-msgstr "יצוא בוטל"
+msgstr "הייצוא בוטל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:919
 msgid "exporting all achievements"
-msgstr "מיצא את כל ההישגים"
+msgstr "מייצא את כל ההישגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:922
 msgid "exporting selected achievements"
-msgstr "מיצא את ההישגים שנבחרו"
+msgstr "מייצא את ההישגים שנבחרו"
 
 #. ($userName, $editForUserID, $setCount)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm:221
 msgid "for  %1 (%2) who has been assigned %3 sets."
-msgstr "עבור %1(%2) שלו הוקצאו %3 אוספים."
+msgstr "עבור %1 (%2) אליו הוקצאו %3 גליונות."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:388
 msgid "for one <b>set</b>"
@@ -8499,20 +8548,20 @@ msgstr "עבור <b>משתמש</b> אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:930
 msgid "giving new passwords to all users"
-msgstr "נותן סיסמה חדשה לכל המשתמשים"
+msgstr "נפתח טופס להגדרת סיסמה חדשה לכל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:936
 msgid "giving new passwords to selected users"
-msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
+msgstr "נפתח טופס להגדרת הגדרת סיסמה חדשה למשתמשים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:933
 msgid "giving new passwords to visible users"
-msgstr "נותן סיסמה חדשה למשתמשים שנבחרו"
+msgstr "נפתח טופס להגדרת  הגדרת סיסמה חדשה למשתמשים שהופיעו ברשימה"
 
 #. ($j, $setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:983
 msgid "global %1 for set %2 not found."
-msgstr "הגלובלי %1 עבור גליון %2 לא נמצא."
+msgstr "שאלה %1 הגלובלי עבור גליון %2 לא נמצא."
 
 #. ($setID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:1055
@@ -8540,11 +8589,11 @@ msgstr "מוחבא מ-"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:86
 msgid "hidden from students"
-msgstr "מוחבא מתלמידים"
+msgstr "מוחבא מהסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:697
 msgid "hidden sets"
-msgstr "אוספים מוחבאים"
+msgstr "גליונות מוחבאים/לא זמינים לסטודנטים"
 
 # does not need to be translated
 #. ('j','k','_0')
@@ -8576,11 +8625,11 @@ msgstr "מדד"
 #. ($restrictLoc, $setName)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1759
 msgid "input set location %1 already exists for set %2."
-msgstr "מיקום הגליון שהוכנס %1 כבר קיים עבור גליון %2."
+msgstr "המיקום %1 שהוזן כבר קיים עבור גליון %2."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:737
 msgid "list of insertable macros"
-msgstr "רשימת קיצורי המאקרו שניתן להכניס"
+msgstr "רשימת קיצורי המאקרו שניתנים לשימוש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2656
 msgid "locations selected below"
@@ -8601,12 +8650,12 @@ msgstr "מזהה משתמש/התחברות:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:116
 msgid "login_proctor"
-msgstr "התחברות_משגיח"
+msgstr "משגיח_התחברות"
 
 # Context is "Set _____ made visibile for _____ users"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:937
 msgid "made visible for"
-msgstr "נהפך לגלוי עבור"
+msgstr "נהפכו לזמינים עבור"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:422
 msgid "max"
@@ -8614,7 +8663,7 @@ msgstr "מקסימום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1235
 msgid "multiple sets"
-msgstr "מספר אוספים"
+msgstr "מספר גליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:396
 msgid "new set:"
@@ -8626,15 +8675,15 @@ msgstr "משתמשים חדשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:535
 msgid "no achievements"
-msgstr "אין הישגים"
+msgstr "אף הישג"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:657
 msgid "no achievements."
-msgstr "אין הישגים."
+msgstr "אף הישג."
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:2657
 msgid "no location"
-msgstr "אין מיקום"
+msgstr "אף מיקום"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:638
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1045
@@ -8642,11 +8691,11 @@ msgstr "אין מיקום"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:902
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:984
 msgid "no sets"
-msgstr "שום אוספים"
+msgstr "אף משימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:618
 msgid "no students"
-msgstr "אין תלמידים"
+msgstr "אף סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:795
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1048
@@ -8654,7 +8703,7 @@ msgstr "אין תלמידים"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:658
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:959
 msgid "no users"
-msgstr "שום משתמשים"
+msgstr "אף משתמש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Config.pm:237
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:116
@@ -8663,15 +8712,15 @@ msgstr "אף אחד"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:746
 msgid "nth colum of merge file"
-msgstr "העמודה ה-n של קובץ האיחוד"
+msgstr "העמודה ה-n של קובץ המיזור merge file"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:225
 msgid "number of students not defined"
-msgstr "מספר התלמידים שלא הוגדרו"
+msgstr "מספר הסטודנטים להוסיף לא הוגדר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1689
 msgid "of"
-msgstr ""
+msgstr "מתוך"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:381
 msgid "one <b>set</b>"
@@ -8720,7 +8769,7 @@ msgstr "חלק"
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1235
 msgid "permissions for %1 not defined"
-msgstr "הההרשאות של %1 לא מוגדרות"
+msgstr "רמת ההרשאה של %1 לא מוגדרת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1934
 msgid "pg debug"
@@ -8732,7 +8781,7 @@ msgstr "שגיאות פנימיות של PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1935
 msgid "pg warning"
-msgstr "הזהרת PG"
+msgstr "אזהרת PG"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2091
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Hardcopy.pm:1343
@@ -8750,7 +8799,7 @@ msgstr "קודות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:451
 msgid "preserve existing data"
-msgstr "שמר מידע קיים"
+msgstr "שמור את הנתונים בקיימים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:2115
 msgid "preview answers"
@@ -8781,19 +8830,19 @@ msgstr "שגיאת קריאת הגדרת גליון, לא יכול לקרוא א
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:798
 msgid "recitation #"
-msgstr "תרגול  #"
+msgstr "קבוצת תרגול  #"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1233
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1306
 msgid "record for visible user %1 not found"
-msgstr "רישום לא נמצא עבור משתמש גלוי %1 לא נמצא"
+msgstr "לא נמצאו נתונים עבור המשתמש %1"
 
 #. ($restrictLoc)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:1762
 msgid ""
 "restriction location %1 does not exist.  IP restrictions have been ignored."
-msgstr "מיקום ההגבלות %1 לא קיים. הגבלות ה-IP לא הופעלו"
+msgstr "מיקום %1 למגבלות מיקום התחברות לא קיים. הגבלות ה-IP להתחברות לא הופעלו"
 
 #: /opt/webwork/pg/macros/PGbasicmacros.pl:668
 msgid "row"
@@ -8810,11 +8859,11 @@ msgstr "קבוצה:"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:392
 msgid "selected <b>sets</b>"
-msgstr "<b>האוספים</b> שנבחרו"
+msgstr "<b>הגליונות</b> שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:407
 msgid "selected <b>users</b> to selected <b>sets</b>"
-msgstr "<b>משתמשים</b> שנבחרו <b>לאוספים</b> שנבחרו"
+msgstr "<b>משתמשים</b> שנבחרו <b>לגליונות</b> שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:406
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm:442
@@ -8834,7 +8883,7 @@ msgstr "ההישגים שנבחרו."
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:904
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:986
 msgid "selected sets"
-msgstr "אוספים שנבחרו"
+msgstr "גליונות שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1047
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1123
@@ -8851,11 +8900,11 @@ msgstr "גליון"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor.pm:646
 msgid "sets"
-msgstr "אוספים"
+msgstr "גליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:733
 msgid "showing all sets"
-msgstr "מציג את כל האוספים"
+msgstr "מציג את כל הגליונות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:709
 msgid "showing all users"
@@ -8863,14 +8912,14 @@ msgstr "מציג את כל המשתמשים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:766
 msgid "showing hidden sets"
-msgstr "מראה אוספים מוחבאים"
+msgstr "מציג גליונות מוחבאים = לא זמינים לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:742
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:747
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:751
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:755
 msgid "showing matching sets"
-msgstr "מראה אוספים תואמים"
+msgstr "מציג גליונות תואמות"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:718
 msgid "showing matching users"
@@ -8878,15 +8927,15 @@ msgstr "מציג את המשתמשים התואמים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:736
 msgid "showing no sets"
-msgstr "לא מציג שום אוספים"
+msgstr "לא מציג אף משימה"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:712
 msgid "showing no users"
-msgstr "לא מציג שום משתמשים"
+msgstr "לא מציג אף משתמש"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:739
 msgid "showing selected sets"
-msgstr "מציג אוספי שנבחרו"
+msgstr "מציג גליונות שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:715
 msgid "showing selected users"
@@ -8894,11 +8943,11 @@ msgstr "מציג משתמשים שנבחרו"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:759
 msgid "showing visible sets"
-msgstr "מראה אוספים גלויים"
+msgstr "מציג גליונות שזמינים לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:1690
 msgid "shown"
-msgstr ""
+msgstr "מוצגים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:616
 msgid "still open"
@@ -8906,7 +8955,7 @@ msgstr "עדיין פתוח"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:116
 msgid "student"
-msgstr "תלמיד"
+msgstr "סטודנט"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1785
 msgid "submission"
@@ -8915,7 +8964,7 @@ msgstr "הגשה"
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1787
 msgid "submission (version %1)"
-msgstr ""
+msgstr "הגשה (גרסה %1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:664
 msgid "summary"
@@ -8923,7 +8972,7 @@ msgstr "תקציר"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/Localize.pm:116
 msgid "ta"
-msgstr "עוזר מורה"
+msgstr "מתרגל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1785
 msgid "test"
@@ -8948,23 +8997,25 @@ msgstr "המסלול המקורי לקבוץ הוא %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm:390
 msgid "then delete them"
-msgstr "ואז תמחק אותם"
+msgstr "ואז מחק אותם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm:803
 msgid "there are no set definition files in this course to look at."
-msgstr ""
+msgstr "אין קבצי הגדרות גליונות בקורס זה לעיין בהם."
 
+# The context here is 1 time, n times
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1762
 msgid "time"
-msgstr "זמן"
+msgstr "פעם"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm:618
 msgid "time limit exceeded"
 msgstr "עברה מגבלת הזמן"
 
+# The context here is 1 time, n times
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:1762
 msgid "times"
-msgstr "מספר פעמים"
+msgstr "פעמים"
 
 # Context is Assign ____ to _____
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm:781
@@ -8974,11 +9025,11 @@ msgstr "ל-"
 #. ($ce->{institutionName})
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:570
 msgid "to %1 main web site"
-msgstr ""
+msgstr "אל האתר הראשי של %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator.pm:548
 msgid "to courses page"
-msgstr ""
+msgstr "לרשימת הקורסים בשרת"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:382
 msgid "to one <b>set</b>"
@@ -8999,7 +9050,7 @@ msgstr "סה\"כ"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:398
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:399
 msgid "unable to write to directory %1"
-msgstr "כתיבה בתיקייה %1 נכשלה"
+msgstr "לא ניתן לכתוב לתיקייה %1"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm:336
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:510
@@ -9008,7 +9059,7 @@ msgstr "לא מוגבל"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Achievements.pm:242
 msgid "unlimited reusability"
-msgstr ""
+msgstr "לשימוש בלתי מוגבל"
 
 #. ($userID)
 #: /opt/webwork/webwork2/lib/WeBWorK/Authen/LTIBasic.pm:618
@@ -9023,12 +9074,12 @@ msgstr "שם משתמש, שם משפחה, שם פרטי, קבוצה, רמת הי
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:660
 msgid "users who match on selected field"
-msgstr "משתמשים שתאמו בשדות שנבחרו"
+msgstr "משתמשים שתאמו בשדה שנבחרה"
 
 #. ($versionNumber)
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm:1787
 msgid "version (%1)"
-msgstr ""
+msgstr "גרסה (%1)"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1449
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/CourseAdmin.pm:1676
@@ -9040,12 +9091,12 @@ msgstr "גלוי"
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:696
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm:858
 msgid "visible sets"
-msgstr "אוספים שניתנים לצפייה"
+msgstr "גליונות שמופיעים בטבלה / בסנן: גליונות זמינים לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Problem.pm:545
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/ProblemSet.pm:86
 msgid "visible to students"
-msgstr "ניתן לצפייה לתלמידים"
+msgstr "זמין לסטודנטים"
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1046
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm:1122
@@ -9071,816 +9122,4 @@ msgstr ""
 
 #: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Index.pm:411
 msgid "your students"
-msgstr "התלמידים שלך"
-
-#~ msgid "Username presented:  %1"
-#~ msgstr "שם משתמש שמוצג: %1"
-
-#~ msgid ""
-#~ "Specify an ID, title, and institution for the new course. The course ID "
-#~ "may contain only letters, numbers, hyphens, and underscores."
-#~ msgstr ""
-#~ "פרט מזהה, כותרת, ומוסד עבור הקורס החדש. מזהה הקורס יכול להכיל רק אותיות, "
-#~ "מספרים, מקפים, וקוים תחתונים."
-
-#~ msgid ""
-#~ "There are currently two themes (or skins) to choose from: math3 and "
-#~ "math4.  The theme specifies a unified look and feel for the WeBWorK "
-#~ "course web pages."
-#~ msgstr ""
-#~ "כרגע יש ני עיצובים (או ערכות נושא) שניתנים לבחירה: math3 ו-math4. העיצוב "
-#~ "מגדיר תחושה ומראה אחידים עבור דפי הרשת של קורס ה-WeBWorK."
-
-#~ msgid "%quant(%1,course was, courses were) successfully unhidden."
-#~ msgstr "%quant(%1,קורס נהפך לגלוי, קורסים נהפכו לגלויים) בהצלחה."
-
-#~ msgid "%quant_1( course was, courses were) successfully hidden."
-#~ msgstr "%quant_1(הקורס הוחבא, הקורסים הוחבאו) בהצלחה."
-
-#~ msgid "Add how many students?"
-#~ msgstr "כמה סטודנטים להוסיף?"
-
-#~ msgid "Download PDF or TeX Hardcopy for Selected Sets"
-#~ msgstr "הורד גרסת הדפסה כ-PDF או TeX של האוספים שנבחרו"
-
-#~ msgid "Edit Which Users?"
-#~ msgstr "ערוך איזה משתמשים?"
-
-#~ msgid "Export selected sets"
-#~ msgstr "יצא את האוספים שנבחרו"
-
-#~ msgid "Export which sets?"
-#~ msgstr "איזה אוספים ליצא?"
-
-#~ msgid "Jump to Page:"
-#~ msgstr "קפוץ לעמוד:"
-
-#~ msgid "Show Which Users?"
-#~ msgstr "אזה משתמשים להציג?"
-
-#~ msgid "The following courses were successfully hidden: %1"
-#~ msgstr "הקורסים הבאים הוחבאו בהצלחה: %1"
-
-#~ msgid "The following courses were successfully unhidden: %1"
-#~ msgstr "הקורסים הבאים נהפכו לגלויים בהצלחה: %1"
-
-#~ msgid ""
-#~ "This table lists out the available homework sets for this class, along "
-#~ "with its current status. Click on the link on the name of the homework "
-#~ "sets to take you to the problems in that homework set.  Clicking on the "
-#~ "links in the table headings will sort the table by the field it "
-#~ "corresponds to.  You can also select sets for download to PDF or TeX "
-#~ "format using the linkx next to the problem set names, and then clicking "
-#~ "on the 'Download PDF or TeX Hardcopy for Selected Sets' button at the end "
-#~ "of the table.  There is also a clear button and an Email instructor "
-#~ "button at the end of the table."
-#~ msgstr ""
-#~ "הטבלה מציגה את אוספי שיעורי הבית הזמינים עבור כיתה זו, ביחד על סטטוס "
-#~ "נוכחי. לחץ על הקישור בשם הגליון כדי לצפות בשאלות בגליון. לחיצה על "
-#~ "הקישורים בראש הטבלה  יסדר את הטבלה לפי השדה המתאים. אתה יכול גם לבחור "
-#~ "אוספים להורדה בפורמט PDF או TeX באזרת הקישור ליד שם אוספי השאלות, ואז "
-#~ "לחיצה על כפתור \"הורד גרסת הדפסה כ-PDF או TeX של האוספים שנבחרו\" שבתחתית "
-#~ "הטבלה. יש גם כפתורי ריקון שלח דוא\"ל למדריך בתחתית הטבלה."
-
-#~ msgid "exporting all sets"
-#~ msgstr "מיצא את כל האוספים"
-
-#~ msgid "exporting selected sets"
-#~ msgstr "מיצא את האוספים שנבחרו"
-
-#~ msgid "exporting visible sets"
-#~ msgstr "מיצא את האוספים שניתנים לצפייה"
-
-#~ msgid "%1 (old editor)"
-#~ msgstr "%1 (עורך ישן)"
-
-#~ msgid ""
-#~ "Any time problem numbers are intentionally changed, the problems will "
-#~ "always be renumbered consecutively, starting from one.  When deleting "
-#~ "problems, gaps will be left in the numbering unless the box above is "
-#~ "checked."
-#~ msgstr ""
-#~ "כל פעם שמשנים שמספרי שאלות, השאלות תמיד ימוספרו באופן עוקב מהמספר אחד. "
-#~ "כשמוחקים שאלות, ישארו רווחים במספור אלא עם כן סומנה האפשרות למעלה."
-
-#~ msgid "Deletion destroys all set-related data and is not undoable!"
-#~ msgstr "מחיקה הורסת את כל המידע הקשור לגליון והיא לא הפיכה!"
-
-#~ msgid "Deletion destroys all user-related data and is not undoable!"
-#~ msgstr "מחיקה הורסת את כת המידע הקשור למשתמש והיא בלתי הפיכה!"
-
-#~ msgid "Don't recognize statistics display type: |%1|"
-#~ msgstr "לא מזהה את סוג תצוגת הסטטיסטיקה: |%1|."
-
-#~ msgid "Edit All Set Data"
-#~ msgstr "ערוך את כל המידע של הגליון"
-
-#~ msgid "Edit it"
-#~ msgstr "ערוך"
-
-#~ msgid ""
-#~ "Force problems to be numbered consecutively from one (always done when "
-#~ "reordering problems)"
-#~ msgstr ""
-#~ "אלץ מספור עוקב של של השאלות החל ממספר אחד ( זה תמיד נעשה כשמסדרים בעיות "
-#~ "מחדש)"
-
-#~ msgid "Give new password to"
-#~ msgstr "תן סיסמה חדשה ל-"
-
-#~ msgid "Hide all paths"
-#~ msgstr "החבא את כל הכתובות"
-
-#~ msgid "Hide path:"
-#~ msgstr "החבא כתובת:"
-
-#~ msgid ""
-#~ "It is before the open date.  You probably want to renumber the problems "
-#~ "if you are deleting some from the middle."
-#~ msgstr ""
-#~ "זה לפני תאריך הפתיחה. כנראה תרצה למספר מחדש את השאלות אם אתה מוחק מהאמצע."
-
-#~ msgid "Library Browser 2"
-#~ msgstr "דפדפן ספרייה 2"
-
-#~ msgid "Library Browser 3"
-#~ msgstr "דפדפן ספרייה 3"
-
-#~ msgid "Library Browser no js"
-#~ msgstr "דפדפן ספרייה ללא js"
-
-#~ msgid "Make"
-#~ msgstr "צור"
-
-# No space
-#~ msgid "NewVersion"
-#~ msgstr "גרסה חדשה"
-
-#~ msgid "Newer problem set def files must be imported using Hmwk Sets Editor2"
-#~ msgstr "יש ליבא קבצי .def של גליון שאלות חדש בעזרת עורך אוספי שיעורי בית 2"
-
-#~ msgid "Old Classlist Editor"
-#~ msgstr "עורך רשימת כיתה ישן"
-
-# Hmwk is short for Homework
-#~ msgid "Old Hmwk Sets Editor"
-#~ msgstr "עורך אוספי שיעורי בית ישן"
-
-#~ msgid "Orig. Lib. Browser"
-#~ msgstr "דפדפן ספרייה מקורית"
-
-# PG is a WeBWorK abreviation and should stay PG
-#~ msgid "PG - Problem Display/Answer Checking"
-#~ msgstr "PG - הצגת שאלה/בדיקת תשובה"
-
-#~ msgid ""
-#~ "Percentile cutoffs for number of attempts. <br/> The 50% column shows the "
-#~ "median number of attempts"
-#~ msgstr ""
-#~ "אחוז התלמידים שניסו כמות מסויימת של פעמים או יותר. <br/>עמודת ה-50% מראה "
-#~ "את החציון של מספר הניסיונות"
-
-#~ msgid "Primary sort"
-#~ msgstr "מיון ראשי"
-
-#~ msgid "Problem"
-#~ msgstr "שאלה"
-
-#~ msgid "Refresh Display"
-#~ msgstr "רענן תצוגה"
-
-#~ msgid "Reorder problems only"
-#~ msgstr "סדר מחדש שאלות בלבד"
-
-#~ msgid "Result of last action performed"
-#~ msgstr "התוצאה של הפעולה האחרונה שבוצעה"
-
-#~ msgid "Secondary sort"
-#~ msgstr "מיון משני"
-
-#~ msgid "Select all sets"
-#~ msgstr "בחר את כל האוספים"
-
-#~ msgid "Select all users"
-#~ msgstr "בחר את כל המשתמשים"
-
-#~ msgid "Set Detail 2 for set %2"
-#~ msgstr "פרטי גליון 2 עבור גליון %2"
-
-#~ msgid "Show"
-#~ msgstr "הצג"
-
-#~ msgid "Show all paths"
-#~ msgstr "הראה את כל המסלולים"
-
-#~ msgid "Show path ..."
-#~ msgstr "הראה מסלול ..."
-
-#~ msgid "Showing"
-#~ msgstr "מראה"
-
-#~ msgid "Statistics for"
-#~ msgstr "סטטיסטיקה עבור"
-
-#~ msgid "Try it"
-#~ msgstr "נסה זאת"
-
-#~ msgid "Unselect all sets"
-#~ msgstr "אל תבחר את כל הקורסים"
-
-#~ msgid "Unselect all users"
-#~ msgstr "אל תבחר את כל המשתמשים"
-
-#~ msgid "View it"
-#~ msgstr "הצג את זה"
-
-#~ msgid ""
-#~ "When changing problem numbers, we will move the problem to be %1 the "
-#~ "chosen number."
-#~ msgstr "כאשר משנים מספרי השאלות, נזיז את השאלה להיות %1 המספר הנבחר."
-
-#~ msgid "You are not authorized to access the Instructor tools"
-#~ msgstr "אתה לא רשאי להשתמש בכלי המדריך"
-
-#~ msgid ""
-#~ "You cannot use this version of Set Detail to edit just-in-time type "
-#~ "sets.  You must use Set Detail 2."
-#~ msgstr ""
-#~ "אתה לא יכוללהשתמש בגרסה הזאת של פרטי הגליון כדי לערוך אוספי מסוג \"בדיוק "
-#~ "בזמן\". אתה צריך להשתמש בפרטי גליון 2."
-
-# Context is "Save to a new file named:"
-#~ msgid "a new file named:"
-#~ msgstr "קובץ חדש בשם:"
-
-#~ msgid "active"
-#~ msgstr "פעיל"
-
-# Context is "Import set from ____ assigning this set to ____"
-#~ msgid "assigning this set to"
-#~ msgstr "מקצה את הגליון ל-"
-
-#~ msgid "for students"
-#~ msgstr "עבור תלמידים"
-
-#~ msgid "from"
-#~ msgstr "מקור"
-
-#~ msgid "global set %1  not found."
-#~ msgstr "גליון גלובלי  %1 לא נמצא."
-
-# Context is " Show users who match _____ in their _____"
-#~ msgid "in their"
-#~ msgstr "בשלהם"
-
-#~ msgid "inactive"
-#~ msgstr "לא פעיל"
-
-#~ msgid "out of"
-#~ msgstr "מתוך"
-
-#~ msgid "record for user %1 not found"
-#~ msgstr "רישם לא נמצא עבור משתמש %1"
-
-#~ msgid "separate multiple IDs with commas"
-#~ msgstr "הפרד מספר מזהים בעזרת פסיקים."
-
-#~ msgid "sets checked below"
-#~ msgstr "אוספים שנבדקו למטה"
-
-#~ msgid "sets hidden from students"
-#~ msgstr "אוספים שמוחבאים מהתלמידים"
-
-#~ msgid "sets visible to students"
-#~ msgstr "אוספים שגלויים לתלמידים"
-
-#~ msgid "sets with matching set IDs:"
-#~ msgstr "אוספים עם מזההים תואמים"
-
-#~ msgid "students"
-#~ msgstr "תלמידים"
-
-#~ msgid "the following file(s)"
-#~ msgstr "הקבצים הבאים"
-
-# Context is "Sort by ___ then by ___"
-#~ msgid "then by"
-#~ msgstr "ואז לפי"
-
-#~ msgid "users"
-#~ msgstr "משתמשים"
-
-#~ msgid "users who match:"
-#~ msgstr "משתמשים שתואמים:"
-
-#~ msgid "with set name(s):"
-#~ msgstr "עם אוספים בשם:"
-
-# Gateway (test 3)
-#~ msgid "%1 (test %2)"
-#~ msgstr "%1 (מבחן %2)"
-
-#~ msgid ""
-#~ "%1 uses an external authentication system (e.g., Oncourse,  CAS,  "
-#~ "Blackboard, Moodle, Canvas, etc.).  Please return to system you used and "
-#~ "try again."
-#~ msgstr ""
-#~ "%1 משתמש במערכת אימות חיצונית (כגון Oncourse, CAS, Blackboard, Moodle, "
-#~ "Canvas, וכו'.) בבקשה חזור למערכת בה השתמשת ונסה שוב."
-
-#~ msgid ""
-#~ "%1 uses an external authentication system.  You've authenticated through "
-#~ "that system, but aren't allowed to log in to this course."
-#~ msgstr ""
-#~ "%1 משתמש במערכת אימות חיצונית. אומתת במערכת החיצונית, אבל אתה לא רשאי "
-#~ "להתחבר לקורס הזה."
-
-#~ msgid "Take %1 test"
-#~ msgstr "בצע את מבחן %1"
-
-#~ msgid "Take %1 test."
-#~ msgstr "בצע את מבחן %1."
-
-#~ msgid "Test Date"
-#~ msgstr "תאריך מבחן"
-
-#~ msgid "Test Score"
-#~ msgstr "ציון מבחן"
-
-#~ msgid "The recorded score for this test is  %1/%2."
-#~ msgstr "הציון המוזן למבחן זה הוא %1/%2."
-
-#~ msgid "The recorded score for this test is %1/%2."
-#~ msgstr "הציון המוזן למבחן זה הוא %1/%2."
-
-#~ msgid ""
-#~ "The test (which is number %1) may  no longer be submitted for a grade."
-#~ msgstr "כבר לא ניתן להגיש את המבחן (מספר %1) לניקוד."
-
-#~ msgid ""
-#~ "You must log into this set via your Learning Management System (e.g. "
-#~ "Blackboard, Moodle, etc...)."
-#~ msgstr ""
-#~ "אתה חייב להתחבר לגליון זה דרך מערכת ניהול הלמידה שלך (לדוגמה: Blackboard, "
-#~ "Moodle, וכו')."
-
-#~ msgid ""
-#~ "You must use your Learning Managment System (E.G. Blackboard, Moodle, "
-#~ "Canvas, etc...) to access this set.  Try logging in to the Learning "
-#~ "Managment System and visiting the set from there."
-#~ msgstr ""
-#~ "אתה חייב להשתמש במערכת ניהול הלמידה שלך (לדוגמה: Blackboard, Moodle, "
-#~ "Canvas, וכו') כדי לגשת לגליון הזה. נסה להתחבר למערכת ניהול הלמידה ולבקר "
-#~ "בגליון משם."
-
-#~ msgid "Your recorded score on this test (number %1) is %2/%3."
-#~ msgstr "הציון שלך במבחן זה (מספר %1) הוא %2/%3."
-
-#~ msgid "submission (test %1)"
-#~ msgstr "הגשה (מבחן %1)"
-
-#~ msgid "test (%1)"
-#~ msgstr "מבחן (%1)"
-
-# Edit with a number 1 after with no space
-#~ msgid "Edit1"
-#~ msgstr "עריכה1"
-
-# Edit with a number 2 after with no space
-#~ msgid "Edit2"
-#~ msgstr "עריכה2"
-
-# Edit with a number 3 after with no space
-#~ msgid "Edit3"
-#~ msgstr "עריכה3"
-
-# No space before number
-#~ msgid "Problem Editor2"
-#~ msgstr "עורך שאלות2"
-
-# No space before number
-#~ msgid "Problem Editor3"
-#~ msgstr "עורך שאלות3"
-
-#~ msgid "That symbolic link takes you outside your course directory"
-#~ msgstr "הקישור הסימלי הזה מוציא אותך מתיקיית הקורס שלך"
-
-#~ msgid "Message:"
-#~ msgstr "הודעה:"
-
-#~ msgid "Messages"
-#~ msgstr "הודעות"
-
-#~ msgid "The answer will be graded later."
-#~ msgstr "התשובה תנוקד מאוחר יותר."
-
-#~ msgid "This answer is NOT completely correct."
-#~ msgstr "התשוב הזאת לא נכונה לגמרי."
-
-#~ msgid "This answer is NOT correct."
-#~ msgstr "התשובה הזאת לא נכונה."
-
-#~ msgid "This answer is correct."
-#~ msgstr "התשובה הזאת נכונה."
-
-#~ msgid "To:"
-#~ msgstr "נמען:"
-
-#~ msgid "Import achievements from"
-#~ msgstr "יבא הישגים מ-"
-
-#~ msgid "Open, reduced scoring starts on %1."
-#~ msgstr "פתוח, תקופת ניקוד מופחת מתחיל ב- %1"
-
-#~ msgid "Reduced Scoring Starts %1"
-#~ msgstr "תקופת ניקוד מופחת מתחיל ב- %1"
-
-#~ msgid "Reduced scoring started on %1."
-#~ msgstr "תקופת ניקוד מופחת התחיל ב-%1."
-
-#
-#, fuzzy
-#~ msgid "set %1."
-#~ msgstr "tr: Revert to %1"
-
-#
-#~ msgid "navNext"
-#~ msgstr "tr:&nbspNext"
-
-#
-#~ msgid "navNextGrey"
-#~ msgstr "tr:&nbspNext"
-
-#
-#~ msgid "navPrev"
-#~ msgstr "tr:&nbspPrev"
-
-#
-#~ msgid "navPrevGrey"
-#~ msgstr "tr:&nbspPrev"
-
-#
-#~ msgid "navProbListGrey"
-#~ msgstr "tr:&nbspUp"
-
-#
-#~ msgid "navUp"
-#~ msgstr "tr:&nbspUp"
-
-#
-#~ msgid "Apply Options"
-#~ msgstr "tr: Apply Options"
-
-#
-#~ msgid "Disable"
-#~ msgstr "tr: Disable"
-
-#
-#, fuzzy
-#~ msgid "Reduced Credit %1 for all sets"
-#~ msgstr "Reduced Credit %1 for all sets"
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_1"
-#~ msgstr ""
-#~ "tr: This assignment has a Reduced Credit Period that begins %1 and ends "
-#~ "on the due date, %2.  During this period all additional work done counts "
-#~ "%3% of the original."
-
-#
-#~ msgid "_REDUCED_CREDIT_MESSAGE_2"
-#~ msgstr ""
-#~ "tr: This assignment had a Reduced Credit Period that began %1 and ended "
-#~ "on the due date, %2.  During that period all additional work done counted "
-#~ "%3% of the original."
-
-#
-#~ msgid ""
-#~ "Report bugs in a WeBWorK question/problem using this link. The very first "
-#~ "time you do this you will need to register with an email address so that "
-#~ "information on the bug fix can be reported back to you."
-#~ msgstr ""
-#~ "tr: Report bugs in a WeBWorK question/problem using this link. The very "
-#~ "first time you do this you will need to register with an email address so "
-#~ "that information on the bug fix can be reported back to you."
-
-#
-#~ msgid "Unable to make '[_1]' the set header for [_2]"
-#~ msgstr "tr: Unable to make '%1' the set header for %2"
-
-#
-#~ msgid "Can't determine user of temporary edit file [_1]."
-#~ msgstr "tr: Can't determine user of temporary edit file %1."
-
-#
-#~ msgid "Top level of author information on the wiki."
-#~ msgstr "tr: Top level of author information on the wiki."
-
-#
-#~ msgid "Reverting to original file '[_1]'"
-#~ msgstr "tr: Reverting to original file '%1'"
-
-#
-#~ msgid "Wiki summary page for MathObjects"
-#~ msgstr "tr: Wiki summary page for MathObjects"
-
-#
-#~ msgid "Snippets of PG code illustrating specific techniques"
-#~ msgstr "tr: Snippets of PG code illustrating specific techniques"
-
-#
-#~ msgid "Error copying [_1] to [_2]"
-#~ msgstr "tr: Error copying %1 to %2"
-
-#
-#~ msgid ""
-#~ "Note: this problem viewer is for viewing purposes only. As of right now, "
-#~ "testing functionality is not possible."
-#~ msgstr ""
-#~ "tr: Note: this problem viewer is for viewing purposes only. As of right "
-#~ "now, testing functionality is not possible."
-
-#
-#~ msgid "webwork"
-#~ msgstr "webwork"
-
-#
-#~ msgid "submit button clicked"
-#~ msgstr "gönder düğmesine basıldı"
-
-#
-#~ msgid ""
-#~ "Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-#~ msgstr ""
-#~ "tr: Test snippets of PG code in interactive lab.  Good way to learn PG "
-#~ "language."
-
-#
-#~ msgid "View Using Seed Number"
-#~ msgstr "tr: View Using Seed Number"
-
-#
-#~ msgid ""
-#~ "Documentation from source code for PG modules and macro files. Often the "
-#~ "most up-to-date information."
-#~ msgstr ""
-#~ "tr: Documentation from source code for PG modules and macro files. Often "
-#~ "the most up-to-date information."
-
-#
-#~ msgid ""
-#~ "PG mark down syntax used to format WeBWorK questions. This interactive "
-#~ "lab can help you to learn the techniques."
-#~ msgstr ""
-#~ "tr: PG mark down syntax used to format WeBWorK questions. This "
-#~ "interactive lab can help you to learn the techniques."
-
-#
-#~ msgid ""
-#~ "Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = [_1]"
-#~ msgstr ""
-#~ "tr: Error: This path is already in the temporary edit directory -- no new "
-#~ "temporary file is created. path = %1"
-
-#
-#~ msgid ""
-#~ "Please use radio buttons to choose the method for saving this file. Can't "
-#~ "recognize saveMode: |[_1]|."
-#~ msgstr ""
-#~ "tr: Please use radio buttons to choose the method for saving this file. "
-#~ "Can't recognize saveMode: |%1|."
-
-#
-#~ msgid "Resources"
-#~ msgstr "tr: Resources"
-
-#
-#~ msgid "Duplicate"
-#~ msgstr "tr: Duplicate"
-
-#
-#~ msgid "This path |[_1]| is not the path to a temporary edit file."
-#~ msgstr "tr: This path |%1| is not the path to a temporary edit file."
-
-#
-#~ msgid "Save as new independent problem"
-#~ msgstr "tr: Save as new independent problem"
-
-#
-#~ msgid "Unknown file type"
-#~ msgstr "tr: Unknown file type"
-
-#~ msgid "answer "
-#~ msgstr "תשובה"
-
-#~ msgid "Will open on %1"
-#~ msgstr "ייפתח ב-%1."
-
-#, fuzzy
-#~ msgid "User ID:"
-#~ msgstr "מזהה משתמש"
-
-#, fuzzy
-#~ msgid "Viewing temporary file"
-#~ msgstr "מציג קובץ זמני:"
-
-#, fuzzy
-#~ msgid "You are not authorized to access instructor tools"
-#~ msgstr "אתה לא רשאי לגשת לכלי המדריך"
-
-#, fuzzy
-#~ msgid "all current users."
-#~ msgstr "כל המשתמשים הפעילים ??? עכשיויים"
-
-#, fuzzy
-#~ msgid "font-hidden"
-#~ msgstr "מוחבא"
-
-#, fuzzy
-#~ msgid "font-visible"
-#~ msgstr "גלוי"
-
-#, fuzzy
-#~ msgid "no users."
-#~ msgstr "שום משתמשים"
-
-#, fuzzy
-#~ msgid "submitAnswers"
-#~ msgstr "שלח תשובות"
-
-#, fuzzy
-#~ msgid "All sets %1 all students"
-#~ msgstr "כל האוספים הם מוחבאים מכל התלמדים"
-
-#, fuzzy
-#~ msgid "Bad Nonce for user "
-#~ msgstr "אין רישום למשתמש %1."
-
-#, fuzzy
-#~ msgid "Can't write to file: %1"
-#~ msgstr "לא יכול לכתוב בקובץ %1"
-
-#, fuzzy
-#~ msgid "Change Display Options"
-#~ msgstr "שנה אפשרויות תצוגה"
-
-#, fuzzy
-#~ msgid "Changes saved."
-#~ msgstr "שינויים נשמרו"
-
-#, fuzzy
-#~ msgid "Hardcopy Theme:"
-#~ msgstr "עיצוב גרסת הדפסה"
-
-#, fuzzy
-#~ msgid "No sets selected for scoring."
-#~ msgstr "לא נבחרו אוספים לנקד"
-
-#, fuzzy
-#~ msgid "Recitation:"
-#~ msgstr "תרגול"
-
-#, fuzzy
-#~ msgid "Save as:"
-#~ msgstr "שמור בשם"
-
-#, fuzzy
-#~ msgid "Log into"
-#~ msgstr "התחבר ל-%1"
-
-#, fuzzy
-#~ msgid "Sets assigned to $userID"
-#~ msgstr "האוספים שהוקצאו למשתמש"
-
-#, fuzzy
-#~ msgid "navProbList"
-#~ msgstr "רשימת שאלות"
-
-#, fuzzy
-#~ msgid "Problem [_1]"
-#~ msgstr "שאלה %1"
-
-#, fuzzy
-#~ msgid "[_1]% correct"
-#~ msgstr "%1% נכון"
-
-#, fuzzy
-#~ msgid "At least one of these answers is NOT completely correct."
-#~ msgstr "לפחות אחת מהתשובות למעלה היא לא נכונה."
-
-#, fuzzy
-#~ msgid "[_1]: Problem [_2]"
-#~ msgstr "%1: שאלה %2"
-
-#, fuzzy
-#~ msgid "Show me another [_1]"
-#~ msgstr "הראה לי עוד אחת %1"
-
-#, fuzzy
-#~ msgid "Edit "
-#~ msgstr "ערוך"
-
-#, fuzzy
-#~ msgid "Assign "
-#~ msgstr "הקצה"
-
-#, fuzzy
-#~ msgid "Delete "
-#~ msgstr "מחק"
-
-#, fuzzy
-#~ msgid "Export "
-#~ msgstr "יצא"
-
-#, fuzzy
-#~ msgid "Add "
-#~ msgstr "הוסף הכל"
-
-#, fuzzy
-#~ msgid "Enable/Disable reduced scoring for selected sets"
-#~ msgstr "בטל הקצאה של האוספים הנבחרים מהמשתמשים הנבחרים"
-
-#, fuzzy
-#~ msgid ""
-#~ "No students shown.  Choose one of the options above to \n"
-#~ "\t              list the students in the course."
-#~ msgstr ""
-#~ "לא מוצגים תלמידים. אנא בחר את אחד  מהאפשרויות לעיל כדי לראות את התלמידים "
-#~ "בקורס."
-
-#, fuzzy
-#~ msgid "Reduced Credit %1 for selected sets"
-#~ msgstr "עורך את האוספים שנבחרו"
-
-#, fuzzy
-#~ msgid "Reduced Credit %1 for visable sets"
-#~ msgstr "הגליון שבוקש '%1' עדיין לא זמין"
-
-#, fuzzy
-#~ msgid "completely"
-#~ msgstr "הושלם."
-
-#, fuzzy
-#~ msgid "Course Information for course [_1]"
-#~ msgstr "דווח עבור קורס %1:"
-
-#, fuzzy
-#~ msgid "Hardcopy Header for set [_1]"
-#~ msgstr "קידומת גירסת הדפסה"
-
-#, fuzzy
-#~ msgid "hardcopy header file"
-#~ msgstr "קידומת גירסת הדפסה"
-
-#, fuzzy
-#~ msgid "Unpublished"
-#~ msgstr "פרסם"
-
-#, fuzzy
-#~ msgid "Unable to change the hardcopy header for set [_1]. Unknown error."
-#~ msgstr "לא ניתן לשנות את המעריך של גליון %1. שגיאה לא מזוהה."
-
-#, fuzzy
-#~ msgid "Password/Email"
-#~ msgstr "סיסמה"
-
-# Context is "This set is visible" or "This set is hidden"
-#, fuzzy
-#~ msgid "This set is [_1] students."
-#~ msgstr "הגליון הזה הוא %1"
-
-#, fuzzy
-#~ msgid "blank problem"
-#~ msgstr "הוסף שאלות"
-
-#, fuzzy
-#~ msgid "Page generated at [_1] at [_2]"
-#~ msgstr "דף נוצר ב-%1"
-
-#, fuzzy
-#~ msgid "Published"
-#~ msgstr "פרסם"
-
-#, fuzzy
-#~ msgid "The selected problem ([_1]) is not a valid problem for set [_2]."
-#~ msgstr "גליון השאלות הנבחר (%1) הוא לא גליון חוקי עבור %2"
-
-#, fuzzy
-#~ msgid ""
-#~ "Unable to change the source file path for set [_1], problem [_2]. Unknown "
-#~ "error."
-#~ msgstr "לא ניתן לשנות את המעריך של גליון %1. שגיאה לא מזוהה."
-
-#, fuzzy
-#~ msgid "Options Information"
-#~ msgstr "תיאור אתר"
-
-#, fuzzy
-#~ msgid "options information"
-#~ msgstr "תיאור אתר"
-
-#, fuzzy
-#~ msgid "The selected problem([_1]) is not a valid problem for set [_2]."
-#~ msgstr "השאלה הנבחר (%1) הוא לא חוקי עבור גליון %2"
+msgstr "הסטודנטים שלך"


### PR DESCRIPTION
Updates to the Hebrew translation dictionary (WW 2.16 version) taken from the Technion's production server. 

The file has translations for many strings not translated before, and changes many poor choices of phrasing/terminology from the first large-scale translation effort for Hebrew.

The current file may still have some typos or issues, but in my opinion if far better and more complete than what was in the original `heb.po` file from WW 2.16.

I would appreciate this being merged before the script to update the translations files for WW 2.17 is run, so these translations are carried into the new version.
