### PR TITLE
Use a fixed submitTime in time based checks in Problem.pm and GatewayQuiz.pm

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -78,7 +78,7 @@ our %SeedCE;
 async sub dispatch {
 	my $controller = shift;
 	my $r          = WeBWorK::Request->new($controller);
-	$r->submitTime(time); # this is Time::HiRes's time, which gives floating point values
+	$r->submitTime(time);    # this is Time::HiRes's time, which gives floating point values
 
 	my $method    = $r->req->method;
 	my $location  = $r->location;

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -78,6 +78,7 @@ our %SeedCE;
 async sub dispatch {
 	my $controller = shift;
 	my $r          = WeBWorK::Request->new($controller);
+	$r->submitTime(time); # this is Time::HiRes's time, which gives floating point values
 
 	my $method    = $r->req->method;
 	my $location  = $r->location;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -75,7 +75,7 @@ sub can_showOldAnswers {
 	return 0 unless $authz->hasPermissions($User->user_id, "can_show_old_answers");
 
 	return (
-		before($Set->due_date(),$self->r->{submitTime})
+		before($Set->due_date(), $self->r->{submitTime})
 			|| $authz->hasPermissions($User->user_id, "view_hidden_work")
 			|| ($Set->hide_work() eq 'N'
 				|| ($Set->hide_work() eq 'BeforeAnswerDate' && time > $tmplSet->answer_date))
@@ -108,12 +108,12 @@ sub can_showCorrectAnswers {
 
 	my $canShowScores = $Set->hide_score_by_problem eq 'N'
 		&& ($Set->hide_score eq 'N'
-			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date,$self->r->{submitTime})));
+			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date, $self->r->{submitTime})));
 
 	return (
 		(
 			(
-				after($Set->answer_date,$self->r->{submitTime}) || ($attemptsUsed >= $maxAttempts
+				after($Set->answer_date, $self->r->{submitTime}) || ($attemptsUsed >= $maxAttempts
 					&& $maxAttempts != 0
 					&& $Set->due_date() == $Set->answer_date())
 			)
@@ -166,12 +166,12 @@ sub can_showSolutions {
 
 	my $canShowScores = $Set->hide_score_by_problem eq 'N'
 		&& ($Set->hide_score eq 'N'
-			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date,$self->r->{submitTime})));
+			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date, $self->r->{submitTime})));
 
 	return (
 		(
 			(
-				after($Set->answer_date,$self->r->{submitTime}) || ($attemptsUsed >= $attempts_per_version
+				after($Set->answer_date, $self->r->{submitTime}) || ($attemptsUsed >= $attempts_per_version
 					&& $attempts_per_version != 0
 					&& $Set->due_date() == $Set->answer_date())
 			)
@@ -283,7 +283,7 @@ sub can_checkAnswers {
 
 	my $canShowScores = $Set->hide_score_by_problem eq 'N'
 		&& ($Set->hide_score eq 'N'
-			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date,$self->r->{submitTime})));
+			|| ($Set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date, $self->r->{submitTime})));
 
 	if (before($Set->open_date, $submitTime)) {
 		return $authz->hasPermissions($User->user_id, "check_answers_before_open_date");
@@ -333,7 +333,7 @@ sub can_showScore {
 	# address hiding scores by problem
 	my $canShowScores = (
 		$Set->hide_score eq 'N' || ($Set->hide_score eq 'BeforeAnswerDate'
-			&& after($tmplSet->answer_date,$self->r->{submitTime}))
+			&& after($tmplSet->answer_date, $self->r->{submitTime}))
 	);
 
 	return ($authz->hasPermissions($User->user_id, "view_hidden_work") || $canShowScores);
@@ -630,9 +630,9 @@ async sub pre_header_initialize {
 	# date.  If a specific version has not been requested and conditional release is enabled, then this also checks to
 	# see if the conditions have been met for a conditional release.
 	my $isOpen = (
-		$requestedVersion ? ($set && $set->open_date && after($set->open_date,$self->r->{submitTime})) : ($tmplSet
+		$requestedVersion ? ($set && $set->open_date && after($set->open_date, $self->r->{submitTime})) : ($tmplSet
 				&& $tmplSet->open_date
-				&& after($tmplSet->open_date,$self->r->{submitTime})
+				&& after($tmplSet->open_date, $self->r->{submitTime})
 				&& !($ce->{options}{enableConditionalRelease} && is_restricted($db, $tmplSet, $effectiveUserName)))
 		)
 		|| $authz->hasPermissions($userName, "view_unopened_sets");
@@ -642,7 +642,7 @@ async sub pre_header_initialize {
 	my $isClosed =
 		$tmplSet
 		&& $tmplSet->due_date
-		&& (after($tmplSet->due_date(),$self->r->{submitTime})
+		&& (after($tmplSet->due_date(), $self->r->{submitTime})
 			&& !$authz->hasPermissions($userName, "record_answers_after_due_date"));
 
 	# to determine if we need a new version, we need to know whether this
@@ -700,11 +700,11 @@ async sub pre_header_initialize {
 	#    more extensible to a limitation like "one version per hour",
 	#    and we can set it to two sets per 12 hours for most "2ce daily"
 	#    type applications
-	my $timeNow = $r->{submitTime}; # Time::HiRes saved time set in dispatch() of lib/WeBWorK.pm
+	my $timeNow = $r->{submitTime};            # Time::HiRes saved time set in dispatch() of lib/WeBWorK.pm
 	my $grace   = $ce->{gatewayGracePeriod};
 
-	my $currentNumVersions = 0;    # this is the number of versions in the
-								   #    time interval
+	my $currentNumVersions = 0;                # this is the number of versions in the
+											   #    time interval
 	my $totalNumVersions   = 0;
 
 	# we don't need to check this if $self->{invalidSet} is already set,
@@ -1652,13 +1652,13 @@ sub body {
 			# Next, store the state in the database if answers are being recorded.
 			if ($submitAnswers && $will{recordAnswers}) {
 				my $score =
-					compute_reduced_score($ce, $problem, $set, $pg_result->{state}{recorded_score},$timeNow);
+					compute_reduced_score($ce, $problem, $set, $pg_result->{state}{recorded_score}, $timeNow);
 				$problem->status($score) if $score > $problem->status;
 
 				$problem->sub_status($problem->status)
 					if (!$ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 						|| !$set->enable_reduced_scoring
-						|| before($set->reduced_scoring_date,$timeNow));
+						|| before($set->reduced_scoring_date, $timeNow));
 
 				$problem->attempted(1);
 				$problem->num_correct($pg_result->{state}{num_of_correct_ans});
@@ -2064,8 +2064,8 @@ sub body {
 	# Display the reduced scoring message if reduced scoring is enabled and the set is in the reduced scoring period.
 	if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 		&& $set->enable_reduced_scoring
-		&& after($set->reduced_scoring_date,$self->r->{submitTime})
-		&& before($set->due_date,$self->r->{submitTime})
+		&& after($set->reduced_scoring_date, $self->r->{submitTime})
+		&& before($set->due_date, $self->r->{submitTime})
 		&& ($can{recordAnswersNextTime} || $submitAnswers))
 	{
 		print CGI::div(

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1650,13 +1650,13 @@ sub body {
 			# Next, store the state in the database if answers are being recorded.
 			if ($submitAnswers && $will{recordAnswers}) {
 				my $score =
-					compute_reduced_score($ce, $problem, $set, $pg_result->{state}{recorded_score});
+					compute_reduced_score($ce, $problem, $set, $pg_result->{state}{recorded_score},$timeNow);
 				$problem->status($score) if $score > $problem->status;
 
 				$problem->sub_status($problem->status)
 					if (!$ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 						|| !$set->enable_reduced_scoring
-						|| before($set->reduced_scoring_date));
+						|| before($set->reduced_scoring_date,$timeNow));
 
 				$problem->attempted(1);
 				$problem->num_correct($pg_result->{state}{num_of_correct_ans});
@@ -1942,7 +1942,7 @@ sub body {
 			my $pScore = 0;
 			if (ref $pg) {
 				# If a pg object is available, then use the pg recorded score and save it in the @probStatus array.
-				$pScore = compute_reduced_score($ce, $problems[$i], $set, $pg->{state}{recorded_score});
+				$pScore = compute_reduced_score($ce, $problems[$i], $set, $pg->{state}{recorded_score}, $timeNow);
 				$probStatus[$i] = $pScore if $pScore > $probStatus[$i];
 			} else {
 				# If a pg object is not available, then use the saved problem status.

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -113,7 +113,7 @@ sub can_showCorrectAnswers {
 	my ($self, $User, $EffectiveUser, $Set, $Problem) = @_;
 	my $authz = $self->r->authz;
 
-	return after($Set->answer_date,$self->r->{submitTime})
+	return after($Set->answer_date, $self->r->{submitTime})
 		|| $authz->hasPermissions($User->user_id, "show_correct_answers_before_answer_date");
 }
 
@@ -177,7 +177,7 @@ sub can_showSolutions {
 
 	return
 		$authz->hasPermissions($User->user_id, 'always_show_solutions')
-		|| after($Set->answer_date,$self->r->{submitTime})
+		|| after($Set->answer_date, $self->r->{submitTime})
 		|| $authz->hasPermissions($User->user_id, "show_solutions_before_answer_date");
 }
 
@@ -188,7 +188,7 @@ sub can_recordAnswers {
 	if ($User->user_id ne $EffectiveUser->user_id) {
 		return $authz->hasPermissions($User->user_id, "record_answers_when_acting_as_student");
 	}
-	if (before($Set->open_date,$self->r->{submitTime})) {
+	if (before($Set->open_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_before_open_date");
 	} elsif (between($Set->open_date, $Set->due_date, $self->r->{submitTime})) {
 		my $max_attempts  = $Problem->max_attempts;
@@ -200,7 +200,7 @@ sub can_recordAnswers {
 		}
 	} elsif (between($Set->due_date, $Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_after_due_date");
-	} elsif (after($Set->answer_date,$self->r->{submitTime})) {
+	} elsif (after($Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_after_answer_date");
 	}
 }
@@ -218,7 +218,7 @@ sub can_checkAnswers {
 		return 0;
 	}
 
-	if (before($Set->open_date,$self->r->{submitTime})) {
+	if (before($Set->open_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_before_open_date");
 	} elsif (between($Set->open_date, $Set->due_date, $self->r->{submitTime})) {
 		my $max_attempts  = $Problem->max_attempts;
@@ -230,7 +230,7 @@ sub can_checkAnswers {
 		}
 	} elsif (between($Set->due_date, $Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_after_due_date");
-	} elsif (after($Set->answer_date,$self->r->{submitTime})) {
+	} elsif (after($Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_after_answer_date");
 	}
 }
@@ -271,7 +271,7 @@ sub can_showMeAnother {
 	# get the hash of information about showMeAnother
 	my %showMeAnother = %{ $self->{showMeAnother} };
 
-	if (after($Set->open_date,$self->r->{submitTime})
+	if (after($Set->open_date, $self->r->{submitTime})
 		or $self->r->authz->hasPermissions($self->r->param('user'), "can_use_show_me_another_early"))
 	{
 		# if $showMeAnother{TriesNeeded} is somehow not an integer or if its -2, use the default value
@@ -387,7 +387,7 @@ async sub content {
 }
 
 async sub pre_header_initialize {
-	my ($self)  = @_;
+	my ($self) = @_;
 
 	my $r       = $self->r;
 	my $ce      = $r->ce;
@@ -708,7 +708,7 @@ async sub pre_header_initialize {
 		$problem->{prCount} += $submitAnswers ? 1 : 0;
 
 		$requestNewSeed = 0
-			if ($problem->{prCount} < $rerandomizePeriod || after($set->due_date,$self->r->{submitTime}));
+			if ($problem->{prCount} < $rerandomizePeriod || after($set->due_date, $self->r->{submitTime}));
 
 		if ($requestNewSeed) {
 			# obtain new random seed to hopefully change the problem
@@ -783,7 +783,7 @@ async sub pre_header_initialize {
 		-value => $problem->num_correct + $problem->num_incorrect + ($submitAnswers ? 1 : 0)
 	});
 
-	if ($prEnabled && $problem->{prCount} >= $rerandomizePeriod && !after($set->due_date,$self->r->{submitTime})) {
+	if ($prEnabled && $problem->{prCount} >= $rerandomizePeriod && !after($set->due_date, $self->r->{submitTime})) {
 		$showMeAnother{active}          = 0;
 		$must{requestNewSeed}           = 1;
 		$can{requestNewSeed}            = 1;
@@ -1611,8 +1611,8 @@ sub output_message {
 
 	if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 		&& $self->{set}->enable_reduced_scoring
-		&& after($self->{set}->reduced_scoring_date,$self->r->{submitTime})
-		&& before($self->{set}->due_date,$self->r->{submitTime}))
+		&& after($self->{set}->reduced_scoring_date, $self->r->{submitTime})
+		&& before($self->{set}->due_date, $self->r->{submitTime}))
 	{
 		print CGI::p(
 			CGI::b($r->maketext('Note') . ': '),
@@ -1949,7 +1949,8 @@ sub output_submit_buttons {
 					tabindex          => '0',
 					data_bs_toggle    => 'tooltip',
 					data_bs_placement => 'right',
-					data_bs_title     => before($r->db->getGlobalSet($self->{set}->set_id)->open_date,$self->r->{submitTime})
+					data_bs_title     =>
+						before($r->db->getGlobalSet($self->{set}->set_id)->open_date, $self->r->{submitTime})
 					? $r->maketext('The problem set is not yet open')
 					: $exhausted eq 'exhausted' ? $r->maketext('Feature exhausted for this problem')
 					: $r->maketext(
@@ -1998,15 +1999,15 @@ sub output_score_summary {
 
 		$prMessage = ' ' . $r->maketext('Request new version now.') if ($attempts_before_rr == 0);
 	}
-	$prMessage = '' if after($set->due_date,$self->r->{submitTime}) or before($set->open_date,$self->r->{submitTime});
+	$prMessage = '' if after($set->due_date, $self->r->{submitTime}) or before($set->open_date, $self->r->{submitTime});
 
 	my $setClosed = 0;
 	my $setClosedMessage;
-	if (before($set->open_date,$self->r->{submitTime}) || after($set->due_date,$self->r->{submitTime})) {
+	if (before($set->open_date, $self->r->{submitTime}) || after($set->due_date, $self->r->{submitTime})) {
 		$setClosed = 1;
-		if (before($set->open_date,$self->r->{submitTime})) {
+		if (before($set->open_date, $self->r->{submitTime})) {
 			$setClosedMessage = $r->maketext("This homework set is not yet open.");
-		} elsif (after($set->due_date,$self->r->{submitTime})) {
+		} elsif (after($set->due_date, $self->r->{submitTime})) {
 			$setClosedMessage = $r->maketext("This homework set is closed.");
 		}
 	}
@@ -2023,8 +2024,15 @@ sub output_score_summary {
 			CGI::br(),
 			$self->{submitAnswers}
 			? (
-				$r->maketext('You received a score of [_1] for this attempt.',
-					wwRound(0, compute_reduced_score($ce, $problem, $set, $pg->{result}{score}, $self->r->{submitTime}) * 100) . '%')
+				$r->maketext(
+					'You received a score of [_1] for this attempt.',
+					wwRound(
+						0,
+						compute_reduced_score($ce, $problem, $set, $pg->{result}{score}, $self->r->{submitTime}) *
+							100
+						)
+						. '%'
+					)
 					. CGI::br()
 				)
 			: '',

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -113,7 +113,7 @@ sub can_showCorrectAnswers {
 	my ($self, $User, $EffectiveUser, $Set, $Problem) = @_;
 	my $authz = $self->r->authz;
 
-	return after($Set->answer_date,$self->{submitTime})
+	return after($Set->answer_date,$self->r->{submitTime})
 		|| $authz->hasPermissions($User->user_id, "show_correct_answers_before_answer_date");
 }
 
@@ -177,7 +177,7 @@ sub can_showSolutions {
 
 	return
 		$authz->hasPermissions($User->user_id, 'always_show_solutions')
-		|| after($Set->answer_date,$self->{submitTime})
+		|| after($Set->answer_date,$self->r->{submitTime})
 		|| $authz->hasPermissions($User->user_id, "show_solutions_before_answer_date");
 }
 
@@ -188,9 +188,9 @@ sub can_recordAnswers {
 	if ($User->user_id ne $EffectiveUser->user_id) {
 		return $authz->hasPermissions($User->user_id, "record_answers_when_acting_as_student");
 	}
-	if (before($Set->open_date,$self->{submitTime})) {
+	if (before($Set->open_date,$self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_before_open_date");
-	} elsif (between($Set->open_date, $Set->due_date, $self->{submitTime})) {
+	} elsif (between($Set->open_date, $Set->due_date, $self->r->{submitTime})) {
 		my $max_attempts  = $Problem->max_attempts;
 		my $attempts_used = $Problem->num_correct + $Problem->num_incorrect + $thisAttempt;
 		if ($max_attempts == -1 or $attempts_used < $max_attempts) {
@@ -198,9 +198,9 @@ sub can_recordAnswers {
 		} else {
 			return $authz->hasPermissions($User->user_id, "record_answers_after_open_date_without_attempts");
 		}
-	} elsif (between($Set->due_date, $Set->answer_date, $self->{submitTime})) {
+	} elsif (between($Set->due_date, $Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_after_due_date");
-	} elsif (after($Set->answer_date,$self->{submitTime})) {
+	} elsif (after($Set->answer_date,$self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "record_answers_after_answer_date");
 	}
 }
@@ -218,9 +218,9 @@ sub can_checkAnswers {
 		return 0;
 	}
 
-	if (before($Set->open_date,$self->{submitTime})) {
+	if (before($Set->open_date,$self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_before_open_date");
-	} elsif (between($Set->open_date, $Set->due_date, $self->{submitTime})) {
+	} elsif (between($Set->open_date, $Set->due_date, $self->r->{submitTime})) {
 		my $max_attempts  = $Problem->max_attempts;
 		my $attempts_used = $Problem->num_correct + $Problem->num_incorrect + $thisAttempt;
 		if ($max_attempts == -1 or $attempts_used < $max_attempts) {
@@ -228,9 +228,9 @@ sub can_checkAnswers {
 		} else {
 			return $authz->hasPermissions($User->user_id, "check_answers_after_open_date_without_attempts");
 		}
-	} elsif (between($Set->due_date, $Set->answer_date, $self->{submitTime})) {
+	} elsif (between($Set->due_date, $Set->answer_date, $self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_after_due_date");
-	} elsif (after($Set->answer_date,$self->{submitTime})) {
+	} elsif (after($Set->answer_date,$self->r->{submitTime})) {
 		return $authz->hasPermissions($User->user_id, "check_answers_after_answer_date");
 	}
 }
@@ -271,7 +271,7 @@ sub can_showMeAnother {
 	# get the hash of information about showMeAnother
 	my %showMeAnother = %{ $self->{showMeAnother} };
 
-	if (after($Set->open_date,$self->{submitTime})
+	if (after($Set->open_date,$self->r->{submitTime})
 		or $self->r->authz->hasPermissions($self->r->param('user'), "can_use_show_me_another_early"))
 	{
 		# if $showMeAnother{TriesNeeded} is somehow not an integer or if its -2, use the default value
@@ -388,8 +388,6 @@ async sub content {
 
 async sub pre_header_initialize {
 	my ($self)  = @_;
-
-	$self->{submitTime} = time(); # Save a fixed value as the submission time
 
 	my $r       = $self->r;
 	my $ce      = $r->ce;
@@ -710,7 +708,7 @@ async sub pre_header_initialize {
 		$problem->{prCount} += $submitAnswers ? 1 : 0;
 
 		$requestNewSeed = 0
-			if ($problem->{prCount} < $rerandomizePeriod || after($set->due_date,$self->{submitTime}));
+			if ($problem->{prCount} < $rerandomizePeriod || after($set->due_date,$self->r->{submitTime}));
 
 		if ($requestNewSeed) {
 			# obtain new random seed to hopefully change the problem
@@ -785,7 +783,7 @@ async sub pre_header_initialize {
 		-value => $problem->num_correct + $problem->num_incorrect + ($submitAnswers ? 1 : 0)
 	});
 
-	if ($prEnabled && $problem->{prCount} >= $rerandomizePeriod && !after($set->due_date,$self->{submitTime})) {
+	if ($prEnabled && $problem->{prCount} >= $rerandomizePeriod && !after($set->due_date,$self->r->{submitTime})) {
 		$showMeAnother{active}          = 0;
 		$must{requestNewSeed}           = 1;
 		$can{requestNewSeed}            = 1;
@@ -1613,8 +1611,8 @@ sub output_message {
 
 	if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 		&& $self->{set}->enable_reduced_scoring
-		&& after($self->{set}->reduced_scoring_date,$self->{submitTime})
-		&& before($self->{set}->due_date,$self->{submitTime}))
+		&& after($self->{set}->reduced_scoring_date,$self->r->{submitTime})
+		&& before($self->{set}->due_date,$self->r->{submitTime}))
 	{
 		print CGI::p(
 			CGI::b($r->maketext('Note') . ': '),
@@ -1951,7 +1949,7 @@ sub output_submit_buttons {
 					tabindex          => '0',
 					data_bs_toggle    => 'tooltip',
 					data_bs_placement => 'right',
-					data_bs_title     => before($r->db->getGlobalSet($self->{set}->set_id)->open_date,$self->{submitTime})
+					data_bs_title     => before($r->db->getGlobalSet($self->{set}->set_id)->open_date,$self->r->{submitTime})
 					? $r->maketext('The problem set is not yet open')
 					: $exhausted eq 'exhausted' ? $r->maketext('Feature exhausted for this problem')
 					: $r->maketext(
@@ -2000,15 +1998,15 @@ sub output_score_summary {
 
 		$prMessage = ' ' . $r->maketext('Request new version now.') if ($attempts_before_rr == 0);
 	}
-	$prMessage = '' if after($set->due_date,$self->{submitTime}) or before($set->open_date,$self->{submitTime});
+	$prMessage = '' if after($set->due_date,$self->r->{submitTime}) or before($set->open_date,$self->r->{submitTime});
 
 	my $setClosed = 0;
 	my $setClosedMessage;
-	if (before($set->open_date,$self->{submitTime}) || after($set->due_date,$self->{submitTime})) {
+	if (before($set->open_date,$self->r->{submitTime}) || after($set->due_date,$self->r->{submitTime})) {
 		$setClosed = 1;
-		if (before($set->open_date,$self->{submitTime})) {
+		if (before($set->open_date,$self->r->{submitTime})) {
 			$setClosedMessage = $r->maketext("This homework set is not yet open.");
-		} elsif (after($set->due_date,$self->{submitTime})) {
+		} elsif (after($set->due_date,$self->r->{submitTime})) {
 			$setClosedMessage = $r->maketext("This homework set is closed.");
 		}
 	}
@@ -2026,7 +2024,7 @@ sub output_score_summary {
 			$self->{submitAnswers}
 			? (
 				$r->maketext('You received a score of [_1] for this attempt.',
-					wwRound(0, compute_reduced_score($ce, $problem, $set, $pg->{result}{score}, $self->{submitTime}) * 100) . '%')
+					wwRound(0, compute_reduced_score($ce, $problem, $set, $pg->{result}{score}, $self->r->{submitTime}) * 100) . '%')
 					. CGI::br()
 				)
 			: '',

--- a/lib/WeBWorK/Request.pm
+++ b/lib/WeBWorK/Request.pm
@@ -144,6 +144,21 @@ sub urlpath {
 	return $self->{urlpath};
 }
 
+=item $r->submitTime([$new])
+
+Return the time this request was received for processing, which we refer
+to as the submitTime. The time is recorded very early on in the processing
+of the request. If $new is specified, set submitTime to $new before returning
+the value.
+
+=cut
+
+sub submitTime {
+	my ($self, $new) = @_;
+	$self->{submitTime} = $new if defined $new;
+	return $self->{submitTime};
+}
+
 sub language_handle {
 	my ($self, $new) = @_;
 	$self->{language_handle} = $new if defined $new;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -103,6 +103,7 @@ our @EXPORT_OK = qw(
 	thaw_base64
 	undefstr
 	writeCourseLog
+	writeCourseLogGivenTime
 	writeLog
 	writeTimingLogEntry
 	wwRound
@@ -816,6 +817,11 @@ sub writeLog($$@) {
 
 sub writeCourseLog($$@) {
 	my ($ce, $facility, @message) = @_;
+	writeCourseLogGivenTime($ce, $facility, time, @message);
+}
+
+sub writeCourseLogGivenTime($$@) {
+	my ($ce, $facility, $myTime, @message) = @_;
 	unless ($ce->{courseFiles}->{logs}->{$facility}) {
 		warn "There is no course log file for the $facility facility defined.\n";
 		return;
@@ -824,7 +830,7 @@ sub writeCourseLog($$@) {
 	surePathToFile($ce->{courseDirs}->{root}, $logFile);
 	local *LOG;
 	if (open LOG, ">>:utf8", $logFile) {
-		print LOG "[", time2str("%a %b %d %H:%M:%S %Y", time), "] @message\n";
+		print LOG "[", time2str("%a %b %d %H:%M:%S %Y", $myTime), "] @message\n";
 		close LOG;
 	} else {
 		warn "failed to open $logFile for writing: $!";

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -31,7 +31,8 @@ use Try::Tiny;
 
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(writeLog writeCourseLog encodeAnswers before after jitar_problem_adjusted_status jitar_id_to_seq);
+use WeBWorK::Utils
+	qw(writeLog writeCourseLogGivenTime encodeAnswers before after jitar_problem_adjusted_status jitar_id_to_seq);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
 
 use Caliper::Sensor;
@@ -87,9 +88,10 @@ sub process_and_log_answer {
 			my $timestamp = int($self->r->{submitTime});
 
 			# store in answer_log
-			writeCourseLog(
+			writeCourseLogGivenTime(
 				$ce,
 				'answer_log',
+				$timestamp,
 				join('',
 					'|', $problem->user_id, '|',  $problem->set_id, '|',  $problem->problem_id,
 					'|', $scores2,          "\t", $timestamp,       "\t", $past_answers_string,

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -123,13 +123,14 @@ sub process_and_log_answer {
 
 			# store state in DB if it makes sense
 			if ($will{recordAnswers}) {
-				my $score = compute_reduced_score($ce, $problem, $set, $pg->{state}{recorded_score}, $self->r->{submitTime});
+				my $score =
+					compute_reduced_score($ce, $problem, $set, $pg->{state}{recorded_score}, $self->r->{submitTime});
 				$problem->status($score) if $score > $problem->status;
 
 				$problem->sub_status($problem->status)
 					if (!$r->{ce}{pg}{ansEvalDefaults}{enableReducedScoring}
 						|| !$set->enable_reduced_scoring
-						|| before($set->reduced_scoring_date,$self->r->{submitTime}));
+						|| before($set->reduced_scoring_date, $self->r->{submitTime}));
 
 				$problem->attempted(1);
 				$problem->num_correct($pg->{state}{num_of_correct_ans});
@@ -265,7 +266,7 @@ sub process_and_log_answer {
 					}
 				}
 			} else {
-				if (before($set->open_date,$self->r->{submitTime}) || after($set->due_date,$self->r->{submitTime})) {
+				if (before($set->open_date, $self->r->{submitTime}) || after($set->due_date, $self->r->{submitTime})) {
 					$scoreRecordedMessage =
 						$r->maketext('Your score was not recorded because this homework set is closed.');
 				} else {
@@ -292,7 +293,7 @@ sub compute_reduced_score {
 		|| !$set->enable_reduced_scoring
 		|| !$set->reduced_scoring_date
 		|| $set->reduced_scoring_date == $set->due_date
-		|| before($set->reduced_scoring_date,$submitTime)
+		|| before($set->reduced_scoring_date, $submitTime)
 		|| $score <= $problem->sub_status)
 	{
 		return $score;


### PR DESCRIPTION
In `Problem.pm` change the code to use a fixed `submitTime` value during all the processing related to time base conditionals, and in particular when determining if the recorded score/answers should be updated.

The time being tested in `compute_reduced_score` should also depend on the recorded `submitTime` (and not the current time) so is passed to that subroutine as an additional parameter.

For `GatewayQuiz.pm` use the already saved `$timeNow` as the submission time which gets passed to `compute_reduced_score`. I hope that is a correct approach for gateways.


One other conditional test in `GatewayQuiz.pm` was also modified to depend on `$timeNow` (line 1659).

Update: Several more tests in `GatewayQuiz.pm` will use the saved `submitTime` when they would have used a new call to `time()` otherwise.

---

Motivation: I seem to have encountered a case where the `answer.log` file recorded an answer with the time being listed as several seconds after the deadline, but the score itself was apparently not updated. This behavior is not consistent, first because the log record reports the submission as being after the deadline and also in terms of the score not having been updated. The only potential cause I could come up with for the inconsistent records was the fact that in `Problem.pm` the various calls to time based tests (`before`, `after`, and `between`) were not providing a "now" time, so that in potential the time could change enough to cross a boundary during the processing.


~~Note: The time entry at the start of the `answer.log` file lines is **not** dependent on the actual submission time.~~

Updated note: The time entry at the start of the `answer.log` file lines **will now be** the actual submission time. 

Until this PR the  logged `timestamp` value also was not (it was the time just before the call to create the log record). After this PR, the timestamp in the log record and that set in the past answer table will use the determined submitTime and not the time just before the records are created. Hopefully that will prevent records being saved for submissions with a time "just after" a deadline. 

~~However, the formatted time at the beginning of the log record will still be the creation time of the log record and not the submission time.~~

