### PR TITLE
installing SVG module for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ RUN apt-get update \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
+        libsvg-perl \
 	libtemplate-perl \
 	libtest-deep-perl \
 	libtest-exception-perl \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -88,6 +88,7 @@ RUN apt-get update \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
+        libsvg-perl \
 	libtemplate-perl \
 	libtest-deep-perl \
 	libtest-exception-perl \


### PR DESCRIPTION
Currently `docker-compose up` yields

```
app_1  | Can't load application from file "/opt/webwork/webwork2/bin/webwork2": Can't locate SVG.pm in @INC (you may need to install the SVG module) (@INC contains: /opt/webwork/pg/lib /opt/webwork/webwork2/lib /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.34.0 /usr/local/share/perl/5.34.0 /usr/lib/x86_64-linux-gnu/perl5/5.34 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.34 /usr/share/perl/5.34 /usr/local/lib/site_perl) at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm line 33.
```