### PR TITLE
Fix the "Grade Problem" link for essay problems on the problem set page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -783,9 +783,10 @@ sub body {
 			if ($authz->hasPermissions($user, "access_instructor_tools") && $authz->hasPermissions($user, "score_sets"))
 			{
 				my @setUsers = $db->listSetUsers($setName);
+				my @globalProblems = $db->getGlobalProblemsWhere({ set_id => $setName }, 'problem_id');
 
 				my @gradeableProblems;
-				for my $problem (@problems) {
+				for my $problem (@globalProblems) {
 					if ($problem->flags =~ /essay/) {
 						$canScoreProblems = 1;
 						$gradeableProblems[ $problem->problem_id ] = 1;


### PR DESCRIPTION
This fixes part of issue #1774.

The issue is that the merged problem does not hold the essay flag.  The global problem does.  So those have to be fetched from the database for this.