### PR TITLE
Also filter Contrib when viewing local problems in the Library Browser

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -120,8 +120,7 @@ sub get_library_sets {
 	my @dirs = grep {!$ignoredir{$_} and -d "$dir/$_"} @lis;
 	if ($top == 1) {@dirs = grep {!$problib{$_}} @dirs}
 	# Never include Library or Contrib at the top level
-	if ($top == 1) {@dirs = grep {$_ ne 'Library'} @dirs}
-        if ($top == 1) {@dirs = grep {$_ ne 'Contrib'} @dirs}
+	if ($top == 1) {@Dirs = grep {$_ ne 'Library' && $_ ne 'Contrib'} @Dirs}
 	foreach my $subdir (@dirs) {
 		my @results = get_library_sets(0, "$dir/$subdir");
 		$pgcount += shift @results; push(@pgdirs,@results);

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -120,7 +120,7 @@ sub get_library_sets {
 	my @dirs = grep {!$ignoredir{$_} and -d "$dir/$_"} @lis;
 	if ($top == 1) {@dirs = grep {!$problib{$_}} @dirs}
 	# Never include Library or Contrib at the top level
-	if ($top == 1) {@Dirs = grep {$_ ne 'Library' && $_ ne 'Contrib'} @Dirs}
+	if ($top == 1) {@dirs = grep {$_ ne 'Library' && $_ ne 'Contrib'} @Dirs}
 	foreach my $subdir (@dirs) {
 		my @results = get_library_sets(0, "$dir/$subdir");
 		$pgcount += shift @results; push(@pgdirs,@results);

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -120,7 +120,7 @@ sub get_library_sets {
 	my @dirs = grep {!$ignoredir{$_} and -d "$dir/$_"} @lis;
 	if ($top == 1) {@dirs = grep {!$problib{$_}} @dirs}
 	# Never include Library or Contrib at the top level
-	if ($top == 1) {@dirs = grep {$_ ne 'Library' && $_ ne 'Contrib'} @Dirs}
+	if ($top == 1) {@dirs = grep {$_ ne 'Library' && $_ ne 'Contrib'} @dirs}
 	foreach my $subdir (@dirs) {
 		my @results = get_library_sets(0, "$dir/$subdir");
 		$pgcount += shift @results; push(@pgdirs,@results);

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -119,8 +119,9 @@ sub get_library_sets {
 	my @pgdirs;
 	my @dirs = grep {!$ignoredir{$_} and -d "$dir/$_"} @lis;
 	if ($top == 1) {@dirs = grep {!$problib{$_}} @dirs}
-	# Never include Library at the top level
+	# Never include Library or Contrib at the top level
 	if ($top == 1) {@dirs = grep {$_ ne 'Library'} @dirs}
+        if ($top == 1) {@dirs = grep {$_ ne 'Contrib'} @dirs}
 	foreach my $subdir (@dirs) {
 		my @results = get_library_sets(0, "$dir/$subdir");
 		$pgcount += shift @results; push(@pgdirs,@results);


### PR DESCRIPTION
When viewing local problems in the library browser, it is hard-coded to skip any subfolders of Library, but by default all subfolders of Contrib are shown.

This hard-codes skipping of Contrib as well.  I don't know enough about the perl grep syntax to know if this could be done in a single command.

It would also be an improvement to have the list of folders to skip be a configuration variable rather than hard-code them.

I have targeted this to main, but if it's deemed not to be hotfix-worthy I can re-target to develop.