### PR TITLE
Fix checkboxes on the AchievementUserEditor.pm page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
@@ -219,9 +219,9 @@ sub body {
 					type    => 'checkbox',
 					name    => 'selected',
 					id      => "$user.assigned",
-					checked => defined $userAchievement,
 					value   => $user,
-					class   => 'form-check-input'
+					class   => 'form-check-input',
+					defined $userAchievement ? (checked => undef) : (),
 				})
 			),
 			CGI::td(CGI::label({ for => "$user.assigned" }, $user)),
@@ -237,8 +237,8 @@ sub body {
 							name            => "$user.earned",
 							aria_labelledby => 'earned_header',
 							value           => '1',
-							checked         => $earned ? 1 : 0,
-							class           => 'form-check-input'
+							class           => 'form-check-input',
+							$earned ? (checked => undef) : (),
 						})
 					),
 					CGI::td(


### PR DESCRIPTION
When I converted the CGI::checkbox to a CGI::label I forgot to convert the way the checked attribute is handled.  The conversion was necessary to remove the invalid empty label that CGI::checkbox adds.