### PR TITLE
Fix utf8 characters in warnings and morbo logs to the terminal.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1419,22 +1419,16 @@ Defined in this package.
 
 Print accumulated warnings.
 
-The implementation in this package checks for a note in the request named
+The implementation in this package checks for a stash key named
 "warnings". If present, its contents are formatted and returned.
 
 =cut
 
 sub warnings {
 	my ($self) = @_;
-	my $r = $self->r;
-	print CGI::p("Entering ContentGenerator::warnings") if $TRACE_WARNINGS;
-	print "\n<!-- BEGIN " . __PACKAGE__ . "::warnings -->\n";
-	my $warnings = $r->stash('warnings') // '';
-	$warnings = Encode::decode("UTF-8", $warnings);
-	print $self->warningOutput($warnings) if $warnings;
-	print "<!-- END " . __PACKAGE__ . "::warnings -->\n";
-
-	return "";
+	print CGI::p("Entering ContentGenerator::warnings")     if $TRACE_WARNINGS;
+	print $self->warningOutput($self->r->stash->{warnings}) if $self->r->stash->{warnings};
+	return '';
 }
 
 =item help()

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -499,10 +499,7 @@ sub browse_local_panel {
 			{ class => 'mb-2' },
 			CGI::label(
 				{ for => 'library_sets', class => 'col-form-label-sm' },
-				$r->maketext(
-					"[_1] Problems:",
-					$lib eq '' ? $r->maketext('Local') : Encode::decode("UTF-8", $problib{$lib})
-				)
+				$r->maketext("[_1] Problems:", $lib eq '' ? $r->maketext('Local') : $problib{$lib})
 			),
 			CGI::popup_menu({
 				name    => 'library_sets',
@@ -1155,7 +1152,7 @@ sub make_top_row {
 	foreach my $lib (sort(keys(%problib))) {
 		$libs .= CGI::submit({
 			name  => "browse_$lib",
-			value => Encode::decode("UTF-8", $problib{$lib}),
+			value => $problib{$lib},
 			class => 'btn btn-secondary btn-sm ms-2 mb-2',
 			($browse_which eq "browse_$lib") ? (disabled => undef) : ()
 		})

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -28,7 +28,6 @@ use warnings;
 #use CGI qw(-nosticky );
 use WeBWorK::CGI;
 use WeBWorK::Utils qw(readFile dequote jitar_id_to_seq format_set_name_display);
-use Encode;
 
 # This content generator is NOT logged in.
 # BUT one must return a 1 so that error messages can be displayed.
@@ -176,7 +175,6 @@ sub body {
 	# us to yell at the user for doing that, since Authen isn't a content-
 	# generating module.
 	my $authen_error = $r->stash('authen_error') // '';
-	$authen_error = Encode::decode("UTF-8", $authen_error);
 
 	if ($authen_error) {
 		print CGI::div({ class => 'alert alert-danger', tabindex => '0' }, $authen_error);

--- a/lib/WeBWorK/FakeRequest.pm
+++ b/lib/WeBWorK/FakeRequest.pm
@@ -14,7 +14,7 @@
 ################################################################################
 
 package WeBWorK::FakeRequest;
-use parent WeBWorK::Request;
+use parent qw(WeBWorK::Request);
 
 =head1 NAME
 

--- a/lib/WeBWorK/File/Classlist.pm
+++ b/lib/WeBWorK/File/Classlist.pm
@@ -38,8 +38,8 @@ our @EXPORT = qw/parse_classlist write_classlist/;
 sub parse_classlist($) {
 	my ($file) = @_;
 
-	use open qw( :encoding(UTF-8) :std );    # assume classlist is utf8 encoded
-	my $fh = new IO::File($file, "<")
+	# assume classlist is utf8 encoded
+	my $fh = IO::File->new($file, '<:encoding(UTF-8)')
 		or die "Failed to open classlist '$file' for reading: $!\n";
 
 	my (@records);
@@ -95,7 +95,7 @@ sub parse_classlist($) {
 sub write_classlist($@) {
 	my ($file, @records) = @_;
 
-	my $fh = new IO::File($file, '>:encoding(UTF-8)')
+	my $fh = IO::File->new($file, '>:encoding(UTF-8)')
 		or die "Failed to open classist '$file' for writing: $!\n";
 
 	my $csv = Text::CSV->new({ binary => 1 });


### PR DESCRIPTION
The 'warnings' stash value is not utf8 encoded.  That was removed with the switch to Mojolicious since there is no need for it.  That means that it should not be utf8 decoded when it is used.

There was also a problem created by the `use open qw(:encoding(UTF-8) :std);` call that was in lib/WeBWorK/File/Classlist.pm.  When `use open` is called in that way it has global scope and affects all standard handles for the entire application.  Most importantly it was setting the encoding for STDERR.  Mojolicious writes already encoded logs to STDERR when morbo is used.  This results in mojibake in the terminal.  Never call `use open` in that way.  Instead use `use open IO => ':encoding(UTF-8)'` to apply encoding only in the lexical scope of where it is called.  Even better, don't call `use open`.  Just apply encoding as needed when opening a file.

Many of the binmode calls also need to be reviewed.  This isn't being done correctly and there are still issues with this.  This is most important for PG code going forward.

You can test this with the following problem:  
[z_squared2.pg.txt](https://github.com/openwebwork/webwork2/files/10044002/z_squared2.pg.txt)

Without this pull request the `warn` statement will make the request die.  With this pull request the problem will render and the warning will be displayed in the usual way.  Furthermore the morbo terminal log will properly display the Hebrew warning.  In production the Hebrew characters will properly appear in the `logs/webwork2.log` log file.