### PR TITLE
ContentGenerator footer updates.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1216,21 +1216,25 @@ Print links to siblings of the current object.
 	combines timestamp() and other elements of the footer, including the copyright, into one output subroutine,
 =cut
 
-sub footer(){
-	my $self = shift;
-	my $r = $self->r;
-	my $ce = $r->ce;
-	my $ww_version = $ce->{WW_VERSION}||"unknown -- set ww version VERSION";
-	my $pg_version = $ce->{PG_VERSION}||"unknown -- set pg version PG_VERSION link to ../pg/VERSION";
-	my $theme = $ce->{defaultTheme}||"unknown -- set defaultTheme in localOverides.conf";
-	my $copyright_years = $ce->{WW_COPYRIGHT_YEARS}||"1996-2019";
-	print CGI::div({-id=>"last-modified"}, $r->maketext("Page generated at [_1]", timestamp($self)));
-	print CGI::div({-id=>"copyright"}, $r->maketext("WeBWorK &copy; [_1]| theme: [_2] | ww_version: [_3] | pg_version [_4]|",
-	                $copyright_years,$theme, $ww_version, $pg_version),
-	                CGI::a({-href=>"http://webwork.maa.org/"},
-	                $r->maketext("The WeBWorK Project"), ));
+sub footer {
+	my $self            = shift;
+	my $r               = $self->r;
+	my $ce              = $r->ce;
+	my $ww_version      = $ce->{WW_VERSION}         || 'unknown -- set WW_VERSION in VERSION';
+	my $pg_version      = $ce->{PG_VERSION}         || 'unknown -- set PG_VERSION in ../pg/VERSION';
+	my $theme           = $ce->{defaultTheme}       || 'unknown -- set defaultTheme in localOverides.conf';
+	my $copyright_years = $ce->{WW_COPYRIGHT_YEARS} || '1996-2022';
+	print CGI::div({ id => 'last-modified' }, $r->maketext('Page generated at [_1]', timestamp($self)));
+	print CGI::div(
+		{ id => 'copyright' },
+		$r->maketext(
+			'WeBWorK &copy; [_1] | theme: [_2] | ww_version: [_3] | pg_version [_4] |',
+			$copyright_years, $theme, $ww_version, $pg_version
+		),
+		CGI::a({ href => 'https://webwork.maa.org/' }, $r->maketext('The WeBWorK Project'))
+	);
 
-	return ""
+	return '';
 }
 
 


### PR DESCRIPTION
Code clean ups in footer subroutine: Add some missing spaces between | characters in copyright div, remove dashes from hash keys, switch double quotes to single quotes, update webwork project link to https, and run perltidy.

I noticed some inconsistency in spacing in the copyright footer, and cleaned up the whole subroutine.