### PR TITLE
provide errors when called scripts fail

### DIFF
--- a/bin/Helper.pm
+++ b/bin/Helper.pm
@@ -1,0 +1,17 @@
+package Helper;
+
+use warnings;
+use strict;
+use base 'Exporter';
+
+our @EXPORT_OK = 'runScript';
+
+sub runScript {
+    my $script_path = shift;
+    unless ( do $script_path ) {
+        warn "Execution of $script_path failed:\n";
+        die $@ if $@;
+    }
+}
+
+1;

--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -32,6 +32,7 @@ use lib "$ENV{WEBWORK_ROOT}/lib";
 use lib "$ENV{PG_ROOT}/lib";
 use lib "$ENV{WEBWORK_ROOT}/bin";
 use WeBWorK::CourseEnvironment;
+use Helper 'runScript';
 
 my $ce = new WeBWorK::CourseEnvironment({webwork_dir=>$ENV{WEBWORK_ROOT}});
 
@@ -58,13 +59,5 @@ if ($ce->{problemLibrary}{showLibraryLocalStats} ||
 }
 
 print "\nDone.\n";
-
-sub runScript {
-    my $script_path = shift;
-    unless ( do $script_path ) {
-        warn "Execution of $script_path failed:\n";
-        die $@ if $@;
-    }
-}
 
 1;

--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -36,25 +36,35 @@ use WeBWorK::CourseEnvironment;
 my $ce = new WeBWorK::CourseEnvironment({webwork_dir=>$ENV{WEBWORK_ROOT}});
 
 print "\nDownloading the latest OPL release.\n";
-do $ENV{WEBWORK_ROOT} . '/bin/download-OPL-metadata-release.pl';
+runScript("$ENV{WEBWORK_ROOT}/bin/download-OPL-metadata-release.pl");
 
 # Generate set definition list files.
-do $ENV{WEBWORK_ROOT} . '/bin/generate-OPL-set-def-lists.pl';
+runScript("$ENV{WEBWORK_ROOT}/bin/generate-OPL-set-def-lists.pl");
 
 if ($ce->{problemLibrary}{showLibraryLocalStats} ||
     $ce->{problemLibrary}{showLibraryGlobalStats}) {
   print "\nUpdating Library Statistics.\n";
-  do $ENV{WEBWORK_ROOT}.'/bin/update-OPL-statistics.pl';
+  runScript("$ENV{WEBWORK_ROOT}/bin/update-OPL-statistics.pl");
 
   print "\nLoading global statistics (if possible).\n";
-  do $ENV{WEBWORK_ROOT}.'/bin/load-OPL-global-statistics.pl';
+  runScript("$ENV{WEBWORK_ROOT}/bin/load-OPL-global-statistics.pl");
 
-  if ( $ENV{SKIP_UPLOAD_OPL_statistics} ) {
+  if ( $ENV{SKIP_UPLOAD_OPL_STATISTICS} ) {
     print "\nSkipping upload-OPL-statistics as requested\n";
   } else {
     print "\nSharing aggregated statistics\n";
-    do $ENV{WEBWORK_ROOT}.'/bin/upload-OPL-statistics.pl';
+    runScript("$ENV{WEBWORK_ROOT}/bin/upload-OPL-statistics.pl");
   }
 }
 
 print "\nDone.\n";
+
+sub runScript {
+    my $script_path = shift;
+    unless ( do $script_path ) {
+        warn "Execution of $script_path failed:\n";
+        die $@ if $@;
+    }
+}
+
+1;

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -94,6 +94,7 @@ my @modulesList = qw(
 	Errno
 	Exception::Class
 	File::Copy
+	File::Fetch
 	File::Find
 	File::Find::Rule
 	File::Path

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -21,9 +21,11 @@ BEGIN {
 }
 
 use lib "$ENV{WEBWORK_ROOT}/lib";
+use lib "$ENV{WEBWORK_ROOT}/bin";
 use lib "$pg_dir/lib";
 
 use WeBWorK::CourseEnvironment;
+use Helper 'runScript';
 
 my $ce = new WeBWorK::CourseEnvironment({ webwork_dir => $ENV{WEBWORK_ROOT} });
 
@@ -94,13 +96,5 @@ unlink($releaseFile);
 rmtree("$ce->{webworkDirs}{tmp}/webwork-open-problem-library");
 
 say 'Done!';
-
-sub runScript {
-	my $script_path = shift;
-	unless (do $script_path) {
-		warn "Execution of $script_path failed:\n";
-		die $@ if $@;
-	}
-}
 
 1;

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -86,7 +86,7 @@ mkdir "$libraryDirectory/TABLE-DUMP" if !-d "$libraryDirectory/TABLE-DUMP";
 copy("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/TABLE-DUMP/OPL-tables.sql", "$libraryDirectory/TABLE-DUMP");
 
 say 'Restoring OPL tables from release database dump.';
-do $ENV{WEBWORK_ROOT} . '/bin/restore-OPL-tables.pl';
+runScript("$ENV{WEBWORK_ROOT}/bin/restore-OPL-tables.pl");
 
 # Remove temporary files.
 say "Removing temporary files.";
@@ -94,5 +94,13 @@ unlink($releaseFile);
 rmtree("$ce->{webworkDirs}{tmp}/webwork-open-problem-library");
 
 say 'Done!';
+
+sub runScript {
+	my $script_path = shift;
+	unless (do $script_path) {
+		warn "Execution of $script_path failed:\n";
+		die $@ if $@;
+	}
+}
 
 1;

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -166,7 +166,7 @@ if [ "$1" = 'apache2' ]; then
     if [ -f "$APP_ROOT/libraries/Restore_or_build_OPL_tables" ]; then
       if [ ! -f "$APP_ROOT/libraries/webwork-open-problem-library/TABLE-DUMP/OPL-tables.sql" ]; then
         # Download the metadata and install it
-        export SKIP_UPLOAD_OPL_statistics=1
+        export SKIP_UPLOAD_OPL_STATISTICS=1
         if [ ! -d $APP_ROOT/libraries/webwork-open-problem-library/JSON-SAVED ]; then
           mkdir $APP_ROOT/libraries/webwork-open-problem-library/JSON-SAVED
         fi


### PR DESCRIPTION

We've seen several occurrences now ([1](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8094), [2](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8104)) where the new OPL-update runs other scripts that may fail -- but any errors are not displayed, giving the impression that the script successfully ran as expected.

This PR modifies the handling of sub-scripts to capture any error messages they produce.