### PR TITLE
Fix overly zealous automatic unchecking on the "Sets assigned to user" page

### DIFF
--- a/htdocs/js/apps/UserDetail/userdetail.js
+++ b/htdocs/js/apps/UserDetail/userdetail.js
@@ -15,7 +15,7 @@
 			// So if it is unchecked, also uncheck any versions that may exist.
 			checkbox.addEventListener('change', () => {
 				if (!checkbox.checked) {
-					document.querySelectorAll(`input[type="checkbox"][name^="set.${setID}"][name$=".assignment"]`)
+					document.querySelectorAll(`input[type="checkbox"][name^="set.${setID},v"][name$=".assignment"]`)
 						.forEach((versionCheckbox) => versionCheckbox.checked = false);
 				}
 			});


### PR DESCRIPTION
The uncheck handling in WeBWorK 2.17 on the "Sets assigned to user" page at present is unchecking assignments whose name started with the name of the assignment being unchecked even if they are **not** versions of that assignment. This should fix the bug.

---

Testing:
  - Create assignments `testA`, `testA1`, and `testA2` as regular homeworks.
  - Make `testA` into a gateway (and make sure it has at least one problem).
  - Assign all these assignments to your user.
  - Start a version of `testA` as your user.
  - Use the Classlist Editor to open the the sets assigned to your user.
  - Uncheck `testA` (and do not save)
  - Observe that `test A (version 1)` gets unchecked (as desired) but also `testA1` and `testA2` get unchecked (not desired).
  - Patch the file changed by this PR, run `./generate-assets.js` in `webwork2/htdocs`
  - Reload the "Sets assigned to" page.
  - Uncheck `testA` (and do not save).
  - Observe that `test A (version 1)` gets unchecked (as desired) and that now `testA1` and `testA2` do not get unchecked.