### PR TITLE
Code mirror RTL hotfix

### DIFF
--- a/htdocs/js/apps/PGCodeMirror/pgeditor.css
+++ b/htdocs/js/apps/PGCodeMirror/pgeditor.css
@@ -22,7 +22,10 @@
 /* CodeMirror overrides */
 .CodeMirror-code {
 	outline: none;
-	direction: ltr !important;
+}
+
+pre.CodeMirror-line {
+	unicode-bidi: embed;
 }
 
 /* Match Highligher CSS */

--- a/htdocs/js/apps/PGCodeMirror/pgeditor.js
+++ b/htdocs/js/apps/PGCodeMirror/pgeditor.js
@@ -114,4 +114,9 @@
 		localStorage.setItem('WW_PGEditor_spellcheck', enableSpell.checked);
 		cm.focus();
 	});
+
+	const forceRTL = document.getElementById('forceRTL');
+	forceRTL.addEventListener('change', () => {
+		cm.setOption('direction', forceRTL.checked ? 'rtl' : 'ltr');
+	});
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/CodeMirrorEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/CodeMirrorEditor.pm
@@ -156,6 +156,21 @@ sub output_codemirror_html {
 						$r->maketext('Enable Spell Checking')
 					)
 				)
+			),
+			CGI::div(
+				{ class => 'col-sm-auto mb-2' },
+				CGI::div(
+					{ class => 'form-check mb-0' },
+					CGI::input({
+						type  => 'checkbox',
+						id    => 'forceRTL',
+						class => 'form-check-input'
+					}),
+					CGI::label(
+						{ for => 'forceRTL', class => 'form-check-label' },
+						'Force editor to RTL' # FIXME should have $r->maketext()
+					)
+				)
 			)
 		);
 	}


### PR DESCRIPTION
This proposed hotfix has 2 parts. The first commit makes two small CSS changes to fix some functionality of the newer version of the CodeMirror editor for use in editing problems which contain text in a right-to-left language like Hebrew.

The CodeMirror editor in WeBWorK 2.17 curently displays Hebrew text differently than did the version in WeBWorK 2.16. In WeBWorK 2.16 the Unicode bidirectional algorithm is applied to the text of each line, so Hebrew works would be displayed on-screen as one expects to read them (from right to left). This is not occurring in WeBWorK 2.17 at present, as Bootstrap 5 is setting `unicode-bidi: bidi-override;` in `node_modules/bootstrap/scss/_reboot.scss` for **all** HTML `pre` elements. That setting gets applies also to the `pre.CodeMirror-line` elements and prevents the bidirectional algorithm from being run on the content of the lines. I have fixed this by changing to `unicode-bidi: embed;` for the `pre.CodeMirror-line` elements.

(A blog post about CodeMirror's bidi support, possibly somewhat outdated is in https://marijnhaverbeke.nl/blog/cursor-in-bidi-text.html)

Along the way I noticed that `rtlcss` is modifying the setting for `direction` for `.CodeMirror-code` which does not have any effect but seems confusing. The original override is no longer needed to force the base text direction of CodeMirror to LTR, as the newer version of CodeMirror has a option called `direction` which is set by default to `ltr` and does not inherit a direction from that set by the HTML page (or enclosing HTML unit). Hence, that override was removed. (The original change to add the override was in https://github.com/openwebwork/webwork2/commit/17384101a9206eb8c619597a098e3990085c8e77 as part of https://github.com/openwebwork/webwork2/pull/850 but the setting was relocated into the current file recently.)

I would appreciate at least those 2 minor changes being accepted as a hotfix, as maintaining custom versions of CSS files on a Docker deployment is far less simple now that there is the asset build system.

---

The second changes adds a new "trick" which can be convenient for authors of problems in right to left languages. It allows flipping the base direction of CodeMirror between the default `ltr` and `rtl` at will. When in `rtl` mode the Perl/PG markup looks somewhat funny, but lines of text in the right-to-left language get displayed without some unusual quirks (primarily regarding the placement of punctuation).

It is easy to flip the `direction` setting of CodeMirror to do this as explained in https://codemirror.net/5/demo/bidi.html I added a checkbox below the the editor to force the editor into right-to-left mode, as a single checkbox seems more convenient to me that a pull-down or a pair of radio buttons.

Since I am relatively certain that the change is quite self contained and unlikely to make problems for regular uses, I am interested in adding it along with the more hotfix suitable changes from the first commit.