### PR TITLE
Change Home to WeBWorK in gateway path.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1130,7 +1130,7 @@ sub path {
 
 	return $self->pathMacro(
 		$args,
-		'Home'      => $navigation_allowed ? $root : '',
+		'WeBWorK'   => $navigation_allowed ? $root : '',
 		$courseName => $navigation_allowed ? "$root/$courseName" : '',
 		$setName eq "Undefined_Set" || $self->{invalidSet}
 		? ($setName => '')


### PR DESCRIPTION
  Use WeBWorK instead of Home for the top path name in gateway quizzes
  (used in breadcrubs and title) to be consistent with other pages.