### PR TITLE
Change calls to hasPermissions to use $userID rather than $r->param('user')

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+# Copyright &copy; 2000-2020 The WeBWorK Project, https://openwebworkorg.wordpress.com/
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
@@ -752,8 +752,7 @@ sub create_session {
 	}
 
 	my $setID =
-		$r->param('user')
-		&& !$r->authz->hasPermissions($r->param('user'), 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
+		!$r->authz->hasPermissions($userID, 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
 
 	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => $timestamp, set_id => $setID);
 
@@ -881,8 +880,7 @@ sub sendCookie {
 	# This sets the setID in the cookie on initial login.
 	$setID = $r->urlpath->arg("setID")
 		if !$setID
-		&& $r->param('user')
-		&& $r->authen->was_verified && !$r->authz->hasPermissions($r->param('user'), 'navigation_allowed');
+		&& $r->authen->was_verified && !$r->authz->hasPermissions($userID, 'navigation_allowed');
 
  	my $timestamp = time();
 

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2020 The WeBWorK Project, https://openwebworkorg.wordpress.com/
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the


### PR DESCRIPTION
For the restricted navigation hasPermissions was checking `$r->param('user')` rather than the `$userID` passed to the function.  This PR reverses that.

I am using a custom LDAP authentication module which sets the user ID for the session to be something different from the username that the student entered on the login page, so in my case for the code to work I need the hasPermissions check to be done on the userID, and not the username from the request.