### PR TITLE
Fix incorrect directories in OPL-update

### DIFF
--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -550,7 +550,7 @@ if($canopenfile) {
 use JSON;
 
 #### Save the official taxonomy in json format
-my $webwork_htdocs = $ce->{webwork_dir}."/htdocs";
+my $webwork_htdocs = $ce->{webworkDirs}{htdocs};
 my $file = "$webwork_htdocs/DATA/tagging-taxonomy.json";
 
 writeJSONtoFile($tagtaxo,$file);

--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -78,7 +78,7 @@ system("chmod -R g+w ".$ce->{webwork_courses_dir});
 system("chmod g+s ".$ce->{webwork_courses_dir});
 
 # Other special directories under webwork2
-for my $dir ( 'DATA', 'htdocs_tmp', 'logs', 'tmp' ) {
+for my $dir ( 'DATA', 'htdocs_temp', 'logs', 'tmp' ) {
   system("chown -R $me $ce->{webworkDirs}{$dir}");
 	system("chgrp -R $servergroup $ce->{webworkDirs}{$dir}");
 	system("chmod -R g+w $ce->{webworkDirs}{$dir}");
@@ -96,9 +96,7 @@ my $libroot = $ce->{problemLibrary}->{root};
 system("chown -R $me $libroot");
 system("chmod -R 755 $libroot");
 
-# OPL-update needs to be able to write to these directories
+# OPL-update needs to be able to write to this directories
 # Let's hope the same user does it
 # This will need adjusting if the admin course starts running this script
-for my $dir ( "$ce->{webworkDirs}{htdocs}/DATA" ) {
-	system("chown -R $me $dir");
-}
+system("chown -R $me $ce->{webworkDirs}{htdocs}/DATA");

--- a/bin/setfilepermissions
+++ b/bin/setfilepermissions
@@ -78,11 +78,11 @@ system("chmod -R g+w ".$ce->{webwork_courses_dir});
 system("chmod g+s ".$ce->{webwork_courses_dir});
 
 # Other special directories under webwork2
-for my $dir ( "DATA", "htdocs/tmp", "logs", "tmp" ) {
-  system("chown -R $me $wwroot/$dir");
-	system("chgrp -R $servergroup $wwroot/$dir");
-	system("chmod -R g+w $wwroot/$dir");
-	system("chmod g+s $wwroot/$dir");
+for my $dir ( 'DATA', 'htdocs_tmp', 'logs', 'tmp' ) {
+  system("chown -R $me $ce->{webworkDirs}{$dir}");
+	system("chgrp -R $servergroup $ce->{webworkDirs}{$dir}");
+	system("chmod -R g+w $ce->{webworkDirs}{$dir}");
+	system("chmod g+s $ce->{webworkDirs}{$dir}");
 }
 
 # A special directory under pg (so the server can compile the chromatic program)
@@ -99,6 +99,6 @@ system("chmod -R 755 $libroot");
 # OPL-update needs to be able to write to these directories
 # Let's hope the same user does it
 # This will need adjusting if the admin course starts running this script
-for my $dir ( "htdocs/DATA", "htdocs/applets" ) {
-	system("chown -R $me $wwroot/$dir");
+for my $dir ( "$ce->{webworkDirs}{htdocs}/DATA" ) {
+	system("chown -R $me $dir");
 }


### PR DESCRIPTION
Fix several of the scripts (most importantly the OPL-update script) to use the correct directories as set in site.conf and defaults.config, instead of assuming that those directories are subdirectories of the webwork root location.  This makes these locations consistent with the locations used by the UI.

This fixes issue #1458.