### PR TITLE
Add and document a set-user facility in CAS authentication

### DIFF
--- a/conf/authen_CAS.conf.dist
+++ b/conf/authen_CAS.conf.dist
@@ -24,12 +24,52 @@ $authen{cas_options} = {
 		# Path of certificate file for CAS server.
 		CAFile => '', #e.g. '/etc/pki/tls/certs/ca-bundle.crt',
 	},
-	# There are no options specific to CAS at this time.  If there were,
-	# though, they would go here.
 
-	# For debugging:
-	#su_from => '8315',
-	su_to => '999999',
+	# Options specific to CAS authentication in WeBWorK
+
+	# On most college campuses, the CAS system is a campus-wide system,
+	# and individual departments may not be able to create their own CAS
+	# userids.  Instead, therefore, we support a "setUser" facility, with
+	# controls over which users can use it and (optionally) which users
+	# they can switch to.
+
+	# This is controlled by a hash, in which the keys are the users allowed
+	# to use the setUser function, and the values are either a string
+	# (optionally ending in '*', signifying pattern matching) or an array
+	# of such strings.
+	#
+	# Examples:
+	#
+	#   sudoers => undef,		# turns off this feature completely
+	#
+	#   sudoers => {admin => '*',
+	#   		alice => ['demo*', 'yxzzy'],
+	#   		bob => ['test1', 'test2'],
+	#   		},
+	#
+	# This option can also be set in a course.conf file (after this file
+	# authen_CAS.conf has been read in).
+	#
+	# Although it is true that users who can use this feature must be
+	# mentioned explicitly in the sudoers hash, they do not have to have
+	# accounts in the course in which it is being used.  Therefore, except
+	# for people who administer the webwork site as a whole, it is best
+	# to put such settings in the relevant course.conf files.
+	#
+	# Examples in course.conf file:
+	#
+	#   $authen{cas_options}{sudoers} = {
+	#     'profgauss' => ['teststudent', 'testta'],
+	#     };
+	#
+	#   # Add to existing hash
+	#   $authen{cas_options}{sudoers}{profwiles} = 'test*';
+	#
+	# Sample usage:  To log in as user "bob" in course Calc101, access
+	# webwork using a url such as:
+	#	https://webwork.ouruniversity.edu/webwork2/Calc101/?setUser=bob
+
+	sudoers => undef,
 };
 
 

--- a/lib/WeBWorK/Authen/CAS.pm
+++ b/lib/WeBWorK/Authen/CAS.pm
@@ -25,6 +25,46 @@ use WeBWorK::Debug;
 #$WeBWorK::Debug::Logfile = "/opt/webwork/webwork2/logs/cas-debug.log";
 #$WeBWorK::Debug::AllowSubroutineOutput = "get_credentials";
 
+sub checkSetUser {
+	my ($self, $user_id, $new_id) = @_;
+	my $ce = $self->{r}->ce;
+
+	unless (defined $ce->{authen}{cas_options}{sudoers}) {
+		$self->{error} = "Set-user capability is not enabled.";
+		$self->write_log_entry("User $user_id tried to use setUser, which is turned off");
+		return 0;
+	}
+
+	my $allowed_targets = $ce->{authen}{cas_options}{sudoers}{$user_id};
+	unless (defined $allowed_targets) {
+		$self->{error} = "User is $user_id is not authorized for setUser.";
+		$self->write_log_entry("User $user_id tried to use setUser, which is not authorized for that user");
+		return 0;
+	}
+
+	if (ref $allowed_targets eq 'ARRAY') {
+		foreach my $x (@{$allowed_targets}) {
+			return 1 if $x =~ m/(.*)\*$/
+				? $new_id =~ m/^$1/
+				: $new_id eq $x;
+		}
+	}
+	elsif (not ref $allowed_targets) {
+		return 1 if $allowed_targets =~ m/(.*)\*$/
+			? $new_id =~ m/^$1/
+			: $new_id eq $allowed_targets;
+	}
+	else {
+		$self->{error} = "Malformed sudoers data structure.";
+		$self->write_log_entry("Malformed sudoers data structure.");
+		return 0;
+	}
+
+	$self->{error} = "User $user_id is not allowed to set user to $new_id.";
+	$self->write_log_entry("User $user_id made invalid attempt to set user to $new_id");
+	return 0;
+}
+
 sub get_credentials {
 	my $self = shift;
 	my $r = $self->{r};
@@ -108,11 +148,12 @@ sub get_credentials {
 			return 0;
 		} else {
 			debug("ticket is good, user is $user_id");
-			if (defined $ce->{authen}{cas_options}{su_from}
-			  && $user_id eq $ce->{authen}{cas_options}{su_from}
-			  && defined $ce->{authen}{cas_options}{su_to}) {
-				$user_id = $ce->{authen}{cas_options}{su_to};
-				debug("hackily changing user to $user_id");
+			my $new_id = $r->param('setUser');
+			if (defined $new_id) {
+				return 0
+				  unless checkSetUser($self, $user_id, $new_id);
+				$self->write_log_entry("setUser: user $user_id logged in as $new_id");
+				$user_id = $new_id;
 			}
 			$self->{'user_id'} = $user_id;
 			$self->{r}->param('user', $user_id);


### PR DESCRIPTION
Add a set-user facility in CAS authentication.  See the comments in authen_CAS.conf.dist for the rationale.