### PR TITLE
Force the set name entry inputs to be left-to-right.

### DIFF
--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -121,6 +121,11 @@
 		(el) => {if (el.dataset.bsTitle) new bootstrap.Tooltip(el, {trigger: 'hover', fallbackPlacements: []});}
 	);
 
+	// Hardcopy tooltips shown on the Problem Sets page.
+	document.querySelectorAll('.hardcopy-tooltip').forEach(
+		(el) => new bootstrap.Tooltip(el, { trigger: 'hover', fallbackPlacements: [], html: true })
+	);
+
 	// PG Problem Editor
 	document.querySelectorAll('.reference-link').forEach((el) => new bootstrap.Tooltip(el));
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -218,6 +218,8 @@ table caption {
 	}
 
 	ul.nav {
+		padding-right: 0;
+
 		li a:hover {
 			background: #e1e1e1;
 		}
@@ -741,6 +743,25 @@ input.changed[type=text] { /* orange */
 	width: 100%;
 	height: 100%;
 }
+
+// Fix the style of the save file path input group.
+// It is forced to be ltr, but the bootstrap rtl style makes that look wrong.
+/* rtl:raw:
+.editor-save-path.input-group > :first-child:not(.dropdown-toggle):not(.dropdown-menu) {
+	border-bottom-left-radius: 0.2rem;
+	border-top-left-radius: 0.2rem;
+	border-bottom-right-radius: 0;
+	border-top-right-radius: 0;
+}
+
+.editor-save-path.input-group >
+:last-child:not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
+	border-bottom-left-radius: 0;
+	border-top-left-radius: 0;
+	border-bottom-right-radius: 0.2rem;
+	border-top-right-radius: 0.2rem;
+}
+*/
 
 /* Page loading busy indicator */
 /* Currently only used on the problem editor page. */

--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -164,7 +164,8 @@ sub print_form {
 			id         => 'res_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -261,7 +262,8 @@ sub print_form {
 			id         => 'ext_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -351,7 +353,8 @@ sub print_form {
 			id         => 'ext_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -445,7 +448,8 @@ sub print_form {
 			id         => 'red_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -542,7 +546,8 @@ sub print_form {
 			id         => 'dub_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -662,7 +667,7 @@ sub print_form {
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
 			labels     => { map { $_ => format_set_name_display($_) } @openSets },
-			menu_attr  => { onchange => $problem_id_script }
+			menu_attr  => { onchange => $problem_id_script, dir => 'ltr' }
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			id                  => 'ria_problem_id',
@@ -786,7 +791,7 @@ sub print_form {
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
 			labels     => { map { $_ => format_set_name_display($_) } @openSets },
-			menu_attr  => { onchange => $problem_id_script }
+			menu_attr  => { onchange => $problem_id_script, dir => 'ltr' }
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			id                  => 'dbp_problem_id',
@@ -912,7 +917,7 @@ sub print_form {
 			values     => \@openSets,
 			labels     => { map { $_ => format_set_name_display($_) } @openSets },
 			label_text => $r->maketext('Set Name'),
-			menu_attr  => { onchange => $problem_id_script }
+			menu_attr  => { onchange => $problem_id_script, dir => 'ltr' }
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			id                  => 'hcp_problem_id',
@@ -1013,7 +1018,8 @@ sub print_form {
 			id         => 'hcs_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -1136,7 +1142,7 @@ sub print_form {
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
 			labels     => { map { $_ => format_set_name_display($_) } @openSets },
-			menu_attr  => { onchange => $problem_id_script }
+			menu_attr  => { onchange => $problem_id_script, dir => 'ltr' }
 		),
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			id                  => 'fcp_problem_id',
@@ -1233,7 +1239,8 @@ sub print_form {
 			id         => 'fcs_set_id',
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
-			labels     => { map { $_ => format_set_name_display($_) } @openSets }
+			labels     => { map { $_ => format_set_name_display($_) } @openSets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -1353,7 +1360,7 @@ sub print_form {
 			label_text => $r->maketext('Set Name'),
 			values     => \@openSets,
 			labels     => { map { $_ => format_set_name_display($_) } @openSets },
-			menu_attr  => { onchange => $problem_id_script }
+			menu_attr  => { onchange => $problem_id_script, dir => 'ltr' }
 		),
 		CGI::div(
 			{ class => 'row mb-3' },
@@ -1539,7 +1546,8 @@ sub print_form {
 			id         => 'adtgw_gw_id',
 			label_text => $r->maketext('Gateway Name'),
 			values     => \@openGateways,
-			labels     => { map { $_ => format_set_name_display($_) } @openGateways }
+			labels     => { map { $_ => format_set_name_display($_) } @openGateways },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -1645,7 +1653,8 @@ sub print_form {
 			id         => 'eddgw_gw_id',
 			label_text => $r->maketext('Gateway Name'),
 			values     => \@openGateways,
-			labels     => { map { $_ => format_set_name_display($_) } @openGateways }
+			labels     => { map { $_ => format_set_name_display($_) } @openGateways },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }
@@ -1753,7 +1762,8 @@ sub print_form {
 			id         => 'resgw_gw_id',
 			label_text => $r->maketext('Gateway Name'),
 			values     => \@sets,
-			labels     => { map { $_ => format_set_name_display($_) } @sets }
+			labels     => { map { $_ => format_set_name_display($_) } @sets },
+			menu_attr  => { dir => 'ltr' }
 		)
 	);
 }

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -269,7 +269,7 @@ sub displayStudentStats {
 			next if $setVersionsCount{$setID};
 			push @rows,
 				CGI::Tr(
-					CGI::td(format_set_name_display($setID)),
+					CGI::td({ dir => 'ltr' }, format_set_name_display($setID)),
 					CGI::td(
 						{ colspan => $max_problems + 3 },
 						CGI::em($r->maketext('No versions of this assignment have been taken.'))
@@ -290,7 +290,7 @@ sub displayStudentStats {
 			push(
 				@rows,
 				CGI::Tr(
-					CGI::td(format_set_name_display($setID) . ' (version ' . $set->version_id . ')'),
+					CGI::td({ dir => 'ltr' }, format_set_name_display($setID) . ' (version ' . $set->version_id . ')'),
 					CGI::td(
 						{ colspan => $max_problems + 3 },
 						CGI::em($r->maketext('Display of scores for this set is not allowed.'))
@@ -385,7 +385,7 @@ sub displayStudentStats {
 
 		push @rows, CGI::Tr(
 			CGI::th(
-				{ scope => 'row' },
+				{ scope => 'row', dir => 'ltr' },
 				CGI::a({ href => $act_as_student_set_url }, format_set_name_display($setID))
 			),
 			CGI::td(CGI::span({ class => $class }, $totalRightPercent . '%')),

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -39,7 +39,7 @@ use WeBWorK::Debug;
 use WeBWorK::Form;
 use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
 use WeBWorK::PG;
-use WeBWorK::Utils qw/readFile decodeAnswers jitar_id_to_seq is_restricted after x/;
+use WeBWorK::Utils qw/readFile decodeAnswers jitar_id_to_seq is_restricted after x format_set_name_display/;
 use PGrandom;
 
 =head1 CONFIGURATION VARIABLES
@@ -506,8 +506,10 @@ sub display_form {
 						default_sort    => 'lnfn',
 						default_format  => 'lnfn_uid',
 						default_filters => ['all'],
-						size            => 20,
-						multiple        => $perm_multiuser,
+						attrs => {
+							size     => 20,
+							multiple => $perm_multiuser
+						}
 					},
 					@Users
 				)
@@ -526,8 +528,11 @@ sub display_form {
 						default_sort    => 'set_id',
 						default_format  => 'sid',
 						default_filters => ['all'],
-						size            => 20,
-						multiple        => $perm_multiset,
+						attrs => {
+							size     => 20,
+							multiple => $perm_multiset,
+							dir      => 'ltr'
+						}
 					},
 					@WantedGlobalSets,
 					@SetVersions
@@ -587,7 +592,7 @@ sub display_form {
 
 		print CGI::p($r->maketext(
 			"Download hardcopy of set [_1] for [_2]?",
-			$selected_set_id,
+			CGI::span({ dir => 'ltr' }, format_set_name_display($selected_set_id)),
 			$user->first_name . " " . $user->last_name
 		));
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
@@ -133,8 +133,10 @@ sub body {
 						default_sort    => 'lnfn',
 						default_format  => 'lnfn_uid',
 						default_filters => ['all'],
-						size            => 20,
-						multiple        => 1,
+						attrs           => {
+							size     => 20,
+							multiple => 1
+						}
 					},
 					@Users
 				)
@@ -153,8 +155,11 @@ sub body {
 						default_sort    => 'set_id',
 						default_format  => 'set_id',
 						default_filters => ['all'],
-						size            => 20,
-						multiple        => 1,
+						attrs           => {
+							size     => 20,
+							multiple => 1,
+							dir      => 'ltr'
+						}
 					},
 					@GlobalSets
 				)

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -278,8 +278,10 @@ sub body {
 					default_sort    => 'lnfn',
 					default_format  => 'lnfn_uid',
 					default_filters => ['all'],
-					size            => 10,
-					multiple        => 1,
+					attrs           => {
+						size     => 10,
+						multiple => 1
+					}
 				},
 				@Users
 			)
@@ -297,8 +299,11 @@ sub body {
 					default_sort    => 'set_id',
 					default_format  => 'sid',
 					default_filters => ['all'],
-					size            => 10,
-					multiple        => 1,
+					attrs           => {
+						size     => 10,
+						multiple => 1,
+						dir      => 'ltr'
+					}
 				},
 				@GlobalSets
 			)
@@ -487,7 +492,8 @@ sub body {
 						id          => 'new_set_name',
 						placeholder => $r->maketext("Name for new set here"),
 						size        => 20,
-						class       => 'form-control form-control-sm'
+						class       => 'form-control form-control-sm',
+						dir         => 'ltr'
 					})
 				)
 			)

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -599,8 +599,10 @@ sub body {
 	my $header = CGI::i(
 		$self->{file_type} eq 'problem'
 		? $r->maketext(
-			'Editing <strong>problem [_1] of set [_2]</strong> in file "[_3]"', $prettyProblemNumber,
-			format_set_name_display($fullSetName),                              $self->shortPath($inputFilePath)
+			'Editing <strong>problem [_1] of set [_2]</strong> in file "[_3]"',
+			$prettyProblemNumber,
+			CGI::span({ dir => 'ltr' }, format_set_name_display($fullSetName)),
+			CGI::span({ dir => 'ltr' }, $self->shortPath($inputFilePath))
 			)
 		: $r->maketext($titles{ $self->{file_type} }, $self->shortPath($inputFilePath))
 	);
@@ -1415,7 +1417,9 @@ sub add_problem_form {
 					id      => 'action_add_problem_target_set_id',
 					name    => 'action.add_problem.target_set',
 					values  => \@allSetNames,
+					labels  => { map { $_ => format_set_name_display($_) } @allSetNames },
 					class   => 'form-select form-select-sm d-inline w-auto',
+					dir     => 'ltr',
 					default => $setName
 				})
 			)
@@ -1586,7 +1590,10 @@ sub save_form {
 		return CGI::div(
 			CGI::div(
 				{ class => 'mb-2' },
-				$r->maketext('Save to [_1] and View', CGI::b($self->shortPath($self->{editFilePath})))
+				$r->maketext(
+					'Save to [_1] and View',
+					CGI::b({ dir => 'ltr' }, $self->shortPath($self->{editFilePath}))
+				)
 			),
 			CGI::div(
 				{ class => 'form-check mb-2' },
@@ -1595,7 +1602,10 @@ sub save_form {
 					id    => 'newWindowSave',
 					class => 'form-check-input'
 				}),
-				CGI::label({ for => 'newWindowSave', class => 'form-check-label' }, $r->maketext('Open in new window'))
+				CGI::label(
+					{ for => 'newWindowSave', class => 'form-check-label' },
+					$r->maketext('Open in new window')
+				)
 			)
 		);
 	} else {
@@ -1774,16 +1784,16 @@ sub save_as_form {
 				$r->maketext('Save file to:')
 			),
 			CGI::div(
-				{ class => 'col-auto d-inline-flex' },
+				{ class => 'col-auto d-inline-flex', dir => 'ltr' },
 				CGI::div(
-					{ class => 'input-group input-group-sm' },
+					{ class => 'editor-save-path input-group input-group-sm' },
 					CGI::label({ for => 'action_save_as_target_file_id', class => 'input-group-text' }, '[TMPL]/'),
 					CGI::textfield({
 						id    => 'action_save_as_target_file_id',
 						name  => 'action.save_as.target_file',
 						size  => 60,
 						value => $shortFilePath,
-						class => 'form-control form-control-sm'
+						class => 'form-control form-control-sm', dir => 'ltr'
 					})
 				)
 			),
@@ -1803,7 +1813,12 @@ sub save_as_form {
 				}),
 				CGI::label(
 					{ for => 'action_save_as_saveMode_rename_id', class => 'form-check-label' },
-					$r->maketext('Replace current problem: [_1]', CGI::strong("$fullSetID/$prettyProbNum"))
+					$r->maketext(
+						'Replace current problem: [_1]',
+						CGI::strong(
+							CGI::span({ dir => 'ltr' }, format_set_name_display($fullSetID)) . "/$prettyProbNum"
+						)
+					)
 				)
 			) : ''
 		),
@@ -1819,7 +1834,10 @@ sub save_as_form {
 				}),
 				CGI::label(
 					{ for => 'action_save_as_saveMode_new_problem_id', class => 'form-check-label' },
-					$r->maketext('Append to end of [_1] set', CGI::strong($fullSetID))
+					$r->maketext(
+						'Append to end of [_1] set',
+						CGI::strong({ dir => 'ltr' }, format_set_name_display($fullSetID))
+					)
 				)
 			) : ''
 		),
@@ -2036,7 +2054,7 @@ sub revert_form {
 	my $editFilePath    = $self->{editFilePath};
 	return $r->maketext("Error: The original file [_1] cannot be read.", $editFilePath) unless -r $editFilePath;
 	return "" unless defined($self->{tempFilePath}) and -e $self->{tempFilePath} ;
-	return $r->maketext("Revert to [_1]",$self->shortPath($editFilePath)) ;
+	return $r->maketext("Revert to [_1]", CGI::span({ dir => 'ltr' }, $self->shortPath($editFilePath)));
 }
 
 sub revert_handler {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -714,6 +714,7 @@ sub FieldHTML {
 				data_override => "$recordType.$recordID.$field.override_id",
 				class         => 'form-control form-control-sm',
 				$forUsers && $check ? (aria_labelledby => "$recordType.$recordID.$field.label") : (),
+				$field eq 'restricted_release' || $field eq 'source_file' ? (dir => 'ltr')      : ()
 			});
 		}
 	} elsif ($choose) {
@@ -776,11 +777,11 @@ sub FieldHTML {
 			? {
 				for   => "$recordType.$recordID.$field.override_id",
 				id    => "$recordType.$recordID.$field.label",
-				class => 'form-check-label'
+				class => 'form-check-label mb-0'
 			}
 			: {
 				for   => "$recordType.$recordID.${field}_id",
-				class => 'form-label'
+				class => 'form-label mb-0'
 			},
 			$r->maketext($properties{name})
 		);
@@ -819,7 +820,7 @@ sub FieldHTML {
 				size            => $properties{size} || 5,
 				class           => 'form-control form-control-sm',
 				aria_labelledby => "$recordType.$recordID.$field.label",
-				$field =~ /date/ ? (dir => 'ltr') : ()
+				$field =~ /date/ || $field eq 'restricted_release' || $field eq 'source_file' ? (dir => 'ltr') : ()
 			})
 			: ''
 		) if $forUsers;
@@ -2184,7 +2185,7 @@ sub body {
 					{ class => 'col-md-6' },
 					$r->maketext(
 						'Editing problem set [_1] data for these individual students: [_2]',
-						CGI::strong(format_set_name_display("$setID$vermsg")),
+						CGI::strong({ dir => 'ltr' }, format_set_name_display("$setID$vermsg")),
 						CGI::br() . CGI::strong(join CGI::br(), @userLinks)
 					)
 				),
@@ -2194,7 +2195,7 @@ sub body {
 						{ href => $self->systemLink($setDetailPage) },
 						$r->maketext(
 							'Edit set [_1] data for ALL students assigned to this set.',
-							CGI::strong(format_set_name_display($setID))
+							CGI::strong({ dir => 'ltr' }, format_set_name_display($setID))
 						)
 					),
 					# Handy messages when editing gateway sets.
@@ -2217,7 +2218,7 @@ sub body {
 					{ class => 'col-md-6' },
 					$r->maketext(
 						'This set [_1] is assigned to [_2].',
-						CGI::strong(format_set_name_display($setID)),
+						CGI::strong({ dir => 'ltr' }, format_set_name_display($setID)),
 						$self->userCountMessage($setUserCount, $userCount)
 					)
 				),
@@ -2226,7 +2227,7 @@ sub body {
 					$r->maketext(
 						'Edit [_1] of set [_2].',
 						CGI::a({ href => $editUsersAssignedToSetURL }, $r->maketext('individual versions')),
-						format_set_name_display($setID)
+						CGI::span({ dir => 'ltr' }, format_set_name_display($setID))
 					)
 				)
 			)
@@ -2688,7 +2689,7 @@ sub body {
 				CGI::div(
 					{ class => 'problem_detail_row card d-flex flex-column p-2 mb-3 g-0' },
 					CGI::div(
-						{ class => 'pdr_block_1 row' },
+						{ class => 'pdr_block_1 row align-items-center' },
 						CGI::div(
 							{ class => 'col-md-4 col-10 order-1 d-flex align-items-center' },
 							CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -169,7 +169,8 @@ sub body {
 					defaults => [ $self->r->param('selectedSet') ],
 					size     => 10,
 					multiple => 1,
-					class    => 'form-select'
+					class    => 'form-select',
+					dir      => 'ltr'
 				})
 			),
 			CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -717,9 +717,11 @@ sub print_form {
 								default_sort        => 'lnfn',
 								default_format      => 'lnfn_uid',
 								default_filters     => ['all'],
-								size                => 5,
-								multiple            => 1,
 								refresh_button_name => $r->maketext('Update settings and refresh page'),
+								attrs               => {
+									size     => 5,
+									multiple => 1
+								}
 							},
 							@{ $self->{ra_user_records} }
 						)

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -412,8 +412,10 @@ sub body {
 						default_sort    => 'lnfn',
 						default_format  => 'lnfn_uid',
 						default_filters => ['all'],
-						size            => 10,
-						multiple        => 1,
+						attrs           => {
+							size     => 10,
+							multiple => 1
+						}
 					},
 					@Users
 				)
@@ -432,7 +434,8 @@ sub body {
 					default  => $selectedSets,
 					size     => 23,
 					multiple => 1,
-					class    => 'form-select form-select-sm'
+					class    => 'form-select form-select-sm',
+					dir      => 'ltr'
 				})
 			),
 			CGI::div(
@@ -492,7 +495,7 @@ sub body {
 				my $prettyProblemNumber = $prettyProblemNumbers->{$setName}{$problemNumber};
 				print CGI::h3($r->maketext(
 					"Past Answers for [_1], set [_2], problem [_3]",
-					$studentUser, format_set_name_display($setName), $prettyProblemNumber
+					$studentUser, CGI::span({ dir => 'ltr' }, format_set_name_display($setName)), $prettyProblemNumber
 				));
 
 				my @row;

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -69,8 +69,9 @@ sub title {
 	} elsif ($type eq 'set') {
 		return $r->maketext(
 			'Statistics for [_1] set [_2]. Closes [_3]',
-			$self->{ce}{courseName},
-			format_set_name_display($self->{setName}), $self->formatDateTime($self->{set_due_date})
+			$self->{ce}{courseName} =~ s/_/ /gr,
+			CGI::span({ dir => 'ltr' }, format_set_name_display($self->{setName})),
+			$self->formatDateTime($self->{set_due_date})
 		);
 	}
 
@@ -91,7 +92,7 @@ sub siblings {
 
 	print CGI::start_div({ class => 'info-box', id => 'fisheye' });
 	print CGI::h2($r->maketext('Statistics'));
-	print CGI::start_ul({ class => 'nav flex-column problem-list' });
+	print CGI::start_ul({ class => 'nav flex-column problem-list', dir => 'ltr' });
 
 	# List links depending on if viewing set progress or student progress
 	if ($self->{type} eq 'student') {
@@ -269,7 +270,7 @@ sub index {
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
 			CGI::h2({ class => 'text-center fs-3' }, $r->maketext('View statistics by set')),
-			CGI::ul(CGI::li([@setLinks])),
+			CGI::ul({ dir => 'ltr' }, CGI::li([@setLinks])),
 		),
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -78,7 +78,7 @@ sub title {
 		return $r->maketext(
 			'Student Progress for [_1] set [_2]. Closes [_3]',
 			$self->{ce}->{courseName},
-			format_set_name_display($self->{setName}),
+			CGI::span({ dir => 'ltr' }, format_set_name_display($self->{setName})),
 			$self->formatDateTime($self->{set_due_date})
 		);
 	}
@@ -87,7 +87,7 @@ sub title {
 }
 
 sub siblings {
-	my ($self)  = @_;
+	my $self    = shift;
 	my $r       = $self->r;
 	my $db      = $r->db;
 	my $urlpath = $r->urlpath;
@@ -100,7 +100,6 @@ sub siblings {
 
 	print CGI::start_div({ class => 'info-box', id => 'fisheye' });
 	print CGI::h2($r->maketext('Student Progress'));
-	print CGI::start_ul({ class => 'nav flex-column problem-list' });
 
 	# List links depending on if viewing set progress or student progress
 	if ($self->{type} eq 'student') {
@@ -129,6 +128,7 @@ sub siblings {
 			[qw/last_name first_name user_id/]
 		);
 
+		print CGI::start_ul({ class => 'nav flex-column problem-list' });
 		for my $studentRecord (@studentRecords) {
 			my $first_name         = $studentRecord->first_name;
 			my $last_name          = $studentRecord->last_name;
@@ -139,28 +139,37 @@ sub siblings {
 				statType => 'student',
 				userID   => $user_id
 			);
-			print CGI::li(CGI::a(
-				{ href => $self->systemLink($userStatisticsPage), class => 'nav-link' },
-				"$last_name, $first_name  ($user_id)"
-			));
+			print CGI::li(
+				{ class => 'nav-item' },
+				CGI::a(
+					{ href => $self->systemLink($userStatisticsPage), class => 'nav-link' },
+					"$last_name, $first_name  ($user_id)"
+				)
+			);
 		}
+		print CGI::end_ul();
 	} else {
 		my @setIDs = sort $db->listGlobalSets;
-		foreach my $setID (@setIDs) {
+
+		print CGI::start_ul({ class => 'nav flex-column problem-list', dir => 'ltr' });
+		for my $setID (@setIDs) {
 			my $problemPage = $urlpath->newFromModule(
 				$urlpath->module, $r,
 				courseID => $courseID,
 				setID    => $setID,
 				statType => 'set',
 			);
-			print CGI::li(CGI::a(
-				{ href => $self->systemLink($problemPage), class => 'nav-link' },
-				format_set_name_display($setID)
-			));
+			print CGI::li(
+				{ class => 'nav-item' },
+				CGI::a(
+					{ href => $self->systemLink($problemPage), class => 'nav-link' },
+					format_set_name_display($setID)
+				)
+			);
 		}
+		print CGI::end_ul();
 	}
 
-	print CGI::end_ul();
 	print CGI::end_div();
 
 	return '';
@@ -279,7 +288,7 @@ sub index {
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },
 			CGI::h2({ class => 'text-center fs-3' }, $r->maketext('View student progress by set')),
-			CGI::ul(CGI::li([@setLinks]))
+			CGI::ul({ dir => 'ltr' }, CGI::li([@setLinks]))
 		),
 		CGI::div(
 			{ class => 'col-lg-5 col-sm-6 border border-dark' },

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -327,7 +327,7 @@ sub outputSetRow {
 				labelattributes => { class => 'form-check-label' }
 			}),
 			defined $mergedSet
-			? CGI::b(CGI::a(
+			? CGI::b({ dir => 'ltr' }, CGI::a(
 				{
 					href => $self->systemLink(
 						$urlpath->new(
@@ -346,7 +346,7 @@ sub outputSetRow {
 				format_set_name_display($version ? "$setID (version $version)" : $setID)
 			))
 				. ($version ? CGI::hidden({ name => "set.$setID,v$version.assignment", value => 'delete' }) : '')
-			: CGI::b(format_set_name_display($setID)),
+			: CGI::b({ dir => 'ltr' }, format_set_name_display($setID)),
 			join '',
 			$self->DBFieldTable($set, $userSet, $mergedSet, 'set', $setID, $dateFields, $dateFieldLabels),
 		]

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -145,7 +145,7 @@ sub body {
 			"When you unassign by unchecking a student's name, you destroy all of the data for homework set [_1] "
 				. 'for this student. You will then need to reassign the set to these students and they will receive '
 				. 'new versions of the problems. Make sure this is what you want to do before unchecking students.',
-			CGI::b(format_set_name_display($setID))
+			CGI::b({ dir => 'ltr' }, format_set_name_display($setID))
 		)
 	);
 
@@ -227,8 +227,9 @@ sub body {
 				{ class => 'alert alert-danger p-1 mb-3' },
 				$r->maketext(
 					'There is NO undo for this function.  Do not use it unless you know what you are doing!  '
-					. 'When you unassign a student using this button, or by unchecking their name, you destroy all '
-					. "of the data for homework set [_1] for this student.", format_set_name_display($setID)
+						. 'When you unassign a student using this button, or by unchecking their name, you destroy all '
+						. "of the data for homework set [_1] for this student.",
+					CGI::span({ dir => 'ltr' }, format_set_name_display($setID))
 				)
 			),
 			CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
-use WeBWorK::Utils qw(readFile dequote jitar_id_to_seq);
+use WeBWorK::Utils qw(readFile dequote jitar_id_to_seq format_set_name_display);
 use Encode;
 
 # This content generator is NOT logged in.
@@ -39,24 +39,26 @@ sub if_loggedin {
 }
 
 sub title {
-    my ($self) = @_;
-    my $r = $self->r;
-    # using the url arguments won't break if the set/problem are invalid
-    my $setID = WeBWorK::ContentGenerator::underscore2nbsp($self->r->urlpath->arg("setID"));
-    my $problemID = $self->r->urlpath->arg("problemID");
+	my ($self) = @_;
+	my $r = $self->r;
+	# using the url arguments won't break if the set/problem are invalid
+	my $setID     = $self->r->urlpath->arg('setID');
+	my $problemID = $self->r->urlpath->arg('problemID');
 
-    # if its a problem page for a jitar set we print the pretty version of the id
-    if ($problemID) {
-	my $set = $r->db->getGlobalSet($setID);
-	if ($set && $set->assignment_type eq 'jitar') {
-	    $problemID = join('.',jitar_id_to_seq($problemID));
+	# If the url is for a problem page, then the title is the set and problem id.
+	if ($problemID) {
+		# Print the pretty version of the problem id for a jitar set.
+		my $set = $r->db->getGlobalSet($setID);
+		if ($set && $set->assignment_type eq 'jitar') {
+			$problemID = join('.', jitar_id_to_seq($problemID));
+		}
+
+		return $r->maketext('[_1]: Problem [_2]', CGI::span({ dir => 'ltr' }, format_set_name_display($setID)),
+			$problemID);
 	}
 
-	return $r->maketext("[_1]: Problem [_2]",$setID, $problemID);
-    }
-
-    my $ref = $self->SUPER::title();
-    return $ref;
+	my $ref = $self->SUPER::title();
+	return $ref;
 }
 
 sub info {

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -37,7 +37,8 @@ use WeBWorK::PG::ImageGenerator;
 use WeBWorK::PG::IO;
 use WeBWorK::Utils qw(readFile writeLog writeCourseLog encodeAnswers decodeAnswers is_restricted ref2string
 	makeTempDirectory path_is_subdir before after between wwRound is_jitar_problem_closed is_jitar_problem_hidden
-	jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id jitar_problem_finished getAssetURL);
+	jitar_problem_adjusted_status jitar_id_to_seq seq_to_jitar_id jitar_problem_finished getAssetURL
+	format_set_name_display);
 use WeBWorK::DB::Utils qw(global2user user2global);
 require WeBWorK::Utils::ListingDB;
 use URI::Escape;
@@ -1392,11 +1393,11 @@ sub title {
 	my $problemID = $self->r->urlpath->arg("problemID");
 
 	my $set = $db->getGlobalSet($setID);
-	$setID = WeBWorK::ContentGenerator::underscore2nbsp($setID);
+	$setID = CGI::span({ dir => 'ltr' }, format_set_name_display($setID));
 	if ($set && $set->assignment_type eq 'jitar') {
 	    $problemID = join('.',jitar_id_to_seq($problemID));
 	}
-	my $out = $r->maketext("[_1]: Problem [_2]",$setID, $problemID);
+	my $out = $r->maketext('[_1]: Problem [_2]', $setID, $problemID);
 
 	# Return here if we don't have the requisite information.
 	return $out if ($self->{invalidSet} || $self->{invalidProblem});

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -396,10 +396,18 @@ sub setListRow {
 				{ class => 'hardcopy-link', href => $link },
 				CGI::i(
 					{
-						class       => 'icon far fa-arrow-alt-circle-down fa-lg',
+						class       => 'hardcopy-tooltip icon far fa-arrow-alt-circle-down fa-lg',
 						aria_hidden => 'true',
-						title       => $r->maketext('Download [_1]', format_set_name_display($set->set_id)),
-						data_alt    => $r->maketext('Download [_1]', format_set_name_display($set->set_id))
+						title       => $r->maketext(
+							'Download [_1]',
+							CGI::span({ dir => 'ltr' }, format_set_name_display($set->set_id))
+						),
+						data_alt => $r->maketext(
+							'Download [_1]',
+							CGI::span({ dir => 'ltr' }, format_set_name_display($set->set_id))
+						),
+						data_bs_toggle    => 'tooltip',
+						data_bs_placement => 'left',
 					},
 					''
 				)
@@ -412,7 +420,8 @@ sub setListRow {
 	my $visiblityStateClass = ($set->visible) ? "font-visible" : "font-hidden";
 	$status = CGI::span({class=>$visiblityStateClass}, $status) if $preOpenSets;
 
-	return CGI::Tr(CGI::td([$interactive, $status]),CGI::td({class => "hardcopy"}, $control));
+	return CGI::Tr(CGI::td({ dir => 'ltr' }, $interactive), CGI::td($status),
+		CGI::td({ class => "hardcopy" }, $control));
 }
 
 sub byname { $a->set_id cmp $b->set_id; }

--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -28,7 +28,7 @@ use warnings;
 use WeBWorK::CGI;
 use WeBWorK::PG;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound before after jitar_id_to_seq);
+use WeBWorK::Utils qw(wwRound before after jitar_id_to_seq format_set_name_display);
 
 ################################################################################
 # output utilities
@@ -367,11 +367,11 @@ sub title {
 	my $problemID = $self->r->urlpath->arg("problemID");
 
 	my $set = $db->getGlobalSet($setID);
-	$setID = WeBWorK::ContentGenerator::underscore2nbsp($setID);
 	if ($set && $set->assignment_type eq 'jitar') {
 		$problemID = join('.', jitar_id_to_seq($problemID));
 	}
-	my $out = $r->maketext("[_1]: Problem [_2] Show Me Another", $setID, $problemID);
+	my $out = $r->maketext('[_1]: Problem [_2] Show Me Another',
+		CGI::span({ dir => 'ltr' }, format_set_name_display($setID)), $problemID);
 
 	# Return here if we don't have the requisite information.
 	return $out if ($self->{invalidSet} || $self->{invalidProblem});

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -174,8 +174,7 @@ sub scrollingRecordList {
 			default => \@selected_records,
 			labels  => \%labels,
 			class   => 'form-select form-select-sm',
-			$options{size}     ? (size     => $options{size})     : (),
-			$options{multiple} ? (multiple => $options{multiple}) : ()
+			$options{attrs} ? %{ $options{attrs} } : ()
 		}),
 	);
 }

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -27,7 +27,7 @@ use Carp;
 use WeBWorK::Debug;
 use WeBWorK::Localize;
 use WeBWorK::DB qw(validateKeyfieldValue);
-use WeBWorK::Utils qw(x);
+use WeBWorK::Utils qw(x format_set_name_display);
 
 use Scalar::Util qw(weaken);
 {
@@ -774,19 +774,26 @@ sub arg {
 =item name()
 
 Returns the human-readable name of this WeBWorK::URLPath.
+This display set ids and course ids with spaces instead of underscores, and
+places the set id into an ltr span so that it is displayed ltr even for rtl
+languages.  Note that the return value of this method should never be used to
+determine what type of path this is or for any sort of further processing.  It
+is a translated string.
 
 =cut
 
 sub name {
 	my ($self) = @_;
-	my $type = $self->{type};
 	my %args = $self->args;
 
-	my $name = $pathTypes{$type}->{name};
-	$name = $self->{r}->maketext($name, $args{userID} // '',
-				     $args{setID} // '',
-				     $args{problemID} // '',
-				     $args{courseID} // '');   # translate the display name
+	# Translate the display name.
+	my $name = $self->{r}->maketext(
+		$pathTypes{ $self->{type} }{name},
+		$args{userID} // '',
+		CGI::span({ dir => 'ltr' }, format_set_name_display($args{setID} // '')),
+		$args{problemID} // '',
+		($args{courseID}  // '') =~ s/_/ /gr
+	);
 
 	return $name;
 }


### PR DESCRIPTION
This makes set name inputs behave better for right-to-left languages.

@taniwallach:  Is this all that is needed?  Or did you want all places that set names are displayed to also be forced to left-to-right?