### PR TITLE
Rename GatewayQuiz as Test.

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -290,7 +290,7 @@ async sub dispatch {
 			# module we double check this, to be sure that someone isn't taking a
 			# proctored quiz but calling the unproctored ContentGenerator
 			my $urlProducedPath = $urlPath->path();
-			if ($urlProducedPath =~ /proctored_quiz_mode/i) {
+			if ($urlProducedPath =~ /proctored_test_mode/i) {
 				my $proctor_authen_module = WeBWorK::Authen::class($ce, "proctor_module");
 				runtime_use $proctor_authen_module;
 				my $authenProctor = $proctor_authen_module->new($r);

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -475,10 +475,8 @@ sub checkSet {
 		&& !WeBWorK::Authen::Proctor->new($r, $ce, $db)->verify())
 	{
 		return $r->maketext(
-			"Requested set '[_1]' is a proctored test/quiz assignment, "
-				. 'but no valid proctor authorization has been obtained.',
-			$setName
-		);
+			"Requested set '[_1]' is a proctored test, but no valid proctor authorization has been obtained.",
+			$setName);
 	}
 
 	# Check for ip restrictions.

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -2224,12 +2224,12 @@ sub body {
 	#    reset the assignment_type in this case, so we'll use that to
 	#    decide if we should give a path to an unproctored test.
 	my $action = $r->uri();
-	$action =~ s/proctored_quiz_mode/quiz_mode/ if ($set->assignment_type() eq 'gateway');
+	$action =~ s/proctored_test_mode/test_mode/ if ($set->assignment_type() eq 'gateway');
 	# we also want to be sure that if we're in a set, the 'action' in the
 	#    form points us to the same set.
 	my $setname = $set->set_id;
 	my $setvnum = $set->version_id;
-	$action =~ s/(quiz_mode\/$setname)\/?$/$1,v$setvnum\//;    #"
+	$action =~ s/(test_mode\/$setname)\/?$/$1,v$setvnum\//;    #"
 
 	if (!$can{recordAnswersNextTime} && !$canShowWork) {
 		# Problems can not be shown.

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -310,9 +310,9 @@ sub displayStudentStats {
 		if (defined $set->assignment_type && $set->assignment_type =~ /gateway/) {
 			$setIsVersioned = 1;
 			if ($set->assignment_type eq 'proctored_gateway') {
-				$act_as_student_set_url =~ s/($courseName)\//$1\/proctored_quiz_mode\//;
+				$act_as_student_set_url =~ s/($courseName)\//$1\/proctored_test_mode\//;
 			} else {
-				$act_as_student_set_url =~ s/($courseName)\//$1\/quiz_mode\//;
+				$act_as_student_set_url =~ s/($courseName)\//$1\/test_mode\//;
 			}
 		}
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -228,10 +228,10 @@ use constant FIELD_PROPERTIES => {
 		override => 'all',
 		choices  => [qw(default gateway proctored_gateway jitar)],
 		labels   => {
-			default           => 'homework',
-			gateway           => 'gateway/quiz',
-			proctored_gateway => 'proctored gateway/quiz',
-			jitar             => 'just-in-time'
+			default           => x('homework'),
+			gateway           => x('test'),
+			proctored_gateway => x('proctored test'),
+			jitar             => x('just-in-time')
 		},
 	},
 	version_time_limit => {
@@ -243,7 +243,7 @@ use constant FIELD_PROPERTIES => {
 		convertby => 60,
 	},
 	time_limit_cap => {
-		name     => x('Cap Test Time at Set Close Date?'),
+		name     => x('Cap Test Time at Set Close Date'),
 		type     => 'choose',
 		override => 'all',
 		choices  => [qw(0 1)],
@@ -293,7 +293,7 @@ use constant FIELD_PROPERTIES => {
 		default  => '1',
 	},
 	'hide_score:hide_score_by_problem' => {
-		name     => x('Show Scores on Finished Assignments?'),
+		name     => x('Show Scores on Finished Tests'),
 		type     => 'choose',
 		choices  => [qw(N:N Y:Y BeforeAnswerDate:N N:Y BeforeAnswerDate:Y)],
 		override => 'any',
@@ -948,7 +948,7 @@ sub extraSetFields {
 				$gwFields .= CGI::Tr(CGI::td([@fieldData]));
 			}
 		}
-		$gwhdr .= CGI::Tr(CGI::td({ colspan => $nF }, CGI::em($r->maketext("Gateway parameters"))))
+		$gwhdr .= CGI::Tr(CGI::td({ colspan => $nF }, CGI::em($r->maketext('Test parameters'))))
 			if ($nF);
 		$extraFields = "$gwhdr$gwFields";
 

--- a/lib/WeBWorK/URLPath.pm
+++ b/lib/WeBWorK/URLPath.pm
@@ -58,9 +58,9 @@ Note:  Only database keyfield values can be used as path parameters.
 
  equation_display                    /$courseID/equation/
  feedback                            /$courseID/feedback/
- gateway_quiz                        /$courseID/quiz_mode/$setID/
- proctored_gateway_quiz              /$courseID/proctored_quiz_mode/$setID/
- proctored_gateway_proctor_login     /$courseID/proctored_quiz_mode/$setID/proctor_login/
+ gateway_quiz                        /$courseID/test_mode/$setID/
+ proctored_gateway_quiz              /$courseID/proctored_test_mode/$setID/
+ proctored_gateway_proctor_login     /$courseID/proctored_test_mode/$setID/proctor_login/
  grades                              /$courseID/grades/
  hardcopy                            /$courseID/hardcopy/
  hardcopy_preselect_set              /$courseID/hardcopy/$setID/
@@ -222,12 +222,12 @@ our %pathTypes = (
 		unrestricted => 1
 	},
 	gateway_quiz => {
-		name         => x('Gateway Quiz [_2]'),
+		name         => x('Test [_2]'),
 		parent       => 'set_list',
 		kids         => [qw//],
-		match        => qr|^quiz_mode/([^/]+)/|,
+		match        => qr|^test_mode/([^/]+)/|,
 		capture      => [qw/setID/],
-		produce      => 'quiz_mode/$setID/',
+		produce      => 'test_mode/$setID/',
 		display      => 'WeBWorK::ContentGenerator::GatewayQuiz',
 		unrestricted => 1
 	},
@@ -243,22 +243,22 @@ our %pathTypes = (
 	},
 
 	proctored_gateway_quiz => {
-		name         => x('Proctored Gateway Quiz [_2]'),
+		name         => x('Proctored Test [_2]'),
 		parent       => 'set_list',
 		kids         => [qw/proctored_gateway_proctor_login/],
-		match        => qr|^proctored_quiz_mode/([^/]+)/|,
+		match        => qr|^proctored_test_mode/([^/]+)/|,
 		capture      => [qw/setID/],
-		produce      => 'proctored_quiz_mode/$setID/',
+		produce      => 'proctored_test_mode/$setID/',
 		display      => 'WeBWorK::ContentGenerator::ProctoredGatewayQuiz',
 		unrestricted => 1
 	},
 	proctored_gateway_proctor_login => {
-		name         => x('Proctored Gateway Quiz [_2] Proctor Login'),
+		name         => x('Proctored Test [_2] Proctor Login'),
 		parent       => 'proctored_gateway_quiz',
 		kids         => [qw//],
-		match        => qr|^proctored_quiz_mode/([^/]+)/|,
+		match        => qr|^proctored_test_mode/([^/]+)/|,
 		capture      => [qw/setID/],
-		produce      => 'proctored_quiz_mode/$setID/proctor_login',
+		produce      => 'proctored_test_mode/$setID/proctor_login',
 		display      => 'WeBWorK::ContentGenerator::LoginProctor',
 		unrestricted => 1
 	},


### PR DESCRIPTION
Rename gateway quizzes as tests in the UI, as discussed in #1838. This also changes the link names from containing `quiz_mode` and `proctored_quiz_mode` to `test_mode` and `proctored_test_mode`.

This changes all the references to `gateway` I could find in the UI (most references were already calling these tests already).