### PR TITLE
Several minor issue fixes and style tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
   && rm -rf  pg/.git
 
 # Optional - include OPL (also need to uncomment further below when an included OPL is desired):
-#RUN git clone --single-branch --branch master --depth 1 https://github.com/openwebwork/webwork-open-problem-library.git \
+#RUN git clone --single-branch --branch main --depth 1 https://github.com/openwebwork/webwork-open-problem-library.git \
 #  && rm -rf  webwork-open-problem-library/.git
 
 # ==================================================================

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -62,7 +62,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
   && rm -rf  pg/.git
 
 # Optional - include OPL (also need to uncomment further below when an included OPL is desired):
-#RUN git clone --single-branch --branch master --depth 1 https://github.com/openwebwork/webwork-open-problem-library.git \
+#RUN git clone --single-branch --branch main --depth 1 https://github.com/openwebwork/webwork-open-problem-library.git \
 #  && rm -rf  webwork-open-problem-library/.git
 
 # ==================================================================

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -153,7 +153,7 @@ $gitWeBWorKBranchName = "main";
 $gitPGRemoteName = "origin";
 $gitPGBranchName = "main";
 $gitLibraryRemoteName = "origin";
-$gitLibraryBranchName = "master";
+$gitLibraryBranchName = "main";
 
 ################################################################################
 # Theme

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -81,7 +81,7 @@ $mail{feedbackRecipients}    = [
 #$gitPGRemoteName = "origin";
 #$gitPGBranchName = "main";
 #$gitLibraryRemoteName = "origin";
-#$gitLibraryBranchName = "master";
+#$gitLibraryBranchName = "main";
 
 ################################################################################
 # Theme

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,13 +87,13 @@ services:
             # should be commented out.
 
             # main branches:
-            #- WEBWORK2_BRANCH=main
-            #- PG_BRANCH=main
+            - WEBWORK2_BRANCH=main
+            - PG_BRANCH=main
 
             # WeBWorK/PG develop branches
             #    (other valid branches can also be used in a similar manner)
-            - WEBWORK2_BRANCH=develop
-            - PG_BRANCH=develop
+            #- WEBWORK2_BRANCH=develop
+            #- PG_BRANCH=develop
 
         # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
         dockerfile: DockerfileStage2

--- a/htdocs/themes/math4-yellow/_theme-overrides.scss
+++ b/htdocs/themes/math4-yellow/_theme-overrides.scss
@@ -16,3 +16,7 @@
 		color-contrast($info) // disabled foreground color
 	);
 }
+
+.text-primary {
+	color: $link-color !important;
+}

--- a/lib/WeBWorK/ContentGenerator/Instructor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor.pm
@@ -674,6 +674,8 @@ sub loadSetDefListFile {
 
 		return @{ JSON->new->decode($data) };
 	}
+
+	return;
 }
 
 sub getDefList {

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -345,7 +345,7 @@ EOF
 			fixSpaces(CGI::scrolling_list({
 				name       => "files",
 				id         => "files",
-				class      => "form-select font-monospace",
+				class      => 'form-select font-monospace h-100',
 				size       => 17,
 				multiple   => 1,
 				values     => $files,

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -48,7 +48,7 @@ sub initialize {
 
 	if (defined $r->param('assignToAll')) {
 		debug("assignSetToAllUsers($setID)");
-		$self->addbadmessage($r->maketext("Problems have been assigned to all current users."));
+		$self->addgoodmessage($r->maketext("Problems have been assigned to all current users."));
 		$self->assignSetToAllUsers($setID);
 		debug("done assignSetToAllUsers($setID)");
 	} elsif (defined $r->param('unassignFromAll')

--- a/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -306,7 +306,7 @@ sub answerTemplate {
     	push @tableRows, CGI::Tr($self->formatAnswerRow($rh_answers->{$ans_id}, $ans_id, $answerNumber++));
     }
 	my $answerTemplate = "";
-	$answerTemplate .= CGI::h3({ class => 'attemptResultsHeader' }, $self->maketext("Results for this submission"))
+	$answerTemplate .= CGI::h2({ class => 'attemptResultsHeader' }, $self->maketext("Results for this submission"))
 		if $self->showHeadline;
 	$answerTemplate .= CGI::table({ class => 'attemptResults table table-sm table-bordered' }, @tableRows);
     ### "results for this submission" is better than "attempt results" for a headline


### PR DESCRIPTION
Make the select on the file manager page vertically fill the div that it is contained in.
    
Make the heading of the attepts table an `h2` instead of an `h3`.
    
Make the `.text-primary` color the same as the link color for the math4-yellow theme.  The yellow primary color is not accessible for a text color.  This can be seen on the library browser page once problems are loaded.  The "Global Usage", "Attempts", and "Status" are all in this color.
    
On the users assigned to set page, change the message from bad to good when the set is assigned to all users.  That is what is used to be and should be.

Switch the branches in docker-compose.yml back to main.

Change the webwork-open-problem-library github branch to main.

Fix a warning that occurs if the library set definition file lists have not been generated.  This fixes issue #1684.