### PR TITLE
Nav menu updates

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -660,12 +660,13 @@ sub links {
 	#return "" unless $authen->was_verified;
 
 	# grab some interesting data from the request
-	my $courseID = $urlpath->arg("courseID");
-	my $userID = $r->param('user');
-	my $eUserID   = $r->param("effectiveUser");
-	my $setID     = $urlpath->arg("setID");
-	my $problemID = $urlpath->arg("problemID");
-	my $achievementID = $urlpath->arg("achievementID");
+	my $courseID      = $urlpath->arg('courseID');
+	my $userID        = $r->param('user');
+	my $urlUserID     = $urlpath->arg('userID');
+	my $eUserID       = $r->param('effectiveUser');
+	my $setID         = $urlpath->arg('setID');
+	my $problemID     = $urlpath->arg('problemID');
+	my $achievementID = $urlpath->arg('achievementID');
 
 	# Determine if navigation is restricted for this user.
 	my $restricted_navigation = $authen->was_verified && !$authz->hasPermissions($userID, 'navigation_allowed');
@@ -914,14 +915,26 @@ sub links {
 
 				print CGI::start_li({ class => 'nav-item' }); # Stats
 				print &$makelink("${pfx}Stats", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
-				if ($userID ne $eUserID or defined $setID) {
+				if ($userID ne $eUserID or defined $setID or defined $urlUserID) {
 					print CGI::start_ul({ class => 'nav flex-column' });
-					if ($userID ne $eUserID) {
+					if (defined $urlUserID) {
 						print CGI::li({ class => 'nav-item' },
 							&$makelink("${pfx}Stats",
-							   	text => "$eUserID",
-							   	urlpath_args => { %args,statType => "student", userID => $eUserID },
-							   	systemlink_args => \%systemlink_args));
+								text => $urlUserID,
+								urlpath_args => { %args, statType => "student", userID => $urlUserID },
+								systemlink_args => \%systemlink_args
+							)
+						);
+					}
+					if ($userID ne $eUserID && (!defined $urlUserID || $urlUserID ne $eUserID)) {
+						print CGI::li({ class => 'nav-item' },
+							&$makelink("${pfx}Stats",
+								text => $eUserID,
+								urlpath_args => { %args, statType => "student", userID => $eUserID },
+								systemlink_args => \%systemlink_args,
+								active => $urlpath->type eq 'instructor_user_statistics' && !defined $urlUserID
+							)
+						);
 					}
 					if (defined $setID) {
 						# make sure we don't try to send a versioned
@@ -944,14 +957,26 @@ sub links {
 
 				print CGI::start_li({ class => 'nav-item' }); # Student Progress
 				print &$makelink("${pfx}StudentProgress", urlpath_args=>{%args}, systemlink_args=>\%systemlink_args);
-				if ($userID ne $eUserID or defined $setID) {
+				if ($userID ne $eUserID or defined $setID or defined $urlUserID) {
 					print CGI::start_ul({ class => 'nav flex-column' });
-					if ($userID ne $eUserID) {
+					if (defined $urlUserID) {
 						print CGI::li({ class => 'nav-item' },
 							&$makelink("${pfx}StudentProgress",
-							   	text => "$eUserID",
-							   	urlpath_args => { %args, statType => "student", userID => $eUserID },
-							   	systemlink_args => \%systemlink_args));
+								text => $urlUserID,
+								urlpath_args => { %args, statType => "student", userID => $urlUserID },
+								systemlink_args => \%systemlink_args
+							)
+						);
+					}
+					if ($userID ne $eUserID && (!defined $urlUserID || $urlUserID ne $eUserID)) {
+						print CGI::li({ class => 'nav-item' },
+							&$makelink("${pfx}StudentProgress",
+								text => $eUserID,
+								urlpath_args => { %args, statType => "student", userID => $eUserID },
+								systemlink_args => \%systemlink_args,
+								active => $urlpath->type eq 'instructor_user_progress' && !defined $urlUserID
+							)
+						);
 					}
 					if (defined $setID) {
 						# make sure we don't try to send a versioned
@@ -1030,7 +1055,8 @@ sub links {
 						&$makelink("${pfx}FileManager",
 							text => $r->maketext("Archive this Course"),
 							urlpath_args => { %args },
-						   	systemlink_args => \%augmentedSystemLinks));
+							systemlink_args => \%augmentedSystemLinks,
+							active => 0));
 				}
 				print CGI::end_ul();
 				print CGI::end_li(); # end Instructor Tools

--- a/lib/WeBWorK/ContentGenerator/Home.pm
+++ b/lib/WeBWorK/ContentGenerator/Home.pm
@@ -64,6 +64,12 @@ sub info {
 	}
 }
 
+# Override the if_can method to disable links for the home page.
+sub if_can {
+	my ($self, $arg) = @_;
+	return $arg eq 'links' ? 0 : $self->SUPER::if_can($arg);
+}
+
 sub body {
 	my ($self) = @_;
 	my $r = $self->r;

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -131,10 +131,17 @@ sub siblings {
 				statType => 'student',
 				userID   => $user_id
 			);
-			print CGI::li(CGI::a(
-				{ href => $self->systemLink($userStatisticsPage), class => 'nav-link' },
-				"$last_name, $first_name  ($user_id)"
-			));
+			print CGI::li(
+				{ class => 'nav-item' },
+				CGI::a(
+					{
+						$user_id eq $self->{studentName}
+						? (class => 'nav-link active')
+						: (href => $self->systemLink($userStatisticsPage), class => 'nav-link')
+					},
+					"$last_name, $first_name ($user_id)"
+				)
+			);
 		}
 	} else {
 		my @setIDs   = sort $db->listGlobalSets;
@@ -148,7 +155,11 @@ sub siblings {
 			print CGI::li(
 				{ class => 'nav-item' },
 				CGI::a(
-					{ href => $self->systemLink($problemPage), class => 'nav-link' },
+					{
+						defined $self->{setName} && $setID eq $self->{setName}
+						? (class => 'nav-link active')
+						: (href => $self->systemLink($problemPage), class => 'nav-link')
+					},
 					format_set_name_display($setID)
 				)
 			);

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -142,8 +142,12 @@ sub siblings {
 			print CGI::li(
 				{ class => 'nav-item' },
 				CGI::a(
-					{ href => $self->systemLink($userStatisticsPage), class => 'nav-link' },
-					"$last_name, $first_name  ($user_id)"
+					{
+						$user_id eq $self->{studentName}
+						? (class => 'nav-link active')
+						: (href => $self->systemLink($userStatisticsPage), class => 'nav-link')
+					},
+					"$last_name, $first_name ($user_id)"
 				)
 			);
 		}
@@ -162,7 +166,11 @@ sub siblings {
 			print CGI::li(
 				{ class => 'nav-item' },
 				CGI::a(
-					{ href => $self->systemLink($problemPage), class => 'nav-link' },
+					{
+						defined $self->{setName} && $setID eq $self->{setName}
+						? (class => 'nav-link active')
+						: (href => $self->systemLink($problemPage), class => 'nav-link')
+					},
 					format_set_name_display($setID)
 				)
 			);

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -937,12 +937,13 @@ sub siblings {
 			}
 		}
 
-		my $class = 'nav-link' . ($progressBarEnabled && $currentProblemID eq $problemID ? ' active' : '');
+		my $active = ($progressBarEnabled && $currentProblemID eq $problemID);
 
 		if ($isJitarSet) {
 			# If it is a jitar set, we need to hide and disable links to hidden or restricted problems.
 			my @seq = jitar_id_to_seq($problemID);
 			my $level = $#seq;
+			my $class = 'nav-link' . ($active ? ' active' : '');
 			if ($level != 0) {
 				$class .= ' nested-problem-' . $level;
 			}
@@ -955,12 +956,22 @@ sub siblings {
 					$r->maketext("Problem [_1]", join('.', @seq))
 				);
 			} else {
-				$link = CGI::a({ href => $self->systemLink($problemPage), class => $class },
-					$r->maketext("Problem [_1]", join('.', @seq)) . ($progressBarEnabled ? $status_symbol : ""));
+				$link = CGI::a(
+					{
+						$active ? (class => $class)
+						: (href => $self->systemLink($problemPage), class => $class)
+					},
+					$r->maketext('Problem [_1]', join('.', @seq)) . ($progressBarEnabled ? $status_symbol : '')
+				);
 			}
 		} else {
-			$link = CGI::a({ href => $self->systemLink($problemPage), class => $class },
-				$r->maketext("Problem [_1]", $problemID) . ($progressBarEnabled ? $status_symbol : ""));
+			$link = CGI::a(
+				{
+					$active ? (class => 'nav-link active')
+					: (href => $self->systemLink($problemPage), class => 'nav-link')
+				},
+				$r->maketext('Problem [_1]', $problemID) . ($progressBarEnabled ? $status_symbol : '')
+			);
 		}
 
 		push @items, CGI::li({ class => 'nav-item' }, $link);

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -127,15 +127,16 @@ sub templateName {
 
 sub siblings {
 	my ($self) = @_;
-	my $r = $self->r;
-	my $db = $r->db;
-	my $ce = $r->ce;
-	my $authz = $r->authz;
-	my $urlpath = $r->urlpath;
+	my $r         = $self->r;
+	my $db        = $r->db;
+	my $ce        = $r->ce;
+	my $authz     = $r->authz;
+	my $urlpath   = $r->urlpath;
 
-	my $courseID = $urlpath->arg("courseID");
-	my $user = $r->param('user');
-	my $eUserID = $r->param("effectiveUser");
+	my $courseID  = $urlpath->arg("courseID");
+	my $user      = $r->param('user');
+	my $eUserID   = $r->param("effectiveUser");
+	my $thisSetID = $urlpath->arg('setID');
 
 	# restrict navigation to other problem sets if not allowed
 	return '' unless $authz->hasPermissions($user, 'navigation_allowed');
@@ -169,11 +170,11 @@ sub siblings {
 			courseID => $courseID, setID => $setID);
 		print CGI::li({ class => 'nav-item' },
 			CGI::a({
-					href => $self->systemLink($setPage),
-					id => $setID,
-					class => 'nav-link'
+					$setID eq $thisSetID
+					? (id => $setID, class => 'nav-link active')
+					: (id => $setID, class => 'nav-link', href => $self->systemLink($setPage))
 				}, format_set_name_display($setID))
-		) ;
+		);
 	}
 	debug("End printing sets from listUserSets()");
 


### PR DESCRIPTION
  On siblings link menu, make the active link unclickable since it is a
  link to the current page (similar breadcrubs). Update siblings link
  menu to show the active link on ProblemSet, Stats, and StudentProgress
  pages. Make the Archive this Course link in the file manager not active.

  Remove the nav menu on the Home page since the only link in the
  nav menu is to the current home page.