### PR TITLE
put sessionKeyTimeout in localOverrides.conf.dist

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -506,6 +506,11 @@ $mail{feedbackRecipients}    = [
 
 #$session_management_via = "key";
 
+## This is the length of time (in seconds) after which a user's session becomes
+## invalid if they have no activity. The default is 30 minutes (60*30 seconds).
+
+#$sessionKeyTimeout = 60*60*2;
+
 ################################################################################
 # Cookie control settings
 ################################################################################


### PR DESCRIPTION
This seems useful as a site-wide setting to override. It is present in `simple.conf`, but faculty do not always understand its importance. Especially when they give timed quizzes. Changing it for the institution is helpful, for example because you might decide to set it to the standard duration of a class at your institution.