### PR TITLE
Manual problem grader update scores in quizzes

### DIFF
--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -77,6 +77,16 @@
 				return;
 			}
 
+			// Update the hidden problem status fields and score table for gateway quizzes
+			if (saveData.versionId !== '0') {
+				var scoreCells = document.querySelectorAll('table td.score');
+				const numberProblems = scoreCells.length / 2;
+				scoreCells[parseInt(saveData.problemId) - 1].textContent =
+					scoreCells[numberProblems + parseInt(saveData.problemId) - 1].textContent =
+					scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
+				document.gwquiz.elements['probstatus' + saveData.problemId].value = parseInt(scoreInput.value) / 100;
+			}
+
 			// FIXME: /webwork2/ should not be hard coded here.
 			// Save the score.
 			const basicWebserviceURL = '/webwork2/instructorXMLHandler';

--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -77,16 +77,6 @@
 				return;
 			}
 
-			// Update the hidden problem status fields and score table for gateway quizzes
-			if (saveData.versionId !== '0') {
-				var scoreCells = document.querySelectorAll('table td.score');
-				const numberProblems = scoreCells.length / 2;
-				scoreCells[parseInt(saveData.problemId) - 1].textContent =
-					scoreCells[numberProblems + parseInt(saveData.problemId) - 1].textContent =
-					scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
-				document.gwquiz.elements['probstatus' + saveData.problemId].value = parseInt(scoreInput.value) / 100;
-			}
-
 			// FIXME: /webwork2/ should not be hard coded here.
 			// Save the score.
 			const basicWebserviceURL = '/webwork2/instructorXMLHandler';
@@ -105,6 +95,16 @@
 				},
 				timeout: 10000,
 				success: () => {
+					// Update the hidden problem status fields and score table for gateway quizzes
+					if (saveData.versionId !== '0') {
+						for (const scoreCell of document.querySelectorAll(
+							`table.gwNavigation td.score[data-problem-id="${saveData.problemId}"]`)) {
+							scoreCell.textContent = scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
+						}
+						document.gwquiz.elements['probstatus' + saveData.problemId].value =
+							parseInt(scoreInput.value) / 100;
+					}
+
 					if (saveData.pastAnswerId !== '0') {
 						// Save the comment.
 						const comment = document.getElementById(`comment_problem${saveData.problemId}`)?.value;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2180,7 +2180,7 @@ sub body {
 		# Set up links between problems and, for multi-page tests, pages.
 		my $jumpLinks = '';
 		my $probRow   = [];
-		my $scoreRow  = [];
+		my @scoreRow;
 		for my $i (0 .. $#pg_results) {
 			my $pn = $i + 1;
 			if ($i >= $startProb && $i <= $endProb) {
@@ -2190,7 +2190,8 @@ sub body {
 			}
 			my $score = $probStatus[ $probOrder[$i] ];
 			$score = $score == 1 ? "\x{1F4AF}" : wwRound(0, 100 * $score);
-			push(@$scoreRow, $score);
+			push(@scoreRow,
+				CGI::td({ class => 'score', data_problem_id => $problems[ $probOrder[$i] ]->problem_id }, $score));
 		}
 		my @tableRows;
 		my @cols = (CGI::colgroup(CGI::col({ class => 'header' })));
@@ -2230,7 +2231,7 @@ sub body {
 				)
 			);
 		}
-		push(@tableRows, CGI::Tr(CGI::th($r->maketext('% Score:')), CGI::td({ class => 'score' }, $scoreRow)))
+		push(@tableRows, CGI::Tr(CGI::th($r->maketext('% Score:')), @scoreRow))
 			if ($canShowProblemScores && $set->version_last_attempt_time);
 		$jumpLinks = CGI::div(
 			{ class => 'table-responsive' },


### PR DESCRIPTION
  Add the functionality for the manual problem grader to update both problem
  score tables (above and below the problems) and update the hidden score field
  when saving a new score in gateway quizzes.