### PR TITLE
Add option to force lowercase usernames with LTI.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -154,6 +154,11 @@ $strip_address_from_email = 0;
 #$preferred_source_of_username = "lis_person_sourcedid";
 #$fallback_source_of_username = "lis_person_contact_email_primary";
 
+# Depending on the username source, capitalization may vary between students,
+# such as when using an email address to get the username. Turning this option
+# on will make all usernames lowercase. Default is 0 (off).
+#$lti_lowercase_username = 1;
+
 ################################################################################
 # LTI Preferred source of Student Id
 ################################################################################

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -234,6 +234,9 @@ sub get_credentials {
 
   # if we were able to set a user_id
   if ( defined($self->{user_id}) && $self->{user_id} ne "" ) {
+	# Make user_id lowercase for consistency in naming if configured.
+	$self->{user_id} = lc($self->{user_id}) if ($ce->{lti_lowercase_username});
+
       map {$self->{$_->[0]} = $r->param($_->[1]);}
 	(
 	 ['role', 'roles'],


### PR DESCRIPTION
This option will make the username source lowercase when logging in via an LTI.