### PR TITLE
Add a script that can be used to download the latest OPL metadata release.

### DIFF
--- a/bin/OPL_releases/Makefile
+++ b/bin/OPL_releases/Makefile
@@ -1,5 +1,5 @@
 RELEASE_FILENAME=webwork-open-problem-library-METADATA.tar.gz
-GITHUB_USERNAME=heiderich
+GITHUB_USERNAME=openwebwork
 GITHUB_REPO=webwork-open-problem-library
 JSON_FILENAME=latest_release.json
 RELEASE_TAG=latest_release.tag

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -1,0 +1,98 @@
+#!/usr/bin/env perl
+
+# This script downloads the latest OPL metadata release, and restores the database dump file in that release.
+
+use feature say;
+use strict;
+use warnings;
+
+use File::Fetch;
+use File::Copy;
+use File::Path;
+use JSON;
+
+my $pg_dir;
+
+BEGIN {
+	die "WEBWORK_ROOT not found in environment.\n"
+		unless exists $ENV{WEBWORK_ROOT};
+	$pg_dir = $ENV{PG_ROOT} // "$ENV{WEBWORK_ROOT}/../pg";
+	die "The pg directory must be defined in PG_ROOT" unless (-e $pg_dir);
+}
+
+use lib "$ENV{WEBWORK_ROOT}/lib";
+use lib "$pg_dir/lib";
+
+use WeBWorK::CourseEnvironment;
+
+my $ce = new WeBWorK::CourseEnvironment({ webwork_dir => $ENV{WEBWORK_ROOT} });
+
+my $rawData;
+my $releaseDataFF =
+	File::Fetch->new(uri => 'https://api.github.com/repos/openwebwork/webwork-open-problem-library/releases/latest');
+my $file        = $releaseDataFF->fetch(to => \$rawData) or die $releaseDataFF->error;
+my $releaseData = JSON->new->utf8->decode($rawData);
+
+my $releaseTag = $releaseData->{tag_name};
+say "Found OPL METADATA release $releaseTag.";
+
+my $downloadURL = '';
+for (@{ $releaseData->{assets} }) {
+	$downloadURL = $_->{browser_download_url} if ($_->{name} =~ /tar\.gz$/);
+}
+
+die 'Unable to determine download url for OPL metadata release.' if !$downloadURL;
+
+# Make sure the webwork temporary directory exists and is writable before proceeding.
+die "The WeBWorK temporary directory $ce->{webworkDirs}{tmp} does not exist or is not writable."
+	if (!-d $ce->{webworkDirs}{tmp} || !-w $ce->{webworkDirs}{tmp});
+
+# Download and extract the OPL metadata release.
+my $releaseDownloadFF = File::Fetch->new(uri => $downloadURL);
+my $releaseFile       = $releaseDownloadFF->fetch(to => $ce->{webworkDirs}{tmp}) or die $releaseDownloadFF->error;
+say 'Downloaded release archive, now extracting.';
+
+`$ce->{externalPrograms}{tar} xzf $releaseFile -C $ce->{webworkDirs}{tmp}`;
+die "There was an error extracting the release: $!" if $?;
+
+# Copy the json files into htdocs.
+for (glob("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/JSON-SAVED/*.json")) {
+	copy($_, "$ce->{webworkDirs}{htdocs}/DATA/") or die "Copy $_ to $ce->{webworkDirs}{htdocs}/DATA/ failed: $!";
+}
+
+# Check to see if there appears to be a clone of the OPL in the location set
+die "The directory $ce->{problemLibrary}{root} does not exist or is not writable.\n"
+	. "Make sure that you have cloned the OPL before executing this script,\n"
+	. "and that location is writable for this user."
+	if (!-d $ce->{problemLibrary}{root} || !-w $ce->{problemLibrary}{root});
+
+my $libraryDirectory = $ce->{problemLibrary}{root} =~ s/OpenProblemLibrary$//r;
+
+# Make sure the library directory exists and is writable before proceeding.
+die "The directory $libraryDirectory does not exist or is not writable."
+	if (!-d $libraryDirectory || !-w $libraryDirectory);
+
+# Checkout the release tag in the library clone if it hasn't already been done.
+`$ce->{externalPrograms}{git} -C $libraryDirectory fetch --tags origin`;
+`$ce->{externalPrograms}{git} -C $libraryDirectory show-ref refs/heads/$releaseTag -q`;
+if ($?) {
+	say "Switching OPL clone in $libraryDirectory to new branch of release tag $releaseTag.";
+	`$ce->{externalPrograms}{git} -C $libraryDirectory checkout -b $releaseTag $releaseTag`;
+}
+
+# Copy the sql database dump file in the metadata release into the library location, and restore it.
+mkdir "$libraryDirectory/TABLE-DUMP" if !-d "$libraryDirectory/TABLE-DUMP";
+
+copy("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/TABLE-DUMP/OPL-tables.sql", "$libraryDirectory/TABLE-DUMP");
+
+say 'Restoring OPL tables from release database dump.';
+do $ENV{WEBWORK_ROOT} . '/bin/restore-OPL-tables.pl';
+
+# Remove temporary files.
+say "Removing temporary files.";
+unlink($releaseFile);
+rmtree("$ce->{webworkDirs}{tmp}/webwork-open-problem-library");
+
+say 'Done!';
+
+1;

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -179,9 +179,7 @@ if [ "$1" = 'apache2' ]; then
         make latest_release.tag
         OPL_TAG=`cat $WEBWORK_ROOT/bin/OPL_releases/latest_release.tag`
         cd $APP_ROOT/libraries/webwork-open-problem-library/
-        git remote rm heiderich || true
-        git remote add heiderich https://github.com/heiderich/webwork-open-problem-library.git
-        git fetch --tags heiderich
+        git fetch --tags origin
         echo "Checking out tag $OPL_TAG"
         git checkout $OPL_TAG
       fi


### PR DESCRIPTION
Also setup docker to use the releases in the openwebwork OPL repository instead of those in heiderich's personal fork.

This all depends on openwebwork/webwork-open-problem-library#924 that adds a workflow to create releases, and that workflow being executed for the first time.