### PR TITLE
Disable browser password autocompletion on the proctor login page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -261,7 +261,7 @@ sub body {
 			print CGI::end_div();
 		}
 
-		print CGI::submit({ type => "submit", value => $r->maketext("Continue"), class => 'btn btn-primary' });
+		print CGI::submit({ value => $r->maketext("Continue"), class => 'btn btn-primary' });
 		print CGI::end_div();
 
 		# Determine if there are valid practice users.

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -239,7 +239,8 @@ sub body {
 				class          => 'form-control',
 				placeholder    => '',
 				autocapitalize => 'none',
-				spellcheck     => 'false'
+				spellcheck     => 'false',
+				autocomplete   => 'new-password'
 			}),
 			CGI::label({ for => 'proctor_user' }, $r->maketext('Proctor Username'))
 		);
@@ -259,11 +260,12 @@ sub body {
 	print CGI::div(
 		{ class => 'col-xl-5 col-lg-6 col-md-7 col-sm-8 form-floating mb-2' },
 		CGI::password_field({
-			name        => 'proctor_passwd',
-			id          => 'proctor_passwd',
-			value       => '',
-			class       => 'form-control',
-			placeholder => ''
+			name         => 'proctor_passwd',
+			id           => 'proctor_passwd',
+			value        => '',
+			class        => 'form-control',
+			placeholder  => '',
+			autocomplete => 'new-password'
 		}),
 		CGI::label({ for => 'proctor_passwd' }, $r->maketext('Proctor Password'))
 	);


### PR DESCRIPTION
This just adds the attribute `autocomplete="new-password"` to the proctor user and password fields.  This is the recommended way to do this according to
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password.

However, this may not be supported by all browsers.  Safari is listed as support unknown.  So could a Safari user test this and let me know if it works?  If it doesn't, I have another way that should work for all browsers.

This is to address issue #1824 (also see the discussion in pull request #1821).