### PR TITLE
Update default class lists

### DIFF
--- a/courses.dist/adminClasslist.lst
+++ b/courses.dist/adminClasslist.lst
@@ -1,3 +1,2 @@
-# $Id: adminClasslist.lst,v 1.2 2009-06-26 00:58:52 gage Exp $
-# Field order: student_id,last_name,first_name,status,comment,section,recitation,email_address,user_id,password,permission
+# Field order: student_id,last_name,first_name,status,comment,section,recitation,email_address,user_id,crypted_password,permission
 admin,Administrator,,C,,,,,admin,.bxpcera4I/bg,20

--- a/courses.dist/defaultClasslist.lst
+++ b/courses.dist/defaultClasslist.lst
@@ -1,5 +1,4 @@
-# $Id: defaultClasslist.lst,v 1.1 2006-09-05 16:27:37 sh002i Exp $
-# Field order: student_id,last_name,first_name,status,comment,section,recitation,email_address,user_id,password,permission
+# Field order: student_id,last_name,first_name,status,comment,section,recitation,email_address,user_id,crypted_password,permission
 practice1,Practice1,,C,,,,,practice1,,-5
 practice2,Practice2,,C,,,,,practice2,,-5
 practice3,Practice3,,C,,,,,practice3,,-5

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -117,7 +117,7 @@ sub initialize {
 		if (!$scoringFileNameOK) { # fileName is not properly formed
 			$self->addbadmessage($r->maketext("Your file name is not valid! "));
 		    $self->addbadmessage($r->maketext("A file name cannot begin with a dot, it cannot be empty, it cannot contain a " .
-				 "directory path component and only the characters -_.a-zA-Z0-9 and space  are allowed.")
+				 "directory path component and only the characters -_.a-zA-Z0-9 and space are allowed.")
 			);
 		}
 	}

--- a/lib/WeBWorK/Localize/webwork2.pot
+++ b/lib/WeBWorK/Localize/webwork2.pot
@@ -276,11 +276,7 @@ msgstr ""
 msgid "A directory already exists with the name %1. You must first delete this existing course before you can unarchive."
 msgstr ""
 
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:119
-msgid "A file name cannot begin with a dot, it cannot be empty, it cannot contain a directory path component and only the characters -_.a-zA-Z0-9 and space  are allowed."
-msgstr ""
-
-#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
+#: /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm:119 /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/ScoringDownload.pm:44
 msgid "A file name cannot begin with a dot, it cannot be empty, it cannot contain a directory path component and only the characters -_.a-zA-Z0-9 and space are allowed."
 msgstr ""
 


### PR DESCRIPTION
Delete the version information from within the files, since versioning is handled by git.

Change the field name from `password` to `crypted_password` to make it clear that plaintext passwords won't import properly.