### PR TITLE
Add button to randomize view seed in PGProblemEditor.

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -46,4 +46,8 @@
 			document.body.appendChild(busyIndicator);
 		}
 	});
+
+	document.getElementById('randomize_view_seed_id')?.addEventListener('click', () => {
+		document.getElementById('action_view_seed_id').value = Math.ceil(Math.random()*9999);
+	});
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -258,7 +258,7 @@ sub body {
 					},
 					$r->maketext($actionFormTitles{$actionID}))));
 			push(@contentArr, CGI::div({
-					class => 'tab-pane pg_editor_action_div fade mb-2' . ($active ? " show$active" : ""),
+					class => 'tab-pane fade mb-2' . ($active ? " show$active" : ""),
 					id => $actionID,
 					role => 'tabpanel',
 					aria_labelledby => "$actionID-tab"

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -671,7 +671,7 @@ sub body {
 				@contentArr,
 				CGI::div(
 					{
-						class            => "tab-pane pg_editor_action_div fade" . ($active ? " show$active" : ''),
+						class            => "tab-pane fade" . ($active ? " show$active" : ''),
 						id               => $actionID,
 						role             => 'tabpanel',
 						aria_labelledby => "$actionID-tab"

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1205,18 +1205,27 @@ sub view_form {
 	unless ($file_type eq 'course_info' || $file_type eq 'options_info') {
 		return CGI::div(
 			CGI::div(
-				{ class => 'row align-items-center mb-2' },
+				{ class => 'row align-items-center' },
 				CGI::label(
-					{ for => 'action_view_seed_id', class => 'col-form-label col-auto' },
+					{ for => 'action_view_seed_id', class => 'col-form-label col-auto mb-2' },
 					$r->maketext('Using what seed?')
 				),
 				CGI::div(
-					{ class => 'col-auto' },
+					{ class => 'col-auto mb-2' },
 					CGI::textfield({
 						id    => 'action_view_seed_id',
 						name  => 'action.view.seed',
 						value => $self->{problemSeed},
 						class => 'form-control form-control-sm'
+					})
+				),
+				CGI::div(
+					{ class => 'col-auto mb-2' },
+					CGI::button({
+						id    => 'randomize_view_seed_id',
+						name  => 'action.randomize.view.seed',
+						value => $r->maketext('Randomize Seed'),
+						class => 'btn btn-info btn-sm'
 					})
 				)
 			),


### PR DESCRIPTION
Adds a button to randomize the view seed for the PG Problem Editor. Although one can manually change the seed, this allows for a quicker way to randomize the seed to test out different random versions. This is a minor feature I find useful and seeing if others may find it useful as well.

Also removes two occurrences of an old `pg_editor_action_div` CSS class which is no longer being used.