### PR TITLE
Update the resource slug for the webwork2.pot file in tx/config.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:webwork:p:webwork2:r:webwork2pot]
+[o:webwork:p:webwork2:r:lib-webwork-localize-webwork2-pot--develop]
 file_filter  = lib/WeBWorK/Localize/<lang>.po
 source_file  = lib/WeBWorK/Localize/webwork2.pot
 source_lang  = en


### PR DESCRIPTION
The slug was created initially in Transifex as webwork2pot, and must be before GitHub integrations are set up.  Once GitHub integrations are set up linking Transifex to the repository the slug is automatically changed in Transifex to the full path of the resource in the GitHub repository (with hyphens instead of forward slashes) and the branch name.  So this needs to be changed in the tx/config file.

I meant to do this  in #1632 because I had read that this would happen, but forgot.

This is not particularly important as this file is only used for the Transifex command line client, and most developers (even myself) will rarely use that.  It is useful to have though.