### PR TITLE
Fix an issue with rendering a student problem in the Hmwk Sets Editor.

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
@@ -315,9 +315,8 @@
 		const problemSeed = document.getElementById(`problem.${id}.problem_seed_id`);
 		ro.problemSeed = problemSeed ? problemSeed.value : 1;
 
-		const sourceFile = document.getElementById(`problem.${id}.source_file_id`);
-		ro.sourceFilePath =
-			sourceFile ? sourceFile.value : document.getElementById(`problem_${id}_default_source_file`)?.value;
+		ro.sourceFilePath = document.getElementById(`problem.${id}.source_file_id`)?.value ||
+			document.getElementById(`problem_${id}_default_source_file`)?.value;
 
 		if (ro.sourceFilePath.startsWith('group')) {
 			renderArea.innerHTML = '<div class="alert alert-danger p-1 mb-0" style="font-weight:bold">'


### PR DESCRIPTION
The issue can be seen by going to the Hmwk Sets Editor, and then editing
a set for a student when an override source file is not set (which is
probably most of the time).  Click the "Render Problem" button to render
the student's problem.  Then click "Check Answers".  The problem will
fail to render, and errors are reported.  The issue was a mistake in the
javascript that checked the existence of the source file input instead
of checking to see if the value was non empty before falling back to the
default source file for the problem.