### PR TITLE
Remove obsolete pg modules and add Types::Serialiser

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1344,7 +1344,7 @@ ${pg}{modules} = [
 	[qw(AlgParser AlgParserWithImplicitExpand Expr ExprWithImplicitExpand utf8)],
 	[qw(AnswerHash AnswerEvaluator)],
 	[qw(LaTeXImage)],
-	[qw(WWPlot)], # required by Circle (and others)
+	[qw(WWPlot)],    # required by Circle (and others)
 	[qw(Circle)],
 	[qw(Class::Accessor)],
 	[qw(Complex)],
@@ -1356,7 +1356,7 @@ ${pg}{modules} = [
 	[qw(Label)],
 	[qw(ChoiceList)],
 	[qw(Match)],
-	[qw(MatrixReal1)], # required by Matrix
+	[qw(MatrixReal1)],    # required by Matrix
 	[qw(Matrix)],
 	[qw(Multiple)],
 	[qw(PGrandom)],
@@ -1367,16 +1367,15 @@ ${pg}{modules} = [
 	[qw(Parser Value)],
 	[qw(Parser::Legacy)],
 	[qw(Statistics)],
-#	[qw(SaveFile)],
-	[qw(Chromatic)], # for Northern Arizona graph problems
-	                 #  -- follow instructions at libraries/nau_problib/lib/README to install
-	[qw(Applet FlashApplet JavaApplet CanvasApplet GeogebraWebApplet)],
-	[qw(PGcore PGalias PGresource PGloadfiles PGanswergroup PGresponsegroup  Tie::IxHash)],
+	[qw(Chromatic)],      # for Northern Arizona graph problems
+	[qw(Applet GeogebraWebApplet)],
+	[qw(PGcore PGalias PGresource PGloadfiles PGanswergroup PGresponsegroup Tie::IxHash)],
 	[qw(Locale::Maketext)],
 	[qw(WeBWorK::Localize)],
 	[qw(JSON)],
 	[qw(Rserve Class::Tiny IO::Handle)],
-	[qw(DragNDrop)]
+	[qw(DragNDrop)],
+	[qw(Types::Serialiser)],
 ];
 
 ##### Problem creation defaults


### PR DESCRIPTION
Remove the FlashApplet, JavaApplet, and CanvasApplet pg modules that no longer exist.

Add the `Types::Serialiser` module.  This is needed for AskSage to prevent the "Can't locate package Types::Serialiser::BooleanBase for @JSON::PP::Boolean::ISA at [PG]/lib/WeBWorK/PG/IO.pm line 475" warnings.

Also remove some obsolete comments.