### PR TITLE
Revisions to controls of SendMail.pm and some changes to what should be translated

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -696,8 +696,8 @@ sub print_form {
 								name   => 'send_to',
 								values => [ 'all_students', 'studentID' ],
 								labels => {
-									all_students => $r->maketext('all'),
-									studentID    => $r->maketext('selected')
+									all_students => $r->maketext('all students'),
+									studentID    => $r->maketext('selected students')
 								},
 								default         => $r->param('send_to') // 'studentID',
 								linebreak       => 0,

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -714,7 +714,7 @@ sub print_form {
 						}),
 						CGI::label(
 							{ for => 'send_to_selected', class => 'form-check-label' },
-							$r->maketext('Send to selected students')
+							$r->maketext('Send to the students selected below')
 						)
 					),
 					CGI::div(

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -513,13 +513,13 @@ sub displaySets {
 					last_name     => $studentRecord->last_name(),
 					first_name    => $studentRecord->first_name(),
 					score         => 0,
-					total         => $r->maketext('n/a'),
+					total         => 'n/a',
 					section       => $studentRecord->section(),
 					recitation    => $studentRecord->recitation(),
 					problemsRow   => [$r->maketext('no attempt recorded')],
 					email_address => $studentRecord->email_address(),
-					date          => $r->maketext('none'),
-					testtime      => $r->maketext('none'),
+					date          => 'n/a',
+					testtime      => 'n/a',
 				};
 			}
 
@@ -534,13 +534,13 @@ sub displaySets {
 				last_name     => $studentRecord->last_name(),
 				first_name    => $studentRecord->first_name(),
 				score         => 0,
-				total         => $r->maketext('n/a'),
+				total         => 'n/a',
 				section       => $studentRecord->section(),
 				recitation    => $studentRecord->recitation(),
 				problemsRow   => ['&nbsp;'],
 				email_address => $studentRecord->email_address(),
-				date          => $r->maketext('none'),
-				testtime      => $r->maketext('none'),
+				date          => 'n/a',
+				testtime      => 'n/a',
 			};
 			push(@score_list,           0);
 			push(@augmentedUserRecords, $dataH);


### PR DESCRIPTION
In `lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm`:
  1. The value `n/a` was being translated, but later a test against the plain value `n/a` is used. That will not work. I do not think that there is any need to translate this special string value. If I am not mistaken only instructors should see it.
  2. The value `none` was being translated. It is a one work term, so could require different translations in different contexts. It is used for when there was no test date/time - so using the plain `n/a` seems suitable here also.

In the other file replace two ambiguous short strings used as labels and set to be translated with slightly longer and explicit strings.

If this is merged - the localization file `webwork.pot` should be updated and synced to Transifex.

