### PR TITLE
Shibboleth bug fix - version for develop - only code sync not meant to be functional.

### DIFF
--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -75,9 +75,9 @@ sub get_credentials {
 		return $self->SUPER::get_credentials(@_);
 	}
 
-	if (defined($ce->{shibboleth}{session_header}) && defined($ce->{shibboleth}{mapping}{user_id})) {
+	if (defined($ENV{ $ce->{shibboleth}{session_header} }) && defined($ENV{ $ce->{shibboleth}{mapping}{user_id} })) {
 		debug('Got shib header and user_id');
-		my $user_id = $ce->{shibboleth}{mapping}{user_id};
+		my $user_id = $ENV{ $ce->{shibboleth}{mapping}{user_id} };
 		if (defined($ce->{shibboleth}{hash_user_id_method})
 			&& $ce->{shibboleth}{hash_user_id_method} ne "none"
 			&& $ce->{shibboleth}{hash_user_id_method} ne "")


### PR DESCRIPTION
Paired with https://github.com/openwebwork/webwork2/pull/1845.

It is known that at present Shibboleth cannot work with develop/2.18, as Apache server variables are not available to Mojolicious. 

The mechanism must be changed so that Shibboleth authentication is handled by a reverse-proxy (Apache and/or nginx) and then the relevant SAML assertions get passed to WeBWorK (apparently as request headers with suitable protection).