### PR TITLE
Prevent duplicate LTI tabs on the course configuration page.

### DIFF
--- a/conf/LTIConfigValues.config
+++ b/conf/LTIConfigValues.config
@@ -93,7 +93,7 @@ $LTIConfigValues = {
 	},
 };
 
-if (@LTIConfigVariables) {
+if (@LTIConfigVariables && !(grep { $_->[0] eq 'LTI' } @$ConfigValues)) {
 	push(@$ConfigValues,
 		[ x('LTI'), map { $LTIConfigValues->{$_} } grep { defined $LTIConfigValues->{$_} } @LTIConfigVariables ]);
 }


### PR DESCRIPTION
Fixes issue #1853.

This just checks the @ConfigValues array for elements whose first sub array element is 'LTI'.  If any are found, then it doesn't add the elements from the @LTIConfigVariables array.