### PR TITLE
Don't show network errors in the library browser when unloading the page.

### DIFF
--- a/htdocs/js/apps/SetMaker/setmaker.js
+++ b/htdocs/js/apps/SetMaker/setmaker.js
@@ -2,8 +2,13 @@
 	const webworkURL = webworkConfig?.webwork_url ?? '/webwork2';
 	const basicWebserviceURL = `${webworkURL}/instructor_rpc`;
 
+	let unloading = false;
+	window.addEventListener('beforeunload', () => unloading = true);
+
 	// Informational alerts/errors
 	const alertToast = (title, msg, good = false) => {
+		if (unloading) return;
+
 		const toastContainer = document.createElement('div');
 		toastContainer.classList.add(
 			'toast-container', 'position-fixed', 'top-50', 'start-50',  'translate-middle', 'p-3');


### PR DESCRIPTION
This just stops showing error toasts when the window's beforeunload event fires on the library browser page.

This can happen if you select a subject and then rapidly click on "View Problems" before the request for library listing for the selected subject completes.

The problem is that when the form on the page is submitted this causes the browser to navigate to a new page, and all javascript network requests are aborted.  That is done by the browser, and there is nothing that can be done about that.  Usually this isn't a problem since the new page loads, except in this case the new page that is requested could be a slow loading page (for example if there are more than 8000 matching problems), giving the javascript time to react and show the error toast that the request was aborted before the new page actually loads.

Although I must say this is a rather extreme edge case.  To test this I had to slow down the server response to have time to select the subject and then click "View Problems" before the page load occurred.  I added `for (0 .. 100000000) {}` to the beginning of WebworkWebservice::LibraryActions::searchLib.

See https://github.com/openwebwork/webwork2/issues/1828.