### PR TITLE
Fix the override checks for the date/time pickers on the problem set detail and user detail pages.

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/apps/ProblemSetDetail/problemsetdetail.js
@@ -453,7 +453,9 @@
 
 	// Make the override checkboxes for text type inputs checked or unchecked appropriately
 	// as determined by the value of the input when that value changes.
-	document.querySelectorAll('input[type="text"][data-override]').forEach((input) => {
+	document.querySelectorAll('input[type="text"][data-override],input[type="hidden"][data-override]')
+		.forEach((input) =>
+	{
 		const overrideCheck = document.getElementById(input.dataset.override);
 		if (!overrideCheck) return;
 		const changeHandler = () => overrideCheck.checked = input.value != '';

--- a/htdocs/js/apps/UserDetail/userdetail.js
+++ b/htdocs/js/apps/UserDetail/userdetail.js
@@ -24,7 +24,9 @@
 
 	// Make the date override checkboxes checked or unchecked appropriately
 	// as determined by the value of the date input when that value changes.
-	document.querySelectorAll('input[type="text"][data-override]').forEach((input) => {
+	document.querySelectorAll('input[type="text"][data-override],input[type="hidden"][data-override]')
+		.forEach((input) =>
+	{
 		const overrideCheck = document.getElementById(input.dataset.override);
 		if (!overrideCheck) return;
 		const changeHandler = () => overrideCheck.checked = input.value != '';


### PR DESCRIPTION
Since the original input is converted to a hidden input by flatpickr, the javascript was missing them.

On the problem set detail page this only affects editing a set for users.

On those pages change a date.  The override check should automatically be checked.  Without this pull request it is not.

I am not sure when this broke.  It was working with flatpickr, but something changed.