### PR TITLE
More student progress table improvements.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -28,7 +28,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::Debug;
 use WeBWorK::ContentGenerator::Grades;
-use WeBWorK::Utils qw(jitar_id_to_seq jitar_problem_adjusted_status wwRound);
+use WeBWorK::Utils qw(jitar_id_to_seq jitar_problem_adjusted_status wwRound grade_set);
 #use WeBWorK::Utils qw(readDirectory list2hash max sortByName);
 use WeBWorK::Utils::Grades qw/list_set_versions/;
 use WeBWorK::DB::Record::UserSet;  #FIXME -- this is only used in one spot.
@@ -253,65 +253,59 @@ sub index {
 	);
 }
 
-###################################################
+# Display student progress table
 sub displaySets {
-	my $self             = shift;
-	my $r                = $self->r;
-	my $urlpath          = $r->urlpath;
-	my $db               = $r->db;
-	my $ce               = $r->ce;
-	my $authz            = $r->authz;
-	my $courseName       = $urlpath->arg("courseID");
-	my $setName          = $urlpath->arg("setID");
-	my $user             = $r->param('user');
-	my $GlobalSet        = $self->{setRecord};
-	my $root             = $ce->{webworkURLs}->{root};
-	my $setStatsPage     = $urlpath->newFromModule($urlpath->module, $r, courseID=>$courseName,statType=>'sets',setID=>$setName);
-	my $primary_sort_method_name = $r->param('primary_sort');
+	my $self       = shift;
+	my $r          = $self->r;
+	my $urlpath    = $r->urlpath;
+	my $db         = $r->db;
+	my $ce         = $r->ce;
+	my $authz      = $r->authz;
+	my $courseName = $urlpath->arg("courseID");
+	my $setName    = $urlpath->arg("setID");
+	my $user       = $r->param('user');
+	my $GlobalSet  = $self->{setRecord};
+	my $root       = $ce->{webworkURLs}->{root};
+	my $setStatsPage = $urlpath->newFromModule($urlpath->module, $r, courseID => $courseName, statType => 'sets', setID => $setName);
+	my $primary_sort_method_name   = $r->param('primary_sort');
 	my $secondary_sort_method_name = $r->param('secondary_sort');
-	my $ternary_sort_method_name = $r->param('ternary_sort');
+	my $ternary_sort_method_name   = $r->param('ternary_sort');
 
 	# another versioning/gateway change.  in many cases we don't want or need
 	# all of the columns that are put in here by default, so we add a set of
 	# flags for which columns to show.  for versioned sets we may also want to
 	# only see the best score, so we include that as an option also.
 	# these are ignored for non-versioned sets
-	my %showColumns = ( 'name' => 1, 'score' => 1, 'outof' => 1,
-			    'date' => 0, 'testtime' => 0, 'index' => 1,
-			    'problems' => 1, 'section' => 1, 'recit' => 1,
-			    'login' => 1 );
+	my %showColumns = (
+		'name'     => 1,
+		'score'    => 1,
+		'outof'    => 1,
+		'date'     => 0,
+		'testtime' => 0,
+		'login'    => 1,
+		'problems' => 1,
+		'section'  => 1,
+		'recit'    => 1,
+	);
 	my $showBestOnly = 0;
 
-   	my @index_list                           = ();  # list of all student index
-	my @score_list                           = ();  # list of all student total percentage scores
-	my %attempts_list_for_problem            = ();  # a list of the number of attempts for each problem
-	my %number_of_attempts_for_problem       = ();  # the total number of attempst for this problem (sum of above list)
-	my %number_of_students_attempting_problem = ();  # the number of students attempting this problem.
-	my %correct_answers_for_problem          = ();  # the number of students correctly answering this problem (partial correctness allowed)
+	my @score_list  = ();     # list of all student total percentage scores
 	my $sort_method = sub {
-		my ($a,$b,$sort_method_name) = @_;
+		my ($a, $b, $sort_method_name) = @_;
 		return 0 unless defined($sort_method_name);
-		return lc($a->{last_name}) cmp lc($b->{last_name}) if $sort_method_name eq 'last_name';
-		return lc($a->{first_name}) cmp lc($b->{first_name}) if $sort_method_name eq 'first_name';
-		return 	lc($a->{email_address}) cmp lc($b->{email_address}) if $sort_method_name eq 'email_address';
-		return $b->{score} <=> $a->{score} if $sort_method_name eq 'score';
-		return $b->{index} <=> $a->{index} if $sort_method_name eq 'index';
-		return lc($a->{section}) cmp lc($b->{section}) if $sort_method_name eq 'section';
-		return lc($a->{recitation}) cmp lc($b->{recitation}) if $sort_method_name eq 'recitation';
-		return lc($a->{user_id}) cmp lc($b->{user_id}) if $sort_method_name eq 'user_id';
-		if ($sort_method_name =~/p(\d+)/) {
-			my $left  =  $b->{problemData}->{$1} ||0;
-			my $right =  $a->{problemData}->{$1} ||0;
-			return $left <=> $right;  # sort by number of attempts.
-		}
-
+		return lc($a->{last_name}) cmp lc($b->{last_name})         if $sort_method_name eq 'last_name';
+		return lc($a->{first_name}) cmp lc($b->{first_name})       if $sort_method_name eq 'first_name';
+		return lc($a->{email_address}) cmp lc($b->{email_address}) if $sort_method_name eq 'email_address';
+		return $b->{score} <=> $a->{score}                         if $sort_method_name eq 'score';
+		return lc($a->{section}) cmp lc($b->{section})             if $sort_method_name eq 'section';
+		return lc($a->{recitation}) cmp lc($b->{recitation})       if $sort_method_name eq 'recitation';
+		return lc($a->{user_id}) cmp lc($b->{user_id})             if $sort_method_name eq 'user_id';
 	};
 	my %display_sort_method_name = (
 		last_name     => $r->maketext('last name'),
 		first_name    => $r->maketext('first name'),
 		email_address => $r->maketext('email address'),
 		score         => $r->maketext('score'),
-		index         => $r->maketext('success indicator'),
 		section       => $r->maketext('section'),
 		recitation    => $r->maketext('recitation'),
 		user_id       => $r->maketext('login name'),
@@ -319,29 +313,21 @@ sub displaySets {
 
 	# get versioning information
 	my $setIsVersioned =
-	    ( defined($GlobalSet->assignment_type()) &&
-	      $GlobalSet->assignment_type() =~ /gateway/ ) ? 1 : 0;
+		(defined($GlobalSet->assignment_type()) && $GlobalSet->assignment_type() =~ /gateway/) ? 1 : 0;
 
 	# reset column view options based on whether the set is versioned and, if so,
 	# the input parameters
-	if ( $setIsVersioned ) {
-		  # the returning parameter lets us set defaults for versioned sets
+	if ($setIsVersioned) {
+		# the returning parameter lets us set defaults for versioned sets
 		my $ret = defined($r->param('returning')) ? $r->param('returning') : 0;
-		$showColumns{'date'} = ($ret && !defined($r->param('show_date'))) ? $r->param('show_date') : 1;
-		$showColumns{'testtime'} = ($ret && !defined($r->param('show_testtime'))) ? $r->param('show_testtime'):1;
-		$showColumns{'index'} = ($ret && defined($r->param('show_index'))) ? $r->param('show_index') : 0;
-		$showColumns{'problems'} = ($ret && defined($r->param('show_problems'))) ? $r->param('show_problems'):0;
-		$showColumns{'section'} = ($ret && defined($r->param('show_section'))) ? $r->param('show_section') : 0;
-		$showColumns{'recit'} = ($ret && defined($r->param('show_recitation'))) ? $r->param('show_recitation') : 0;
-		$showColumns{'login'} = ($ret && defined($r->param('show_login'))) ? $r->param('show_login') : 0;
-		$showBestOnly = ($ret && defined($r->param('show_best_only'))) ? $r->param('show_best_only') : 0;
+		$showColumns{'date'}     = ($ret && !defined($r->param('show_date')))      ? $r->param('show_date')       : 1;
+		$showColumns{'testtime'} = ($ret && !defined($r->param('show_testtime')))  ? $r->param('show_testtime')   : 1;
+		$showColumns{'problems'} = ($ret && defined($r->param('show_problems')))   ? $r->param('show_problems')   : 0;
+		$showColumns{'section'}  = ($ret && defined($r->param('show_section')))    ? $r->param('show_section')    : 0;
+		$showColumns{'recit'}    = ($ret && defined($r->param('show_recitation'))) ? $r->param('show_recitation') : 0;
+		$showColumns{'login'}    = ($ret && defined($r->param('show_login')))      ? $r->param('show_login')      : 0;
+		$showBestOnly            = ($ret && defined($r->param('show_best_only')))  ? $r->param('show_best_only')  : 0;
 	}
-
-	###############################################################
-	#  Print tables
-	###############################################################
-
-	my $max_num_problems  = 0;
 
 	# Get all users except the set level proctors and practice users, and restrict to the sections or recitations that
 	# are allowed for the user if such restrictions are defined.  This list is sorted by last_name, then first_name,
@@ -363,240 +349,173 @@ sub displaySets {
 	);
 	debug("End obtaining user records for set $setName");
 
-    debug("begin main loop");
- 	my @augmentedUserRecords    = ();
- 	my $number_of_active_students;
+	debug("begin main loop");
+	my @augmentedUserRecords = ();
 
-	foreach my $studentRecord (@studentRecords)   {
+	foreach my $studentRecord (@studentRecords) {
 		my $studentName = $studentRecord->user_id;
 		next unless $ce->status_abbrev_has_behavior($studentRecord->status, "include_in_stats");
-		$number_of_active_students++;
 
-        my( $ra_allSetVersionNames, $notAssignedSet) = list_set_versions($db, $studentName, $setName, $setIsVersioned);
-        my @allSetVersionNames = @{$ra_allSetVersionNames};
+		my ($ra_allSetVersionNames, $notAssignedSet) = list_set_versions($db, $studentName, $setName, $setIsVersioned);
+		my @allSetVersionNames = @{$ra_allSetVersionNames};
 
 		# for versioned sets, we might be keeping only the high score
 		my $maxScore = -1;
 		my $max_hash = {};
 
-		foreach my $setName ( @allSetVersionNames ) {
-
-			my $status          = 0;
-			my $longStatus      = '';
-			my $string          = '';
-			my $twoString       = '';
-			my $totalRight      = 0;
-			my $total           = 0;
-			my $total_num_of_attempts_for_set = 0;
-			my %h_problemData   = ();
-			my $num_of_attempts;
-			my $num_of_problems;
-
+		foreach my $setName (@allSetVersionNames) {
 			my $set;
 			my $userSet;
-            if ( $setIsVersioned ) {
-				my ($setN,$vNum) = ($setName =~ /(.+),v(\d+)$/);
+			if ($setIsVersioned) {
+				my ($setN, $vNum) = ($setName =~ /(.+),v(\d+)$/);
 				# we'll also need information from the set
-				#    as we set up the display below, so get
-				#    the merged userset as well
-				$set = $db->getMergedSetVersion($studentRecord->user_id, $setN, $vNum);
+				# as we set up the display below, so get
+				# the merged userset as well
+				$set     = $db->getMergedSetVersion($studentRecord->user_id, $setN, $vNum);
 				$userSet = $set;
 				$setName = $setN;
 			} else {
-			    $set = $db->getMergedSet( $studentName, $setName );
-
+				$set = $db->getMergedSet($studentName, $setName);
 			}
-		     #FIXME -- this seems like over kill -- perhaps we only need to pass in the set_id.
-		     # that is the only aspect of $set that is used in grade set.
-		     # the problem_random order sequence is used in the corresponding routine in Grades.pm
+			#FIXME -- this seems like over kill -- perhaps we only need to pass in the set_id.
+			# that is the only aspect of $set that is used in grade set.
+			# the problem_random order sequence is used in the corresponding routine in Grades.pm
 
-		    unless ( ref($set) ) {
-		    	$set = new WeBWorK::DB::Record::UserSet;
-		    	$set->set_id($setName);
-		    }
+			unless (ref($set)) {
+				$set = new WeBWorK::DB::Record::UserSet;
+				$set->set_id($setName);
+			}
 
-           ( $status,
-             $longStatus,
-             $string,
-             $twoString,
-             $totalRight,
-             $total,
-             $num_of_attempts,
-             $num_of_problems) = grade_set( $db, $set, $setName, $studentName, $setIsVersioned,
-									    \%number_of_students_attempting_problem,
-									    \%attempts_list_for_problem,
-										\%number_of_attempts_for_problem,
-										\%h_problemData,
-										\$total_num_of_attempts_for_set,
-										\%correct_answers_for_problem,
-						       );
-			my $probNum         = 0;
-			my $act_as_student_url = '';
+			my $problemsRow = generate_problems_row($db, $set, $setName, $studentName, $setIsVersioned);
 
 			# for versioned tests we might be displaying the
 			# test date and test time
 			my $dateOfTest = '';
-			my $testTime = '';
-			if ( $setIsVersioned ) {
+			my $testTime   = '';
+			if ($setIsVersioned) {
 				# if this isn't defined, something's wrong
-				if ( defined($userSet) ) {
+				if (defined($userSet)) {
 					$dateOfTest = localtime($userSet->version_creation_time());
-					if ( defined($userSet->version_last_attempt_time()) && $userSet->version_last_attempt_time() ) {
-						$testTime = ($userSet->version_last_attempt_time() - $userSet->open_date() ) / 60;
-						my $timeLimit = $userSet->version_time_limit()/60;
-						$testTime = $timeLimit if ( $testTime > $timeLimit );
+					if (defined($userSet->version_last_attempt_time()) && $userSet->version_last_attempt_time()) {
+						$testTime = ($userSet->version_last_attempt_time() - $userSet->open_date()) / 60;
+						my $timeLimit = $userSet->version_time_limit() / 60;
+						$testTime = $timeLimit if ($testTime > $timeLimit);
 						$testTime = sprintf("%3.1f min", $testTime);
-					} elsif ( time() - $userSet->open_date() < $userSet->version_time_limit() ) {
+					} elsif (time() - $userSet->open_date() < $userSet->version_time_limit()) {
 						$testTime = $r->maketext('still open');
 					} else {
 						$testTime = $r->maketext('time limit exceeded');
 					}
 				} else {
 					$dateOfTest = '???';
-					$testTime = '???';
+					$testTime   = '???';
 				}
 			}
 
+			my $email = $studentRecord->email_address;
+			my ($score, $total) = grade_set($db, $set, $setName, $studentRecord->user_id, $setIsVersioned);
+			$score = wwRound(2, $score);
 
-			$act_as_student_url = $self->systemLink($urlpath->new(type=>'set_list',args=>{courseID=>$courseName}), params=>{effectiveUser => $studentRecord->user_id});
-			my $email              = $studentRecord->email_address;
-			# FIXME  this needs formatting
-
-			# change to give better output for gateways with;
-			# only one attempt per version: just reports the
-			# result for each problem, not the number of attempts.
-			my $longtwo = ($setIsVersioned &&
-				       $userSet->attempts_per_version == 1) ?
-				       $string : "$string\n$twoString";
-
-			my $avg_num_attempts = ($num_of_problems) ? $total_num_of_attempts_for_set/$num_of_problems : 0;
-			my $successIndicator = ($avg_num_attempts && $total) ? ($totalRight/$total)**2/$avg_num_attempts : 0 ;
-
-			my $temp_hash         = { user_id        => $studentRecord->user_id,
-		                                  last_name      => $studentRecord->last_name,
-		                                  first_name     => $studentRecord->first_name,
-		                                  score          => $totalRight,
-		                                  total          => $total,
-		                                  index          => $successIndicator,
-		                                  section        => $studentRecord->section,
-		                                  recitation     => $studentRecord->recitation,
-		                                  problemString  => "<span dir=\"ltr\"><pre class=\"mb-0\" dir=\"ltr\">$longtwo</pre></span>", # RTL mode does not handle the pre well
-		                                  act_as_student => $act_as_student_url,
-		                                  email_address  => $studentRecord->email_address,
-		                                  problemData    => {%h_problemData},
-						  date           => $dateOfTest,
-						  testtime       => $testTime,
-					      };
+			my $temp_hash = {
+				user_id       => $studentRecord->user_id,
+				last_name     => $studentRecord->last_name,
+				first_name    => $studentRecord->first_name,
+				score         => $score,
+				total         => $total,
+				section       => $studentRecord->section,
+				recitation    => $studentRecord->recitation,
+				problemsRow   => $problemsRow,
+				email_address => $studentRecord->email_address,
+				date          => $dateOfTest,
+				testtime      => $testTime,
+			};
 
 			# keep track of best score
-			if ( $totalRight > $maxScore ) {
-				$maxScore = $totalRight;
-				$max_hash = { %$temp_hash };
+			if ($score > $maxScore) {
+				$maxScore = $score;
+				$max_hash = {%$temp_hash};
 			}
 
 			# if we're showing all records, add it in to the list
-			if ( ! $showBestOnly ) {
+			if (!$showBestOnly) {
 				# add this data to the list of total scores (out of 100)
 				# add this data to the list of success indices.
-				push( @index_list, $temp_hash->{index});
-				push( @score_list, ($temp_hash->{total}) ?$temp_hash->{score}/$temp_hash->{total} : 0 ) ;
-				push( @augmentedUserRecords, $temp_hash );
+				push(@score_list,           ($temp_hash->{total}) ? $temp_hash->{score} / $temp_hash->{total} : 0);
+				push(@augmentedUserRecords, $temp_hash);
 			}
 
-		} # this closes the loop through all set versions
+		}    # this closes the loop through all set versions
 
 		# if we're showing only the best score, add the best score now
-		if ( $showBestOnly ) {
+		if ($showBestOnly) {
 			# if there's no %$max_hash, then we had no results
-			#    this occurs for proctors, for example
-			if ( $notAssignedSet ) {
+			# this occurs for proctors, for example
+			if ($notAssignedSet) {
 				next;
-			} elsif ( ! %$max_hash ) {
+			} elsif (!%$max_hash) {
 				$max_hash = {
-					user_id => $studentRecord->user_id(),
-					last_name=>$studentRecord->last_name(),
-					first_name=>$studentRecord->first_name(),
-					score => 0,
-					total => 'n/a',
-					index => 0,
-					section => $studentRecord->section(),
-					recitation=>$studentRecord->recitation(),
-					problemString => 'no attempt recorded',
-					act_as_student => $self->systemLink($urlpath->new(type=>'set_list',args=>{courseID=>$courseName}), params=>{effectiveUser => $studentRecord->user_id}),
+					user_id       => $studentRecord->user_id(),
+					last_name     => $studentRecord->last_name(),
+					first_name    => $studentRecord->first_name(),
+					score         => 0,
+					total         => $r->maketext('n/a'),
+					section       => $studentRecord->section(),
+					recitation    => $studentRecord->recitation(),
+					problemsRow   => [$r->maketext('no attempt recorded')],
 					email_address => $studentRecord->email_address(),
-					problemData => {},
-					date => 'none',
-					testtime => 'none',
+					date          => $r->maketext('none'),
+					testtime      => $r->maketext('none'),
 				};
 			}
 
-			push( @index_list, $max_hash->{index} );
-			push( @score_list,
-			      ($max_hash->{total} && $max_hash->{total} ne 'n/a') ?
-			      $max_hash->{score}/$max_hash->{total} : 0 );
-			push( @augmentedUserRecords, $max_hash );
+			push(@score_list,
+				($max_hash->{total} && $max_hash->{total} ne 'n/a') ? $max_hash->{score} / $max_hash->{total} : 0);
+			push(@augmentedUserRecords, $max_hash);
 		# if there were no set versions and the set was assigned
-		#    to the user, also keep the data
-		} elsif ( ! @allSetVersionNames && ! $notAssignedSet ) {
-			my $dataH = { user_id => $studentRecord->user_id(),
-				      last_name=>$studentRecord->last_name(),
-				      first_name=>$studentRecord->first_name(),
-				      score => 0,
-				      total => 'n/a',
-				      index => 0,
-				      section => $studentRecord->section(),
-				      recitation=>$studentRecord->recitation(),
-				      problemString => 'no attempt recorded',
-				      act_as_student => $self->systemLink($urlpath->new(type=>'set_list',args=>{courseID=>$courseName}), params=>{effectiveUser => $studentRecord->user_id}),
-				      email_address => $studentRecord->email_address(),
-				      problemData => {},
-				      date => 'none',
-				      testtime => 'none',
-				  };
-			push( @index_list, 0 );
-			push( @score_list, 0 );
-			push( @augmentedUserRecords, $dataH );
-
+		# to the user, also keep the data
+		} elsif (!@allSetVersionNames && !$notAssignedSet) {
+			my $dataH = {
+				user_id       => $studentRecord->user_id(),
+				last_name     => $studentRecord->last_name(),
+				first_name    => $studentRecord->first_name(),
+				score         => 0,
+				total         => $r->maketext('n/a'),
+				section       => $studentRecord->section(),
+				recitation    => $studentRecord->recitation(),
+				problemsRow   => ['&nbsp;'],
+				email_address => $studentRecord->email_address(),
+				date          => $r->maketext('none'),
+				testtime      => $r->maketext('none'),
+			};
+			push(@score_list,           0);
+			push(@augmentedUserRecords, $dataH);
 		}
-
-        } # this closes the loop through all student records
-
+	} # this closes the loop through all student records
 	debug("end mainloop");
 
 	@augmentedUserRecords = sort {
-		&$sort_method($a,$b,$primary_sort_method_name)
-			||
-		&$sort_method($a,$b,$secondary_sort_method_name)
-			||
-		&$sort_method($a,$b,$ternary_sort_method_name)
-			||
-		lc($a->{last_name}) cmp lc($b->{last_name})
-			||
-		lc($a->{first_name}) cmp lc($b->{first_name})
-			||
-		lc($a->{user_id}) cmp lc($b->{user_id})
-		}
-		@augmentedUserRecords;
-
+		&$sort_method($a, $b, $primary_sort_method_name)
+			|| &$sort_method($a, $b, $secondary_sort_method_name)
+			|| &$sort_method($a, $b, $ternary_sort_method_name)
+			|| lc($a->{last_name}) cmp lc($b->{last_name})
+			|| lc($a->{first_name}) cmp lc($b->{first_name})
+			|| lc($a->{user_id}) cmp lc($b->{user_id})
+	} @augmentedUserRecords;
 
 	# construct header
-	my $problem_header = '';
 	my @list_problems = map { $_->[1] } $db->listGlobalProblemsWhere({ set_id => $setName }, 'problem_id');
+	@list_problems    = ($r->maketext('None')) unless (@list_problems);
+	my $maxProblem    = scalar @list_problems;
 
 	# for a jitar set we only get the top level problems
-	if($GlobalSet->assignment_type eq 'jitar') {
-	    my @topLevelProblems;
-
-	    foreach my $id (@list_problems) {
-		my @seq = jitar_id_to_seq($id);
-		push @topLevelProblems, $seq[0] if ($#seq == 0);
-	    }
-
-	    @list_problems = @topLevelProblems;
+	if ($GlobalSet->assignment_type eq 'jitar') {
+		my @topLevelProblems;
+		foreach my $id (@list_problems) {
+			my @seq = jitar_id_to_seq($id);
+			push @topLevelProblems, $seq[0] if ($#seq == 0);
+		}
+		@list_problems = @topLevelProblems;
 	}
-
-
-	$problem_header = '<span dir="ltr"><pre class="mb-0" dir="ltr">'.join("", map {&fourSpaceFill($_)}  @list_problems  ).'</pre></span>'; # RTL mode does not handle the pre well
 
 	# Changes for gateways/versioned sets here.  In this case we allow instructors
 	# to modify the appearance of output, which we do with a form.  So paste in the
@@ -700,32 +619,39 @@ sub displaySets {
 		print CGI::end_div();
 	}
 
-	#####################################################################################
 	# Table description. Only show the problem description if the problems column is shown.
 	print CGI::start_div();
-	if (! $setIsVersioned || $showColumns{'problems'}) {
+	if (!$setIsVersioned || $showColumns{'problems'}) {
 		print CGI::p($r->maketext(
 			'A period (.) indicates a problem has not been attempted, and a number from 0 to 100 '
-			. 'indicates the grade earned. The number on the second line gives the number of incorrect attempts.'
+				. 'indicates the grade earned. The number on the second line gives the number of incorrect attempts.'
 		));
 	}
 	if ($setIsVersioned) {
 		print CGI::p($r->maketext(
 			'Click a student\'s name to see the student\'s test summary page. '
-			. 'Click a test\'s version number to see the corresponding test version. '
-			. 'Click a heading to sort the table.'
+				. 'Click a test\'s version number to see the corresponding test version. '
+				. 'Click a heading to sort the table.'
 		));
 	} else {
 		print CGI::p($r->maketext(
-			'Click a student\'s name to see the student\'s homework set. '
-			. 'Click a heading to sort the table.'
+			'Click a student\'s name to see the student\'s homework set. ' . 'Click a heading to sort the table.'
 		));
 	}
 	if (defined $primary_sort_method_name) {
-		print CGI::p($r->maketext('Entries are sorted by [_1]', $display_sort_method_name{$primary_sort_method_name})
-			. (defined $secondary_sort_method_name ? $r->maketext(', then by [_1]', $display_sort_method_name{$secondary_sort_method_name}) : '')
-			. (defined $ternary_sort_method_name   ? $r->maketext(', then by [_1]', $display_sort_method_name{$ternary_sort_method_name})   : '')
-			. '.'
+		print CGI::p(
+			$r->maketext('Entries are sorted by [_1]', $display_sort_method_name{$primary_sort_method_name})
+				. (
+				defined $secondary_sort_method_name
+				? $r->maketext(', then by [_1]', $display_sort_method_name{$secondary_sort_method_name})
+				: ''
+				)
+				. (
+				defined $ternary_sort_method_name
+				? $r->maketext(', then by [_1]', $display_sort_method_name{$ternary_sort_method_name})
+				: ''
+				)
+				. '.'
 		);
 	}
 	print CGI::end_div();
@@ -733,82 +659,12 @@ sub displaySets {
 	# calculate secondary and ternary sort methods parameters if appropriate
 	my %past_sort_methods = ();
 	%past_sort_methods = (secondary_sort => "$primary_sort_method_name",) if defined($primary_sort_method_name);
-	%past_sort_methods = (%past_sort_methods, ternary_sort => "$secondary_sort_method_name",) if defined($secondary_sort_method_name);
+	%past_sort_methods = (%past_sort_methods, ternary_sort => "$secondary_sort_method_name",)
+		if defined($secondary_sort_method_name);
+	my %params = (%past_sort_methods);
 
-	# Continue with table output
-	print CGI::start_div({ class => 'table-responsive' }),
-		CGI::start_table({ class => 'progress-table table table-bordered table-sm font-xs' });
-
-	if ( ! $setIsVersioned ) {
-		print CGI::thead(CGI::Tr(CGI::th(
-			{ align => 'left' },
-			[
-				$r->maketext('Name')
-					. CGI::br()
-					. CGI::a(
-						{
-							href => $self->systemLink(
-								$setStatsPage, params => { primary_sort => 'first_name', %past_sort_methods }
-							)
-						},
-						$r->maketext('First')
-					)
-					. '&nbsp;&nbsp;&nbsp;'
-					. CGI::a(
-						{
-							href => $self->systemLink(
-								$setStatsPage, params => { primary_sort => 'last_name', %past_sort_methods }
-							)
-						},
-						$r->maketext('Last')
-					)
-					. CGI::br()
-					. CGI::a(
-						{
-							href => $self->systemLink(
-								$setStatsPage, params => { primary_sort => 'email_address', %past_sort_methods }
-							)
-						},
-						$r->maketext('Email')
-					),
-				CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'score', %past_sort_methods }
-						)
-					},
-					$r->maketext('Score')
-				),
-				$r->maketext('Out Of'),
-				$r->maketext('Problems') . CGI::br() . $problem_header,
-				CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'section', %past_sort_methods }
-						)
-					},
-					$r->maketext('Section')
-				),
-				CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'recitation', %past_sort_methods }
-						)
-					},
-					$r->maketext('Recitation')
-				),
-				CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'user_id', %past_sort_methods }
-						)
-					},
-					$r->maketext('Login Name')
-				),
-			]
-		))), CGI::start_tbody();
-	} else {
-		# we need to preserve display options when the sort headers are clicked
+	# we need to preserve display options when the sort headers are clicked on gateway quizzes
+	if ($setIsVersioned) {
 		my %display_options = (
 			returning       => 1,
 			show_best_only  => $showBestOnly,
@@ -819,152 +675,215 @@ sub displaySets {
 			show_recitation => $showColumns{recit},
 			show_login      => $showColumns{login},
 		);
-		my %params = (%past_sort_methods, %display_options);
-		my @columnHdrs = ();
-		push(@columnHdrs,
-			$r->maketext('Name')
-				. CGI::br()
-				. CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'first_name', %params }
-						)
-					},
-					$r->maketext('First')
-				)
-				. '&nbsp;&nbsp;&nbsp;'
-				. CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'last_name', %params }
-						)
-					},
-					$r->maketext('Last')
-				)
-				. CGI::br()
-				. CGI::a(
-					{
-						href => $self->systemLink(
-							$setStatsPage, params => { primary_sort => 'email_address', %past_sort_methods }
-						)
-					},
-					$r->maketext('Email')
-				)
-		);
-	    push( @columnHdrs, CGI::a({"href"=>$self->systemLink($setStatsPage,params=>{primary_sort=>'score', %params})},$r->maketext('Score')) );
-	    push( @columnHdrs, $r->maketext('Out Of') );
-	    push( @columnHdrs, $r->maketext('Date') ) if ( $showColumns{ 'date' } );
-	    push( @columnHdrs, $r->maketext('Test Time') ) if ( $showColumns{ 'testtime' } );
-#	    push( @columnHdrs, CGI::a({"href"=>$self->systemLink($setStatsPage,params=>{primary_sort=>'index', %params})},'Ind') )
-#		if ( $showColumns{ 'index' } );
-	    push( @columnHdrs, $r->maketext("Problems").CGI::br().$problem_header )
-		if ( $showColumns{ 'problems' } );
-	    push( @columnHdrs, CGI::a({"href"=>$self->systemLink($setStatsPage,params=>{primary_sort=>'section', %params})},$r->maketext('Section')) )
-		if ( $showColumns{ 'section' } );
-	    push( @columnHdrs, CGI::a({"href"=>$self->systemLink($setStatsPage,params=>{primary_sort=>'recitation', %params})},$r->maketext('Recitation')) )
-		if ( $showColumns{ 'recit' } );
-	    push( @columnHdrs, CGI::a({"href"=>$self->systemLink($setStatsPage,params=>{primary_sort=>'user_id', %params})},$r->maketext('Login Name')) )
-		if ( $showColumns{ 'login' } );
-
-		print CGI::thead(CGI::Tr(CGI::th({ align => 'left' }, [@columnHdrs]))), CGI::start_tbody();
+		%params = (%past_sort_methods, %display_options);
 	}
 
-    # variables to keep track of versioned sets
-	my $prevFullName = '';
-	my $vNum = 1;
-    # and to make formatting nice for students who haven't taken any tests
-    #    (the total number of columns is two more than this; we want the
-    #    number that missing record information should span)
+	# To deal with the variable number of columns and the problems columns
+	# split the headers into two pieces.
+	# @columnHeaders1 are the columns before the problem columns.
+	# @columnHeaders2 are the columns after the problem columns.
+	my @columnHeaders1 = (
+		$r->maketext('Name')
+			. CGI::br()
+			. CGI::a(
+				{
+					href => $self->systemLink(
+						$setStatsPage, params => { primary_sort => 'first_name', %params }
+					)
+				},
+				$r->maketext('First')
+			)
+			. '&nbsp;&nbsp;&nbsp;'
+			. CGI::a(
+				{
+					href => $self->systemLink(
+						$setStatsPage, params => { primary_sort => 'last_name', %params }
+					)
+				},
+				$r->maketext('Last')
+			)
+			. CGI::br()
+			. CGI::a(
+				{
+					href => $self->systemLink(
+						$setStatsPage, params => { primary_sort => 'email_address', %params }
+					)
+				},
+				$r->maketext('Email')
+			),
+		CGI::a(
+			{
+				href => $self->systemLink(
+					$setStatsPage, params => { primary_sort => 'score', %params }
+				)
+			},
+			$r->maketext('Score')
+		),
+		$r->maketext('Out Of'),
+	);
+	my @columnHeaders2 = ();
 
+	# Additional columns that may or may not be shown depending on if
+	# showing a gateway quiz and any user configuration.
+	push(@columnHeaders1, $r->maketext('Date'))      if ($setIsVersioned && $showColumns{'date'});
+	push(@columnHeaders1, $r->maketext('Test Time')) if ($setIsVersioned && $showColumns{'testtime'});
+	push(
+		@columnHeaders2,
+		CGI::a(
+			{
+				href => $self->systemLink(
+					$setStatsPage, params => { primary_sort => 'section', %params }
+				)
+			},
+			$r->maketext('Section')
+		)
+	) if (!$setIsVersioned || $showColumns{'section'});
+	push(
+		@columnHeaders2,
+		CGI::a(
+			{
+				href => $self->systemLink(
+					$setStatsPage, params => { primary_sort => 'recitation', %params }
+				)
+			},
+			$r->maketext('Recitation')
+		)
+	) if (!$setIsVersioned || $showColumns{'recit'});
+	push(
+		@columnHeaders2,
+		CGI::a(
+			{
+				href => $self->systemLink(
+					$setStatsPage, params => { primary_sort => 'user_id', %params }
+				)
+			},
+			$r->maketext('Login Name')
+		)
+	) if (!$setIsVersioned || $showColumns{'login'});
+
+	# Start table output
+	print CGI::start_div({ class => 'table-responsive' }),
+		CGI::start_table({ class => 'progress-table table table-bordered table-sm font-xs' });
+
+	if (!@columnHeaders2 && $showColumns{'problems'}) {
+		print CGI::thead(
+			CGI::Tr(
+				CGI::th({ rowspan => 2 },           [@columnHeaders1]),
+				CGI::th({ colspan => $maxProblem }, $r->maketext('Problems'))
+			),
+			CGI::Tr(CGI::th([@list_problems]))
+		);
+	} elsif ($showColumns{'problems'}) {
+		print CGI::thead(
+			CGI::Tr(
+				CGI::th({ rowspan => 2 },           [@columnHeaders1]),
+				CGI::th({ colspan => $maxProblem }, $r->maketext('Problems')),
+				CGI::th({ rowspan => 2 },           [@columnHeaders2])
+			),
+			CGI::Tr(CGI::th([@list_problems]))
+		);
+	} else {
+		print CGI::thead(CGI::Tr(CGI::th([ @columnHeaders1, @columnHeaders2 ])));
+	}
+	print CGI::start_tbody();
+
+	# variables to keep track of versioned sets
+	my $prevFullName = '';
+	my $vNum         = 1;
+
+	# and to make formatting nice for students who haven't taken any tests
+	# (the total number of columns is two more than this; we want the
+	# number that missing record information should span)
 	my $numCol = 1;
 	$numCol++ if $showColumns{'date'};
 	$numCol++ if $showColumns{'testtime'};
-	$numCol++ if $showColumns{'problems'};
+	$numCol += $maxProblem if $showColumns{'problems'};
 
+	# Loop that prints the table rows
 	foreach my $rec (@augmentedUserRecords) {
-		my $fullName = join("", $rec->{first_name}," ", $rec->{last_name});
+		my $fullName = join("", $rec->{first_name}, " ", $rec->{last_name});
 		my $email    = $rec->{email_address};
-		my $twoString  = $rec->{twoString};
-		if ( ! $setIsVersioned ) {
-			my $problemSetPage = $urlpath->newFromModule('WeBWorK::ContentGenerator::ProblemSet', $r,
-				courseID => $courseName, setID => $setName);
-			my $interactiveURL = $self->systemLink($problemSetPage, params => { effectiveUser => $rec->{user_id} });
-			print CGI::Tr({},
-				CGI::td({}, CGI::a({ href => $interactiveURL }, $fullName), CGI::br(), CGI::a({ href => "mailto:$email" }, $email)),
-				CGI::td(wwRound(2,$rec->{score}) ), # score
-				CGI::td($rec->{total}), # out of
-#				CGI::td(sprintf("%0.0f",100*($rec->{index}) )),   # indicator
-				CGI::td($rec->{problemString}), # problems
-				CGI::td($self->nbsp($rec->{section})),
-				CGI::td($self->nbsp($rec->{recitation})),
-				CGI::td($rec->{user_id}),
+
+		if (!$setIsVersioned) {
+			my $problemSetPage = $urlpath->newFromModule(
+				'WeBWorK::ContentGenerator::ProblemSet', $r,
+				courseID => $courseName,
+				setID    => $setName
 			);
-		} else {
-            # we separate versioned sets so that we can restrict what columns
-            # we show
-			my $problemSetPage = $urlpath->newFromModule('WeBWorK::ContentGenerator::ProblemSet', $r,
-				courseID => $courseName, setID => $setName);
 			my $interactiveURL = $self->systemLink($problemSetPage, params => { effectiveUser => $rec->{user_id} });
-		    # if total is 'n/a', then it's a user who hasn't taken
-		    #    any tests, which we treat separately
-			if ( $rec->{total} ne 'n/a' ) {
+			print CGI::Tr(CGI::td([
+				CGI::a({ href => $interactiveURL }, $fullName)
+					. CGI::br()
+					. CGI::a({ href => "mailto:$email" }, $email),
+				$rec->{score},
+				$rec->{total},
+				@{ $rec->{problemsRow} },
+				$self->nbsp($rec->{section}),
+				$self->nbsp($rec->{recitation}),
+				$rec->{user_id}
+			]));
+		} else {
+			my $problemSetPage = $urlpath->newFromModule(
+				'WeBWorK::ContentGenerator::ProblemSet', $r,
+				courseID => $courseName,
+				setID    => $setName
+			);
+			my $interactiveURL = $self->systemLink($problemSetPage, params => { effectiveUser => $rec->{user_id} });
+
+			# if total is 'n/a', then it's a user who hasn't taken
+			# any tests, which we treat separately
+			if ($rec->{total} ne 'n/a') {
 				$vNum++ if ($fullName eq $prevFullName);
 				my @cols = ();
 				# make make versioned sets' name format nicer and link to appropriate test version
-				my $nameEntry = '';
-				my $versionPage = $urlpath->newFromModule('WeBWorK::ContentGenerator::GatewayQuiz', $r,
-					courseID => $courseName, setID => $setName . ',v' . $vNum);
-				my $versionLink = CGI::a({ href => $self->systemLink($versionPage, params => { effectiveUser => $rec->{user_id} })}, "version $vNum");
-				if ( $fullName eq $prevFullName ) {
+				my $nameEntry   = '';
+				my $versionPage = $urlpath->newFromModule(
+					'WeBWorK::ContentGenerator::GatewayQuiz', $r,
+					courseID => $courseName,
+					setID    => $setName . ',v' . $vNum
+				);
+				my $versionLink = CGI::a(
+					{
+						href => $self->systemLink(
+							$versionPage, params => { effectiveUser => $rec->{user_id} }
+						)
+					},
+					"version $vNum"
+				);
+				if ($fullName eq $prevFullName) {
 					$nameEntry = CGI::div({ class => 'ms-4' }, "($versionLink)");
 				} else {
-					$nameEntry = CGI::a({ href => $interactiveURL }, $fullName)
-						. ($setIsVersioned && ! $showBestOnly ? " ($versionLink)" : ' ')
+					$nameEntry =
+						CGI::a({ href => $interactiveURL }, $fullName)
+						. ($setIsVersioned && !$showBestOnly ? " ($versionLink)" : ' ')
 						. CGI::br()
 						. CGI::a({ href => "mailto:$email" }, $email);
-					$vNum = 1;
+					$vNum         = 1;
 					$prevFullName = $fullName;
 				}
 
 				# build columns to show
-				push(@cols, $nameEntry,
-				     wwRound(2,$rec->{score}),
-				     $rec->{total});
-				push(@cols, $self->nbsp($rec->{date}))
-				    if ($showColumns{'date'});
-				push(@cols, $self->nbsp($rec->{testtime}))
-				    if ($showColumns{'testtime'});
-#				push(@cols, sprintf("%0.0f",$rec->{index}))
-#				    if ($showColumns{'index'});
-				push(@cols, $self->nbsp($rec->{problemString}))
-				    if ($showColumns{'problems'});
-				push(@cols, $self->nbsp($rec->{section}))
-				    if ($showColumns{'section'});
-				push(@cols, $self->nbsp($rec->{recitation}))
-				    if ($showColumns{'recit'});
-				push(@cols, $rec->{user_id}) if ($showColumns{'login'});
-				print CGI::Tr( CGI::td( [ @cols ] ) );
+				push(@cols, $nameEntry, $rec->{score}, $rec->{total});
+				push(@cols, $self->nbsp($rec->{date}))       if ($showColumns{'date'});
+				push(@cols, $self->nbsp($rec->{testtime}))   if ($showColumns{'testtime'});
+				push(@cols, @{ $rec->{problemsRow} })        if ($showColumns{'problems'});
+				push(@cols, $self->nbsp($rec->{section}))    if ($showColumns{'section'});
+				push(@cols, $self->nbsp($rec->{recitation})) if ($showColumns{'recit'});
+				push(@cols, $rec->{user_id})                 if ($showColumns{'login'});
+				print CGI::Tr(CGI::td([@cols]));
 			} else {
 				my @cols = (
 					CGI::td(
 						CGI::a({ href => $interactiveURL }, $fullName)
-						. CGI::br()
-						. CGI::a({ href => "mailto:$email" }, $email)
+							. CGI::br()
+							. CGI::a({ href => "mailto:$email" }, $email)
 					),
 					CGI::td($rec->{score}),
-					CGI::td({colspan => $numCol},
-						CGI::em($self->nbsp($r->maketext('No tests taken.')))
-					)
+					CGI::td({ colspan => $numCol }, CGI::em($self->nbsp($r->maketext('No tests taken.'))))
 				);
-				push(@cols,
-				     CGI::td($self->nbsp($rec->{section})))
-					if ( $showColumns{'section'} );
-				push(@cols,
-				     CGI::td($self->nbsp($rec->{recitation})))
-					if ( $showColumns{'recit'} );
-				push(@cols,
-				     CGI::td($self->nbsp($rec->{user_id})))
-					if ( $showColumns{'login'} );
+				push(@cols, CGI::td($self->nbsp($rec->{section})))    if ($showColumns{'section'});
+				push(@cols, CGI::td($self->nbsp($rec->{recitation}))) if ($showColumns{'recit'});
+				push(@cols, CGI::td($self->nbsp($rec->{user_id})))    if ($showColumns{'login'});
 				print CGI::Tr(@cols);
 			}
 		}
@@ -975,237 +894,97 @@ sub displaySets {
 	return '';
 }
 
-#############################################################
-# Grading utilities
-#############################################################
+# Creates the problem table row which shows the status and number
+# of incorrect attempts for each problem in the set.
+sub generate_problems_row {
+	my ($db, $set, $setName, $studentName, $setIsVersioned) = @_;
+	my $setID = $set->set_id();    # FIXME setName and setID should be the same
 
-
-# 			########################################
-# 			# Notes for factoring the calculation in this loop.
-# 			#
-# 			# Inputs include:
-# 			#   @problemRecords
-# 			# returns
-# 			#   $num_of_attempts
-# 			#   $status
-# 			# updates
-# 			#   $number__studofents_attempting_problem{$probID}++;
-# 			#   @{ $attempts_list_for_problem{$probID} }
-# 			#   $number_of_attempts_for_problem{$probID}
-# 			#   $total_num_of_attempts_for_set
-# 			#   $correct_answers_for_problem{$probID}
-# 			#
-# 			#   $string (formatting output)
-# 			#   $twoString (more formatted output)
-# 			#   $longtwo (a combination of $string and $twostring)
-# 			#   $total
-# 			#   $totalRight
-# 			###################################
-
-###############################################################
-# requires = grade_set( $db, $set, $setName, $studentName, $setIsVersioned);
-# returns   my ($status,
-#            $longStatus,
-#            $string,
-#            $twoString,
-#            $totalRight,
-#            $total,
-#            $num_of_attempts,
-#            $num_of_problems) = grade_set(...);
-#########################
-
-sub grade_set {
-
-        my ($db, $set, $setName, $studentName, $setIsVersioned,
-        $rh_number_of_students_attempting_problem,
-        $rh_attempts_list_for_problem,
-        $rh_number_of_attempts_for_problem,
-        $rh_problemData,
-        $rh_total_num_of_attempts_for_set,
-        $rh_correct_answers_for_problem
-        ) = @_;
-
-        my $setID = $set->set_id();  #FIXME   setName and setID should be the same
-
-		my $status = 0;
-		my $longStatus = '';
-		my $class     = '';
-		my $string     = '';
-		my $twoString  = '';
-		my $totalRight = 0;
-		my $total      = 0;
-		my $num_of_attempts = 0;
-
-		debug("Begin collecting problems for set $setName");
-		# DBFIXME: to collect the problem records, we have to know
-		#    which merge routines to call.  Should this really be an
-		#    issue here?  That is, shouldn't the database deal with
-		#    it invisibly by detecting what the problem types are?
-		#    oh well.
-
-		my @problemRecords = $db->getAllMergedUserProblems( $studentName, $setID );
-		my $num_of_problems  = @problemRecords || 0;
-		if ( $setIsVersioned ) {
-			@problemRecords =  $db->getAllMergedProblemVersions( $studentName, $setID, $set->version_id );
-		}
-
+	debug("Begin collecting problems for set $setName");
+	# DBFIXME: to collect the problem records, we have to know
+	# which merge routines to call.  Should this really be an
+	# issue here?  That is, shouldn't the database deal with
+	# it invisibly by detecting what the problem types are?
+	# oh well.
+	my @problemRecords = $db->getAllMergedUserProblems($studentName, $setID);
+	if ($setIsVersioned) {
+		@problemRecords = $db->getAllMergedProblemVersions($studentName, $setID, $set->version_id);
+	}
 
 	# for jitar sets we only use the top level problems
 	if ($set->assignment_type && $set->assignment_type eq 'jitar') {
-	    my @topLevelProblems;
-	    foreach my $problem (@problemRecords) {
-		my @seq = jitar_id_to_seq($problem->problem_id);
-		push @topLevelProblems, $problem if ($#seq == 0);
-	    }
-
-	    @problemRecords = @topLevelProblems;
+		my @topLevelProblems;
+		foreach my $problem (@problemRecords) {
+			my @seq = jitar_id_to_seq($problem->problem_id);
+			push @topLevelProblems, $problem if ($#seq == 0);
+		}
+		@problemRecords = @topLevelProblems;
 	}
+	my $num_of_problems = @problemRecords || 0;
 
+	# If there are no problems, don't create table.
+	return ['&nbsp;'] unless ($num_of_problems > 0);
+
+	my $colWidth = 100 / $num_of_problems;
 	debug("End collecting problems for set $setName");
 
-	####################
 	# Resort records
-	#####################
-		@problemRecords = sort {$a->problem_id <=> $b->problem_id } @problemRecords;
+	@problemRecords = sort { $a->problem_id <=> $b->problem_id } @problemRecords;
 
-#
-# 		# for gateway/quiz assignments we have to be careful about
-# 		#    the order in which the problems are displayed, because
-# 		#    they may be in a random order
-# 		if ( $set->problem_randorder ) {
-# 			my @newOrder = ();
-# 			my @probOrder = (0..$#problemRecords);
-# 			# we reorder using a pgrand based on the set psvn
-# 			my $pgrand = PGrandom->new();
-# 			$pgrand->srand( $set->psvn );
-# 			while ( @probOrder ) {
-# 				my $i = int($pgrand->rand(scalar(@probOrder)));
-# 				push( @newOrder, $probOrder[$i] );
-# 				splice(@probOrder, $i, 1);
-# 			}
-# 			# now $newOrder[i] = pNum-1, where pNum is the problem
-# 			#    number to display in the ith position on the test
-# 			#    for sorting, invert this mapping:
-# 			my %pSort = map {($newOrder[$_]+1)=>$_} (0..$#newOrder);
-#
-# 			@problemRecords = sort {$pSort{$a->problem_id} <=> $pSort{$b->problem_id}} @problemRecords;
-# 		}
+	# Construct problems row
+	my @problemsRow = ();
+	foreach my $problemRecord (@problemRecords) {
+		my $prob = $problemRecord->problem_id;
 
-    #######################################################
-	# construct header
+		# warn "Can't find record for problem $prob in set $setName for $student";
+		# FIXME check the legitimate reasons why a student record might not be defined
+		next unless (defined($problemRecord));
 
-		foreach my $problemRecord (@problemRecords) {
-			my $prob = $problemRecord->problem_id;
+		my $status = $problemRecord->status || 0;
+		if ($set->assignment_type eq 'jitar') {
+			$status = jitar_problem_adjusted_status($problemRecord, $db);
+		}
 
-			unless (defined($problemRecord) ){
-				# warn "Can't find record for problem $prob in set $setName for $student";
-			# FIXME check the legitimate reasons why a student record might not be defined
-				next;
+		my $attempted       = $problemRecord->attempted;
+		my $num_correct     = $problemRecord->num_correct   || 0;
+		my $num_incorrect   = $problemRecord->num_incorrect || 0;
+		my $num_of_attempts = $num_correct + $num_incorrect;
+
+		#######################################################
+		# This is a fail safe mechanism that makes sure that
+		# the problem is marked as attempted if the status has
+		# been set or if the problem has been attempted
+		# DBFIXME this should happen in the database layer, not here!
+		if (!$attempted && ($status || $num_of_attempts)) {
+			$attempted = 1;
+			$problemRecord->attempted('1');
+			# DBFIXME: this is another case where it
+			# seems we shouldn't have to check for
+			# which routine to use here...
+			if ($setIsVersioned) {
+				$db->putProblemVersion($problemRecord);
+			} else {
+				$db->putUserProblem($problemRecord);
 			}
+		}
+		######################################################
 
-			$status           = $problemRecord->status || 0;
+		# sanity check that the status (score) is between 0 and 1
+		$status = ($status >= 0 && $status <= 1) ? $status : 0;
 
-			if ($set->assignment_type eq 'jitar') {
-			    $status = jitar_problem_adjusted_status($problemRecord,$db);
-			}
+		$status = 100 * wwRound(2, $status);
+		my $output = '';
+		if ($status == 100) {
+			$output = CGI::span({ class => 'correct' }, $status);
+		} elsif (!$attempted) {
+			$output = CGI::span({ class => 'unattempted px-1' }, '.');
+		} else {
+			$output = CGI::span($status);
+		}
+		push(@problemsRow, $output . CGI::br() . $num_incorrect);
+	}
 
-			my $attempted     = $problemRecord->attempted;
-			my $num_correct   = $problemRecord->num_correct || 0;
-			my $num_incorrect = $problemRecord->num_incorrect   || 0;
-			$num_of_attempts  = $num_correct + $num_incorrect;
-
-			#######################################################
-			# This is a fail safe mechanism that makes sure that
-			# the problem is marked as attempted if the status has
-			# been set or if the problem has been attempted
-			# DBFIXME this should happen in the database layer, not here!
-			if (!$attempted && ($status || $num_of_attempts)) {
-				$attempted = 1;
-				$problemRecord->attempted('1');
-				# DBFIXME: this is another case where it
-				#    seems we shouldn't have to check for
-				#    which routine to use here...
-				if ( $setIsVersioned ) {
-					$db->putProblemVersion($problemRecord);
-				} else {
-					$db->putUserProblem($problemRecord );
-				}
-			}
-			######################################################
-
-			# sanity check that the status (score) is
-			# between 0 and 1
-			my $valid_status = ($status>=0 && $status<=1)?1:0;
-
-			###########################################
-			# Determine the string $longStatus which
-			# will display the student's current score
-			###########################################
-
-			if (!$attempted){
-				$longStatus     = '.';
-			} elsif   ($valid_status) {
-				$longStatus     = 100*wwRound(2,$status);
-
-			} else	{
-				$longStatus 	= 'X';
-			}
-
-                        $class = ($longStatus eq '100')?"correct": (($longStatus eq '.')?'unattempted':'');
-                        $string      .= '<span class="'.$class.'">'.fourSpaceFill($longStatus).'</span>';
-			$twoString      .= fourSpaceFill($num_incorrect);
-			my $probValue   =  $problemRecord->value;
-			$probValue      =  1 unless defined($probValue) and $probValue ne "";  # FIXME?? set defaults here?
-			$total          += $probValue;
-			$totalRight     += $status*$probValue if $valid_status;
-
-#
-# 			# initialize the number of correct answers
-# 			# for this problem if the value has not been
-# 			# defined.
-# 			$correct_answers_for_problem{$probID} = 0
-# 				unless defined($correct_answers_for_problem{$probID});
-
-
-		# add on the scores for this problem
-			if (defined($rh_correct_answers_for_problem ) ) {  #skip this if we are not updating records
-			    my $probID          = $problemRecord->problem_id;
-				$rh_correct_answers_for_problem->{$probID} = 0  	unless defined($rh_correct_answers_for_problem->{$probID});
-				if (defined($attempted) and $attempted) {
-					$rh_number_of_students_attempting_problem->{$probID}++;
-					push( @{ $rh_attempts_list_for_problem->{$probID} } ,     $num_of_attempts);
-					$rh_number_of_attempts_for_problem->{$probID}          += $num_of_attempts;
-					$rh_problemData->{$probID}                              = $num_incorrect;
-					$$rh_total_num_of_attempts_for_set                     += $num_of_attempts;
-					$rh_correct_answers_for_problem->{$probID}             += $status;
-				}
-			}
-
-		}  # end of problem record loop
-
-		$totalRight = wwRound(2,$totalRight);  # round the final total
-
-		return($status,
-			   $longStatus,
-			   $string,
-			   $twoString,
-			   $totalRight,
-			   $total,
-			   $num_of_attempts,
-			   $num_of_problems
-		);
+	return \@problemsRow;
 }
-#################################
-# Utility function NOT a method
-#################################
-sub fourSpaceFill {
-	my $num = shift @_ || 0;
-
-	if (length($num)<=1) {return "$num".'&nbsp;&nbsp;&nbsp;';}
-	elsif (length($num)==2) {return "$num".'&nbsp;&nbsp;';}
-	elsif (length($num)==3) {return "$num".'&nbsp;';}
-	else {return "### ";}
-}
-
 
 1;


### PR DESCRIPTION
  Remove the pre elements and use a nested table to display the
  problems scores for each set as mentioned in #1616.

  This is done by removing the custom grade_set method and creating
  a new generate_problem_table method, which creates a two row table
  listing the problem status and number of incorrect attempts.

  Switches to using the WeBWorK::Utils::grade_set method to grade
  each set instead of the custom grade_set method.

  Removes the success indicator index which was no longer being
  shown on the student progress table.

  Removes the two instances of using obsolete align attribute
  in the table headers.