### PR TITLE
Hide LMS notice for users who can access the assignment anyways in ProblemSets.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -360,12 +360,15 @@ sub setListRow {
 			$status .= restricted_progression_msg($r,0,$restriction, @restricted);
 			$setIsOpen = 0;
 		} elsif ($LTIRestricted) {
-			$status .= CGI::br().$r->maketext(
-				"You must log into this set via your Learning Management System ([_1]).",
-				$ce->{LMS_name}
-			);
-			$control = "" unless $preOpenSets;
-			$interactive = $display_name unless $preOpenSets;
+			unless ($preOpenSets) {
+				my $LMS = $ce->{LMS_url} ? CGI::a({ href => $ce->{LMS_url} }, $ce->{LMS_name}) : $ce->{LMS_name};
+				$status .= CGI::br().$r->maketext(
+					"You must log into this set via your Learning Management System ([_1]).",
+					$LMS
+				);
+				$control = "";
+				$interactive = $display_name;
+			}
 			$setIsOpen = 0;
 		} else {
 			$setIsOpen = 1;


### PR DESCRIPTION
  When a set must be accessed via an LMS, add a link to the
  LMS_name and only show message about accessing sets via the
  LMS to users who cannot access the set.