### PR TITLE
Show gateway quizzes for students with the same name separately (fix issue #1514)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -786,7 +786,7 @@ sub displaySets {
 	print CGI::start_tbody();
 
 	# variables to keep track of versioned sets
-	my $prevFullName = '';
+	my $prevUserID = '';
 
 	# and to make formatting nice for students who haven't taken any tests
 	# (the total number of columns is two more than this; we want the
@@ -846,7 +846,7 @@ sub displaySets {
 					},
 					"version $rec->{version}"
 				);
-				if ($fullName eq $prevFullName) {
+				if ($rec->{user_id} eq $prevUserID) {
 					$nameEntry = CGI::div({ class => 'ms-4' }, "($versionLink)");
 				} else {
 					$nameEntry =
@@ -854,7 +854,7 @@ sub displaySets {
 						. ($setIsVersioned && !$showBestOnly ? " ($versionLink)" : ' ')
 						. CGI::br()
 						. CGI::a({ href => "mailto:$email" }, $email);
-					$prevFullName = $fullName;
+					$prevUserID = $rec->{user_id};
 				}
 
 				# build columns to show


### PR DESCRIPTION
Fix an issue on the student progress page in which the gateway quiz versions for two students with the same first and last name are shown under the first users name only (first by whichever sort method is used).  The problem (as identified by @dlglin) is that the method was looking for a change in student full names to determine when to move on to the next student.  It now uses the student id for this purpose.  This fixes issue #1514.