### PR TITLE
Update OPL statistics upload target

### DIFF
--- a/bin/upload-OPL-statistics.pl
+++ b/bin/upload-OPL-statistics.pl
@@ -177,7 +177,7 @@ print "Zipping files\n";
 `tar -czf $tar_file $output_file $desc_file`;
 
 print "Uploading file\n";
-`echo "put $tar_file" | sshpass -p 'wwdata_upload' sftp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null wwdata_upload\@146.111.135.122:wwdata/`;
+`echo "put $tar_file" | sftp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null wwdata_upload\@146.111.135.122:wwdata/`;
 
 print "Cleaning up\n";
 `rm $desc_file $tar_file $output_file`;

--- a/bin/upload-OPL-statistics.pl
+++ b/bin/upload-OPL-statistics.pl
@@ -177,8 +177,10 @@ print "Zipping files\n";
 `tar -czf $tar_file $output_file $desc_file`;
 
 print "Uploading file\n";
+`echo "put $tar_file" | sshpass -p 'wwdata_upload' sftp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null wwdata_upload\@146.111.135.122:wwdata/`;
 
-`echo "put $tar_file" | sftp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oPort=57281 wwdata\@52.88.32.79`;
+print "Cleaning up\n";
+`rm $desc_file $tar_file $output_file`;
 
-
+print "Done\n";
 1;


### PR DESCRIPTION
The community will benefit from reviving the collection of OPL statistics.

This functionality has been dead for several years, and should be resurrected.

The sharing of OPL statistics is completely voluntary, and should pose no issue with rules concerning the sharing of student PII.

Statistics collected:
----------------------
| field | description |
|----|----|
| source_file | path to problem source (only paths =~ `/^Library\//`) |
| students_attempted | *number* of students who attempted the problem |
| average_attempts | average number of attempts per student |
| average_status | average completion of problem per student |
---------------------

There should be little concern over data sharing, as absolutely zero student PII will be shared. The data is entirely in aggregate as far as individual students are concerned. The data to be shared can be confirmed by checking your server's OPL_local_statistics table.
