### PR TITLE
Revise rtl.css for WeBWorK 2.17 - old style change no longer needed for RTL problems

### DIFF
--- a/htdocs/css/rtl.css
+++ b/htdocs/css/rtl.css
@@ -12,8 +12,9 @@
  * Artistic License for more details.
  */
 
-/* --- Modify some CSS for Right to left courses/problems ---------------------------------------------------- */
+/* --- Modify some CSS for Right to left courses/problems --- */
 
-input[type="radio"], input[type="checkbox"] {
-  float: right !important;
-}
+/* The changes which were needed here in WeBWorK 2.16 are no
+ * longer needed in WeBWorK 2.17. The file is being retained
+ * for potential future use. */
+


### PR DESCRIPTION
Remove contents of `rtl.css`. The changes in the old version of the file were needed to override the `float: left` setting applied to check-boxes and radio-buttons from the old version of `bootstap.css` for right-to-left problems.

The new version of bootstrap does not use `float` and does not seem to need any special modifications for check-boxes or radio button formatting. The location of check-boxes and radio-buttons in WW 2.17 comes out properly automatically in my testing in Hebrew courses/problems, also when they are enclosed in a DIV which locally sets to an LTR direction in RTL problems.

A sample PG file for such testing is below.

I did not delete the file, as there may be potential future use. We can do that in the future, if experience with WeBWorK 2.17 in RTL courses shows there is no need for such a file.

---

```
DOCUMENT(); 
loadMacros(
  "PGstandard.pl",
  "PGchoicemacros.pl",
  "parserRadioButtons.pl",
);

SET_PROBLEM_TEXTDIRECTION("rtl");
SET_PROBLEM_LANGUAGE("he-IL");

TEXT(beginproblem());

# Checkboxes needed in an LTR setting

$cmc1 = new_checkbox_multiple_choice();
$cmc1->qa("",
  '\( \text{Span} \lbrace u, v \rbrace = \text{Span} \lbrace u, w, z \rbrace \)'
);
$cmc1->extra(
  '\( \text{Span} \lbrace u, z \rbrace = \text{Span} \lbrace v, w \rbrace \)'
);

# Checkboxes needed in an RTL setting

$cmc2 = new_checkbox_multiple_choice();
$cmc2->qa("", 
  'תשובה נכונה 1',
  'תשובה נכונה 2'
);
$cmc2->extra(
  'תשובה לא נכונה 1',
  'תשובה לא נכונה 2'
);

# Radio buttons needed in an LTR setting

$radio1 = RadioButtons( [
    "כן",
    "לא"
  ],
  # correct answer:
  "כן", # correct answer
  labels => "ABC",
  displayLabels => 1,
);

# Radio buttons needed in an LTR setting

$radio2 = RadioButtons( [
    "\( \text{Span} \lbrace u, v \rbrace = \text{Span} \lbrace w \rbrace \)",
    "\( \text{Span} \lbrace u, v \rbrace = \text{Span} \lbrace u \rbrace \)"
  ],
  # correct answer:
  "\( \text{Span} \lbrace u, v \rbrace = \text{Span} \lbrace w \rbrace \)", # correct answer     
  labels => "ABC", 
  displayLabels => 1,
  separator => "$BR",
);

BEGIN_TEXT

\{ $radio1->buttons() \}
$BR
\{ $cmc2->print_a \}

$BCENTER
\{ openDiv( { "dir" => "ltr", "allowStyle" => 1, "style" => "width: 290px; text-align: left;" } ) \}
\{ $cmc1->print_a \}
$BR
\{ $radio2->buttons() \}
\{ closeDiv() \}
$ECENTER

END_TEXT

ANS($radio1->cmp);
ANS(checkbox_cmp($cmc2->correct_ans));
ANS(checkbox_cmp($cmc1->correct_ans));
ANS($radio2->cmp);
               
ENDDOCUMENT();
```
---

As seen in WW 2.17 without any `rtl.css` file in use:

![AsSeenInWW217withoutRTLCSS](https://user-images.githubusercontent.com/39089094/178942165-137e9fca-4fc2-42e8-b645-9e22c203c34e.png)

---

As seen in WW 2.16 without the old `rtl.css` file in use:

![AsSeenInWW216withoutRTLCSS](https://user-images.githubusercontent.com/39089094/178942345-128378e6-6e1b-40bd-85e6-be804f142238.png)

---

As seen in WW 2.16 with the old `rtl.css` file in use:
![AsSeenInWW216withRTLCSS](https://user-images.githubusercontent.com/39089094/178942319-ac9fc10e-fd84-4e24-97ea-29f18438c46a.png)
