### PR TITLE
Fix the showHintsAfter setting for old style problem list files

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -2168,14 +2168,14 @@ sub readSetDef {
 				push(
 					@problemData,
 					{
-						source_file    => $name,
-						value          => $weight,
-						max_attempts   => $attemptLimit,
-						showMeAnother  => $showMeAnother,
-						showHintsAfter => $showHintsAfter,
-						# use default since it's not going to be in the file
-						prPeriod     => $prPeriod_default,
-						continuation => $continueFlag,
+						source_file   => $name,
+						value         => $weight,
+						max_attempts  => $attemptLimit,
+						showMeAnother => $showMeAnother,
+						continuation  => $continueFlag,
+						# Use defaults for these since they are not going to be in the file.
+						prPeriod       => $prPeriod_default,
+						showHintsAfter => $showHintsAfter_default,
 					}
 				);
 			}


### PR DESCRIPTION
I didn't test this for version 1 type problem list set definition files when I added the showHintsAfter setting, and of course it doesn't work. The showHintsAfter setting is guaranteed to not be in any of these files, and so the setting ends up being set to the empty string.  The old style list format doesn't fill in defaults, and so the empty string is put into the database.  The database interprets this as a null value and croaks since the column is not null.

To fix this the method for parsing the old style lists just needs to use the default value from the conf files.

To test this try to import one of these old style problem set list files (for example `Contrib/Michigan/gateways/calIIentr/setchain_rule.def`).  Without the current develop branch you will get the error "DBD::MariaDB::st execute failed: Column 'showHintsAfter' cannot be null".  With this pull request the set will import correctly.