### PR TITLE
Do not UTF-8 encode email body text.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -215,7 +215,7 @@ $emailableURL
 		}
 
 		my $email = Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)
-			->text_body(Encode::encode('UTF-8', $msg))->header('X-Remote-Host' => $remote_host);
+			->text_body($msg)->header('X-Remote-Host' => $remote_host);
 
 		# Extra headers
 		$email->header('X-WeBWorK-Module', $module)   if defined $module;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -969,7 +969,7 @@ sub mail_message_to_recipients {
 		$error_messages .= "There were errors in processing user $recipient, merge file $merge_file. \n$@\n" if $@;
 
 		my $email = Email::Stuffer->to($ur->email_address)->from($from)->subject($subject)
-			->text_body(Encode::encode('UTF-8', $msg))->header('X-Remote-Host' => $self->{remote_host});
+			->text_body($msg)->header('X-Remote-Host' => $self->{remote_host});
 
 		# $ce->{mail}{set_return_path} is the address used to report returned email if defined and non empty.
 		# It is an argument used in sendmail() (aka Email::Stuffer::send_or_die).
@@ -1017,7 +1017,7 @@ sub email_notification {
 	my $ce             = $self->r->ce;
 
 	my $email = Email::Stuffer->to($self->{defaultFrom})->from($self->{defaultFrom})->subject('WeBWorK email sent')
-		->text_body(Encode::encode('UTF-8', $result_message))->header('X-Remote-Host' => $self->{remote_host});
+		->text_body($result_message)->header('X-Remote-Host' => $self->{remote_host});
 
 	try {
 		$email->send_or_die({

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -615,8 +615,7 @@ Recitation: $recitation
 Comment:    $comment
 /;
 
-	my $email = Email::Stuffer->to(join(",", @recipients))->from($sender)->subject($subject)
-		->text_body(Encode::encode('UTF-8', $msg));
+	my $email = Email::Stuffer->to(join(",", @recipients))->from($sender)->subject($subject)->text_body($msg);
 
 	# Extra headers
 	$email->header('X-WeBWorK-Course: ', $courseID) if defined $courseID;


### PR DESCRIPTION
The Email::Stuffer package tries to automatically detect if the body needs to be UTF-8 encoded (either that or it just does so by default), and so if you UTF-8 encode the message first, then Email::Stuffer does it again resulting in "Mojibake".

I am putting this in as a hotfix.  I am sure @taniwallach will agree.