### PR TITLE
Delete extra tables and fields when a course database is upgraded.

### DIFF
--- a/htdocs/js/apps/SelectAll/selectall.js
+++ b/htdocs/js/apps/SelectAll/selectall.js
@@ -6,9 +6,19 @@
 		const checks = document.querySelectorAll(`input[name$=${selectAll.dataset.selectGroup}]`);
 
 		if (selectAll.type.toLowerCase() === 'checkbox') {
-			selectAll.addEventListener('click', () => checks.forEach(check => check.checked = selectAll.checked));
+			// Find additional select alls in the same group if any.
+			const pairedSelectAlls =
+				document.querySelectorAll(`.select-all[data-select-group="${selectAll.dataset.selectGroup}"]`);
+
+			selectAll.addEventListener('click', () => {
+				checks.forEach(check => check.checked = selectAll.checked);
+
+				// Also check/uncheck any select alls in the same group.
+				pairedSelectAlls.forEach((check) => check.checked = selectAll.checked);
+			});
+
 			checks.forEach(check => check.addEventListener('click',
-				() => { if (!check.checked) selectAll.checked = false }));
+				() => { if (!check.checked) selectAll.checked = false; }));
 
 			// If all checks in the group are checked when the page loads, then also check the select all check.
 			// This can happen in AchievementList.pm.

--- a/htdocs/js/apps/SelectAll/selectall.js
+++ b/htdocs/js/apps/SelectAll/selectall.js
@@ -1,12 +1,27 @@
 // Select all checkbox handling
-// Used in UserList.pm, AchievementList.pm, and ProblemSetList.pm.
+// Used in UserList.pm, AchievementList.pm, ProblemSetList.pm, and CourseAdmin.pm.
 
 (() => {
-	const selectAll = document.getElementById('select-all');
-	if (selectAll) {
-		const checks = document.querySelectorAll(`input[name=${selectAll.dataset.selectGroup}]`);
-		selectAll.addEventListener('click', () => checks.forEach(check => check.checked = selectAll.checked));
-		checks.forEach(check => check.addEventListener('click',
-			() => { if (!check.checked) selectAll.checked = false }));
+	for (const selectAll of document.querySelectorAll('.select-all')) {
+		const checks = document.querySelectorAll(`input[name$=${selectAll.dataset.selectGroup}]`);
+
+		if (selectAll.type.toLowerCase() === 'checkbox') {
+			selectAll.addEventListener('click', () => checks.forEach(check => check.checked = selectAll.checked));
+			checks.forEach(check => check.addEventListener('click',
+				() => { if (!check.checked) selectAll.checked = false }));
+
+			// If all checks in the group are checked when the page loads, then also check the select all check.
+			// This can happen in AchievementList.pm.
+			selectAll.checked = checks.length && Array.from(checks).every((check) => check.checked);
+		}
+
+		if (selectAll.type.toLowerCase() === 'button') {
+			selectAll.addEventListener('click', () => checks.forEach(check => check.checked = true));
+		}
+	}
+
+	for (const selectNone of document.querySelectorAll('.select-none')) {
+		const checks = document.querySelectorAll(`input[name$=${selectNone.dataset.selectGroup}]`);
+		selectNone.addEventListener('click', () => checks.forEach(check => check.checked = false));
 	}
 })();

--- a/htdocs/themes/math4/achievements.scss
+++ b/htdocs/themes/math4/achievements.scss
@@ -12,15 +12,6 @@
  * Artistic License for more details.
  */
 
-.facebookbox {
-	margin-top: 7px;
-	text-align: center;
-
-	form {
-		margin-bottom: 0px;
-	}
-}
-
 .levelouterbar {
 	height: 20px;
 	border-style: solid;

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -292,28 +292,6 @@ sub checkForAchievements {
 			}
 			$cheevoMessage .= CGI::end_div();
 
-			# This feature doesn't really work anymore because of a change in facebook's api.
-			# If facebook integration is enabled, then create a facebook popup.
-			if ($ce->{allowFacebooking} && $globalUserAchievement->facebooker) {
-				$cheevoMessage .= CGI::div({ id => 'fb-root' }, '');
-				$cheevoMessage .= CGI::script({ src => 'http://connect.facebook.net/en_US/all.js' }, '');
-				$cheevoMessage .= CGI::start_script();
-
-				$cheevoMessage .=
-					"FB.init({appId:'" . $ce->{facebookAppId} . "', cookie:true,status:true, xfbml:true });\n";
-
-				my $facebookmessage;
-				if ($achievement->category eq 'level') {
-					$facebookmessage = sprintf("I leveled up and am now a %s", $achievement->{name});
-				} else {
-					$facebookmessage = sprintf("%s: %s", $achievement->{name}, $achievement->{description});
-				}
-
-				$cheevoMessage .=
-					"FB.ui({ method: 'feed', display: 'popup', picture: '$imgSrc', description: '$facebookmessage'});\n";
-				$cheevoMessage .= CGI::end_script();
-			}
-
 			$cheevoMessage .= q{<button type="button" class="btn-close me-2 m-auto"
 								data-bs-dismiss="toast" aria-label="Close"></button>};
 			$cheevoMessage .= CGI::end_div() . CGI::end_div();

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -2949,10 +2949,10 @@ sub do_upgrade_course {
 		my @tables_to_alter =
 			grep { $dbStatus->{$_}[0] == WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B } @schema_table_names;
 		$update_error_msg{$upgrade_courseID} = $CIchecker->updateCourseTables($upgrade_courseID, [@tables_to_create],
-			[ $r->param("$upgrade_courseID.delete_tableIDs") // () ]);
+			[ ($r->param("$upgrade_courseID.delete_tableIDs")) ]);
 		for my $table_name (@tables_to_alter) {
 			$update_error_msg{$upgrade_courseID} .= $CIchecker->updateTableFields($upgrade_courseID, $table_name,
-				[ $r->param("$upgrade_courseID.$table_name.delete_fieldIDs") // () ]);
+				[ ($r->param("$upgrade_courseID.$table_name.delete_fieldIDs")) ]);
 		}
 
 		# Add missing directories when it can be done safely

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2021 The WeBWorK Project, https://github.com/openwebwork
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -1145,7 +1145,7 @@ sub rename_course_confirm {
 			foreach my $table_name (@tables_to_alter) {
 				$msg .= $CIchecker->updateTableFields($rename_oldCourseID, $table_name);
 			}
-			print CGI::p({-style=>'color:green; font-weight:bold'}, $msg);
+			print CGI::p({ class => 'text-success fw-bold' }, $msg);
 
 		}
  		($tables_ok,$dbStatus) = $CIchecker->checkCourseTables($rename_oldCourseID);
@@ -1153,15 +1153,29 @@ sub rename_course_confirm {
 
 		# print db status
 
-		my %msg =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A         => CGI::span({style=>"color:red"},$r->maketext("Table defined in schema but missing in database")),
-		              WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"},$r->maketext("Table defined in database but missing in schema")),
-		              WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"},$r->maketext("Table is ok")),
-		              WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"},$r->maketext("Schema and database table definitions do not agree")),
+		my %msg = (
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Table defined in schema but missing in database")),
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Table defined in database but missing in schema")),
+			WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+				CGI::span({ class => 'text-success' }, $r->maketext("Table is ok")),
+			WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span(
+				{ class => 'text-danger' },
+				$r->maketext("Schema and database table definitions do not agree")
+			),
 		);
-		my %msg2 =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A        => CGI::span({style=>"color:red"},$r->maketext("Field missing in database")),
-		              WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"},$r->maketext("Field missing in schema")),
-		              WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"},$r->maketext("Field is ok")),
-		              WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"},$r->maketext("Schema and database field definitions do not agree")),
+		my %msg2 = (
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Field missing in database")),
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Field missing in schema")),
+			WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+				CGI::span({ class => 'text-success' }, $r->maketext("Field is ok")),
+			WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span(
+				{ class => 'text-danger' },
+				$r->maketext("Schema and database field definitions do not agree")
+			),
 		);
 		my $all_tables_ok=1;
 		my $extra_database_tables=0;
@@ -1211,27 +1225,47 @@ sub rename_course_confirm {
 
 		print CGI::p($str);
 		if ($extra_database_tables) {
-				print CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database tables which are not defined in the schema.  They can only be removed manually from the database. They will not be renamed."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database tables which are not defined in the schema.  '
+						. 'These can be deleted when upgrading the course.'
+				)
+			);
 		}
 		if ($extra_database_fields) {
-				print CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database fields  which are not defined in the schema for at least one table.  They can only be removed manually from the database."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database fields which are not defined in the schema for at least one table.  '
+						. 'They can only be removed when upgrading the course.'
+				)
+			);
 		}
 		if ($all_tables_ok) {
-			print CGI::p({-style=>'color:green; font-weight:bold'},$r->maketext("Course [_1] database is in order",$rename_oldCourseID));
+			print CGI::p({ class => 'text-success fw-bold' },
+				$r->maketext("Course [_1] database is in order", $rename_oldCourseID));
 		} else {
-			print CGI::p({-style=>'color:red; font-weight:bold'}, $r->maketext("Course [_1] databases must be updated before renaming this course.",$rename_oldCourseID));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					"Course [_1] databases must be updated before renaming this course.",
+					$rename_oldCourseID
+				)
+			);
 		}
 
 #############################################################################
 # Check directories
 #############################################################################
 
-
-      my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories($ce2);
-      my $style = ($directories_ok)?"color:green" : "color:red";
-      print CGI::h2("Directory structure"), CGI::p($str2),
-      ($directories_ok)? CGI::p({style=>$style},$r->maketext("Directory structure is ok")) :
-              CGI::p({style=>$style},$r->maketext("Directory structure is missing directories or the webserver lacks sufficient privileges."));
+		my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories($ce2);
+		print CGI::h2('Directory structure'), CGI::p($str2),
+			$directories_ok ? CGI::p({ class => 'text-success' }, $r->maketext('Directory structure is ok')) : CGI::p(
+				{ class => 'text-danger' },
+				$r->maketext(
+					'Directory structure is missing directories or the webserver lacks sufficient privileges.')
+			);
 
 #############################################################################
 # Print form for choosing next action.
@@ -2044,7 +2078,7 @@ sub archive_course_confirm {
 			foreach my $table_name (@tables_to_alter) {
 				$msg .= $CIchecker->updateTableFields($archive_courseID, $table_name);
 			}
-			print CGI::p({-style=>'color:green; font-weight:bold'}, $msg);
+			print CGI::p({ class => 'text-success fw-bold' }, $msg);
 		}
 		if ($r->param("upgrade_course_tables") ) {
 
@@ -2055,15 +2089,29 @@ sub archive_course_confirm {
 
 		# print db status
 
-		my %msg =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A         => CGI::span({style=>"color:red"}, $r->maketext("Table defined in schema but missing in database")),
-		              WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"}, $r->maketext("Table defined in database but missing in schema")),
-		              WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"}, $r->maketext("Table is ok")),
-		              WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"}, $r->maketext("Schema and database table definitions do not agree")),
+		my %msg = (
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Table defined in schema but missing in database")),
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Table defined in database but missing in schema")),
+			WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+				CGI::span({ class => 'text-success' }, $r->maketext("Table is ok")),
+			WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span(
+				{ class => 'text-danger' },
+				$r->maketext("Schema and database table definitions do not agree")
+			),
 		);
-		my %msg2 =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A        => CGI::span({style=>"color:red"}, $r->maketext("Field missing in database")),
-		              WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"}, $r->maketext("Field missing in schema")),
-		              WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"}, $r->maketext("Field is ok")),
-		              WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"}, $r->maketext("Schema and database field definitions do not agree")),
+		my %msg2 = (
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Field missing in database")),
+			WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+				CGI::span({ class => 'text-danger' }, $r->maketext("Field missing in schema")),
+			WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+				CGI::span({ class => 'text-success' }, $r->maketext("Field is ok")),
+			WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span(
+				{ class => 'text-danger' },
+				$r->maketext("Schema and database field definitions do not agree")
+			),
 		);
 		my $all_tables_ok=1;
 		my $extra_database_tables=0;
@@ -2113,31 +2161,54 @@ sub archive_course_confirm {
 
 		print CGI::p($str);
 		if ($extra_database_tables) {
-				print CGI::p({-style=>'color:red; font-weight:bold'}, $r->maketext("There are extra database tables which are not defined in the schema.  They can only be removed manually from the database."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database tables which are not defined in the schema.  '
+						. 'These can be deleted when upgrading the course.'
+				)
+			);
 		}
 		if ($extra_database_fields) {
-				print CGI::p({-style=>'color:red; font-weight:bold'}, $r->maketext("There are extra database fields  which are not defined in the schema for at least one table.  They can only be removed manually from the database."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database fields which are not defined in the schema for at least one table.  '
+						. 'They can only be removed when upgrading the course.'
+				)
+			);
 		}
 		if ($all_tables_ok) {
-			print CGI::p({-style=>'color:green; font-weight:bold'}, $r->maketext("Course [_1] database is in order", $archive_courseID));
-			print(CGI::p({-style=>'color:red; font-weight:bold'},  $r->maketext("Are you sure that you want to delete the course [_1] after archiving? This cannot be undone!", CGI::b($archive_courseID)))) if $delete_course_flag;
+			print CGI::p({ class => 'text-success fw-bold' },
+				$r->maketext("Course [_1] database is in order", $archive_courseID));
+			print(CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					"Are you sure that you want to delete the course [_1] after archiving? This cannot be undone!",
+					CGI::b($archive_courseID)
+				)
+			))
+				if $delete_course_flag;
 		} else {
-			print CGI::p({-style=>'color:red; font-weight:bold'},  $r->maketext("There are tables or fields missing from the database.  The database must be upgraded before archiving this course.")
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are tables or fields missing from the database.  '
+						. 'The database must be upgraded before archiving this course.'
+				)
 			);
 		}
 #############################################################################
 # Check directories and report
 #############################################################################
 
-
-      my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories();
-      my $style = ($directories_ok)?"color:green" : "color:red";
-      print CGI::h2( $r->maketext("Directory structure")), CGI::p($str2),
-      ($directories_ok)? CGI::p({style=>$style}, $r->maketext("Directory structure is ok")) :
-              CGI::p({style=>$style}, $r->maketext("Directory structure is missing directories or the webserver lacks sufficient privileges."));
-
-
-
+		my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories($ce2);
+		print CGI::h2('Directory structure'), CGI::p($str2),
+			$directories_ok ? CGI::p({ class => 'text-success' }, $r->maketext('Directory structure is ok')) : CGI::p(
+				{ class => 'text-danger' },
+				$r->maketext(
+					'Directory structure is missing directories or the webserver lacks sufficient privileges.')
+			);
 
 #############################################################################
 # Print form for choosing next action.
@@ -2160,10 +2231,15 @@ sub archive_course_confirm {
 		if ($all_tables_ok && $directories_ok ) { # no missing fields
 			# Warn about overwriting an existing archive
 			if (-e $archive_path and -w $archive_path) {
-				print CGI::p({ -style => 'color:red; font-weight:bold'},
-					$r->maketext("The course '[_1]' has already been archived at '[_2]'. " .
-						"This earlier archive will be erased.  This cannot be undone.",
-					   	$archive_courseID, $archive_path));
+				print CGI::p(
+					{ class => 'text-danger fw-bold' },
+					$r->maketext(
+						"The course '[_1]' has already been archived at '[_2]'. "
+							. "This earlier archive will be erased.  This cannot be undone.",
+						$archive_courseID,
+						$archive_path
+					)
+				);
 			}
 			# archive execute button
 			print CGI::p({ style => "text-align: center" },
@@ -2219,7 +2295,7 @@ sub archive_course_confirm {
 		}
 		print CGI::end_form();
 	} else {
-		print CGI::p({-style=>'color:red; font-weight:bold'},"Unable to find database layout for $archive_courseID");
+		print CGI::p({ class => 'text-danger fw-bold' }, "Unable to find database layout for $archive_courseID");
 	}
 }
 
@@ -2600,6 +2676,7 @@ sub do_unarchive_course {
 }
 
 ##########################################################################
+# Course upgrade methods
 
 sub upgrade_course_form {
 	my ($self) = @_;
@@ -2607,7 +2684,7 @@ sub upgrade_course_form {
 	my $ce     = $r->ce;
 
 	my @courseIDs = listCourses($ce);
-	@courseIDs = sort { lc($a) cmp lc($b) } @courseIDs;    #make sort case insensitive
+	@courseIDs = sort { lc($a) cmp lc($b) } @courseIDs;    # make sort case insensitive
 
 	print CGI::h2($r->maketext('Upgrade Courses'));
 
@@ -2623,7 +2700,7 @@ sub upgrade_course_form {
 			value   => $r->maketext('Select all eligible courses'),
 			class   => 'btn btn-sm btn-secondary',
 			onclick => 'for (i in document.courselist.elements)  {
-							if (document.courselist.elements[i].name =="upgrade_courseIDs") {
+							if (document.courselist.elements[i].name == "upgrade_courseIDs") {
 								document.courselist.elements[i].checked = true
 							}
 						}'
@@ -2634,7 +2711,7 @@ sub upgrade_course_form {
 			value   => $r->maketext('Unselect all courses'),
 			class   => 'btn btn-sm btn-secondary',
 			onclick => 'for (i in document.courselist.elements)  {
-							if (document.courselist.elements[i].name =="upgrade_courseIDs") {
+							if (document.courselist.elements[i].name == "upgrade_courseIDs") {
 								document.courselist.elements[i].checked = false
 							}
 						}'
@@ -2695,245 +2772,223 @@ sub upgrade_course_form {
 }
 
 sub upgrade_course_validate {
-	my ($self) = @_;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	#my $db = $r->db;
-	#my $authz = $r->authz;
-	my $urlpath = $r->urlpath;
+	my $self = shift;
+	my $r    = $self->r;
 
-	my @upgrade_courseIDs     = $r->param("upgrade_courseIDs") ;
-	@upgrade_courseIDs        = () unless  @upgrade_courseIDs;
-	#warn "validate: upgrade ids ", join("|",@upgrade_courseIDs);
+	my @upgrade_courseIDs = ($r->param("upgrade_courseIDs"));
+
 	my @errors;
-	foreach my $upgrade_courseID (@upgrade_courseIDs) {
-		if ($upgrade_courseID eq "") {
-			push @errors, $r->maketext("You must specify a course name.");
+	for my $upgrade_courseID (@upgrade_courseIDs) {
+		if ($upgrade_courseID eq '') {
+			push @errors, $r->maketext('You must specify a course name.');
 		}
 	}
-
 
 	return @errors;
 }
 
 sub upgrade_course_confirm {
 	my ($self) = @_;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $db = $r->db;
+	my $r      = $self->r;
+	my $ce     = $r->ce;
+	my $db     = $r->db;
 
+	my @upgrade_courseIDs = ($r->param("upgrade_courseIDs"));
 
-	my @upgrade_courseIDs     = $r->param("upgrade_courseIDs");
-	@upgrade_courseIDs        = () unless @upgrade_courseIDs;
-    #my $upgrade_courseID      = $upgrade_courseIDs[0];
-    my %update_error_msg 	  = ();
-    print CGI::start_form(-method=>"POST", -action=>$r->uri);
-    foreach my $upgrade_courseID (@upgrade_courseIDs) {
-        next unless $upgrade_courseID =~/\S/;   # skip empty values
-    	##########################
-		# analyze one course
-		##########################
-		my $ce2 = new WeBWorK::CourseEnvironment({
-			%WeBWorK::SeedCE,
-			courseName => $upgrade_courseID,
-		});
-		#warn "upgrade_course_confirm: updating |$upgrade_courseID| from course list: " , join("|",@upgrade_courseIDs);
+	my %update_error_msg;
 
-		#############################################################################
+	print CGI::start_form({ method => 'POST', action => $r->uri });
+	for my $upgrade_courseID (@upgrade_courseIDs) {
+		next unless $upgrade_courseID =~ /\S/;    # skip empty values
+
+		# Analyze one course
+		my $ce2 = new WeBWorK::CourseEnvironment({ %WeBWorK::SeedCE, courseName => $upgrade_courseID });
+
 		# Create integrity checker
-		#############################################################################
+		my $CIchecker = new WeBWorK::Utils::CourseIntegrityCheck(ce => $ce2);
 
-		my $CIchecker = new WeBWorK::Utils::CourseIntegrityCheck(ce=>$ce2);
-
-		#############################################################################
 		# Report on database status
-		#############################################################################
+		my ($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
+		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str) =
+			$self->formatReportOnDatabaseTables($tables_ok, $dbStatus, $upgrade_courseID);
 
-		my ($tables_ok,$dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
- 		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str) = $self->formatReportOnDatabaseTables($tables_ok, $dbStatus);
- 		# prepend course name
+		# Prepend course name
 		$str = CGI::div(
 			CGI::div(
 				{ class => 'form-check mb-2' },
 				CGI::checkbox({
 					name            => 'upgrade_courseIDs',
-					label           => $r->maketext('Upgrade'),
+					label           => $r->maketext('Upgrade [_1]', $upgrade_courseID),
 					selected        => 1,
 					value           => $upgrade_courseID,
 					class           => 'form-check-input',
 					labelattributes => { class => 'form-check-label' }
 				})
 			),
-			CGI::div({ class => 'mb-3' }, $r->maketext('Report for course [_1]:', $upgrade_courseID)),
-			CGI::div({ class => 'mb-2' }, $r->maketext('Report for course [_1]:', $r->maketext('Database:'))),
+			CGI::h2($r->maketext('Report for course [_1]:', $upgrade_courseID)),
+			CGI::div({ class => 'mb-2' }, $r->maketext('Database:')),
 			$str
 		);
 
-		#############################################################################
 		# Report on databases
-		#############################################################################
-
 		print CGI::p($str);
+
 		if ($extra_database_tables) {
-				print CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database tables which are not defined in the schema.  They can only be removed manually from the database."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext('There are extra database tables which are not defined in the schema. ')
+					. 'Check the checkbox below the table to delete it when upgrading the course. '
+					. 'Warning: Deletion destroys all data contained in the table and is not undoable!'
+			);
 		}
+
 		if ($extra_database_fields) {
-				print CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database fields  which are not defined in the schema for at least one table.  They can only be removed manually from the database."));
+			print CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database fields which are not defined in the schema for at least one table. '
+						. 'Check the checkbox below the field to delete it when upgrading the course. '
+						. 'Warning: Deletion destroys all data contained in the field and is not undoable!'
+				)
+			);
 		}
 
-
-		#############################################################################
 		# Report on directory status
-		#############################################################################
 		my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories();
-		my $style = ($directories_ok)?"color:green" : "color:red";
-		print $r->maketext("Directory structure").CGI::br(), CGI::p($str2),
-		($directories_ok)? CGI::p({style=>$style},$r->maketext("Directory structure is ok")) :
-			  CGI::p({style=>$style},$r->maketext("Directory structure is missing directories or the webserver lacks sufficient privileges."));
+		print $r->maketext('Directory structure'), CGI::br(), CGI::p($str2),
+			$directories_ok ? CGI::p({ class => 'text-success' }, $r->maketext('Directory structure is ok')) : CGI::p(
+				{ class => 'text-danger' },
+				$r->maketext(
+					'Directory structure is missing directories or the webserver lacks sufficient privileges.')
+			);
 	}
-	#warn "upgrade_course_confirm:  now print form";
-	#############################################################################
-	# Print form for choosing next action.
-	#############################################################################
-    print CGI::h3($r->maketext("No course id defined")) unless @upgrade_courseIDs;
 
+	# Print form for choosing next action.
+	print CGI::h3($r->maketext('No course id defined')) unless @upgrade_courseIDs;
 
 	print $self->hidden_authen_fields;
-	print $self->hidden_fields("subDisplay");
-	#print CGI::hidden('upgrade_courseIDs',@upgrade_courseIDs);
+	print $self->hidden_fields('subDisplay');
 
-	####################################################################
 	# Submit buttons
-	# After presenting a detailed summary of status of selected courses the choice is made to
-	# upgrade the selected courses (confirm_upgrade_course is set
-	# or return to the beginning (decline_upgrade_course   is set
-
-	####################################################################
-	print CGI::p({style=>"text-align: center"},
-	    CGI::submit({
-				name => "decline_upgrade_course",
-			   	value => $r->maketext("Don't Upgrade"),
-				class => 'btn btn-primary'
-			}),
+	# After presenting a detailed summary of status of selected courses the choice is made to upgrade the selected
+	# courses (confirm_upgrade_course is set or return to the beginning (decline_upgrade_course is set)
+	print CGI::p(
+		{ class => 'text-center' },
 		CGI::submit({
-				name => "confirm_upgrade_course",
-			   	value => $r->maketext("Upgrade"),
-				class => 'btn btn-primary'
-			}));
+			name  => 'decline_upgrade_course',
+			value => $r->maketext("Don't Upgrade"),
+			class => 'btn btn-primary'
+		}),
+		CGI::submit({
+			name  => 'confirm_upgrade_course',
+			value => $r->maketext('Upgrade'),
+			class => 'btn btn-primary'
+		})
+	);
 
 	print CGI::end_form();
-
 }
 
 sub do_upgrade_course {
-	my ($self) = @_;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $db = $r->db;
+	my $self = shift;
+	my $r    = $self->r;
+	my $ce   = $r->ce;
+	my $db   = $r->db;
 
+	my @upgrade_courseIDs = ($r->param("upgrade_courseIDs"));
 
-	my @upgrade_courseIDs     = $r->param("upgrade_courseIDs");
-	@upgrade_courseIDs        = () unless @upgrade_courseIDs;
-    my %update_error_msg 				  = ();
-    #warn "do_upgrade_course:  upgrade_courseIDs = ", join(" ", @upgrade_courseIDs);
-    foreach my $upgrade_courseID (@upgrade_courseIDs) {
-    	next unless $upgrade_courseID =~ /\S/; # omit blank course IDs
+	my %update_error_msg;
 
-		##########################
-		# update one course
-		##########################
-		my $ce2 = new WeBWorK::CourseEnvironment({
-			%WeBWorK::SeedCE,
-			courseName => $upgrade_courseID,
-		});
-		#warn "do_upgrade_course: updating |$upgrade_courseID| from" , join("|",@upgrade_courseIDs);
-		#############################################################################
+	for my $upgrade_courseID (@upgrade_courseIDs) {
+		next unless $upgrade_courseID =~ /\S/;    # Omit blank course IDs
+
+		# Update one course
+		my $ce2 = new WeBWorK::CourseEnvironment({ %WeBWorK::SeedCE, courseName => $upgrade_courseID });
+
 		# Create integrity checker
-		#############################################################################
+		my $CIchecker = new WeBWorK::Utils::CourseIntegrityCheck(ce => $ce2);
 
-		my $CIchecker = new WeBWorK::Utils::CourseIntegrityCheck(ce=>$ce2);
-
-		#############################################################################
 		# Add missing tables and missing fields to existing tables
-		#############################################################################
-
-		my ($tables_ok,$dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
-		my @schema_table_names = keys %$dbStatus;  # update tables missing from database;
-		my @tables_to_create = grep {$dbStatus->{$_}->[0] == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A} @schema_table_names;
-		my @tables_to_alter  = grep {$dbStatus->{$_}->[0] == WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B} @schema_table_names;
-		$update_error_msg{$upgrade_courseID} = $CIchecker->updateCourseTables($upgrade_courseID, [@tables_to_create]);
-		foreach my $table_name (@tables_to_alter) {	#warn "do_upgrade_course: adding new fields to table $table_name in course $upgrade_courseID";
-			$update_error_msg{$upgrade_courseID} .= $CIchecker->updateTableFields($upgrade_courseID, $table_name);
+		my ($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
+		my @schema_table_names = keys %$dbStatus;
+		my @tables_to_create =
+			grep { $dbStatus->{$_}[0] == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A } @schema_table_names;
+		my @tables_to_alter =
+			grep { $dbStatus->{$_}[0] == WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B } @schema_table_names;
+		$update_error_msg{$upgrade_courseID} = $CIchecker->updateCourseTables($upgrade_courseID, [@tables_to_create],
+			[ $r->param("$upgrade_courseID.delete_tableIDs") // () ]);
+		for my $table_name (@tables_to_alter) {
+			$update_error_msg{$upgrade_courseID} .= $CIchecker->updateTableFields($upgrade_courseID, $table_name,
+				[ $r->param("$upgrade_courseID.$table_name.delete_fieldIDs") // () ]);
 		}
-		### $update_error_msg{$upgrade_courseID} is printed below
-		#############################################################################
+
 		# Add missing directories when it can be done safely
-		#############################################################################	#warn "do_upgrade_course: updating course directories for $upgrade_courseID";
-		$CIchecker -> updateCourseDirectories();   # needs more error messages
+		$CIchecker->updateCourseDirectories();       # Needs more error messages
 
-
-		#############################################################################
 		# Analyze database status and prepare status report
-		#############################################################################
+		($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
 
-		($tables_ok,$dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
+		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str) =
+			$self->formatReportOnDatabaseTables($tables_ok, $dbStatus);
 
-		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str)
-		      = $self->formatReportOnDatabaseTables($tables_ok, $dbStatus);
- 		# prepend course name
-		$str = CGI::br().$r->maketext("Database:").CGI::br(). $str;
+		# Prepend course name
+		$str = CGI::p($r->maketext('Database:')) . $str;
 
-		#############################################################################
 		# Report on databases and report summary
-		#############################################################################
+		if ($extra_database_tables) {
+			$str .= CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext('There are extra database tables which are not defined in the schema.')
+			);
+		}
+		if ($extra_database_fields) {
+			$str .= CGI::p(
+				{ class => 'text-danger fw-bold' },
+				$r->maketext(
+					'There are extra database fields which are not defined in the schema for at least one table.')
+			);
+		}
 
-
-			if ($extra_database_tables) {
-					$str .= CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database tables which are not defined in the schema.  They can only be removed manually from the database."));
-			}
-			if ($extra_database_fields) {
-					$str .= CGI::p({-style=>'color:red; font-weight:bold'},$r->maketext("There are extra database fields  which are not defined in the schema for at least one table.  They can only be removed manually from the database."));
-			}
-
-		#############################################################################
 		# Prepare report on directory status
-		#############################################################################
-		  my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories();
-		  my $style = ($directories_ok)?"color:green" : "color:red";
-		  my $dir_msg  = join ('',
-		  	$r->maketext("Directory structure"),CGI::br(),
-		  	CGI::p($str2),
-		  	($directories_ok)? CGI::p({style=>$style},$r->maketext("Directory structure is ok")) :
-				  CGI::p({style=>$style},$r->maketext("Directory structure is missing directories or the webserver lacks sufficient privileges."))
-		  );
+		my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories();
+		my $dir_msg = join(
+			'',
+			$r->maketext('Directory structure'),
+			CGI::br(),
+			CGI::p($str2),
+			$directories_ok
+			? CGI::p({ class => 'text-success' }, $r->maketext('Directory structure is ok'))
+			: CGI::p(
+				{ class => 'text-danger' },
+				$r->maketext(
+					'Directory structure is missing directories or the webserver lacks sufficient privileges.')
+			)
+		);
 
-		#############################################################################
 		# Print status
-		#############################################################################
-		print $r->maketext("Report for course [_1]:", $upgrade_courseID).CGI::br();
-		print CGI::p({-style=>'color:green; font-weight:bold'}, $update_error_msg{$upgrade_courseID});
+		print CGI::h2($r->maketext('Report for course [_1]:', $upgrade_courseID));
+		print CGI::p({ class => 'text-success fw-bold' }, $update_error_msg{$upgrade_courseID})
+			if $update_error_msg{$upgrade_courseID};
 
-		print CGI::p($str);     # print message about tables
-		print CGI::p($dir_msg); # message about directories
-
+		print $str;                # Print message about tables
+		print CGI::p($dir_msg);    # Print message about directories
 	}
-	#############################################################################
+
 	# Submit buttons -- return to beginning
-	#############################################################################
-	print CGI::h3($r->maketext("Upgrade process completed"));
-	print CGI::start_form(-method=>"POST", -action=>$r->uri);  #send back to this script
+	print CGI::h2($r->maketext('Upgrade process completed'));
+	print CGI::start_form({ method => 'POST', action => $r->uri });    # send back to this script
 	print $self->hidden_authen_fields;
-	print $self->hidden_fields("subDisplay");
-	print CGI::p({ style => "text-align: center" },
+	print $self->hidden_fields('subDisplay');
+	print CGI::p(
+		{ class => 'text-center' },
 		CGI::submit({
-				name => "decline_upgrade_course",
-				value => $r->maketext("Done"),
-				class => 'btn btn-primary'
-			}));
+			name  => 'decline_upgrade_course',
+			value => $r->maketext('Done'),
+			class => 'btn btn-primary'
+		})
+	);
 	print CGI::end_form();
 }
-
-
 
 ################################################################################
 ## location management routines; added by DG [Danny Ginn] 20070215
@@ -4130,72 +4185,91 @@ sub do_registration {
 	print "</center>";
 
 }
-################################################################################
-# Utilities
-################################################################################
+
+# Format a list of tables and fields in the database, and the status of each.
 sub formatReportOnDatabaseTables {
-	my ($self, $tables_ok,$dbStatus) =  @_;
+	my ($self, $tables_ok, $dbStatus, $courseID) = @_;
 	my $r = $self->r;
 
-	# print db status
+	my %msg = (
+		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Table defined in schema but missing in database')),
+		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Table defined in database but missing in schema')),
+		WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+			CGI::span({ class => 'text-success' }, $r->maketext('Table is ok')),
+		WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Schema and database table definitions do not agree')),
+	);
+	my %msg2 = (
+		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Field missing in database')),
+		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Field missing in schema')),
+		WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
+			CGI::span({ class => 'text-success' }, $r->maketext('Field is ok')),
+		WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B =>
+			CGI::span({ class => 'text-danger' }, $r->maketext('Schema and database field definitions do not agree')),
+	);
+	my $all_tables_ok         = 1;
+	my $extra_database_tables = 0;
+	my $extra_database_fields = 0;
 
-		my %msg =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A         => CGI::span({style=>"color:red"},$r->maketext("Table defined in schema but missing in database")),
-					  WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"},$r->maketext("Table defined in database but missing in schema")),
-					  WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"},$r->maketext("Table is ok")),
-					  WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"},$r->maketext("Schema and database table definitions do not agree")),
-		);
-		my %msg2 =(    WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A        => CGI::span({style=>"color:red"},$r->maketext("Field missing in database")),
-					  WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B         => CGI::span({style=>"color:red"},$r->maketext("Field missing in schema")),
-					  WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B   => CGI::span({style=>"color:green"},$r->maketext("Field is ok")),
-					  WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B => CGI::span({style=>"color:red"},$r->maketext("Schema and database field definitions do not agree")),
-		);
-		my $all_tables_ok=1;
-		my $extra_database_tables=0;
-		my $extra_database_fields=0;
-		my $str ='';
-		$str .= CGI::start_ul();
-		foreach my $table (sort keys %$dbStatus) {
-			my $table_status = $dbStatus->{$table}->[0];
-			$str .= CGI::li( CGI::b($table) . ': ' . $msg{ $table_status } );
+	my $str                   = CGI::start_ul();
+	for my $table (sort keys %$dbStatus) {
+		my $table_status = $dbStatus->{$table}[0];
+		$str .= CGI::start_li();
+		$str .= CGI::b($table) . ': ' . $msg{$table_status};
 
-			CASE: {
-				$table_status == WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B
-					&& do{ last CASE;
-					};
-				$table_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A
-					&& do{
-						   $all_tables_ok = 0; last CASE;
-					};
-				$table_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B
-					&& do{
-						   $extra_database_tables = 1; last CASE;
-					};
-				$table_status == WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B
-					&& do{
-						my %fieldInfo = %{ $dbStatus->{$table}->[1] };
-						$str .=CGI::start_ul();
-						foreach my $key (keys %fieldInfo) {
-							my $field_status = $fieldInfo{$key}->[0];
-							CASE2: {
-								$field_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B
-									&& do{
-									   $extra_database_fields = 1; last CASE2;
-									};
-								$field_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A
-									&& do{
-									   $all_tables_ok=0; last CASE2;
-									};
-							}
-							$str .= CGI::li("$key => ". $msg2{$field_status });
-						}
-						$str .= CGI::end_ul();
-					};
+		if ($table_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A) {
+			$all_tables_ok = 0;
+		} elsif ($table_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B) {
+			$extra_database_tables = 1;
+			$str .= CGI::span(
+				{ class => 'form-check' },
+				CGI::checkbox({
+					name            => "$courseID.delete_tableIDs",
+					value           => $table,
+					label           => $r->maketext('Delete table when upgrading'),
+					class           => 'form-check-input',
+					labelattributes => { class => 'form-check-label' }
+				})
+			) if defined $courseID;
+		} elsif ($table_status == WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B) {
+			my %fieldInfo = %{ $dbStatus->{$table}->[1] };
+			$str .= CGI::start_ul();
+
+			for my $key (keys %fieldInfo) {
+				my $field_status = $fieldInfo{$key}->[0];
+				$str .= CGI::start_li();
+				$str .= "$key => $msg2{$field_status}";
+
+				if ($field_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B) {
+					$extra_database_fields = 1;
+					$str .= CGI::span(
+						{ class => 'form-check' },
+						CGI::checkbox({
+							name            => "$courseID.$table.delete_fieldIDs",
+							value           => $key,
+							label           => $r->maketext('Delete field when upgrading'),
+							class           => 'form-check-input',
+							labelattributes => { class => 'form-check-label' }
+						})
+					) if defined $courseID;
+				} elsif ($field_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A) {
+					$all_tables_ok = 0;
+				}
+				$str .= CGI::end_li();
 			}
-
-
+			$str .= CGI::end_ul();
 		}
-		$str.=CGI::end_ul();
-		$str .= ($all_tables_ok)?CGI::p($r->maketext("Database tables are ok")) : "";
-		return ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str);
+		$str .= CGI::end_li();
+	}
+	$str .= CGI::end_ul();
+
+	$str .= $all_tables_ok ? CGI::p({ class => 'text-success' }, $r->maketext('Database tables are ok')) : '';
+
+	return ($all_tables_ok, $extra_database_tables, $extra_database_fields, $str);
 }
+
 1;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -2832,7 +2832,7 @@ sub upgrade_course_confirm {
 			print CGI::p(
 				{ class => 'text-danger fw-bold' },
 				$r->maketext('There are extra database tables which are not defined in the schema. ')
-					. 'Check the checkbox below the table to delete it when upgrading the course. '
+					. 'Check the checkbox by the table to delete it when upgrading the course. '
 					. 'Warning: Deletion destroys all data contained in the table and is not undoable!'
 			);
 		}
@@ -2843,7 +2843,7 @@ sub upgrade_course_confirm {
 				{ class => 'text-danger fw-bold' },
 				$r->maketext(
 					'There are extra database fields which are not defined in the schema for at least one table. '
-						. 'Check the checkbox below the field to delete it when upgrading the course. '
+						. 'Check the checkbox by the field to delete it when upgrading the course. '
 						. 'Warning: Deletion destroys all data contained in the field and is not undoable!'
 				)
 			);
@@ -4221,7 +4221,7 @@ sub formatReportOnDatabaseTables {
 		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
 			CGI::span({ class => 'text-danger' }, $r->maketext('Table defined in schema but missing in database')),
 		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
-			CGI::span({ class => 'text-danger' }, $r->maketext('Table defined in database but missing in schema')),
+			CGI::span({ class => 'text-danger me-2' }, $r->maketext('Table defined in database but missing in schema')),
 		WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
 			CGI::span({ class => 'text-success' }, $r->maketext('Table is ok')),
 		WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B =>
@@ -4231,7 +4231,7 @@ sub formatReportOnDatabaseTables {
 		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_A =>
 			CGI::span({ class => 'text-danger' }, $r->maketext('Field missing in database')),
 		WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B =>
-			CGI::span({ class => 'text-danger' }, $r->maketext('Field missing in schema')),
+			CGI::span({ class => 'text-danger me-2' }, $r->maketext('Field missing in schema')),
 		WeBWorK::Utils::CourseIntegrityCheck::SAME_IN_A_AND_B =>
 			CGI::span({ class => 'text-success' }, $r->maketext('Field is ok')),
 		WeBWorK::Utils::CourseIntegrityCheck::DIFFER_IN_A_AND_B =>
@@ -4252,7 +4252,7 @@ sub formatReportOnDatabaseTables {
 		} elsif ($table_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B) {
 			$extra_database_tables = 1;
 			$str .= CGI::span(
-				{ class => 'form-check' },
+				{ class => 'form-check d-inline-block' },
 				CGI::checkbox({
 					name            => "$courseID.delete_tableIDs",
 					value           => $table,
@@ -4273,7 +4273,7 @@ sub formatReportOnDatabaseTables {
 				if ($field_status == WeBWorK::Utils::CourseIntegrityCheck::ONLY_IN_B) {
 					$extra_database_fields = 1;
 					$str .= CGI::span(
-						{ class => 'form-check' },
+						{ class => 'form-check d-inline-block' },
 						CGI::checkbox({
 							name            => "$courseID.$table.delete_fieldIDs",
 							value           => $key,

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -2956,7 +2956,7 @@ sub do_upgrade_course {
 		}
 
 		# Add missing directories when it can be done safely
-		$CIchecker->updateCourseDirectories();       # Needs more error messages
+		$CIchecker->updateCourseDirectories();    # Needs more error messages
 
 		# Analyze database status and prepare status report
 		($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
@@ -2965,14 +2965,12 @@ sub do_upgrade_course {
 			$self->formatReportOnDatabaseTables($tables_ok, $dbStatus);
 
 		# Prepend course name
-		$str = CGI::p($r->maketext('Database:')) . $str;
+		$str = CGI::div({ class => 'mb-2' }, $r->maketext('Database:')) . $str;
 
 		# Report on databases and report summary
 		if ($extra_database_tables) {
-			$str .= CGI::p(
-				{ class => 'text-danger fw-bold' },
-				$r->maketext('There are extra database tables which are not defined in the schema.')
-			);
+			$str .= CGI::p({ class => 'text-danger fw-bold' },
+				$r->maketext('There are extra database tables which are not defined in the schema.'));
 		}
 		if ($extra_database_fields) {
 			$str .= CGI::p(
@@ -2986,25 +2984,26 @@ sub do_upgrade_course {
 		my ($directories_ok, $str2) = $CIchecker->checkCourseDirectories();
 		my $dir_msg = join(
 			'',
-			$r->maketext('Directory structure'),
-			CGI::br(),
-			CGI::p($str2),
+			CGI::div({ class => 'mb-2' }, $r->maketext('Directory structure:')),
+			$str2,
 			$directories_ok
-			? CGI::p({ class => 'text-success' }, $r->maketext('Directory structure is ok'))
+			? CGI::p({ class => 'text-success mb-0' }, $r->maketext('Directory structure is ok'))
 			: CGI::p(
-				{ class => 'text-danger' },
+				{ class => 'text-danger mb-0' },
 				$r->maketext(
 					'Directory structure is missing directories or the webserver lacks sufficient privileges.')
 			)
 		);
 
 		# Print status
+		print CGI::start_div({ class => 'border border-dark rounded p-2 mb-2' });
 		print CGI::h2($r->maketext('Report for course [_1]:', $upgrade_courseID));
 		print CGI::p({ class => 'text-success fw-bold' }, $update_error_msg{$upgrade_courseID})
 			if $update_error_msg{$upgrade_courseID};
 
-		print $str;                # Print message about tables
-		print CGI::p($dir_msg);    # Print message about directories
+		print $str;        # Print message about tables
+		print $dir_msg;    # Print message about directories
+		print CGI::end_div();
 	}
 
 	# Submit buttons -- return to beginning

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -981,16 +981,17 @@ sub rename_course_form {
 						checked         => $r->param('rename_newCourseID_checkbox') || '',
 						value           => 'on',
 						class           => 'form-check-input',
-						labelattributes => { class => 'form-check-label' }
+						labelattributes => { class => 'form-check-label', id => 'rename_newCourseID_label' }
 					})
 				)
 			),
 			CGI::div(
 				{ class => 'col-sm-6' },
 				CGI::textfield({
-					name  => 'rename_newCourseID',
-					value => $r->param('rename_newCourseID') || '',
-					class => 'form-control'
+					name            => 'rename_newCourseID',
+					value           => $r->param('rename_newCourseID') || '',
+					class           => 'form-control',
+					aria_labelledby => 'rename_newCourseID_label'
 				}),
 			)
 		),
@@ -1006,16 +1007,17 @@ sub rename_course_form {
 						selected        => $r->param('rename_newCourseTitle_checkbox') || '',
 						value           => 'on',
 						class           => 'form-check-input',
-						labelattributes => { class => 'form-check-label' }
+						labelattributes => { class => 'form-check-label', id => 'rename_newCourseTitle_label' }
 					})
 				)
 			),
 			CGI::div(
 				{ class => 'col-sm-6' },
 				CGI::textfield({
-					name  => 'rename_newCourseTitle',
-					value => $r->param('rename_newCourseTitle') || '',
-					class => 'form-control'
+					name            => 'rename_newCourseTitle',
+					value           => $r->param('rename_newCourseTitle') || '',
+					class           => 'form-control',
+					aria_labelledby => 'rename_newCourseTitle_label'
 				})
 			),
 		),
@@ -1031,16 +1033,17 @@ sub rename_course_form {
 						checked         => $r->param('rename_newCourseInstitution_checkbox') || '',
 						value           => 'on',
 						class           => 'form-check-input',
-						labelattributes => { class => 'form-check-label' }
+						labelattributes => { class => 'form-check-label', id => 'rename_newCourseInstitution_label' }
 					})
 				)
 			),
 			CGI::div(
 				{ class => 'col-sm-6' },
 				CGI::textfield({
-					name  => 'rename_newCourseInstitution',
-					value => $r->param('rename_newCourseInstitution') || '',
-					class => 'form-control'
+					name            => 'rename_newCourseInstitution',
+					value           => $r->param('rename_newCourseInstitution') || '',
+					class           => 'form-control',
+					aria_labelledby => 'rename_newCourseInstitution_label'
 				})
 			)
 		)
@@ -2504,18 +2507,19 @@ sub unarchive_course_form {
 						value           => 1,
 						label           => $r->maketext('New Name:'),
 						class           => 'form-check-input',
-						labelattributes => { class => 'form-check-label' }
+						labelattributes => { class => 'form-check-label', id => 'create_newCourseID_label' }
 					})
 				)
 			),
 			CGI::div(
 				{ class => 'col-sm-8' },
 				CGI::textfield({
-					name      => 'new_courseID',
-					value     => '',
-					size      => 25,
-					maxlength => $ce->{maxCourseIdLength},
-					class     => 'form-control'
+					name            => 'new_courseID',
+					value           => '',
+					size            => 25,
+					maxlength       => $ce->{maxCourseIdLength},
+					class           => 'form-control',
+					aria_labelledby => 'create_newCourseID_label'
 				})
 			)
 		)

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -1441,7 +1441,7 @@ sub printTableHTML {
 				id                => 'select-all',
 				aria_label        => $r->maketext('Select all achievements'),
 				data_select_group => 'selected_export',
-				class             => 'form-check-input'
+				class             => 'select-all form-check-input'
 			}),
 			CGI::label({ for => 'select-all' }, $r->maketext('Achievement ID')),
 			$r->maketext('Name')
@@ -1477,7 +1477,7 @@ sub printTableHTML {
 				id                => 'select-all',
 				aria_label        => $r->maketext('Select all achievements'),
 				data_select_group => 'selected_achievements',
-				class             => 'form-check-input'
+				class             => 'select-all form-check-input'
 			}),
 			CGI::label({ for => 'select-all' }, $r->maketext('Achievement ID')),
 			$r->maketext('Enabled'),

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -2721,7 +2721,7 @@ sub printTableHTML {
 				id                => 'select-all',
 				aria_label        => $r->maketext('Select all sets'),
 				data_select_group => 'selected_sets',
-				class             => 'form-check-input'
+				class             => 'select-all form-check-input'
 			}));
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -1965,7 +1965,7 @@ sub printTableHTML {
 				id                => 'select-all',
 				aria_label        => $r->maketext('Select all users'),
 				data_select_group => 'selected_users',
-				class             => 'form-check-input',
+				class             => 'select-all form-check-input',
 			})),
 			CGI::th(CGI::label(
 				{ for => 'select-all' },

--- a/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
+++ b/lib/WeBWorK/DB/Record/GlobalUserAchievement.pm
@@ -35,7 +35,6 @@ BEGIN {
 		# later, but it makes freezing and thawing safer to have
 		# more available characters
 		frozen_hash => { type => "VARCHAR(1024)" },
-		facebooker  => { type => "INT" },
 	);
 }
 


### PR DESCRIPTION
If a course has tables or fields that are not present in the database schema, then a checkbox will be displayed below the table or field asking to delete the table or field when the course is upgraded.

In order to make it easy to test this, the obsolete `facebooker` column is deleted from the global_user_achievement table (and all related code removed).  That does not work.  I personally don't think that integrating with a social media platform is a good idea for WeBWorK in any case.

To test table deletion, you will probably need to manually create a table in the database.  You can do this with `create table courseID_bad_table (name int);` for example.

Note that the code previously added to delete the old "published" field has been removed.  If you have that column, then you can now upgrade the course, and check to delete that column.  This is a more correct way to deal with this.  I believe this fixes issue #1419.

There are also some html validation issues that were fixed, and all of the inline styles for color:red and color:green were change to use bootstraps text-danger and text-success classes in the admin tools.