### PR TITLE
Keep manual grader open when using sibling links in Problem.pm.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -888,6 +888,9 @@ sub siblings {
 
 	my @items;
 
+	# Keep manual grader open when linking to problems if it's already open.
+	my %problemGraderLink = $self->{will}{showProblemGrader} ? (params => { showProblemGrader => 1 }) : ();
+
 	foreach my $problemID (@problemIDs) {
 		if ($isJitarSet && !$authz->hasPermissions($eUserID, "view_unopened_sets") && is_jitar_problem_hidden($db,$eUserID, $setID, $problemID)) {
 			shift(@problemRecords) if $progressBarEnabled;
@@ -950,7 +953,7 @@ sub siblings {
 				$link = CGI::a(
 					{
 						$active ? (class => $class)
-						: (href => $self->systemLink($problemPage), class => $class)
+						: (href => $self->systemLink($problemPage, %problemGraderLink), class => $class)
 					},
 					$r->maketext('Problem [_1]', join('.', @seq)) . ($progressBarEnabled ? $status_symbol : '')
 				);
@@ -959,7 +962,7 @@ sub siblings {
 			$link = CGI::a(
 				{
 					$active ? (class => 'nav-link active')
-					: (href => $self->systemLink($problemPage), class => 'nav-link')
+					: (href => $self->systemLink($problemPage, %problemGraderLink), class => 'nav-link')
 				},
 				$r->maketext('Problem [_1]', $problemID) . ($progressBarEnabled ? $status_symbol : '')
 			);


### PR DESCRIPTION
When using the manual grader in a homework set, add showProblemGrader=1 to the sibling's link parameters, so it remains visible (just like the next/previous problem links) when using those links to navigate the problems.