### PR TITLE
Add achievementExcludeSet to course configuration

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1709,6 +1709,16 @@ $ConfigValues = [
 			type => 'boolean'
 		},
 		{
+			var  => 'achievementExcludeSet',
+			doc  => x('List of sets excluded from achievements'),
+			doc2 => x(
+				'Comma separated list of set names that are excluded from all achievements. '
+					. 'No achievement points and badges can be earned for submitting problems in these sets. '
+					. 'Note that underscores (_) must be used for spaces in set names.'
+			),
+			type => 'list'
+		},
+		{
 			var  => 'options{enableConditionalRelease}',
 			doc  => x('Enable Conditional Release'),
 			doc2 => x(


### PR DESCRIPTION
  This makes it so instructors can use the course configuration
  tools to list the sets in $achievementExcludedSet, and not
  need to modify course.conf, which cannot be done by non
  admin users.