### PR TITLE
Fix overly zealous automatic unchecking on the "Sets assigned to user" page (as in #1783) for develop

### DIFF
--- a/htdocs/js/apps/UserDetail/userdetail.js
+++ b/htdocs/js/apps/UserDetail/userdetail.js
@@ -15,7 +15,7 @@
 			// So if it is unchecked, also uncheck any versions that may exist.
 			checkbox.addEventListener('change', () => {
 				if (!checkbox.checked) {
-					document.querySelectorAll(`input[type="checkbox"][name^="set.${setID}"][name$=".assignment"]`)
+					document.querySelectorAll(`input[type="checkbox"][name^="set.${setID},v"][name$=".assignment"]`)
 						.forEach((versionCheckbox) => versionCheckbox.checked = false);
 				}
 			});


### PR DESCRIPTION
This is the commit from https://github.com/openwebwork/webwork2/pull/1783 targeted to develop.

---

The uncheck handling in WeBWorK 2.17 on the "Sets assigned to user" page at present is unchecking assignments whose name started with the name of the assignment being unchecked even if they are **not** versions of that assignment. This should fix the bug.