### PR TITLE
Make adding all/multiple users to a given set more efficient

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -95,7 +95,7 @@ sub initialize ($c) {
 		}
 		if (defined $c->param('assignSets')) {
 			my @setIDs = $c->param('assignSets');
-			assignSetsToUsers($db, \@setIDs, \@userIDs);
+			assignSetsToUsers($db, $ce, \@setIDs, \@userIDs);
 		}
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Assigner.pm
@@ -45,7 +45,7 @@ sub pre_header_initialize ($c) {
 		if (@selected_users && @selected_sets) {
 			my @results;    # This is not used?
 			if (defined $c->param('assign')) {
-				assignSetsToUsers($db, \@selected_sets, \@selected_users);
+				assignSetsToUsers($db, $ce, \@selected_sets, \@selected_users);
 				$c->addgoodmessage($c->maketext('All assignments were made successfully.'));
 			}
 			if (defined $c->param('unassign')) {

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -2137,28 +2137,18 @@ sub addUserProblem {
 sub addUserMultipleProblems {
 	my ($self, @problemLists) = @_;
 
-	my $firstUserProblem = $problemLists[0][0];
-	if (!defined($firstUserProblem) || !defined($firstUserProblem->user_id)) {
-		croak "Error in request to addUserMultipleProblems";
-	}
-	my $user_id = $firstUserProblem->user_id;
-	my $set_id  = $firstUserProblem->set_id;
-
-	my ($nv_set_id, $versionNum) = grok_vsetID($set_id);
-	croak "addUserMultipleProblems does not support versioned sets"
-		if defined($versionNum);
-
-	# Possible improvement, if a version set was sent, make calls to addUserProblem for each one.
+	croak "Error in request to addUserMultipleProblems" if ref($problemLists[0]) ne 'ARRAY';
 
 	# Do a single checkArgs call, all records in the list were made in the same manner
-	my @tmp = ($firstUserProblem);
-	$self->checkArgs(\@tmp, qw/VREC:problem_user/);
+	$self->checkArgs([ $problemLists[0][0] ], qw/REC:problem_user/);
+
+	my $set_id = $problemLists[0][0]->set_id;
 
 	# Array in which all records to add are collected
-	my @collectedProblemList = ();
+	my @collectedProblemList;
 
 	for my $problemListRef (@problemLists) {
-		$user_id = $problemListRef->[0]->user_id;
+		my $user_id = $problemListRef->[0]->user_id;
 		croak "addMultipleUserProblems: user set $set_id for user $user_id not found"
 			unless $self->{set_user}->exists($user_id, $set_id);
 

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -465,6 +465,48 @@ sub restore_tables {
 }
 
 ################################################################################
+# transaction support
+################################################################################
+
+# Any course will have the user table, so that allows getting the database
+# handle.
+
+sub start_transaction {
+	my $self = shift;
+	eval { $self->{user}->dbh->begin_work; };
+	if ($@) {
+		my $msg = "Error in start_transaction: $@";
+		if ($msg =~ /Already in a transaction/) {
+			warn "Aborting active transaction.";
+			$self->{user}->dbh->rollback;
+		}
+		croak $msg;
+	}
+}
+
+sub end_transaction {
+	my $self = shift;
+	eval { $self->{user}->dbh->commit; };
+	if ($@) {
+		my $msg = "Error in end_transaction: $@";
+		$self->abort_transaction;
+		croak $msg;
+	}
+}
+
+sub abort_transaction {
+	my $self = shift;
+	eval {
+		$self->{user}->dbh->{AutoCommit} = 0;
+		$self->{user}->dbh->rollback;
+	};
+	if ($@) {
+		my $msg = "Error in abort_transaction: $@";
+		croak $msg;
+	}
+}
+
+################################################################################
 # user functions
 ################################################################################
 
@@ -1537,6 +1579,41 @@ sub addUserSet {
 	}
 }
 
+# Used to add a list of UserSet records to the DB in less DB calls.
+sub addMultipleUserSets {
+	my ($self, @userSetList) = @_;
+
+	# Do a single checkArgs call, all records in the list were made in the same manner
+	$self->checkArgs([ $userSetList[0] ], qw/REC:set_user/);
+
+	my @badUserIDs;
+	my %badSetIDs;
+	my @toInsert;
+	for my $userSet (@userSetList) {
+		if ($self->{user}->exists($userSet->user_id)) {
+			if ($self->{set}->exists($userSet->set_id)) {
+				# This record is OK
+				push(@toInsert, $userSet);
+			} else {
+				$badSetIDs{ $userSet->set_id } = 1;
+			}
+		} else {
+			push(@badUserIDs, join("", 'user ', $userSet->user_id, " not found, cannot add set ", $userSet->set_id));
+		}
+	}
+	my $badSetIDerrorMsg =
+		keys(%badSetIDs) ? join(" ", 'bad set IDs seen:', keys(%badSetIDs)) : "";
+
+	eval { return $self->{set_user}->insert_records([@toInsert]); };
+	if ($@) {
+		croak join("\n", "addMultipleUserSets errors:\nDB call error: $@", $badSetIDerrorMsg, @badUserIDs);
+	}
+
+	if (@badUserIDs || keys(@badUserIDs)) {
+		croak join("\n", "addMultipleUserSets errors:\n", $badSetIDerrorMsg, @badUserIDs);
+	}
+}
+
 # the code from putUserSet() is duplicated in large part in the following
 # putVersionedUserSet; c.f. that routine
 sub putUserSet {
@@ -2050,6 +2127,54 @@ sub addUserProblem {
 		croak "addUserProblem: user problem exists (perhaps you meant to use putUserProblem?)";
 	} elsif ($@) {
 		die $@;
+	}
+}
+
+# Used to add multiple problems to a SINGLE set with less DB calls.
+# Not for use by versioned sets
+# This expects @problemLists to be a 2 dimensional array, each
+# entry being the problemList array for one user.
+sub addUserMultipleProblems {
+	my ($self, @problemLists) = @_;
+
+	my $firstUserProblem = $problemLists[0][0];
+	if (!defined($firstUserProblem) || !defined($firstUserProblem->user_id)) {
+		croak "Error in request to addUserMultipleProblems";
+	}
+	my $user_id = $firstUserProblem->user_id;
+	my $set_id  = $firstUserProblem->set_id;
+
+	my ($nv_set_id, $versionNum) = grok_vsetID($set_id);
+	croak "addUserMultipleProblems does not support versioned sets"
+		if defined($versionNum);
+
+	# Possible improvement, if a version set was sent, make calls to addUserProblem for each one.
+
+	# Do a single checkArgs call, all records in the list were made in the same manner
+	my @tmp = ($firstUserProblem);
+	$self->checkArgs(\@tmp, qw/VREC:problem_user/);
+
+	# Array in which all records to add are collected
+	my @collectedProblemList = ();
+
+	for my $problemListRef (@problemLists) {
+		$user_id = $problemListRef->[0]->user_id;
+		croak "addMultipleUserProblems: user set $set_id for user $user_id not found"
+			unless $self->{set_user}->exists($user_id, $set_id);
+
+		# Test whether there are already problem records for this user in this set, as in that case
+		# inserting multiple records at once would trigger an error.
+		my $where = [ user_id_eq_set_id_eq => $user_id, $set_id ];
+
+		croak "addMultipleUserProblems cannot be run as set $set_id already contains some problems for user $user_id"
+			if $self->{problem_user}->count_where($where);
+		# If we got here, we can add this list of problems to those to insert into the database
+		push(@collectedProblemList, @{$problemListRef});
+	}
+
+	eval { $self->{problem_user}->insert_records([@collectedProblemList]); };
+	if ($@) {
+		croak "addUserMultipleProblems: $@";
 	}
 }
 


### PR DESCRIPTION
The updated version of this PR is far more efficient than the earlier versions. Thanks to @drgrice1 for pointing out how to do multiple inserts in a single call to the lower layer which at least gets the prepared statement to be reused.

The improvement based on some very rough bench-marking for an assignment with 25 problems is almost 10 fold, once the inserts for all students are batched into a single group. 

The improvement is almost certainly a function of the size of the assignment as the improvement is mainly due to getting the actual user-problem records to be inserted sequentially using one request of the prepared statement.

---

Add code to allow adding multiple records to the `problem_user` table (for a single set for a single user) as a batch, which allows reducing the number of test calls made to the database. It would be better to be able to add all records in a single database call, but at present the underlying database abstraction layer does not seem to have any support for inserting multiple records in one call.

For a large sample course (862 user accounts) and test assignments with 25 problems each, I observed the "until rendered" time of assigning a set to all users as taking 44-47 seconds with the old code and 38-44 seconds with the new code (on my laptop, using a Docker based setup). That seems to be about a 10% increase in performance. I had hoped for better, as the number of test calls made in the process decreased from 50 per assignment (2 per problem) to 1 per assignment, and there are less calls to subroutines in the process, but clearly that is not that larger bottleneck.