### PR TITLE
Update bin/dev_scripts/update-localization-files so that it will

### DIFF
--- a/bin/dev_scripts/update-localization-files
+++ b/bin/dev_scripts/update-localization-files
@@ -55,7 +55,7 @@ cd $LOCDIR
 
 echo "Updating $WEBWORK_ROOT/webwork2.pot"
 
-xgettext.pl -o webwork2.pot -D $WEBWORK_ROOT/lib -D $WEBWORK_ROOT/conf -D $PG_ROOT/lib -D $PG_ROOT/macros
+xgettext.pl -o webwork2.pot -D $WEBWORK_ROOT/lib -D $PG_ROOT/lib -D $PG_ROOT/macros $WEBWORK_ROOT/conf/defaults.config $WEBWORK_ROOT/conf/LTIConfigValues.config
 
 if $UPDATE_PO; then
 	find $LOCDIR -name '*.po' -exec bash -c "echo \"Updating {}\"; msgmerge -qUN {} webwork2.pot" \;


### PR DESCRIPTION
At present the recently revised `bin/dev_scripts/update-localization-files` pulls in too much from the `webwork2/conf` directory.
At present it was getting a string from `/opt/webwork/webwork2/conf/snippets/hardcopyThemes/common/CAPA.tex` which should not be included, but potentially other junk would get pulled in accidentally.
Fix this by explicitly listing what files in `webwork2/conf` should be processed.