### PR TITLE
When viewing student progress list students instead of sets in sliblings.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -90,40 +90,80 @@ sub siblings {
 	my ($self)  = @_;
 	my $r       = $self->r;
 	my $db      = $r->db;
-	my $authz   = $r->authz;
-	my $user    = $r->param('user');
 	my $urlpath = $r->urlpath;
 
 	# Check permissions
-	return "" unless $authz->hasPermissions($user, "access_instructor_tools");
+	return '' unless $r->authz->hasPermissions($r->param('user'), 'access_instructor_tools');
 
-	my $courseID = $urlpath->arg("courseID");
-	my $eUserID  = $r->param("effectiveUser");
-	my @setIDs   = sort $db->listGlobalSets;
+	my $courseID = $urlpath->arg('courseID');
+	my $eUserID  = $r->param('effectiveUser');
 
-	my $progress =
-		$urlpath->newFromModule("WeBWorK::ContentGenerator::Instructor::StudentProgress", $r, courseID => $courseID);
+	print CGI::start_div({ class => 'info-box', id => 'fisheye' });
+	print CGI::h2($r->maketext('Student Progress'));
+	print CGI::start_ul({ class => 'nav flex-column problem-list' });
 
-	print CGI::start_div({ class => "info-box", id => "fisheye" });
-	print CGI::h2($r->maketext("Student Progress"));
-	print CGI::start_ul({ class => "nav flex-column problem-list" });
-	foreach my $setID (@setIDs) {
-		my $problemPage = $urlpath->newFromModule(
-			"WeBWorK::ContentGenerator::Instructor::StudentProgress", $r,
-			courseID => $courseID,
-			setID    => $setID,
-			statType => 'set',
+	# List links depending on if viewing set progress or student progress
+	if ($self->{type} eq 'student') {
+		my $ce   = $r->ce;
+		my $user = $r->param('user');
+		# Get all users except the set level proctors, and restrict to the
+		# sections or recitations that are allowed for the user if such
+		# restrictions are defined.  This list is sorted by last_name,
+		# then first_name, then user_id.
+		my @studentRecords = $db->getUsersWhere(
+			{
+				user_id => { not_like => 'set_id:%' },
+				$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+				? (
+					-or => [
+						$ce->{viewable_sections}{$user}
+						? (section => { in => $ce->{viewable_sections}{$user} })
+						: (),
+						$ce->{viewable_recitations}{$user}
+						? (recitation => { in => $ce->{viewable_recitations}{$user} })
+						: ()
+					]
+					)
+				: ()
+			},
+			[qw/last_name first_name user_id/]
 		);
-		print CGI::li(CGI::a(
-			{ href => $self->systemLink($problemPage), class => 'nav-link' },
-			format_set_name_display($setID)
-		));
+
+		for my $studentRecord (@studentRecords) {
+			my $first_name         = $studentRecord->first_name;
+			my $last_name          = $studentRecord->last_name;
+			my $user_id            = $studentRecord->user_id;
+			my $userStatisticsPage = $urlpath->newFromModule(
+				$urlpath->module, $r,
+				courseID => $courseID,
+				statType => 'student',
+				userID   => $user_id
+			);
+			print CGI::li(CGI::a(
+				{ href => $self->systemLink($userStatisticsPage), class => 'nav-link' },
+				"$last_name, $first_name  ($user_id)"
+			));
+		}
+	} else {
+		my @setIDs = sort $db->listGlobalSets;
+		foreach my $setID (@setIDs) {
+			my $problemPage = $urlpath->newFromModule(
+				$urlpath->module, $r,
+				courseID => $courseID,
+				setID    => $setID,
+				statType => 'set',
+			);
+			print CGI::li(CGI::a(
+				{ href => $self->systemLink($problemPage), class => 'nav-link' },
+				format_set_name_display($setID)
+			));
+		}
 	}
 
 	print CGI::end_ul();
 	print CGI::end_div();
 
-	return "";
+	return '';
 }
 
 sub body {

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -507,7 +507,7 @@ our %pathTypes = (
 		display => 'WeBWorK::ContentGenerator::Instructor::Stats',
 	},
 	instructor_set_statistics => {
-		name    => x('Statistics'),
+		name    => '[_2]',
 		parent  => 'instructor_statistics',
 		kids    => [ qw// ],
 		match   => qr|^(set)/([^/]+)/|,
@@ -516,7 +516,7 @@ our %pathTypes = (
 		display => 'WeBWorK::ContentGenerator::Instructor::Stats',
 	},
 	instructor_user_statistics => {
-		name    => x('Statistics'),
+		name    => '[_1]',
 		parent  => 'instructor_statistics',
 		kids    => [ qw// ],
 		match   => qr|^(student)/([^/]+)/|,
@@ -570,7 +570,7 @@ our %pathTypes = (
 		display => 'WeBWorK::ContentGenerator::Instructor::StudentProgress',
 	},
 	instructor_set_progress => {
-		name    => x('Student Progress'),
+		name    => '[_2]',
 		parent  => 'instructor_progress',
 		kids    => [ qw// ],
 		match   => qr|^(set)/([^/]+)/|,
@@ -579,7 +579,7 @@ our %pathTypes = (
 		display => 'WeBWorK::ContentGenerator::Instructor::StudentProgress',
 	},
 	instructor_user_progress => {
-		name    => x('Student Progress'),
+		name    => '[_1]',
 		parent  => 'instructor_progress',
 		kids    => [ qw// ],
 		match   => qr|^(student)/([^/]+)/|,


### PR DESCRIPTION
When viewing student progress on the student progress or stats page, use the siblings links to list the students in the course instead of sets, so when viewing a student progress one can view progress of other students without having to return to the main student progress page or stats page each time.

In addition, make the breadcrumbs on the student progress and stats page show the userid or the set name that is being viewed.