### PR TITLE
Remove HTML from page title

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -704,7 +704,7 @@ sub links {
 		my $new_urlpath = $self->r->urlpath->newFromModule($module, $r, %$urlpath_args);
 		my $new_systemlink = $self->systemLink($new_urlpath, %$systemlink_args);
 
-		defined $text or $text = $new_urlpath->name;
+		defined $text or $text = $new_urlpath->name(1);
 
 
 		# try to set $active automatically by comparing
@@ -1300,7 +1300,7 @@ sub title {
 		print $db->getSettingValue('courseTitle');
 	} else {
 		# Display the urlpath name
-		print $urlpath->name;
+		print $urlpath->name(1);
 	}
 
 	return '';

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -781,25 +781,27 @@ sub arg {
 =item name()
 
 Returns the human-readable name of this WeBWorK::URLPath.
-This display set ids and course ids with spaces instead of underscores, and
-places the set id into an ltr span so that it is displayed ltr even for rtl
-languages.  Note that the return value of this method should never be used to
-determine what type of path this is or for any sort of further processing.  It
-is a translated string.
+This displays set ids and course ids with spaces instead of underscores, and if
+C<$displayHTML> is true, it places the set id into an ltr span so that it is
+displayed ltr even for rtl languages.  Note that the return value of this method
+should never be used to determine what type of path this is or for any sort of
+further processing.  It is a translated string.
 
 =cut
 
 sub name {
-	my ($self) = @_;
+	my ($self, $displayHTML) = @_;
 	my %args = $self->args;
 
 	# Translate the display name.
 	my $name = $self->{r}->maketext(
 		$pathTypes{ $self->{type} }{name},
 		$args{userID} // '',
-		CGI::span({ dir => 'ltr' }, format_set_name_display($args{setID} // '')),
+		$displayHTML
+		? CGI::span({ dir => 'ltr' }, format_set_name_display($args{setID} // ''))
+		: format_set_name_display($args{setID} // ''),
 		$args{problemID} // '',
-		($args{courseID}  // '') =~ s/_/ /gr
+		($args{courseID} // '') =~ s/_/ /gr
 	);
 
 	return $name;


### PR DESCRIPTION
The URLPath name method can not contain a span with the dir="ltr" attribute when it is used in the page title. However, it needs that markup when it is displayed as a page heading for left-to-right languages like Hebrew.  So a new $displayHTML argument is added to the method that tells it if that is desired.

This argument is then passed for the ContentGenerator.pm title method which is used for the system.template page-title that displayed as a page heading.

The ContentGenerator.pm `title` method is used for what is called "page-title" in the system.template, but is not the "page title".  The ContentGenerator.pm `path` method is use for the page title.  Both call the URLPath name method.

This fixes issue #1703.