### PR TITLE
Hotfix (change from PR #1765): Move the "busy indicator" of the pg problem editor into the modal and show the modal immediately

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -23,7 +23,6 @@
 		frame.contentWindow.addEventListener('resize',
 			() => frame.contentDocument.getElementById('content').classList.remove('col-md-10')
 		);
-		bsModal.show();
 	});
 
 	document.getElementById('submit_button_id')?.addEventListener('click', () => {
@@ -39,13 +38,14 @@
 		document.getElementById('editor').target = target;
 
 		if (target == "pg_editor_frame") {
+			bsModal.show();
 			busyIndicator = document.createElement('div');
 			busyIndicator.classList.add('page-loading-busy-indicator');
 			busyIndicator.innerHTML = '<div class="busy-text"><h2>Loading...</h2></div>' +
 				'<div><i class="fas fa-circle-notch fa-spin fa-3x"></i></div>' +
 				'<div class="busy-text">Press escape to cancel</div>';
 			busyIndicator.tabIndex = -1;
-			document.body.appendChild(busyIndicator);
+			bsModal._element.querySelector('.modal-body')?.appendChild(busyIndicator);
 			busyIndicator.focus();
 
 			// Allow the user to cancel loading of the iframe by pressing escape.

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -766,7 +766,7 @@ input.changed[type=text] { /* orange */
 /* Page loading busy indicator */
 /* Currently only used on the problem editor page. */
 .page-loading-busy-indicator {
-	position: fixed;
+	position: absolute;
 	width: 100%;
 	height: 100%;
 	left: 0;


### PR DESCRIPTION
Cherry-pick the commit from https://github.com/openwebwork/webwork2/pull/1765 as a hotfix to main.

---

Copied from https://github.com/openwebwork/webwork2/pull/1765 :

Move the "busy indicator" of the pg problem editor into the modal and show the modal immediately, rather than showing the "busy indicator", and then showing the modal after the page loads.

This solves several issues with content not being rendered correctly due to the page not having size yet (for example MathJax in SVG mode).