### PR TITLE
Graded proctored gateway quizzes are no longer proctored

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -380,6 +380,7 @@ sub body {
 			$data->{version} = $verSet->version_id;
 			$data->{start} =
 				$self->formatDateTime($verSet->version_creation_time, undef, $ce->{studentDateDisplayFormat});
+			$data->{proctored} = $verSet->assignment_type =~ /proctored/;
 
 			# Display close date if this is not a timed test.
 			my $closeText = '';
@@ -677,7 +678,10 @@ sub body {
 				my $interactive = $r->maketext('Version [_1]', $ver->{version});
 				if ($authz->hasPermissions($user, 'view_hidden_work') || $ver->{show_link}) {
 					my $interactiveURL = $self->systemLink($urlpath->newFromModule(
-						$urlModule, $r,
+						$ver->{proctored}
+						? 'WeBWorK::ContentGenerator::ProctoredGatewayQuiz'
+						: 'WeBWorK::ContentGenerator::GatewayQuiz',
+						$r,
 						courseID => $courseID,
 						setID    => $ver->{id}
 					));


### PR DESCRIPTION
On the ProblemSet.pm page for a proctored gateway quiz if there is a version that has been submitted and graded, it should no longer use the proctored gateway quiz module.  It should use the usual gateway quiz module.  The mistake was in the assumption that all versions are of the same type as the template.  This is an incorrect assumption.