### PR TITLE
Fix the filter on the ProblemSetList.pm for showing visible or hidden sets.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -713,10 +713,10 @@ sub filter_handler {
 		$self->{visibleSetIDs} = \@setIDs;
 	} elsif ($scope eq "visible") {
 		$result = $r->maketext("showing sets that are visible to students");
-		$self->{visibleSetIDs} = [ $db->listGlobalSetsWhere({ visible => 1 }) ];
+		$self->{visibleSetIDs} = [ map { $_->[0] } $db->listGlobalSetsWhere({ visible => 1 }) ];
 	} elsif ($scope eq "unvisible") {
 		$result = $r->maketext("showing sets that are hidden from students");
-		$self->{visibleSetIDs} = [ $db->listGlobalSetsWhere({ visible => 0 }) ];
+		$self->{visibleSetIDs} = [ map { $_->[0] } $db->listGlobalSetsWhere({ visible => 0 }) ];
 	}
 
 	return CGI::div({ class => 'alert alert-success p-1 mb-0' }, $result);


### PR DESCRIPTION
This was a regression introduced in #1585.  I missed a place where the result of a list...Where method was used and needed to be mapped to the actual field value.  I double checked, and this is the only place this was forgotten.

Thanks @taniwallach for pointing this out.