### PR TITLE
Missing merge file locks Email page

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -85,6 +85,7 @@ sub initialize {
 	  $db->setSettingValue("${user}_mergefile",$mergefile);
 	} elsif ($db->settingExists("${user}_mergefile")) {
 	  $mergefile = $db->getSettingValue("${user}_mergefile");
+	  $mergefile = undef unless (-e "$ce->{courseDirs}{scoring}/$mergefile");
 	}
 
 	# Figure out action from submit data


### PR DESCRIPTION
## Email Bugfix

### To replicate
1. Set a merge file on the email page and *perform any submit action* (preview message will suffice)
2. Go into File Manager and change the name of the merge file (or remove it)
3. Attempt to return to email page -- WeBWorK 'die's because merge file is not found
4. Email page is unrecoverable until merge file is restored

### Background
For persistence on the Email page, WeBWorK stores the last-used merge file in the database. If the file is (re)moved, the DB has no knowledge of the change. As a result, the Email page attempts to restore the last-used settings and dies un-gracefully, leaving the user with no way to recover -- except by restoring a file with the original name.

The fix, as implemented here, is checking for the existence of the merge file when the filename is retrieved from the database. I'm open to feedback if anyone has of a better way of handling this.