### PR TITLE
Hotfix: Set MathJax to SVG output

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -37,7 +37,7 @@
 <link rel="stylesheet" href="<!--#url type="webwork" name="theme" file="math4-overrides.css"-->"/>
 <!--#endif-->
 <script src="<!--#url type="webwork" name="htdocs" file="js/apps/MathJaxConfig/mathjax-config.js"-->" defer></script>
-<script src="<!--#url type="webwork" name="htdocs" file="node_modules/mathjax/es5/tex-chtml.js"-->" id="MathJax-script" defer></script>
+<script src="<!--#url type="webwork" name="htdocs" file="node_modules/mathjax/es5/tex-svg.js"-->" id="MathJax-script" defer></script>
 <script src="<!--#url type="webwork" name="htdocs" file="node_modules/jquery/dist/jquery.min.js"-->"></script>
 <script src="<!--#url type="webwork" name="htdocs" file="node_modules/jquery-ui-dist/jquery-ui.min.js"-->"></script>
 <script src="<!--#url type="webwork" name="htdocs" file="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"-->" defer></script>

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -42,7 +42,7 @@
 
 <!-- JS Loads -->
 <script src="<!--#url type="webwork" name="htdocs" file="js/apps/MathJaxConfig/mathjax-config.js"-->" defer></script>
-<script src="<!--#url type="webwork" name="htdocs" file="node_modules/mathjax/es5/tex-chtml.js"-->" id="MathJax-script" defer></script>
+<script src="<!--#url type="webwork" name="htdocs" file="node_modules/mathjax/es5/tex-svg.js"-->" id="MathJax-script" defer></script>
 <script src="<!--#url type="webwork" name="htdocs" file="node_modules/jquery/dist/jquery.min.js"-->"></script>
 <script src="<!--#url type="webwork" name="htdocs" file="node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"-->" defer></script>
 <!--#if can="output_JS"-->

--- a/htdocs/third-party-assets.json
+++ b/htdocs/third-party-assets.json
@@ -99,6 +99,6 @@
 	"node_modules/jquery-ui-dist/jquery-ui.min.js": "https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.13.1/jquery-ui.min.js",
 	"node_modules/jquery/dist/jquery.min.js": "https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js",
 	"node_modules/luxon/build/global/luxon.min.js": "https://cdn.jsdelivr.net/npm/luxon@2.3.1/build/global/luxon.min.js",
-	"node_modules/mathjax/es5/tex-chtml.js": "https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml.js",
+	"node_modules/mathjax/es5/tex-svg.js": "https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-svg.js",
 	"node_modules/sortablejs/Sortable.min.js": "https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"
 }

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -194,7 +194,7 @@ sub formatRenderedProblem {
 		[ 'node_modules/jquery-ui-dist/jquery-ui.min.js',                      0, {} ],
 		[ 'node_modules/iframe-resizer/js/iframeResizer.contentWindow.min.js', 0, {} ],
 		[ 'js/apps/MathJaxConfig/mathjax-config.js',                0, { defer => undef } ],
-		[ 'node_modules/mathjax/es5/tex-chtml.js',                  0, { defer => undef, id => 'MathJax-script' } ],
+		[ 'node_modules/mathjax/es5/tex-svg.js',                    0, { defer => undef, id => 'MathJax-script' } ],
 		[ 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js', 0, { defer => undef } ],
 		[ 'js/apps/Problem/problem.js',                             0, { defer => undef } ],
 		[ 'math4.js',                                               1, { defer => undef } ],


### PR DESCRIPTION
Change to using MathJax's SVG output, as Firefox had a bug which caused some thin lines to disappear when it renders from MathJax's CHTML output at certain Zoom levels.

WW 2.17 no longer allows changing the MathJax mode by modifying a config file, so this hotfix changes the hard-wired default.

See:
  - https://github.com/openwebwork/webwork2/issues/1524
  - https://bugzilla.mozilla.org/show_bug.cgi?id=1741887
