### PR TITLE
Add the select all checkbox to the Hmwk Sets Editor export sets page (hotfix).

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -2723,7 +2723,7 @@ sub printTableHTML {
 
 	my @tableHeadings = map { $fieldHeaders{$_} } @realFieldNames;
 
-	if (!($editMode || $exportMode)) {
+	if (!$editMode) {
 		unshift @tableHeadings,
 			CGI::th(CGI::input({
 				type              => 'checkbox',


### PR DESCRIPTION
See issue #1786.

Note that this is different than WeBWorK 2.16 and before.  Prior versions of WeBWorK had an empty table heading above the select set checkbox.  This adds the select all checkbox instead.

I can't exactly figure out how the empty header was added by looking at the WeBWorK 2.16 code.  So I took the approach of adding the select all checkbox instead, since that was clearly easy to implement.  In my opinion this is better anyway.

Added as a hotfix pull request.