### PR TITLE
Add a Minion job queue.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -114,6 +114,8 @@ my @modulesList = qw(
 	Locale::Maketext::Simple
 	LWP::Protocol::https
 	MIME::Base64
+	Minion
+	Minion::Backend::SQLite
 	Mojolicious
 	Mojolicious::Plugin::NotYAMLConfig
 	Net::IP

--- a/conf/README.md
+++ b/conf/README.md
@@ -33,6 +33,8 @@ Server configuration files.
   `webwork2.mojolicious.yml` if you need to change those settings. You usually will need to do this.
 - `webwork2.dist.service` is a systemd configuration file for linux systems that serves the webwork2 app via the
   Mojolicious hypnotoad server. If you need to change it, then copy it to `webwork2.service`.
+- `webwork2-job-queue.dist.service` is a systemd configuration file for linux systems that runs the webwork2 job queue
+  via Minion. If you need to change it, then copy it to `webwork2-job-queue.service`.
 - `webwork2.apache2.4.dist.conf` is only used if you proxy hypnotoad via apache2. Copy this to `webwork2.apache2.4.conf`
   if any changes need to be made.
 - `webwork2.nginx.dist.conf` is only used if you proxy hypnotoad via nginx. Copy this to `webwork2.nginx.conf` if any
@@ -78,6 +80,18 @@ Use the server user on your system instead of "www-data" if it is different.
 
 You can now open your browser to `http://localhost:3000/webwork2`.
 
+For development and testing of the webwork2 job queue additionally execute the following.
+
+```bash
+./bin/webwork2 minion worker
+```
+
+Note that this needs to be run by the same user as the webwork2 app. Both need to have read and write access to the
+SQLite database file that is used for the job queue.
+
+Additionally note that the Minion worker does not hot reload. You must manually restart the worker to reload with
+changes to the task modules.
+
 ## Direct deployment of webwork2 for production via hypnotoad
 
 This is the simplest way to deploy webwork2 for production. Note that you should only use this if your server is
@@ -115,7 +129,7 @@ sudo chmod 500 /etc/autobind/byport/443
 Then set up the systemd service:
 
 - Copy `webwork2.dist.service` to `webwork2.servcice`.
-- Comment out the the `Environment` setting in the copy.
+- Comment out the `Environment` setting in the copy.
 - Set the `User` and `Group` settings to the user chosen above.
 - Append `authbind --deep` to the beginning of the `ExecStart` command.
 - To enable and start the service, execute
@@ -184,4 +198,21 @@ Now set up the systemd service:
 ```bash
 sudo systemctl enable /opt/webwork/webwork2/conf/webwork2.service
 sudo systemctl start webwork2
+```
+
+### Deployment of the webwork2 job queue for all server arrangments
+
+Some long running processes are not directly run by the webwork2 Mojolicious app. Particularly mass grade updates via
+LTI and sending of instructor emails. Instead these tasks are executed via the webwork2 Minion job queue.
+
+Set up the job queue:
+
+- Copy `webwork2-job-queue.dist.service` to `webwork2-job-queue.service`.
+
+Then execute the following to start the job queue:
+
+```bash
+sudo systemctl enable /opt/webwork/webwork2/conf/webwork2-job-queue.service
+sudo systemctl start webwork2-job-queue
+
 ```

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -319,6 +319,26 @@ $mail{tls_allowed} = 0;
 $mail{maxAttachmentSize} = 10;
 
 ################################################################################
+# Minion job queue options
+################################################################################
+
+# This is the Minion backend that will be used by the job queue.
+# The corresponding perl package for this backend must be installed.
+# Some availabled backends are:
+# Minion::Backend::Pg (use 'Pg' below)
+# Minion::Backend::mysql (use 'mysql' below)
+# Minion::Backend::SQLite (use 'SQLite' below)
+# The simplest to use is the SQLite backend as it requires no additional setup.
+$job_queue{backend} = 'SQLite';
+
+# Database dsn for the Minion job queue. Some examples of settings for the
+# respective backends follow. The postgres and mysql examples will need to be
+# modified to work. The default sqlite setting will work as is.
+#$job_queue{database_dsn} = "postgresql://dbuser@/webwork2_job_queue";
+#$job_queue{database_dsn} = "mysql://dbuser:dbpasswd@localhost/webwork2_job_queue";
+$job_queue{database_dsn} = "sqlite:$webwork_dir/DATA/webwork2_job_queue.db";
+
+################################################################################
 # Problem library options
 ################################################################################
 #

--- a/conf/webwork2-job-queue.dist.service
+++ b/conf/webwork2-job-queue.dist.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=webwork2 job queue
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+RuntimeDirectory=webwork2
+PIDFile=/run/webwork2/webwork2-job-queue.pid
+WorkingDirectory=/opt/webwork/webwork2
+ExecStart=/opt/webwork/webwork2/bin/webwork2 minion worker -m production
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -61,6 +61,11 @@ sub startup ($app) {
 			"webwork_server_admin_email for reporting bugs has been set to $WEBWORK_SERVER_ADMIN in site.conf");
 	}
 
+	# Setup the Minion job queue.
+	$app->plugin(Minion => { $ce->{job_queue}{backend} => $ce->{job_queue}{database_dsn} });
+	$app->minion->add_task(lti_mass_update       => 'Mojolicious::WeBWorK::Tasks::LTIMassUpdate');
+	$app->minion->add_task(send_instructor_email => 'Mojolicious::WeBWorK::Tasks::SendInstructorEmail');
+
 	# Helpers
 
 	# This replaces the previous Apache2::RequestUtil method that was overriden in the WeBWorK::Request module to return

--- a/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
@@ -1,0 +1,87 @@
+###############################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package Mojolicious::WeBWorK::Tasks::LTIMassUpdate;
+use Mojo::Base 'Minion::Job', -signatures;
+
+use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+
+# Perform a mass update of grades via LTI.
+sub run ($job, $courseID, $userID = '', $setID = '') {
+	# Establish a lock guard that only allow 1 job at a time (technichally more than one could run at a time if a job
+	# takes more than an hour to complete).  As soon as a job completes (or fails) the lock is released and a new job
+	# can start.  New jobs retry every minute until they can aquire their own lock.
+	return $job->retry({ delay => 60 }) unless my $guard = $job->minion->guard('lti_mass_update', 3600);
+
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ %WeBWorK::SeedCE, courseName => $courseID }) };
+	return $job->fail("Could not construct course environment for $courseID.") unless $ce;
+
+	my $db = WeBWorK::DB->new($ce->{dbLayout});
+	return $job->fail("Could not obtain database connection for $courseID.") unless $db;
+
+	if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+		$job->app->log->info("LTI Mass Update: Starting grade update for user $userID and set $setID.");
+	} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+		$job->app->log->info("LTI Mass Update: Starting grade update for all users assigned to set $setID.");
+	} elsif ($userID) {
+		$job->app->log->info("LTI Mass Update: Starting grade update of all sets assigned to user $userID.");
+	} else {
+		$job->app->log->info('LTI Mass Update: Starting grade update for all sets and users.');
+	}
+
+	# Construct a fake r object that will work for the grader.
+	my $r = { ce => $ce, db => $db, app => $job->app };
+
+	my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($r);
+	$grader->{post_processing_mode} = 1;
+
+	eval {
+		# Determine what needs to be updated.
+		my %updateUsers;
+		if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+			$updateUsers{$userID} = [$setID];
+		} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+			%updateUsers = map { $_ => [$setID] } $db->listSetUsers($setID);
+		} else {
+			if ($ce->{LTIGradeMode} eq 'course') {
+				%updateUsers = map { $_ => 'update_course_grade' } ($userID || $db->listUsers);
+			} elsif ($ce->{LTIGradeMode} eq 'homework') {
+				%updateUsers = map { $_ => [ $db->listUserSets($_) ] } ($userID || $db->listUsers);
+			}
+		}
+
+		for my $user (keys %updateUsers) {
+			if (ref($updateUsers{$user}) eq 'ARRAY') {
+				for my $set (@{ $updateUsers{$user} }) {
+					$grader->submit_set_grade($user, $set);
+				}
+			} elsif ($updateUsers{$user} eq 'update_course_grade') {
+				$grader->submit_course_grade($user);
+			}
+		}
+	};
+	if ($@) {
+		# Write errors to the Mojolicious log.
+		$job->app->log->error("An error occured while trying to mass update grades via LTI: $@");
+		return $job->fail("An error ocurred while trying to mass update grades for $courseID: $@");
+	}
+
+	$job->app->log->info("Updated grades via LTI for course $courseID.");
+	return $job->finish("Updated grades via LTI for course $courseID.");
+}
+
+1;

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -1,0 +1,141 @@
+###############################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package Mojolicious::WeBWorK::Tasks::SendInstructorEmail;
+use Mojo::Base 'Minion::Job', -signatures;
+
+use Email::Stuffer;
+use Email::Sender::Transport::SMTP;
+
+use WeBWorK::Debug qw(debug);
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Localize;
+use WeBWorK::Utils qw/processEmailMessage createEmailSenderTransportSMTP/;
+
+# Send instructor email messages to students.
+# FIXME: This job currently allows multiple jobs to run at once.  Should it be limited?
+sub run ($job, $mail_data) {
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ %WeBWorK::SeedCE, courseName => $mail_data->{courseName} }) };
+	return $job->fail("Could not construct course environment for $mail_data->{courseName}.") unless $ce;
+
+	my $db = WeBWorK::DB->new($ce->{dbLayout});
+	return $job->fail("Could not obtain database connection for $mail_data->{courseName}.") unless $db;
+
+	$job->{language_handle} = WeBWorK::Localize::getLoc($ce->{language} || 'en');
+
+	my $result_message = eval { $job->mail_message_to_recipients($ce, $db, $mail_data) };
+	if ($@) {
+		$result_message .= "An error occurred while trying to send email.\n" . "The error message is:\n\n$@\n\n";
+		$job->app->log->error("An error occurred while trying to send email: $@\n");
+	}
+
+	eval { $job->email_notification($ce, $mail_data, $result_message) };
+	if ($@) {
+		$job->app->log->error("An error occured while trying to send the email notification: $@\n");
+		return $job->fail("FAILURE: Unable to send email notifation to instructor.");
+	}
+
+	return $job->finish("SUCCESS: Email messages sent.");
+}
+
+sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
+	my $result_message  = '';
+	my $failed_messages = 0;
+	my $error_messages  = '';
+
+	my @recipients = @{ $mail_data->{recipients} };
+
+	for my $recipient (@recipients) {
+		$error_messages = '';
+
+		my $user_record = $db->getUser($recipient);
+		unless ($user_record) {
+			$error_messages .= "Record for user $recipient not found\n";
+			next;
+		}
+		unless ($user_record->email_address =~ /\S/) {
+			$error_messages .= "User $recipient does not have an email address -- skipping\n";
+			next;
+		}
+
+		my $msg = processEmailMessage(
+			$mail_data->{text}, $user_record,
+			$ce->status_abbrev_to_name($user_record->status),
+			$mail_data->{merge_data}
+		);
+
+		my $email =
+			Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})->subject($mail_data->{subject})
+			->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+
+		eval {
+			$email->send_or_die({
+				transport => createEmailSenderTransportSMTP($ce),
+				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
+			});
+			debug 'email sent successfully to ' . $user_record->email_address;
+		};
+		if ($@) {
+			debug "Error sending email: $@";
+			$error_messages .= "Error sending email: $@";
+			next;
+		}
+
+		$result_message .=
+			$job->maketext('Message sent to [_1] at [_2].', $recipient, $user_record->email_address) . "\n"
+			unless $error_messages;
+	} continue {
+		# Update failed messages before continuing loop.
+		if ($error_messages) {
+			$failed_messages++;
+			$result_message .= $error_messages;
+		}
+	}
+
+	my $number_of_recipients = @recipients - $failed_messages;
+	return $job->maketext(
+		'A message with the subject line "[_1]" has been sent to [quant,_2,recipient] in the class [_3].  '
+			. 'There were [_4] message(s) that could not be sent.',
+		$mail_data->{subject}, $number_of_recipients, $mail_data->{courseName},
+		$failed_messages
+		)
+		. "\n\n"
+		. $result_message;
+}
+
+sub email_notification ($job, $ce, $mail_data, $result_message) {
+	my $email =
+		Email::Stuffer->to($mail_data->{defaultFrom})->from($mail_data->{defaultFrom})->subject('WeBWorK email sent')
+		->text_body($result_message)->header('X-Remote-Host' => $mail_data->{remote_host});
+
+	eval {
+		$email->send_or_die({
+			transport => createEmailSenderTransportSMTP($ce),
+			$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
+		});
+	};
+	$job->app->log->error("Error sending email: $@") if $@;
+
+	$job->app->log->info("WeBWorK::Tasks::SendInstructorEmail: Instructor message sent from $mail_data->{defaultFrom}");
+
+	return;
+}
+
+sub maketext ($job, @args) {
+	return &{ $job->{language_handle} }(@args);
+}
+
+1;

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -38,7 +38,7 @@ use WeBWorK::Upload;
 
 use Socket qw/unpack_sockaddr_in inet_ntoa/;    # for remote host/port info
 use Text::Wrap qw(wrap);
-use WeBWorK::Utils qw/ decodeAnswers/;
+use WeBWorK::Utils qw/decodeAnswers createEmailSenderTransportSMTP/;
 
 # request paramaters used
 #
@@ -270,17 +270,17 @@ $emailableURL
 			$email->attach($contents, filename => $filename);
 		}
 
-	# $ce->{mail}{set_return_path} is the address used to report returned email if defined and non empty.
-	# It is an argument used in sendmail() (aka Email::Stuffer::send_or_die).
-	# For arcane historical reasons sendmail actually sets the field "MAIL FROM" and the smtp server then
-	# uses that to set "Return-Path".
-	# references:
-	#  https://stackoverflow.com/questions/1235534/what-is-the-behavior-difference-between-return-path-reply-to-and-from
-	#  https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
+		# $ce->{mail}{set_return_path} is the address used to report returned email if defined and non empty.
+		# It is an argument used in sendmail() (aka Email::Stuffer::send_or_die).
+		# For arcane historical reasons sendmail actually sets the field "MAIL FROM" and the smtp server then
+		# uses that to set "Return-Path".
+		# references:
+		#  https://stackoverflow.com/questions/1235534/
+		#    what-is-the-behavior-difference-between-return-path-reply-to-and-from
+		#  https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
 		try {
 			$email->send_or_die({
-				# createEmailSenderTransportSMTP is defined in ContentGenerator
-				transport => $self->createEmailSenderTransportSMTP(),
+				transport => createEmailSenderTransportSMTP($ce),
 				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 			});
 			print CGI::p($r->maketext('Your message was sent successfully.'));

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -31,8 +31,8 @@ use Try::Tiny;
 
 use WeBWorK::CGI;
 use WeBWorK::Debug;
-use WeBWorK::Utils
-	qw(writeLog writeCourseLogGivenTime encodeAnswers before after jitar_problem_adjusted_status jitar_id_to_seq);
+use WeBWorK::Utils qw(writeLog writeCourseLogGivenTime encodeAnswers before after jitar_problem_adjusted_status
+	jitar_id_to_seq createEmailSenderTransportSMTP);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
 
 use Caliper::Sensor;
@@ -494,8 +494,7 @@ Comment:    $comment
 	#  https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
 	try {
 		$email->send_or_die({
-			# createEmailSenderTransportSMTP is defined in ContentGenerator
-			transport => $self->createEmailSenderTransportSMTP(),
+			transport => createEmailSenderTransportSMTP($ce),
 			$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 		});
 		debug('Successfully sent JITAR alert message');


### PR DESCRIPTION
This is used for LTI mass grade updates and sending instructor emails.

A special warnings method is added to submit grade that sends debugging warnings to the log instead of using a native warn.  During a mass update those warn statements fall on deaf ears in production deployment with hypnotoad.

The code is generally cleaned up in that file.  Replace CGI::escapeHTML with HTML::Entities::encode_entities which does the same thing (for the most part).  Also, replace LWP::UserAgent with Mojo::UserAgent.

For this to work with the Minion::Backend::SQLite module, you will need to install version 3.002 of the Mojo::SQLite package.  Newer versions of that module cause issues.  Note that by default the sqlite database file is "$webwork_dir/DATA/webwork2_job_queue.db".

Other backends that can be used are the Minion::Backend::Pg module with postgres, and the Minion::Backend::mysql module with mysql.  Setting those up takes a little more work though.  The SQLite backend is much simpler.

The usage is documented in conf/README.md.

In short, for development you can run the job queue with `./bin/webwork2 minion worker`,
and for production copy conf/webwork2-job-queue.dist.service to conf/webwork2-job-queue.service and run
`sudo systemctl enable /opt/webwork/webwork2/conf/webwork2-job-queue.service` and
`sudo systemctl start webwork2-job-queue`