### PR TITLE
Fix override check logic in ProblemSetDetail.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -628,30 +628,24 @@ sub FieldHTML {
 			push(@bVals, '');
 		}
 		# I don't like this, but combining multiple values is a bit messy
-		$globalValue = (grep { defined($_) } @gVals) ? join(':', (map { defined($_) ? $_ : '' } @gVals)) : undef;
-		$userValue   = (grep { defined($_) } @uVals) ? join(':', (map { defined($_) ? $_ : '' } @uVals)) : undef;
+		$globalValue = (grep { defined $_ } @gVals) ? join(':', (map { defined $_ ? $_ : '' } @gVals)) : undef;
+		$userValue   = (grep { defined $_ } @uVals) ? join(':', (map { defined $_ ? $_ : '' } @uVals)) : undef;
 		$blankfield  = join(':', @bVals);
 	} else {
 		$globalValue = $globalRecord->{$field};
 		$userValue   = $userRecord->{$field};
 	}
 
-	# use defined instead of value in order to allow 0 to printed, e.g. for the 'value' field
-	$globalValue =
-		defined($globalValue)
-		? ($labels{ $globalValue // '' } || $globalValue)
-		: '';    # this allows for a label if value is 0
-	$userValue =
-		defined($userValue)
-		? ($labels{ $userValue // '' } || $userValue)
-		: $blankfield;    # this allows for a label if value is 0
+	# Use defined instead of value in order to allow 0 to printed, e.g. for the 'value' field.
+	$globalValue = defined $globalValue ? ($labels{$globalValue} || $globalValue) : '';
+	$userValue = defined $userValue ? ($labels{$userValue} || $userValue) : $blankfield;
 
 	if ($field =~ /_date/) {
 		$globalValue = $self->formatDateTime($globalValue, '', 'datetime_format_short', $r->ce->{language})
 			if $forUsers && defined $globalValue && $globalValue ne '';
 	}
 
-	if (defined($properties{convertby}) && $properties{convertby}) {
+	if (defined $properties{convertby} && $properties{convertby}) {
 		$globalValue = $globalValue / $properties{convertby} if $globalValue;
 		$userValue   = $userValue / $properties{convertby}   if $userValue;
 	}
@@ -748,9 +742,9 @@ sub FieldHTML {
 		});
 	}
 
-	my $gDisplVal = defined($properties{labels})
-		&& defined($properties{labels}->{$globalValue})
-		? $r->maketext($properties{labels}->{$globalValue})
+	my $gDisplVal =
+		(defined $properties{labels} && defined $properties{labels}{$globalValue})
+		? $r->maketext($properties{labels}{$globalValue})
 		: $globalValue;
 	$gDisplVal = format_set_name_display($gDisplVal) if $field eq 'restricted_release';
 
@@ -765,7 +759,7 @@ sub FieldHTML {
 				id    => "$recordType.$recordID.$field.override_id",
 				value => $field,
 				$r->param("$recordType.$recordID.$field.override")
-				|| ($userValue ne ($labels{''} // '') || $blankfield) ? (checked => undef) : (),
+				|| ($userValue ne (($labels{''} // '') || $blankfield)) ? (checked => undef) : (),
 				class => 'form-check-input'
 			})
 			: ''

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -2595,7 +2595,7 @@ sub recordEditHTML {
 				name  => 'selected_sets',
 				value => $set_id,
 				class => 'form-check-input',
-				$setSelected ? (checked => 'checked') : (),
+				$setSelected ? (checked => undef) : (),
 			}));
 
 		push @tableCells,


### PR DESCRIPTION
Fix the logic for determining if a user value is set to override the global set value on the problem set detail page.

Note the only actual change to ProblemSetDetail.pm is on line 762.  The rest is general clean up I did while sorting out the issue.

See isue #1664 for details.

There is also a fix for an invalid value for the checked attribute in ProblemSetDetail.pm.