### PR TITLE
Set a few form/display fields to force left-to-right direction.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -314,6 +314,7 @@ EOF
 					values   => $dirs,
 					labels   => $dirlabels,
 					class    => 'form-select',
+					dir      => 'ltr',
 					onChange => "doForm('Go')"
 				})
 			)
@@ -346,6 +347,7 @@ EOF
 				name       => "files",
 				id         => "files",
 				class      => 'form-select font-monospace h-100',
+				dir        => 'ltr',
 				size       => 17,
 				multiple   => 1,
 				values     => $files,

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1301,6 +1301,7 @@ sub import_form {
 					? $actionParams{'action.import.source'}
 					: '',
 					class => 'form-select form-select-sm',
+					dir   => 'ltr',
 					size  => $actionParams{'action.import.number'}[0] || '1',
 					defined($actionParams{'action.import.number'}[0])
 						&& $actionParams{'action.import.number'}[0] ne '1' ? (multiple => undef) : ()

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -1144,6 +1144,7 @@ sub import_form {
 					values  => [ $self->getCSVList() ],
 					default => $actionParams{'action.import.source'}[0] || '',
 					class   => 'form-select form-select-sm',
+					dir     => 'ltr',
 				})
 			)
 		),

--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -141,7 +141,8 @@ sub body {
 							name => 'currPassword',
 							id   => 'currPassword',
 							(defined $Password) ? () : (disabled => 1),
-							class => 'form-control'
+							class => 'form-control',
+							dir => 'ltr'
 						})
 					),
 				),
@@ -153,7 +154,7 @@ sub body {
 					),
 					CGI::div(
 						{ class => 'col-sm-6' },
-						CGI::password_field({ name => 'newPassword', id => 'newPassword', class => 'form-control' })
+						CGI::password_field({ name => 'newPassword', id => 'newPassword', class => 'form-control', dir => 'ltr' })
 					)
 				),
 				CGI::div(
@@ -167,7 +168,8 @@ sub body {
 						CGI::password_field({
 							name  => 'confirmPassword',
 							id    => 'confirmPassword',
-							class => 'form-control'
+							class => 'form-control',
+							dir   => 'ltr'
 						})
 					)
 				)
@@ -211,7 +213,8 @@ sub body {
 							id       => 'currAddress',
 							name     => 'currAddress',
 							value    => $EUser->email_address,
-							class    => 'form-control'
+							class    => 'form-control',
+							dir      => 'ltr'
 						})
 					)
 				),
@@ -223,7 +226,7 @@ sub body {
 					),
 					CGI::div(
 						{ class => 'col-sm-6' },
-						CGI::textfield({ name => 'newAddress', id => 'newAddress', class => 'form-control' })
+						CGI::textfield({ name => 'newAddress', id => 'newAddress', class => 'form-control', dir => 'ltr' })
 					)
 				)
 			)


### PR DESCRIPTION
Force a few more things to be left-to-right where in Hebrew courses the default would have been right-to-left which seems less appropriate. The changes should not have an effect on courses in left-to-right languages.