### PR TITLE
Rename Docker stage 1 image for develop (to become 2.18) to avoid conflict with that from WW 2.17

### DIFF
--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -33,7 +33,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # We need to change FROM before setting the ENV variables.
 
-FROM webwork-base:forWW217
+FROM webwork-base:forWW218
 
 ENV WEBWORK_URL=/webwork2 \
 	WEBWORK_ROOT_URL=http://localhost::8080 \

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -97,7 +97,7 @@ services:
       # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
       dockerfile: DockerfileStage2
       # For the 2 stage build process run
-      #     docker build --tag webwork-base:forWW217 -f DockerfileStage1 .
+      #     docker build --tag webwork-base:forWW218 -f DockerfileStage1 .
       # and then
       #     docker-compose build
       # When rebuilding to get updated images add the "--no-cache" option to both commands.


### PR DESCRIPTION
Refer to the Docker base image in the two stage Docker build as `webwork-base:forWW218` since the change to Mojolicious requires a very different base image than was needed for Apache+mod_perl.

As a result, building a stage 2 image for WW 2.17 and develop/WW 2.18 requires using the correct base image, and the tag difference allows both the be available at the same time.