### PR TITLE
Fix the handling of moving/removing the temporary course archive file.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -28,6 +28,7 @@ use Carp;
 use DBI;
 use WeBWorK::Debug;
 use File::Path qw(rmtree);
+use File::Copy qw(move);
 use File::Spec;
 use String::ShellQuote;
 use WeBWorK::CourseEnvironment;
@@ -53,9 +54,9 @@ our @EXPORT_OK = qw(
 );
 
 use constant {             # constants describing the comparison of two hashes.
-           ONLY_IN_A=>0, 
+           ONLY_IN_A=>0,
            ONLY_IN_B=>1,
-           DIFFER_IN_A_AND_B=>2, 
+           DIFFER_IN_A_AND_B=>2,
            SAME_IN_A_AND_B=>3
 };
 ################################################################################
@@ -75,7 +76,7 @@ use constant {             # constants describing the comparison of two hashes.
 
 =item listCourses($ce)
 
-Lists the courses defined. 
+Lists the courses defined.
 
 =cut
 
@@ -126,7 +127,7 @@ sub listCourses {
 
 =item listArchivedCourses($ce)
 
-Lists the courses which have been archived (end in .tar.gz). 
+Lists the courses which have been archived (end in .tar.gz).
 
 =cut
 
@@ -144,7 +145,7 @@ sub listArchivedCourses {
 
  courseID => $courseID,
  ce => $ce,
- courseOptions => $courseOptions, 
+ courseOptions => $courseOptions,
  dbOptions => $dbOptions,
  users => $users
 
@@ -189,7 +190,7 @@ templates directory will be copied to the new course.
 
 sub addCourse {
 	my (%options) = @_;
-	
+
 	for my $key (keys(%options)){
 		  	my $value = '####UNDEF###';
 		  	$value = $options{$key} if (defined($options{$key}));
@@ -202,16 +203,16 @@ sub addCourse {
 	my %courseOptions = %{ $options{courseOptions} };
 	my %dbOptions = defined $options{dbOptions} ? %{ $options{dbOptions} } : ();
 	my @users = exists $options{users} ? @{ $options{users} } : ();
-	
+
 	debug \@users;
 
 	# get the database layout out of the options hash
 	my $dbLayoutName = $courseOptions{dbLayoutName};
-	
+
 	# collect some data
 	my $coursesDir = $ce->{webworkDirs}->{courses};
 	my $courseDir = "$coursesDir/$courseID";
-	
+
 	# fail if the course already exists
 	# IMPORTANT: this must be the first check! if any check other than this one
 	# fails, CourseAdmin deletes the course!! Oh no!!!
@@ -222,11 +223,11 @@ sub addCourse {
 	if (-e $courseDir) {
 		croak "$courseID: course exists";
 	}
-	
+
 	# fail if the course ID contains invalid characters
 	croak "Invalid characters in course ID: '$courseID' (valid characters are [-A-Za-z0-9_])"
 		unless $courseID =~ m/^[-A-Za-z0-9_]*$/;
-	
+
 	# fail if requested course ID is too long
 	croak "Course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters."
 		if ( length($courseID) > $ce->{maxCourseIdLength} );
@@ -235,18 +236,18 @@ sub addCourse {
 	if (not defined $dbLayoutName) {
 		$dbLayoutName = $ce->{dbLayoutName};
 	}
-	
+
 	# fail if the database layout is invalid
 	if (not exists $ce->{dbLayouts}->{$dbLayoutName}) {
 		croak "$dbLayoutName: not found in \%dbLayouts";
 	}
-	
+
 	##### step 1: create course directory structure #####
-	
+
 	my %courseDirs = %{$ce->{courseDirs}};
-	
+
 	# deal with root directory first -- if we can't create it, we have to give up.
-	
+
 	exists $courseDirs{root} or croak "Can't create the course '$courseID' because no root directory is specified in the '%courseDirs' hash.";
 	my $root = $courseDirs{root};
 	delete $courseDirs{root};
@@ -261,19 +262,19 @@ sub addCourse {
 		# try to create it
 		mkdir $root or croak "Can't create the course '$courseID' becasue the root directory '$root' could not be created: $!.";
 	}
-	
+
 	# deal with the rest of the directories
-	
+
 	my @courseDirNames = sort { $courseDirs{$a} cmp $courseDirs{$b} } keys %courseDirs;
 	foreach my $courseDirName (@courseDirNames) {
 		my $courseDir = File::Spec->canonpath($courseDirs{$courseDirName});
-		
+
 		# does the directory already exist?
 		if (-e $courseDir) {
 			warn "Can't create $courseDirName directory '$courseDir', since it already exists. Using existing directory.\n";
 			next;
 		}
-		
+
 		# is the parent directory writeable?
 		my @courseDirElements = File::Spec->splitdir($courseDir);
 		pop @courseDirElements;
@@ -282,28 +283,28 @@ sub addCourse {
 			warn "Can't create $courseDirName directory '$courseDir', since the parent directory is not writeable. You will have to create this directory manually.\n";
 			next;
 		}
-		
+
 		# try to create it
 		mkdir $courseDir or warn "Failed to create $courseDirName directory '$courseDir': $!. You will have to create this directory manually.\n";
 	}
-	
+
 	##### step 2: create course database #####
-	
+
 	my $db = new WeBWorK::DB($ce->{dbLayouts}->{$dbLayoutName});
 	my $create_db_result = $db->create_tables;
 	die "$courseID: course database creation failed.\n" unless $create_db_result;
-	
+
 	##### step 3: populate course database #####
-	
+
 	if ($ce->{dbLayouts}{$dbLayoutName}{user}{params}{non_native}) {
 		debug("not adding users to the course database: 'user' table is non-native.\n");
 	} else {
 		# see above
 		#my $db = WeBWorK::DB->new($ce->{dbLayouts}->{$dbLayoutName});
-		
+
 		foreach my $userTriple (@users) {
 			my ($User, $Password, $PermissionLevel) = @$userTriple;
-			
+
 			eval { $db->addUser($User)                       }; warn $@ if $@;
 			eval { $db->addPassword($Password)               }; warn $@ if $@;
 			eval { $db->addPermissionLevel($PermissionLevel) }; warn $@ if $@;
@@ -317,17 +318,17 @@ sub addCourse {
 	    $db->setSettingValue('courseInstitution',$options{courseInstitution});
 	}
 
-	
+
 	##### step 4: write course.conf file #####
-	
+
 	my $courseEnvFile = $ce->{courseFiles}->{environment};
 	open my $fh, ">:utf8", $courseEnvFile
 		or die "failed to open $courseEnvFile for writing.\n";
 	writeCourseConf($fh, $ce, %courseOptions);
 	close $fh;
-	
+
 	##### step 5: copy templates and html #####
-	
+
 	if (exists $options{templatesFrom}) {
 		my $sourceCourse = $options{templatesFrom};
 		my $sourceCE = new WeBWorK::CourseEnvironment({
@@ -432,7 +433,7 @@ Any errors encountered while renaming the course are returned.
 
 sub renameCourse {
 	my (%options) = @_;
-	
+
 	# renameCourseHelper needs:
 	#    $fromCourseID ($oldCourseID)
 	#    $fromCE ($oldCE)
@@ -440,21 +441,21 @@ sub renameCourse {
 	#    $toCE (construct from $oldCE)
 	#    $dbLayoutName ($oldCE->{dbLayoutName})
 	#    %options ($dbOptions)
-	
+
 	my $oldCourseID = $options{courseID};
 	my $oldCE = $options{ce};
 	my %dbOptions = defined $options{dbOptions} ? %{ $options{dbOptions} } : ();
 	my $newCourseID = $options{newCourseID};
 	my $skipDBRename = $options{skipDBRename} || 0;
-	
+
 	# get the database layout out of the options hash
 	my $dbLayoutName = $oldCE->{dbLayoutName};
-	
+
 	# collect some data
 	my $coursesDir = $oldCE->{webworkDirs}->{courses};
 	my $oldCourseDir = "$coursesDir/$oldCourseID";
 	my $newCourseDir = "$coursesDir/$newCourseID";
-	
+
 	# fail if the target course already exists
 	if (-e $newCourseDir) {
 		croak "$newCourseID: course exists";
@@ -463,14 +464,14 @@ sub renameCourse {
 	# fail if the target courseID is too long
 	croak "New course ID cannot exceed " . $oldCE->{maxCourseIdLength} . " characters."
 		if ( length($newCourseID) > $oldCE->{maxCourseIdLength} );
-	
+
 	# fail if the source course does not exist
 	unless (-e $oldCourseDir) {
 		croak "$oldCourseID: course not found";
 	}
-	
+
 	##### step 1: move course directory #####
-	
+
 	# move top-level course directory
 	my $mv_cmd = "2>&1"." ".$oldCE->{externalPrograms}{mv}." ".shell_quote($oldCourseDir)." ".shell_quote($newCourseDir);
 	debug("moving course dir: $mv_cmd");
@@ -481,7 +482,7 @@ sub renameCourse {
 		my $core = $? & 128;
 		die "Failed to move course directory with command '$mv_cmd' (exit=$exit signal=$signal core=$core): $mv_out\n";
 	}
-	
+
 	# get new course environment
 	my $newCE = $oldCE->new(
 		$oldCE->{webworkDirs}->{root},
@@ -489,7 +490,7 @@ sub renameCourse {
 		$oldCE->{pg}->{directories}->{root},
 		$newCourseID,
 	);
-	
+
 	# find the course dirs that still exist in their original locations
 	# (i.e. are not subdirs of $courseDir)
 	my %oldCourseDirs = %{ $oldCE->{courseDirs} };
@@ -500,22 +501,22 @@ sub renameCourse {
 		my $newDir = File::Spec->canonpath($newCourseDirs{$courseDirName});
 		if (-e $oldDir) {
 			debug("oldDir $oldDir still exists. might move it...\n");
-			
+
 			# check for a few likely error conditions, since the mv error is not that helpful
-			
+
 			# is the source really a directory
 			unless (-d $oldDir) {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the source is not a directory. You will have to move this directory manually.\n";
 				next;
 			}
-			
+
 			# does the destination already exist?
 			# (this should only happen on extra-coursedir directories, since we make sure the root dir doesn't exist above.)
 			if (-e $newDir) {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the target already exists. You will have to move this directory manually.\n";
 				next;
 			}
-			
+
 			# is oldDir's parent writeable
 			my @oldDirElements = File::Spec->splitdir($oldDir);
 			pop @oldDirElements;
@@ -524,7 +525,7 @@ sub renameCourse {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the source parent directory is not writeable. You will have to move this directory manually.\n";
 				next;
 			}
-			
+
 			# is newDir's parent writeable?
 			my @newDirElements = File::Spec->splitdir($newDir);
 			pop @newDirElements;
@@ -533,7 +534,7 @@ sub renameCourse {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the destination parent directory is not writeable. You will have to move this directory manually.\n";
 				next;
 			}
-			
+
 			# try to move the directory
 			debug("Going to move $oldDir to $newDir...\n");
 			my $mv_cmd = "2>&1"." ".$oldCE->{externalPrograms}{mv}." ".shell_quote($oldDir)." ".shell_quote($newDir);
@@ -548,12 +549,12 @@ sub renameCourse {
 			debug("oldDir $oldDir was already moved.\n");
 		}
 	}
-	
+
 	##### step 2: rename database #####
-	
+
 	unless ($skipDBRename) {
 		my $oldDB = new WeBWorK::DB($oldCE->{dbLayouts}{$dbLayoutName});
-		
+
 		my $rename_db_result = $oldDB->rename_tables($newCE->{dbLayouts}{$dbLayoutName});
 		die "$oldCourseID: course database renaming failed.\n" unless $rename_db_result;
 		#update title and institution
@@ -572,21 +573,21 @@ sub renameCourse {
 ################################################################################
 =item retitleCourse
 
-	Simply changes the title and institution of the course. 
+	Simply changes the title and institution of the course.
 
 Options must contain:
 
  courseID => $courseID,
  ce => $ce,
  dbOptions => $dbOptions,
- 
- 
+
+
 Options may contain
  newCourseTitle => $courseTitle,
  newCourseInstitution => $courseInstitution,
 
 
-=cut 
+=cut
 
 sub retitleCourse {
 	my %options = @_;
@@ -613,7 +614,7 @@ sub retitleCourse {
 			}
 		};  warn "Problems from resetting course title and institution = $@" if $@;
 
-	
+
 
 
 }
@@ -646,21 +647,21 @@ Any errors encountered while deleting the course are returned.
 
 sub deleteCourse {
 	my (%options) = @_;
-	
+
 	my $courseID = $options{courseID};
 	my $ce = $options{ce};
 	my %dbOptions = defined $options{dbOptions} ? %{ $options{dbOptions} } : ();
-	
+
 	# make sure the user isn't brain damaged
 	die "the course environment supplied doesn't appear to describe the course $courseID. can't proceed."
 		unless $ce->{courseName} eq $courseID;
-	
+
 	my %courseDirs = %{$ce->{courseDirs}};
-	
+
 	##### step 0: make sure course directory is deleteable #####
-	
+
 	# deal with root directory first -- if we won't be able to delete it, we have to give up.
-	
+
 	exists $courseDirs{root} or croak "Can't delete the course '$courseID' because no root directory is specified in the '%courseDirs' hash.";
 	my $root = $courseDirs{root};
 	if (-e $root) {
@@ -672,30 +673,30 @@ sub deleteCourse {
 	} else {
 		warn "Warning: the course root directory '$root' does not exist. Attempting to delete the course database and other course directories...\n";
 	}
-	
+
 	##### step 1: delete course database (if necessary) #####
-	
+
 	my $dbLayoutName = $ce->{dbLayoutName};
 	my $db = new WeBWorK::DB($ce->{dbLayouts}->{$dbLayoutName});
 	my $create_db_result = $db->delete_tables;
 	die "$courseID: course database deletion failed.\n" unless $create_db_result;
-	
+
 	##### step 2: delete course directory structure #####
-	
+
 	my @courseDirNames = sort { $courseDirs{$a} cmp $courseDirs{$b} } keys %courseDirs;
 	foreach my $courseDirName (@courseDirNames) {
 		my $courseDir = File::Spec->canonpath($courseDirs{$courseDirName});
 		if (-e $courseDir) {
 			debug("courseDir $courseDir still exists. might delete it...\n");
-			
+
 			# check for a few likely error conditions, since the mv error is not that helpful
-			
+
 			# is it really a directory
 			unless (-d $courseDir) {
 				warn "Can't delete $courseDirName directory '$courseDir', since is not a directory. If it is not wanted, you will have to delete it manually.\n";
 				next;
 			}
-			
+
 			# is the parent writeable
 			my @courseDirElements = File::Spec->splitdir($courseDir);
 			pop @courseDirElements;
@@ -704,7 +705,7 @@ sub deleteCourse {
 				warn "Can't delete $courseDirName directory '$courseDir', since its parent directory is not writeable. If it is not wanted, you will have to delete it manually.\n";
 				next;
 			}
-			
+
 			# try to delete the directory
 			debug("Going to delete $courseDir...\n");
 			rmtree($courseDir, 0, 1);
@@ -745,21 +746,21 @@ sub archiveCourse {
 	my (%options) = @_;
 	my $courseID = $options{courseID};
 	my $ce = $options{ce};
-	
+
 	# make sure the user isn't brain damaged
 	croak "The course environment supplied doesn't appear to match the course $courseID. Can't proceed"
 		unless $ce->{courseName} eq $courseID;
-	
+
 	# grab some values we'll need
 	my $course_dir = $ce->{courseDirs}{root};
-	
+
 	# tmp_archive_path is used as the target of the tar.gz operation
 	# After this is done the final tar.gz file is moved either to the course directory
 	# or the course/myCourse/templates   directory (when saving individual courses)
 	# this prevents us from tarring a directory to which we have just added a file
 	# see bug #2022 -- for error messages on some operating systems
 	my $uuidStub = create_uuid_as_string();
-	my $tmp_archive_path = $ce->{webworkDirs}{courses} . "/ ${uuidStub}_$courseID.tar.gz";
+	my $tmp_archive_path = $ce->{webworkDirs}{courses} . "/${uuidStub}_$courseID.tar.gz";
 	my $data_dir = $ce->{courseDirs}{DATA};
 	my $dump_dir = "$data_dir/mysqldump";
 	my $archive_path;
@@ -768,13 +769,13 @@ sub archiveCourse {
 	} else {
 		$archive_path = $ce->{webworkDirs}{courses} . "/$courseID.tar.gz";
 	}
-	
-	
+
+
 	# fail if the source course does not exist
 	unless (-e $course_dir) {
 		croak "$courseID: course not found";
 	}
-	
+
     # replace previous archived file if it exists.
 	if (-e $archive_path) {
 		unlink($archive_path) if (-w $archive_path);
@@ -784,25 +785,25 @@ sub archiveCourse {
 			croak "Unable to replace the archival version of '$courseID'";
 		}
 	}
-	
+
 	#### step 1: dump tables #####
-	
+
 	unless (-e $dump_dir) {
 		mkdir $dump_dir or croak "Failed to create course database dump directory '$dump_dir': $!";
 	}
-	
+
 	my $db = new WeBWorK::DB($ce->{dbLayout});
 	my $dump_db_result = $db->dump_tables($dump_dir);
 	unless ($dump_db_result) {
 		_archiveCourse_remove_dump_dir($ce, $dump_dir);
 		croak "$courseID: course database dump failed.\n";
 	}
-	
+
 	##### step 2: tar and gzip course directory (including dumped database) #####
-	
+
 	# we want tar to run from the parent directory of the course directory
 	my $chdir_to = "$course_dir/..";
-	
+
 	my $tar_cmd = "2>&1 " . $ce->{externalPrograms}{tar}
 		. " -C " . shell_quote($chdir_to)
 		. " -czf " . shell_quote($tmp_archive_path)
@@ -815,14 +816,17 @@ sub archiveCourse {
 		_archiveCourse_remove_dump_dir($ce, $dump_dir);
 		croak "Failed to archive course directory '$course_dir' with command '$tar_cmd' (exit=$exit signal=$signal core=$core): $tar_out\n";
 	}
-	
+
 	##### step 3: cleanup -- remove database dump files from course directory #####
-	
+
 	unless (-e $archive_path) {
-		rename $tmp_archive_path, $archive_path;
-	} else {  
-		croak "Failed to create archived file at  '$archive_path'. File already exists.";
-		unlink($tmp_archive_path);  #clean up	
+		unless (move($tmp_archive_path, $archive_path)) {
+			unlink($tmp_archive_path);  #clean up
+			croak "Failed to rename archived file to '$archive_path': $!";
+		}
+	} else {
+		unlink($tmp_archive_path);  #clean up
+		croak "Failed to create archived file at '$archive_path'. File already exists.";
 	}
 	_archiveCourse_remove_dump_dir($ce, $dump_dir);
 }
@@ -871,31 +875,31 @@ If an error occurs, an exception is thrown.
 
 sub unarchiveCourse {
 	my (%options) = @_;
-	
+
 	my $newCourseID = $options{newCourseID};
 	my $currCourseID = $options{oldCourseID};
 	my $archivePath = $options{archivePath};
 	my $ce = $options{ce};
-	
+
 	my $coursesDir  = $ce->{webworkDirs}{courses};
-	
+
 	# Double check that the new course does not exist
 	if (-e "$coursesDir/$newCourseID") {
 		die "Cannot overwrite existing course $coursesDir/$newCourseID";
 	}
-	
+
 	# fail if the target courseID is too long
 	croak "New course ID cannot exceed " . $ce->{maxCourseIdLength} . " characters."
 		if ( length($newCourseID) > $ce->{maxCourseIdLength} );
 
 
 	##### step 1: move a conflicting course away #####
-	
+
 	# if this function returns undef, it means there was no course in the way
 	my $restoreCourseData = _unarchiveCourse_move_away($ce, $currCourseID);
-	
+
 	##### step 2: crack open the tarball #####
-	
+
 	my $tar_cmd = "2>&1 " . $ce->{externalPrograms}{tar}
 		. " -C " . shell_quote($coursesDir)
 		. " -xzf " . shell_quote($archivePath);
@@ -907,22 +911,22 @@ sub unarchiveCourse {
 		_unarchiveCourse_move_back($restoreCourseData);
 		die "Failed to unarchive course directory with command '$tar_cmd' (exit=$exit signal=$signal core=$core): $tar_out\n";
 	}
-	
+
 	##### step 3: read the course environment for this course #####
-	
+
 	my $ce2 = new WeBWorK::CourseEnvironment({
 		get_SeedCE($ce),
 		courseName => $currCourseID,
 	});
-	
+
 	# pull out some useful stuff
 	my $course_dir = $ce2->{courseDirs}{root};
 	my $data_dir = $ce2->{courseDirs}{DATA};
 	my $dump_dir = "$data_dir/mysqldump";
 	my $old_dump_file = "$data_dir/${currCourseID}_mysql.database";
-	
+
 	##### step 4: restore the database tables #####
-	
+
 	my $no_database;
 	my $restore_db_result = 1;
 	if (-e $dump_dir) {
@@ -946,13 +950,13 @@ sub unarchiveCourse {
 		warn "course '$currCourseID' has no database dump in its data directory (checked for $dump_dir and $old_dump_file). database tables will not be restored.\n";
 		$no_database = 1;
 	}
-	
+
 	unless ($restore_db_result) {
 		warn "database restore of course '$currCourseID' failed: the course will probably not be usable.\n";
 	}
-	
+
 	##### step 5: delete dump_dir and/or old_dump_file #####
-	
+
 	if (-e $dump_dir) {
 		_archiveCourse_remove_dump_dir($ce, $dump_dir);
 	}
@@ -966,9 +970,9 @@ sub unarchiveCourse {
 	if (! -e $tmpDir) {
 	  mkdir $tmpDir or warn "Failed to create html_temp directory '$tmpDir': $!. You will have to create this directory manually.\n";
 	}
-	
+
 	##### step 6: rename course #####
-	
+
 	if (defined $newCourseID and $newCourseID ne $currCourseID) {
 		renameCourse(
 			courseID     => $currCourseID,
@@ -977,55 +981,55 @@ sub unarchiveCourse {
 			skipDBRename => $no_database,
 		);
 	}
-	
+
 	##### step 7: return conflicting course to its rightful place #####
-	
+
 	_unarchiveCourse_move_back($restoreCourseData);
 }
 
 sub _unarchiveCourse_move_away {
 	my ($ce, $courseID) = @_;
-	
+
 	# course environment for before the course is moved
 	my $ce2 = new WeBWorK::CourseEnvironment({
 		get_SeedCE($ce),
 		courseName => $courseID,
 	});
-	
+
 	# if course directory doesn't exist, we don't have to do anything
 	return unless -e $ce2->{courseDirs}{root};
-	
+
 	# temporary name for course
 	my $tmpCourseID = "${courseID}_tmp";
-	
+
 	debug("Temporarily moving $courseID to $tmpCourseID to make room for course unarchiving");
 	renameCourse(
 		courseID    => $courseID,
 		ce          => $ce2,
 		newCourseID => $tmpCourseID,
 	);
-	
+
 	# course environment for after the course is moved
 	my $ce3 = new WeBWorK::CourseEnvironment({
 		get_SeedCE($ce),
 		courseName => $tmpCourseID,
 	});
-	
+
 	# data to pass to renameCourse when moving the course back to it's original name
 	my $restore_course_data = {
 		courseID    => $tmpCourseID,
 		ce          => $ce3, # course environment for moved course
 		newCourseID => $courseID,
 	};
-	
+
 	return $restore_course_data;
 }
 
 sub _unarchiveCourse_move_back {
 	my ($restore_course_data) = @_;
-	
+
 	return unless $restore_course_data;
-	
+
 	debug("Moving $$restore_course_data{courseID} back to $$restore_course_data{newCourseID} after course unarchiving");
 	renameCourse(%$restore_course_data);
 }
@@ -1049,27 +1053,27 @@ In the common case, there will only be one source returned.
 
 sub dbLayoutSQLSources {
 	my ($dbLayout) = @_;
-	
+
 	my %dbLayout = %$dbLayout;
 	my @tables = keys %dbLayout;
-	
+
 	my %sources;
-	
+
 	foreach my $table (@tables) {
 		my %table = %{ $dbLayout{$table} };
 		my %params = %{ $table{params} };
-		
+
 		if ($params{non_native}) {
 			debug("$table: marked non-native, skipping\n");
 			next;
 		}
-		
+
 		my $source = $table{source};
 		my $username = $params{username};
 		my $password = $params{password};
-		
+
 		push @{$sources{$source}{tables}}, $table;
-		
+
 		if (defined $sources{$source}{username}) {
 			if ($sources{$source}{username} ne $username) {
 				warn "conflicting usernames for source '$source':",
@@ -1080,7 +1084,7 @@ sub dbLayoutSQLSources {
 		} else {
 			$sources{$source}{username} = $username;
 		}
-		
+
 		if (defined $sources{$source}{password}) {
 			if ($sources{$source}{password} ne $password) {
 				warn "conflicting passwords for source '$source':",
@@ -1092,7 +1096,7 @@ sub dbLayoutSQLSources {
 			$sources{$source}{password} = $password;
 		}
 	}
-	
+
 	return %sources;
 }
 
@@ -1153,19 +1157,19 @@ sub initNonNativeTables {
 	my $str = '';
 	# Create a database handler
 	my $db = new WeBWorK::DB($ce->{dbLayouts}->{$dbLayoutName});
-	
+
 	 # lock database
-	 
-	# Find the names of the non-native database tables 
+
+	# Find the names of the non-native database tables
 	foreach my $table (sort keys %$db) {
 	    next unless $db->{$table}{params}{non_native}; # only look at non-native tables
-	    # hack: these two tables are virtual and don't need to be created 
+	    # hack: these two tables are virtual and don't need to be created
 	    # for the admin course or in the database in general
-	    # if they were created in earlier versions for the admin course 
+	    # if they were created in earlier versions for the admin course
 	    # you can use mysql to drop the field version_id manually
 	    # this will get rid of a spurious error
 	    next if $table eq 'problem_version' or $table eq 'set_version';
-	   
+
 	    my $database_table_name = (exists $db->{$table}->{params}->{tableOverride})? $db->{$table}->{params}->{tableOverride}:$table;
 	    #warn "table is $table";
 	    #warn "checking $database_table_name";
@@ -1188,10 +1192,10 @@ sub initNonNativeTables {
 		my %schema_override_field_names=();
 		foreach my $field (sort @schema_field_names) {
 		    my $field_name  = $db->{$table}->{params}->{fieldOverride}->{$field} ||$field;
-		    $schema_override_field_names{$field_name}=$field;	
+		    $schema_override_field_names{$field_name}=$field;
 		    my $database_field_exists = $db->{$table}->tableFieldExists($field_name);
-		    #if the field doesn't exist then try to add it... 
-		    if (!$database_field_exists) { 
+		    #if the field doesn't exist then try to add it...
+		    if (!$database_field_exists) {
 			$fields_ok = 0;
 			$fieldStatus{$field} =[ONLY_IN_A];
 			warn "$field from $database_table_name (aka |$table|) is only in schema, not in database, so adding it ... ";
@@ -1202,16 +1206,16 @@ sub initNonNativeTables {
 				warn "couldn't add column $field_name to table $database_table_name";
 			    }
 		    }
-			
+
 		}
-	       
+
 		}
-			
+
 	    }
-	    
-	   
+
+
 	}
-	
+
 	# unlock database
 	$str;
 
@@ -1240,7 +1244,7 @@ class exists and contains a function named "${helperName}Helper".
 
 sub callHelperIfExists {
 	my ($helperName, $dbLayoutName, @args) = @_;
-	
+
 	my $helperRef = getHelperRef($helperName, $dbLayoutName);
 	if (ref $helperRef) {
 		return $helperRef->(@args);
@@ -1258,11 +1262,11 @@ class exists and contains a function named "${helperName}Helper".
 
 sub getHelperRef {
 	my ($helperName, $dbLayoutName) = @_;
-	
+
 	my $result;
-	
+
 	my $package = __PACKAGE__ . "::$dbLayoutName";
-	
+
 	eval { runtime_use $package };
 	if ($@) {
 		if ($@ =~ /^Can't locate/) {
@@ -1281,7 +1285,7 @@ sub getHelperRef {
 			$result = 1;
 		}
 	}
-	
+
 	#warn "getHelperRef = '$result'\n";
 	return $result;
 }
@@ -1310,21 +1314,21 @@ the pairs accepted in %courseOptions by addCourse(), above.
 
 sub writeCourseConf {
 	my ($fh, $ce, %options) = @_;
-	
+
 	# several options should be defined no matter what
 	$options{dbLayoutName} = $ce->{dbLayoutName} unless defined $options{dbLayoutName};
-	
+
 	print $fh <<'EOF';
 #!perl
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -1338,23 +1342,23 @@ sub writeCourseConf {
 # options are noted below.
 
 EOF
-	
+
 	print $fh <<'EOF';
 # Database Layout (global value typically defined in defaults.config)
-# 
+#
 # Several database are defined in the file conf/database.conf and stored in the
 # hash %dbLayouts.
-# 
+#
 # The database layout is always set here, since one should be able to change the
 # default value in localOverrides.conf without disrupting existing courses.
-# 
+#
 # defaults.config values:
 EOF
-	
+
 	print $fh "# \t", '$dbLayoutName = \'', protectQString($ce->{dbLayoutName}), '\';', "\n";
 	print $fh "# \t", '*dbLayout = $dbLayouts{$dbLayoutName};', "\n";
 	print $fh "\n";
-	
+
 	if (defined $options{dbLayoutName}) {
 		print $fh '$dbLayoutName = \'', protectQString($options{dbLayoutName}), '\';', "\n";
 		print $fh '*dbLayout = $dbLayouts{$dbLayoutName};', "\n";
@@ -1362,18 +1366,18 @@ EOF
 	} else {
 		print $fh "\n\n\n";
 	}
-	
+
 	print $fh <<'EOF';
 # Allowed Mail Recipients (global value typically not defined)
-# 
+#
 # Defines addresses to which the PG system is allowed to send mail. This should
 # probably be set to the addresses of professors of this course. Sending mail
 # from the PG system (i.e. questionaires, essay questions) will fail if this is
 # not set.
-# 
+#
 # defaults.config values:
 EOF
-	
+
 	if (defined $ce->{mail}->{allowedRecipients}) {
 		print $fh "# \t", '$mail{allowedRecipients} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $ce->{mail}->{allowedRecipients} }), '];', "\n";
@@ -1381,7 +1385,7 @@ EOF
 		print $fh "# \t", '$mail{allowedRecipients} = [  ];', "\n";
 	}
 	print $fh "\n";
-	
+
 	if (defined $options{allowedRecipients}) {
 		print $fh '$mail{allowedRecipients} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $options{allowedRecipients} }), '];', "\n";
@@ -1389,25 +1393,25 @@ EOF
 	} else {
 		print $fh "\n\n\n";
 	}
-	
+
 	print $fh <<'EOF';
 # By default, feedback is sent to all users who have permission to
 # receive_feedback. If this list is non-empty, feedback is also sent to the
 # addresses specified here.
-# 
+#
 # * If you want to disable feedback altogether, leave this empty and set
 #   $permissionLevels{submit_feedback} = undef;
 #   This will cause the
 #   feedback button to go away as well.
-# 
+#
 # * If you want to send email ONLY to addresses in this list, set
-#   $permissionLevels{receive_feedback} = undef; 
-# 
+#   $permissionLevels{receive_feedback} = undef;
+#
 # It's often useful to set this in the course.conf to change the behavior of
 # feedback for a specific course.
 # defaults.config values:
 EOF
-	
+
 	if (defined $ce->{mail}->{feedbackRecipients}) {
 		print $fh "# \t", '$mail{feedbackRecipients} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $ce->{mail}->{feedbackRecipients} }), '];', "\n";
@@ -1415,7 +1419,7 @@ EOF
 		print $fh "# \t", '$mail{feedbackRecipients} = [  ];', "\n";
 	}
 	print $fh "\n";
-	
+
 	if (defined $options{feedbackRecipients}) {
 		print $fh '$mail{feedbackRecipients} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $options{feedbackRecipients} }), '];', "\n";
@@ -1423,15 +1427,15 @@ EOF
 	} else {
 		print $fh "\n\n\n";
 	}
-	
+
 	print $fh <<'EOF';
 # Users for whom to label problems with the PG file name (global value typically "professor")
-# 
+#
 # For users in this list, PG will display the source file name when rendering a problem.
-# 
+#
 # defaults.config values:
 EOF
-	
+
 	if (defined $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR}) {
 		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} }), '];', "\n";
@@ -1439,7 +1443,7 @@ EOF
 		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [  ];', "\n";
 	}
 	print $fh "\n";
-	
+
 	if (defined $options{PRINT_FILE_NAMES_FOR}) {
 		print $fh '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [',
 				join(", ", map { "'" . protectQString($_) . "'" } @{ $options{PRINT_FILE_NAMES_FOR} }), '];', "\n";


### PR DESCRIPTION
In the process of creating a course archive, first a temporary tar file is created in the courses directory.  Then that file is moved to the requested location.

There were several issues with the coding of how the temporary file was moved to the requested location.

First the perl `rename` method was used.  If the requested location is not on the same file system as the courses directory that will fail.  So this switches to using the `move` method in the `File::Copy` module. Note that webwork already uses this module elsewher, so this is not a new dependency.

Second, in the case that the `rename` method fails, the error was never checked.  The result was that the temporary archive file is left in the courses directory, and no errors are reported even though the requested archive file does not exist.

Third, in the case that a previous archive file exists in the courses directory, the `croak` call occured before the `unlink` call to delete the temporary archive file (in the clean up according to the comments). Thus the temporary archive file is not actually deleted.

This also removes the space at the beginning of the temporary file name. That worked, but why have it?

Note:  Hide spaces to review without seeing the removal of the space at the end of lines (done automatically by my text editor).
