### PR TITLE
Fix the hasPermission calls for the navigation_allowed permission in Authen.pm

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -736,8 +736,10 @@ sub unexpired_session_exists {
 # clobbers any existing session for this $userID
 # if $newKey is not specified, a random key is generated
 # the key is returned
+# When this is called in Proctor.pm, the actual user id is passed in via $trueUserID.
+# The $userID is modified in that case and will not work in the hasPermissions call.
 sub create_session {
-	my ($self, $userID, $newKey) = @_;
+	my ($self, $userID, $newKey, $trueUserID) = @_;
 	my $r = $self->{r};
 	my $ce = $r->ce;
 	my $db = $r->db;
@@ -752,7 +754,7 @@ sub create_session {
 	}
 
 	my $setID =
-		!$r->authz->hasPermissions($userID =~ s/,.*$//r, 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
+		!$r->authz->hasPermissions($trueUserID // $userID, 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
 
 	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => $timestamp, set_id => $setID);
 
@@ -880,7 +882,7 @@ sub sendCookie {
 	# This sets the setID in the cookie on initial login.
 	$setID = $r->urlpath->arg("setID")
 		if !$setID
-		&& $r->authen->was_verified && !$r->authz->hasPermissions($userID =~ s/,.*$//r, 'navigation_allowed');
+		&& $r->authen->was_verified && !$r->authz->hasPermissions($userID, 'navigation_allowed');
 
  	my $timestamp = time();
 

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -752,7 +752,7 @@ sub create_session {
 	}
 
 	my $setID =
-		!$r->authz->hasPermissions($userID, 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
+		!$r->authz->hasPermissions($userID =~ s/,.*$//r, 'navigation_allowed') ? $r->urlpath->arg("setID") : '';
 
 	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => $timestamp, set_id => $setID);
 
@@ -880,7 +880,7 @@ sub sendCookie {
 	# This sets the setID in the cookie on initial login.
 	$setID = $r->urlpath->arg("setID")
 		if !$setID
-		&& $r->authen->was_verified && !$r->authz->hasPermissions($userID, 'navigation_allowed');
+		&& $r->authen->was_verified && !$r->authz->hasPermissions($userID =~ s/,.*$//r, 'navigation_allowed');
 
  	my $timestamp = time();
 

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -49,7 +49,7 @@ sub get_credentials {
 
 	my $urlpath = $r->urlpath;
 	my ($set_id, $version_id) = grok_vsetID( $urlpath->arg('setID') );
-	
+
 	# at least the user ID is available in request parameters
 	if (defined $r->param("proctor_user")) {
 		my $student_user_id = $r->param("effectiveUser");
@@ -59,15 +59,15 @@ sub get_credentials {
 		}
 		$self->{session_key} = $r->param("proctor_key");
 		$self->{password} = $r->param("proctor_passwd");
-		$self->{login_type} = $r->param("submitAnswers") 
-			? "proctor_grading:$student_user_id" 
+		$self->{login_type} = $r->param("submitAnswers")
+			? "proctor_grading:$student_user_id"
 			: "proctor_login:$student_user_id";
 		$self->{credential_source} = "params";
 		return 1;
 	}
 }
 
-# duplicates method in superclass, adding additional check for permission 
+# duplicates method in superclass, adding additional check for permission
 #    to proctor quizzes
 sub check_user {
 	my $self = shift;
@@ -89,19 +89,19 @@ sub check_user {
 		$self->{error} = "You must specify a user ID.";
 		return 0;
 	}
-	
+
 	my $User = $db->getUser($user_id);
-	
+
 	unless ($User) {
 		$self->{log_error} = "user unknown";
 		$self->{error} = GENERIC_ERROR_MESSAGE;
 		return 0;
 	}
-	
+
 	# proctors may be tas, instructors, or proctors; if the last, they
-	#    do not have the behavior course_access, so we don't bother to 
-	#    check that here.  they must, however, be able to login, which 
-	#    it seems to me is an overlap between course permissions and 
+	#    do not have the behavior course_access, so we don't bother to
+	#    check that here.  they must, however, be able to login, which
+	#    it seems to me is an overlap between course permissions and
 	#    course status behaviors.
 
 	unless ($authz->hasPermissions($user_id, "login")) {
@@ -112,7 +112,7 @@ sub check_user {
 
 	if ( $submitAnswers ) {
 		unless ($authz->hasPermissions($user_id,"proctor_quiz_grade")) {
-			# only set the error if this proctor is different 
+			# only set the error if this proctor is different
 			#    than the past proctor, implying that we have
 			#    tried to grade with a new proctor id
 			if ( $past_proctor_id ne $user_id ) {
@@ -122,7 +122,7 @@ sub check_user {
 				    "authorized to proctor test grade " .
 				    "submissions in this course.";
 			}
-				
+
 			return 0;
 		}
 	} else {
@@ -134,7 +134,7 @@ sub check_user {
 				"course.";
 			return 0;
 		}
-	} 
+	}
 }
 
 # this is similar to the method in the base class, excpet that the parameters
@@ -142,7 +142,7 @@ sub check_user {
 sub set_params {
 	my $self = shift;
 	my $r = $self->{r};
-	
+
 	$r->param("proctor_user", $self->{user_id});
 	$r->param("proctor_key", $self->{session_key});
 	$r->param("proctor_passwd", "");
@@ -152,15 +152,15 @@ sub set_params {
 # and then call the default create_session method.
 sub create_session {
 	my ($self, $userID, $newKey) = @_;
-	
-	return $self->SUPER::create_session($self->proctor_key_id($userID), $newKey);
+
+	return $self->SUPER::create_session($self->proctor_key_id($userID), $newKey, $userID);
 }
 
 # rewrite the userID to include bith the proctor's and the student's user ID
 # and then call the default check_session method.
 sub check_session {
 	my ($self, $userID, $possibleKey, $updateTimestamp) = @_;
-	
+
 	return $self->SUPER::check_session($self->proctor_key_id($userID), $possibleKey, $updateTimestamp);
 }
 
@@ -168,10 +168,10 @@ sub check_session {
 sub proctor_key_id {
 	my ($self, $userID, $newKey) = @_;
 	my $r = $self->{r};
-	
+
 	my $proctor_key_id = $r->param("effectiveUser") . "," . $userID;
 	$proctor_key_id .= ",g" if $self->{login_type} =~ /^proctor_grading/;
-	
+
 	return $proctor_key_id;
 }
 

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -156,7 +156,7 @@ sub create_session {
 	return $self->SUPER::create_session($self->proctor_key_id($userID), $newKey, $userID);
 }
 
-# rewrite the userID to include bith the proctor's and the student's user ID
+# rewrite the userID to include both the proctor's and the student's user ID
 # and then call the default check_session method.
 sub check_session {
 	my ($self, $userID, $possibleKey, $updateTimestamp) = @_;


### PR DESCRIPTION
When the proctored gateway quiz module is used and proctor authentication is obtained, the userID string that is passed into create_session is the student user id and the proctor user id separated by a comma.  In addition, when the gateway quiz is graded and proctor authentication is obtained in that case ",g" is appended to the end ofthat.  So those will not work in the hasPermission call.  This strips off the proctor user id and ",g" to pass as the user id to the hasPermission call.

This was introduced in #1695.  See the discussion there.

This does not fix the other unrelated bug revealed in testing this issue, and that I mentioned in #1695.