### PR TITLE
LMS grade passback message new line

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -246,24 +246,27 @@ sub process_and_log_answer{
 
 				#Try to update the student score on the LMS
 				# if that option is enabled.
-				my $LTIGradeMode = $self->{ce}->{LTIGradeMode} // '';
-				if ($LTIGradeMode && $self->{ce}->{LTIGradeOnSubmit}) {
-				  my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($r);
-				  if ($LTIGradeMode eq 'course') {
-				    if ($grader->submit_course_grade($problem->user_id)) {
-				      $scoreRecordedMessage .= $r->maketext("Your score was successfully sent to the LMS.");
-				    } else {
-				      $scoreRecordedMessage .= $r->maketext("Your score was not successfully sent to the LMS.");
-				    }
-				  } elsif ($LTIGradeMode eq 'homework') {
-				    if ($grader->submit_set_grade($problem->user_id, $problem->set_id)) {
-				      $scoreRecordedMessage .= $r->maketext("Your score was successfully sent to the LMS.");
-				    } else {
-				      $scoreRecordedMessage .= $r->maketext("Your score was not successfully sent to the LMS.");
-				    }
-				  }
+				my $LTIGradeMode = $self->{ce}{LTIGradeMode} // '';
+				if ($LTIGradeMode && $self->{ce}{LTIGradeOnSubmit}) {
+					my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($r);
+					if ($LTIGradeMode eq 'course') {
+						if ($grader->submit_course_grade($problem->user_id)) {
+							$scoreRecordedMessage .=
+								CGI::br() . $r->maketext('Your score was successfully sent to the LMS.');
+						} else {
+							$scoreRecordedMessage .=
+								CGI::br() . $r->maketext('Your score was not successfully sent to the LMS.');
+						}
+					} elsif ($LTIGradeMode eq 'homework') {
+						if ($grader->submit_set_grade($problem->user_id, $problem->set_id)) {
+							$scoreRecordedMessage .=
+								CGI::br() . $r->maketext('Your score was successfully sent to the LMS.');
+						} else {
+							$scoreRecordedMessage .=
+								CGI::br() . $r->maketext('Your score was not successfully sent to the LMS.');
+						}
+					}
 				}
-
 			} else {
 				if (before($set->open_date) or after($set->due_date)) {
 					$scoreRecordedMessage = $r->maketext("Your score was not recorded because this homework set is closed.");


### PR DESCRIPTION
Put the message about whether or not the grade was successfully sent to the LMS on a new line.

This was observed by @drdrew in testing #1588.