### PR TITLE
Add a Minion job queue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,8 @@ RUN apt-get update \
 	libmail-sender-perl \
 	libmariadb-dev \
 	libmime-tools-perl \
+	libminion-backend-sqlite-perl \
+	libminion-perl \
 	libmodule-build-perl \
 	libmodule-pluggable-perl \
 	libmojolicious-perl \
@@ -126,7 +128,7 @@ RUN apt-get update \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
-        libsvg-perl \
+	libsvg-perl \
 	libtemplate-perl \
 	libtest-deep-perl \
 	libtest-exception-perl \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -70,6 +70,8 @@ RUN apt-get update \
 	libmail-sender-perl \
 	libmariadb-dev \
 	libmime-tools-perl \
+	libminion-backend-sqlite-perl \
+	libminion-perl \
 	libmodule-build-perl \
 	libmodule-pluggable-perl \
 	libmojolicious-perl \
@@ -88,7 +90,7 @@ RUN apt-get update \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
-        libsvg-perl \
+	libsvg-perl \
 	libtemplate-perl \
 	libtest-deep-perl \
 	libtest-exception-perl \
@@ -138,7 +140,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install Statistics::R::IO Mojolicious::Plugin::NotYAMLConfig DBD::MariaDB \
+RUN cpanm install -n Statistics::R::IO Mojolicious::Plugin::NotYAMLConfig DBD::MariaDB Mojo::SQLite@3.002 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -112,6 +112,8 @@ my @modulesList = qw(
 	Locale::Maketext::Simple
 	LWP::Protocol::https
 	MIME::Base64
+	Minion
+	Minion::Backend::SQLite
 	Mojolicious
 	Mojolicious::Plugin::NotYAMLConfig
 	Net::IP

--- a/conf/README.md
+++ b/conf/README.md
@@ -33,6 +33,8 @@ Server configuration files.
   `webwork2.mojolicious.yml` if you need to change those settings. You usually will need to do this.
 - `webwork2.dist.service` is a systemd configuration file for linux systems that serves the webwork2 app via the
   Mojolicious hypnotoad server. If you need to change it, then copy it to `webwork2.service`.
+- `webwork2-job-queue.dist.service` is a systemd configuration file for linux systems that runs the webwork2 job queue
+  via Minion. If you need to change it, then copy it to `webwork2-job-queue.service`.
 - `webwork2.apache2.4.dist.conf` is only used if you proxy hypnotoad via apache2. Copy this to `webwork2.apache2.4.conf`
   if any changes need to be made.
 - `webwork2.nginx.dist.conf` is only used if you proxy hypnotoad via nginx. Copy this to `webwork2.nginx.conf` if any
@@ -78,6 +80,18 @@ Use the server user on your system instead of "www-data" if it is different.
 
 You can now open your browser to `http://localhost:3000/webwork2`.
 
+For development and testing of the webwork2 job queue additionally execute the following.
+
+```bash
+./bin/webwork2 minion worker
+```
+
+Note that this needs to be run by the same user as the webwork2 app. Both need to have read and write access to the
+SQLite database file that is used for the job queue.
+
+Additionally note that the Minion worker does not hot reload. You must manually restart the worker to reload with
+changes to the task modules.
+
 ## Direct deployment of webwork2 for production via hypnotoad
 
 This is the simplest way to deploy webwork2 for production. Note that you should only use this if your server is
@@ -115,7 +129,7 @@ sudo chmod 500 /etc/autobind/byport/443
 Then set up the systemd service:
 
 - Copy `webwork2.dist.service` to `webwork2.servcice`.
-- Comment out the the `Environment` setting in the copy.
+- Comment out the `Environment` setting in the copy.
 - Set the `User` and `Group` settings to the user chosen above.
 - Append `authbind --deep` to the beginning of the `ExecStart` command.
 - To enable and start the service, execute
@@ -184,4 +198,21 @@ Now set up the systemd service:
 ```bash
 sudo systemctl enable /opt/webwork/webwork2/conf/webwork2.service
 sudo systemctl start webwork2
+```
+
+### Deployment of the webwork2 job queue for all server arrangments
+
+Some long running processes are not directly run by the webwork2 Mojolicious app. Particularly mass grade updates via
+LTI and sending of instructor emails. Instead these tasks are executed via the webwork2 Minion job queue.
+
+Set up the job queue:
+
+- Copy `webwork2-job-queue.dist.service` to `webwork2-job-queue.service`.
+
+Then execute the following to start the job queue:
+
+```bash
+sudo systemctl enable /opt/webwork/webwork2/conf/webwork2-job-queue.service
+sudo systemctl start webwork2-job-queue
+
 ```

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -319,6 +319,26 @@ $mail{tls_allowed} = 0;
 $mail{maxAttachmentSize} = 10;
 
 ################################################################################
+# Minion job queue options
+################################################################################
+
+# This is the Minion backend that will be used by the job queue.
+# The corresponding perl package for this backend must be installed.
+# Some availabled backends are:
+# Minion::Backend::Pg (use 'Pg' below)
+# Minion::Backend::mysql (use 'mysql' below)
+# Minion::Backend::SQLite (use 'SQLite' below)
+# The simplest to use is the SQLite backend as it requires no additional setup.
+$job_queue{backend} = 'SQLite';
+
+# Database dsn for the Minion job queue. Some examples of settings for the
+# respective backends follow. The postgres and mysql examples will need to be
+# modified to work. The default sqlite setting will work as is.
+#$job_queue{database_dsn} = "postgresql://dbuser@/webwork2_job_queue";
+#$job_queue{database_dsn} = "mysql://dbuser:dbpasswd@localhost/webwork2_job_queue";
+$job_queue{database_dsn} = "sqlite:$webwork_dir/DATA/webwork2_job_queue.db";
+
+################################################################################
 # Problem library options
 ################################################################################
 #

--- a/conf/webwork2-job-queue.dist.service
+++ b/conf/webwork2-job-queue.dist.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=webwork2 job queue
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+RuntimeDirectory=webwork2
+PIDFile=/run/webwork2/webwork2-job-queue.pid
+WorkingDirectory=/opt/webwork/webwork2
+ExecStart=/opt/webwork/webwork2/bin/webwork2 minion worker -m production
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -238,6 +238,10 @@ chown www-data:www-data  $APP_ROOT/courses/admin/*
 
 echo "End fixing ownership and permissions"
 
+# Start the Minion job queue.
+echo "Starting Minion job queue"
+sudo -E -u www-data bin/webwork2 minion worker -m production &
+
 # The code below allows you to use
 #    docker container exec -it webwork2_app_1 hypnotoad -s bin/webwork2
 # to restart the webwork2 Mojolicious app in the container in a "nice" way.

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -71,6 +71,11 @@ sub startup ($app) {
 	# Add the themes directory to the template search paths.
 	push(@{ $app->renderer->paths }, $ce->{webworkDirs}{themes});
 
+	# Setup the Minion job queue.
+	$app->plugin(Minion => { $ce->{job_queue}{backend} => $ce->{job_queue}{database_dsn} });
+	$app->minion->add_task(lti_mass_update       => 'Mojolicious::WeBWorK::Tasks::LTIMassUpdate');
+	$app->minion->add_task(send_instructor_email => 'Mojolicious::WeBWorK::Tasks::SendInstructorEmail');
+
 	# Helpers
 
 	# This replaces the previous Apache2::RequestUtil method that was overriden in the WeBWorK::Request module to return

--- a/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
@@ -1,0 +1,85 @@
+###############################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package Mojolicious::WeBWorK::Tasks::LTIMassUpdate;
+use Mojo::Base 'Minion::Job', -signatures;
+
+use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+
+# Perform a mass update of grades via LTI.
+sub run ($job, $courseID, $userID = '', $setID = '') {
+	# Establish a lock guard that only allow 1 job at a time (technichally more than one could run at a time if a job
+	# takes more than an hour to complete).  As soon as a job completes (or fails) the lock is released and a new job
+	# can start.  New jobs retry every minute until they can aquire their own lock.
+	return $job->retry({ delay => 60 }) unless my $guard = $job->minion->guard('lti_mass_update', 3600);
+
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ %WeBWorK::SeedCE, courseName => $courseID }) };
+	return $job->fail("Could not construct course environment for $courseID.") unless $ce;
+
+	my $db = WeBWorK::DB->new($ce->{dbLayout});
+	return $job->fail("Could not obtain database connection for $courseID.") unless $db;
+
+	if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+		$job->app->log->info("LTI Mass Update: Starting grade update for user $userID and set $setID.");
+	} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+		$job->app->log->info("LTI Mass Update: Starting grade update for all users assigned to set $setID.");
+	} elsif ($userID) {
+		$job->app->log->info("LTI Mass Update: Starting grade update of all sets assigned to user $userID.");
+	} else {
+		$job->app->log->info('LTI Mass Update: Starting grade update for all sets and users.');
+	}
+
+	# Pass a fake controller object that will work for the grader.
+	my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new({ ce => $ce, db => $db, app => $job->app });
+	$grader->{post_processing_mode} = 1;
+
+	eval {
+		# Determine what needs to be updated.
+		my %updateUsers;
+		if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+			$updateUsers{$userID} = [$setID];
+		} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+			%updateUsers = map { $_ => [$setID] } $db->listSetUsers($setID);
+		} else {
+			if ($ce->{LTIGradeMode} eq 'course') {
+				%updateUsers = map { $_ => 'update_course_grade' } ($userID || $db->listUsers);
+			} elsif ($ce->{LTIGradeMode} eq 'homework') {
+				%updateUsers = map { $_ => [ $db->listUserSets($_) ] } ($userID || $db->listUsers);
+			}
+		}
+
+		for my $user (keys %updateUsers) {
+			if (ref($updateUsers{$user}) eq 'ARRAY') {
+				for my $set (@{ $updateUsers{$user} }) {
+					$grader->submit_set_grade($user, $set);
+				}
+			} elsif ($updateUsers{$user} eq 'update_course_grade') {
+				$grader->submit_course_grade($user);
+			}
+		}
+	};
+	if ($@) {
+		# Write errors to the Mojolicious log.
+		$job->app->log->error("An error occured while trying to mass update grades via LTI: $@");
+		return $job->fail("An error ocurred while trying to mass update grades for $courseID: $@");
+	}
+
+	$job->app->log->info("Updated grades via LTI for course $courseID.");
+	return $job->finish("Updated grades via LTI for course $courseID.");
+}
+
+1;

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -1,0 +1,141 @@
+###############################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package Mojolicious::WeBWorK::Tasks::SendInstructorEmail;
+use Mojo::Base 'Minion::Job', -signatures;
+
+use Email::Stuffer;
+use Email::Sender::Transport::SMTP;
+
+use WeBWorK::Debug qw(debug);
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Localize;
+use WeBWorK::Utils qw/processEmailMessage createEmailSenderTransportSMTP/;
+
+# Send instructor email messages to students.
+# FIXME: This job currently allows multiple jobs to run at once.  Should it be limited?
+sub run ($job, $mail_data) {
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ %WeBWorK::SeedCE, courseName => $mail_data->{courseName} }) };
+	return $job->fail("Could not construct course environment for $mail_data->{courseName}.") unless $ce;
+
+	my $db = WeBWorK::DB->new($ce->{dbLayout});
+	return $job->fail("Could not obtain database connection for $mail_data->{courseName}.") unless $db;
+
+	$job->{language_handle} = WeBWorK::Localize::getLoc($ce->{language} || 'en');
+
+	my $result_message = eval { $job->mail_message_to_recipients($ce, $db, $mail_data) };
+	if ($@) {
+		$result_message .= "An error occurred while trying to send email.\n" . "The error message is:\n\n$@\n\n";
+		$job->app->log->error("An error occurred while trying to send email: $@\n");
+	}
+
+	eval { $job->email_notification($ce, $mail_data, $result_message) };
+	if ($@) {
+		$job->app->log->error("An error occured while trying to send the email notification: $@\n");
+		return $job->fail("FAILURE: Unable to send email notifation to instructor.");
+	}
+
+	return $job->finish("SUCCESS: Email messages sent.");
+}
+
+sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
+	my $result_message  = '';
+	my $failed_messages = 0;
+	my $error_messages  = '';
+
+	my @recipients = @{ $mail_data->{recipients} };
+
+	for my $recipient (@recipients) {
+		$error_messages = '';
+
+		my $user_record = $db->getUser($recipient);
+		unless ($user_record) {
+			$error_messages .= "Record for user $recipient not found\n";
+			next;
+		}
+		unless ($user_record->email_address =~ /\S/) {
+			$error_messages .= "User $recipient does not have an email address -- skipping\n";
+			next;
+		}
+
+		my $msg = processEmailMessage(
+			$mail_data->{text}, $user_record,
+			$ce->status_abbrev_to_name($user_record->status),
+			$mail_data->{merge_data}
+		);
+
+		my $email =
+			Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})->subject($mail_data->{subject})
+			->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+
+		eval {
+			$email->send_or_die({
+				transport => createEmailSenderTransportSMTP($ce),
+				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
+			});
+			debug 'email sent successfully to ' . $user_record->email_address;
+		};
+		if ($@) {
+			debug "Error sending email: $@";
+			$error_messages .= "Error sending email: $@";
+			next;
+		}
+
+		$result_message .=
+			$job->maketext('Message sent to [_1] at [_2].', $recipient, $user_record->email_address) . "\n"
+			unless $error_messages;
+	} continue {
+		# Update failed messages before continuing loop.
+		if ($error_messages) {
+			$failed_messages++;
+			$result_message .= $error_messages;
+		}
+	}
+
+	my $number_of_recipients = @recipients - $failed_messages;
+	return $job->maketext(
+		'A message with the subject line "[_1]" has been sent to [quant,_2,recipient] in the class [_3].  '
+			. 'There were [_4] message(s) that could not be sent.',
+		$mail_data->{subject}, $number_of_recipients, $mail_data->{courseName},
+		$failed_messages
+		)
+		. "\n\n"
+		. $result_message;
+}
+
+sub email_notification ($job, $ce, $mail_data, $result_message) {
+	my $email =
+		Email::Stuffer->to($mail_data->{defaultFrom})->from($mail_data->{defaultFrom})->subject('WeBWorK email sent')
+		->text_body($result_message)->header('X-Remote-Host' => $mail_data->{remote_host});
+
+	eval {
+		$email->send_or_die({
+			transport => createEmailSenderTransportSMTP($ce),
+			$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
+		});
+	};
+	$job->app->log->error("Error sending email: $@") if $@;
+
+	$job->app->log->info("WeBWorK::Tasks::SendInstructorEmail: Instructor message sent from $mail_data->{defaultFrom}");
+
+	return;
+}
+
+sub maketext ($job, @args) {
+	return &{ $job->{language_handle} }(@args);
+}
+
+1;

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -150,7 +150,7 @@ sub get_credentials {
 			"oauth_nonce        = $oauth_time",
 			"WW_server_time     = $curr_time",
 			"diff(server-oauth) = $delta_time seconds ($delta_min minutes)",
-			"============================");
+			"============================\n");
 	}
 
 	#disable password login
@@ -257,7 +257,7 @@ sub get_credentials {
 		# For setting up its helpful to print out what the system think the
 		# User id and address is at this point
 		if ($ce->{debug_lti_parameters}) {
-			warn "=========== summary ============";
+			warn "=========== summary ============\n";
 			warn "User id is |$self->{user_id}| (obtained from $user_id_source which was $type_of_source)\n";
 			warn "User mail address is |$self->{email}|\n";
 			warn "strip_address_from_email is |", $ce->{strip_address_from_email} // 0, "|\n";
@@ -445,8 +445,8 @@ sub authenticate {
 	my $path = $ce->{LTIBasicToThisSiteURL} || ($c->url_for->to_abs =~ s|/?$|/|r);
 
 	if ($ce->{debug_lti_parameters}) {
-		warn("The following path was reconstructed by WeBWorK.  It should match the path in the LMS:");
-		warn($path);
+		warn("The following path was reconstructed by WeBWorK.  It should match the path in the LMS:\n");
+		warn("$path\n");
 	}
 
 	# We also try a version without the trailing / in case that was not

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -26,7 +26,6 @@ use warnings;
 
 use Carp;
 use Net::OAuth;
-use HTML::Entities;
 use Mojo::UserAgent;
 use UUID::Tiny ':std';
 use Digest::SHA qw(sha1_base64);
@@ -55,7 +54,7 @@ sub warning {
 	if ($self->{post_processing_mode}) {
 		$self->{c}{app}->log->warn($warning);
 	} else {
-		warn $warning;
+		warn "$warning\n";
 	}
 	return;
 }
@@ -174,18 +173,6 @@ sub submit_set_grade {
 	return $self->submit_grade($userSet->lis_source_did, $score);
 }
 
-# Escape HTML in messages when post processing is not being done.  When post processing is being done these messages are
-# sent to a log file, and so escaping HTML makes the messages even less readable.  Note that this should never be used
-# with the "debug" method as those messages always go into a log file.
-sub local_escape_html {
-	my ($self, @message) = @_;
-	if ($self->{post_processing_mode}) {
-		return join('', @message);
-	} else {
-		return HTML::Entities::encode_entities(join('', @message));
-	}
-}
-
 # Submits a score of $score to the lms with $sourcedid as the identifier.
 sub submit_grade {
 	my ($self, $sourcedid, $score) = @_;
@@ -297,9 +284,9 @@ EOS
 
 		# debug section
 		if ($ce->{debug_lti_grade_passback} && $ce->{debug_lti_parameters}) {
-			$self->warning("The request was:\n " . $self->local_escape_html($readResultXML));
+			$self->warning("The request was:\n " . $readResultXML);
 			$self->warning("The nonce used is ${uuid_p1}__${uuid_p2}");
-			$self->warning("The response is:\n " . $self->local_escape_html($response->to_string));
+			$self->warning("The response is:\n " . $response->to_string);
 			debug("The request was:\n " . $readResultXML);
 			debug("The nonce used is ${uuid_p1}__${uuid_p2}");
 			debug("The response is:\n " . $response->to_string);
@@ -436,9 +423,9 @@ EOS
 
 		# debug section
 		if ($ce->{debug_lti_grade_passback} && $ce->{debug_lti_parameters}) {
-			$self->warning("The request was:\n " . $self->local_escape_html($replaceResultXML));
+			$self->warning("The request was:\n " . $replaceResultXML);
 			$self->warning("The nonce used is ${uuid_p1}__${uuid_p2}");
-			$self->warning("The response is:\n " . $self->local_escape_html($response->to_string));
+			$self->warning("The response is:\n " . $response->to_string);
 			debug("The request was:\n " . $replaceResultXML);
 			debug("The nonce used is ${uuid_p1}__${uuid_p2}");
 			debug("The response is:\n " . $response->to_string);

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -14,7 +14,6 @@
 ################################################################################
 
 package WeBWorK::Authen::LTIAdvanced::SubmitGrade;
-use base qw/WeBWorK::Authen::LTIAdvanced/;
 
 =head1 NAME
 
@@ -24,75 +23,74 @@ WeBWorK::Authen::LTIAdvanced::SubmitGrade - pass back grades to an enabled LMS
 
 use strict;
 use warnings;
-use WeBWorK::Debug;
+
 use Carp;
-use WeBWorK::Utils qw(grade_set grade_gateway grade_all_sets wwRound);
 use Net::OAuth;
 use HTML::Entities;
-use HTTP::Request;
-use LWP::UserAgent;
+use Mojo::UserAgent;
 use UUID::Tiny ':std';
-use Mojo::IOLoop;
-
 use Digest::SHA qw(sha1_base64);
+
+use WeBWorK::Debug;
+use WeBWorK::Utils qw(grade_set grade_gateway grade_all_sets wwRound);
 
 # This package contains utilities for submitting grades to the LMS
 sub new {
 	my ($invocant, $c) = @_;
-	my $class = ref($invocant) || $invocant;
-	my $self  = { c => $c, };
-	# sanity check
-	my $ce = $c->ce;
-	my $db = $self->{c}->db;
 
-	unless (ref($ce // '') and ref($db) // '') {
-		warn("course environment is not defined") unless ref($ce // '');
-		warn("database reference is not defined") unless ref($db // '');
-		croak("Could not create WeBWorK::Authen::LTIAdvanced::SubmitGrade object, missing items from request");
+	# Sanity check
+	unless (ref($c->{ce}) && ref($c->{db})) {
+		warn('course environment is not defined') unless ref($c->{ce});
+		warn('database reference is not defined') unless ref($c->{db});
+		croak('Could not create WeBWorK::Authen::LTIAdvanced::SubmitGrade object, missing items from request');
 	}
 
-	bless $self, $class;
-	return $self;
+	return bless { c => $c }, ref($invocant) || $invocant;
+}
+
+# Use the app log for warnings in post processing mode as perl warnings are not caught in the job queue.
+# Otherwise just use warn as those are caught by the global webwork2 warn handler.
+sub warning {
+	my ($self, $warning) = @_;
+	if ($self->{post_processing_mode}) {
+		$self->{c}{app}->log->warn($warning);
+	} else {
+		warn $warning;
+	}
+	return;
 }
 
 # This updates the sourcedid for the object we are looking at.  Its either
 # the sourcedid for the user for course grades or the sourcedid for the
 # userset for homework grades.
 sub update_sourcedid {
-	my $self   = shift;
-	my $userID = shift;
-	my $c      = $self->{c};
-	my $ce     = $c->ce;
-	my $db     = $self->{c}->db;
+	my ($self, $userID) = @_;
+	my $c  = $self->{c};
+	my $ce = $c->{ce};
+	my $db = $c->{db};
 
 	# These parameters are used to build the passback request
 	# warn if no outcome service url
 	if (!defined($c->param('lis_outcome_service_url'))) {
-		carp "The parameter lis_outcome_service_url is not defined.  Unable to report grades to the LMS."
-			. " Are external grades enabled in the LMS?"
+		carp 'The parameter lis_outcome_service_url is not defined.  Unable to report grades to the LMS.'
+			. ' Are external grades enabled in the LMS?'
 			if $ce->{debug_lti_grade_passback};
 	} else {
 		# otherwise keep it up to date
 		my $lis_outcome_service_url = $db->getSettingValue('lis_outcome_service_url');
-		if (!defined($lis_outcome_service_url)
-			|| $lis_outcome_service_url ne $c->param('lis_outcome_service_url'))
-		{
+		if (!defined($lis_outcome_service_url) || $lis_outcome_service_url ne $c->param('lis_outcome_service_url')) {
 			$db->setSettingValue('lis_outcome_service_url', $c->param('lis_outcome_service_url'));
 		}
 	}
 
 	# these parameters have to be here or we couldn't have gotten this far
 	my $consumer_key = $db->getSettingValue('consumer_key');
-	if (!defined($consumer_key)
-		|| $consumer_key ne $c->param('oauth_consumer_key'))
-	{
+	if (!defined($consumer_key) || $consumer_key ne $c->param('oauth_consumer_key')) {
 		$db->setSettingValue('consumer_key', $c->param('oauth_consumer_key'));
 	}
 
 	my $signature_method = $db->getSettingValue('signature_method');
-	if (!defined($signature_method)
-		|| $signature_method ne $c->param('oauth_signature_method'))
-	{
+	if (!defined($signature_method) || $signature_method ne $c->param('oauth_signature_method')) {
 		$db->setSettingValue('signature_method', $c->param('oauth_signature_method'));
 	}
 
@@ -101,8 +99,8 @@ sub update_sourcedid {
 	# depending on the request and the mode we are in.
 	my $sourcedid = $c->param('lis_result_sourcedid');
 	if (!defined($sourcedid)) {
-		warn "No LISSourceID! Some LMS's do not give grades to instructors, but this "
-			. "could also be a sign that external grades are not enabled in your LMS."
+		warn q{No LISSourceID! Some LMS's do not give grades to instructors, but this }
+			. 'could also be a sign that external grades are not enabled in your LMS.'
 			if $ce->{debug_lti_grade_passback};
 	} elsif ($ce->{LTIGradeMode} eq 'course') {
 		# Update the SourceDID for the user if we are in course mode
@@ -114,57 +112,45 @@ sub update_sourcedid {
 	} elsif ($ce->{LTIGradeMode} eq 'homework') {
 		my $setID = $c->stash('setID');
 		if (!defined($setID)) {
-			warn "Not a link to a Problem Set and in homework grade mode."
-				. " Links to WeBWorK should point to specific problem sets.";
+			warn 'Not a link to a Problem Set and in homework grade mode.'
+				. ' Links to WeBWorK should point to specific problem sets.';
 		} else {
 			my $set = $db->getUserSet($userID, $setID);
-			# if set is not defined and we are going to a page with
-			# is set dependent then there are problems that will be caught
-			# later
-			if (
-				defined($set)
-				&& (!defined($set->lis_source_did)
-					|| $set->lis_source_did ne $sourcedid)
-				)
-			{
+			if (defined($set) && (!defined($set->lis_source_did) || $set->lis_source_did ne $sourcedid)) {
 				$set->lis_source_did($sourcedid);
 				$db->putUserSet($set);
-
 			}
 		}
 	}
-}    # end update_sourcedid
 
-# computes and submits the course grade for userID to the LMS
-# the course grade is the average of all sets assigned to the user.
+	return;
+}
+
+# Computes and submits the course grade for userID to the LMS.
+# The course grade is the average of all sets assigned to the user.
 sub submit_course_grade {
-	my $self   = shift;
-	my $userID = shift;
-	my $c      = $self->{c};
-	my $ce     = $c->ce;
-	my $db     = $self->{c}->db;
+	my ($self, $userID) = @_;
+	my $c  = $self->{c};
+	my $ce = $c->{ce};
+	my $db = $c->{db};
 
 	my $score = grade_all_sets($db, $userID);
 	my $user  = $db->getUser($userID);
 
-	die("$userID does not exist") unless $user;
-	warn "submitting all grades for user: $userID  \n" if $ce->{debug_lti_grade_passback};
-	warn "lis_source_did is not available for user: $userID \n"
-		if !($user->lis_source_did)
-		and $ce->{debug_lti_grade_passback};
-	return $self->submit_grade($user->lis_source_did, $score);
+	die "$userID does not exist" unless $user;
+	$self->warning("submitting all grades for user: $userID") if $ce->{debug_lti_grade_passback};
+	$self->warning("lis_source_did is not available for user: $userID")
+		if !($user->lis_source_did) && $ce->{debug_lti_grade_passback};
 
+	return $self->submit_grade($user->lis_source_did, $score);
 }
 
-# computes and submits the set grade for $userID and $setID to the
-# LMS.  For gateways the best score is used.
+# Computes and submits the set grade for $userID and $setID to the LMS.  For gateways the best score is used.
 sub submit_set_grade {
-	my $self   = shift;
-	my $userID = shift;
-	my $setID  = shift;
-	my $c      = $self->{c};
-	my $ce     = $c->ce;
-	my $db     = $c->db;
+	my ($self, $userID, $setID) = @_;
+	my $c  = $self->{c};
+	my $ce = $c->{ce};
+	my $db = $c->{db};
 
 	my $user = $db->getUser($userID);
 
@@ -173,17 +159,18 @@ sub submit_set_grade {
 	my $userSet = $db->getMergedSet($userID, $setID);
 	my $score   = 0;
 
-	if ($userSet->assignment_type() =~ /gateway/) {
+	if ($userSet->assignment_type =~ /gateway/) {
 		$score = grade_gateway($db, $userSet, $userSet->set_id, $userID);
 	} else {
 		$score = grade_set($db, $userSet, $userID, 0);
 	}
-	# make debug prettier
+
 	my $message_string = '';
-	$message_string .= "\nmass_update: " if $self->{post_processing_mode};
+	$message_string .= 'mass_update: ' if $self->{post_processing_mode};
 	$message_string .= "submitting grade for user: $userID set $setID ";
-	$message_string .= "-- lis_source_did is not available " unless ($userSet->lis_source_did);
-	warn($message_string . "\n") if $ce->{debug_lti_grade_passback};
+	$message_string .= '-- lis_source_did is not available ' unless ($userSet->lis_source_did);
+	$self->warning($message_string) if $ce->{debug_lti_grade_passback};
+
 	return $self->submit_grade($userSet->lis_source_did, $score);
 }
 
@@ -199,26 +186,17 @@ sub local_escape_html {
 	}
 }
 
-# submits a score of $score to the lms with $sourcedid as the
-# identifier.
+# Submits a score of $score to the lms with $sourcedid as the identifier.
 sub submit_grade {
-	my $self      = shift;
-	my $sourcedid = shift;
-	my $score     = shift;
-	my $c         = $self->{c};
-	my $ce        = $c->ce;
-	my $db        = $self->{c}->db;
+	my ($self, $sourcedid, $score) = @_;
+	my $c  = $self->{c};
+	my $ce = $c->{ce};
+	my $db = $c->{db};
 
 	$score = wwRound(2, $score);
 
-	# We have to fail gracefully here because some users, like instructors,
-	# may not actually have a sourcedid
-	if (!$sourcedid) {
-		#     debug("No sourcedid for this user/assignment.  Some LMS's do not provide ".
-		#      "sourcedid for instructors so this may not be a problem, or it might ".
-		#      "mean your settings are not correct.") if $ce->{debug_lti_grade_passback};
-		return 0;
-	}
+	# Fail gracefully.  Some users, like instructors, may not actually have a sourcedid.
+	return 0 if (!$sourcedid);
 
 	# Needed in both phases
 	my $bodyhash;
@@ -228,44 +206,41 @@ sub submit_grade {
 	my $response;
 
 	my $request_url = $db->getSettingValue('lis_outcome_service_url');
-	if (!defined($request_url) || $request_url eq "") {
-		warn("Cannot send/retrieve grades to/from the LMS, no lis_outcome_service_url");
+	if (!$request_url) {
+		$self->warning('Cannot send/retrieve grades to/from the LMS, no lis_outcome_service_url');
 		return 0;
 	}
 
 	my $consumer_key = $db->getSettingValue('consumer_key');
-	if (!defined($consumer_key) || $consumer_key eq "") {
-		warn("Cannot send/retrieve grades to/from the LMS, no consumer_key");
+	if (!$consumer_key) {
+		$self->warning('Cannot send/retrieve grades to/from the LMS, no consumer_key');
 		return 0;
 	}
 
 	my $signature_method = $db->getSettingValue('signature_method');
-	if (!defined($signature_method) || $signature_method eq "") {
-		warn("Cannot send/retrieve grades to/from the LMS, no signature_method");
+	if (!$signature_method) {
+		$self->warning('Cannot send/retrieve grades to/from the LMS, no signature_method');
 		return 0;
 	}
 
-	debug("found data required for submitting grades to LMS");
+	debug('found data required for submitting grades to LMS');
 
-	# Generate a better nonce, first a portion unique for the sourcedid
-	# which should be dependent on the student + the assignment if a
-	# "homework" level sourcedid. This part can be used twice
+	# Generate a nonce. Start with a portion that is unique for the sourcedid.  This should be dependent on the student.
+	# If grade mode is "homework", this is also dependent on the assignment.  This part can be used twice.
 	my $uuid_p1 = create_uuid_as_string(UUID_SHA1, UUID_NS_URL, $sourcedid);
 
-	# Second part is a time dependent portion
+	# The second part is time dependent.
 	my $uuid_p2 = create_uuid_as_string(UUID_TIME);
 
-	my $lti_check_prior = $ce->{lti_check_prior} // 0;    # Should we first poll the LMS for the current grade
+	my $lti_do_send = 1;
 
-	my $lti_do_send = 1;                                  # Default to yes
+	if ($ce->{lti_check_prior} // 0) {
+		# Poll the LMS for prior grade.
 
-	if ($lti_check_prior) {
+		$lti_do_send = 0;
 
-		# Poll the LMS for prior grade
-
-		$lti_do_send = 0;                                 # Change default to no, and change below if needed
-
-	 # This is boilerplate XML used to retrieve the currently recorded score for $sourcedid (which will later be tested)
+		# This is boilerplate XML used to retrieve the currently recorded score for $sourcedid
+		# (which will later be tested)
 		my $readResultXML = <<EOS;
 <?xml version = "1.0" encoding = "UTF-8"?>
 <imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
@@ -291,126 +266,103 @@ EOS
 
 		$bodyhash = sha1_base64($readResultXML);
 
-		# since sha1_base64 doesn't pad we have to do so manually
+		# Since sha1_base64 doesn't pad we have to do so manually.
 		while (length($bodyhash) % 4) {
 			$bodyhash .= '=';
 		}
 
-		warn("Retrieving prior grade using sourcedid: $sourcedid")
-			if $ce->{debug_lti_parameters};
+		$self->warning("Retrieving prior grade using sourcedid: $sourcedid") if $ce->{debug_lti_parameters};
 
-		$requestGen = Net::OAuth->request("consumer");
+		$requestGen = Net::OAuth->request('consumer');
 
 		$requestGen->add_required_message_params('body_hash');
 
 		$gradeRequest = $requestGen->new(
 			request_url      => $request_url,
-			request_method   => "POST",
+			request_method   => 'POST',
 			consumer_secret  => $ce->{LTIBasicConsumerSecret},
 			consumer_key     => $consumer_key,
 			signature_method => $signature_method,
 			nonce            => "${uuid_p1}__${uuid_p2}",
-			timestamp        => time(),
+			timestamp        => time,
 			body_hash        => $bodyhash
 		);
 		$gradeRequest->sign();
 
-		$HTTPRequest = HTTP::Request->new(
-			$gradeRequest->request_method,
+		$response = Mojo::UserAgent->new->post(
 			$gradeRequest->request_url,
-			[
-				'Authorization' => $gradeRequest->to_authorization_header,
-				'Content-Type'  => 'application/xml',
-			],
-			$readResultXML,
-		);
-
-		$response = LWP::UserAgent->new->request($HTTPRequest);
+			{ 'Authorization' => $gradeRequest->to_authorization_header, 'Content-Type' => 'application/xml' },
+			$readResultXML
+		)->result;
 
 		# debug section
-		if ($ce->{debug_lti_grade_passback} and $ce->{debug_lti_parameters}) {
-			warn "The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest)));
-			warn "The nonce used is ${uuid_p1}__${uuid_p2}\n";
-			warn "The response is:\n " . ($self->local_escape_html(join(" ", %$response)));
-			warn "The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest)));
-			debug("The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest))));
-			debug("The nonce used is ${uuid_p1}__${uuid_p2}\n");
-			debug("The response is:\n " . ($self->local_escape_html(join(" ", %$response))));
+		if ($ce->{debug_lti_grade_passback} && $ce->{debug_lti_parameters}) {
+			$self->warning("The request was:\n " . $self->local_escape_html($readResultXML));
+			$self->warning("The nonce used is ${uuid_p1}__${uuid_p2}");
+			$self->warning("The response is:\n " . $self->local_escape_html($response->to_string));
+			debug("The request was:\n " . $readResultXML);
+			debug("The nonce used is ${uuid_p1}__${uuid_p2}");
+			debug("The response is:\n " . $response->to_string);
 		}
 
 		if ($response->is_success) {
-			$response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
+			my $content = $response->body;
+			$content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
 			my $message = $1;
 			if ($message ne 'success') {
-				warn(
-					"Unable to retrieve prior grade from LMS. Note that if your server time is not correct, this may fail for reasons which are less than obvious from the error messages. Error: "
+				$self->warning(
+					'Unable to retrieve prior grade from LMS. Note that if your server time is not correct, '
+						. 'this may fail for reasons which are less than obvious from the error messages. Error: '
 						. $message);
-				debug(
-					"Unable to retrieve prior grade from LMS. Note that if your server time is not correct, this may fail for reasons which are less than obvious from the error messages. Error: "
+				debug('Unable to retrieve prior grade from LMS. Note that if your server time is not correct, '
+						. 'this may fail for reasons which are less than obvious from the error messages. Error: '
 						. $message);
-				#debug(CGI::escapeHTML($response->content));
 				return 0;
 			} else {
 				my $oldScore;
 				# Possibly no score yet.
-				if ($response->content =~ /<textString\/>/) {
-					$oldScore = "";
+				if ($content =~ /<textString\/>/) {
+					$oldScore = '';
 				} else {
-					$response->content =~ /<textString>\s*(\S+)\s*<\/textString>/;
+					$content =~ /<textString>\s*(\S+)\s*<\/textString>/;
 					$oldScore = $1;
 				}
 				# Do not update the score if no change.
-				if ($oldScore eq "success") {
+				if ($oldScore eq 'success') {
 					# Blackboard seems to return this when there is no prior grade.
 					# See: https://webwork.maa.org/moodle/mod/forum/discuss.php?d=5002
-					debug("LMS grade will be updated. sourcedid: "
-							. $sourcedid
-							. " Old score: "
-							. $oldScore
-							. " New score: "
-							. $score)
-						if ($ce->{debug_lti_grade_passback});
+					debug("LMS grade will be updated. sourcedid: $sourcedid; Old score: $oldScore; New score: $score")
+						if $ce->{debug_lti_grade_passback};
 					$lti_do_send = 1;    # Change back to sending the update
-				} elsif ($oldScore ne "" && abs($score - $oldScore) < 0.001) {
+				} elsif ($oldScore ne '' && abs($score - $oldScore) < 0.001) {
 					# LMS has essentially the same score, no reason to update it
-					debug("LMS grade will NOT be updated - grade unchanges. Old score: "
-							. $oldScore
-							. " New score: "
-							. $score)
-						if ($ce->{debug_lti_grade_passback});
-					warn("LMS grade will NOT be updated - grade unchanges. Old score: "
-							. $oldScore
-							. " New score: "
-							. $score)
+					debug("LMS grade will NOT be updated - grade unchanges. Old score: $oldScore; New score: $score")
+						if $ce->{debug_lti_grade_passback};
+					$self->warning('LMS grade will NOT be updated - grade unchanged. '
+							. "Old score: $oldScore; New score: $score")
 						if ($ce->{debug_lti_grade_passback});
 					$lti_do_send = 0;    # Do not send
 					return 1;
 				} else {
 					$lti_do_send = 1;    # Change back to sending the update
-					debug("LMS grade will be updated. sourcedid: "
-							. $sourcedid
-							. " Old score: "
-							. $oldScore
-							. " New score: "
-							. $score)
-						if ($ce->{debug_lti_grade_passback});
+					debug("LMS grade will be updated. sourcedid: $sourcedid; Old score: $oldScore; New score: $score")
+						if $ce->{debug_lti_grade_passback};
 				}
 			}
 		} else {
-			warn(
-				"Unable to retrieve prior grade from LMS. Note that if your server time is not correct, this may fail for reasons which are less than obvious from the error messages. Error: "
+			$self->warning('Unable to retrieve prior grade from LMS. Note that if your server time is not correct, '
+					. 'this may fail for reasons which are less than obvious from the error messages. Error: '
 					. $response->message)
 				if ($ce->{debug_lti_grade_passback});
-			debug(
-				"Unable to retrieve prior grade from LMS. Note that if your server time is not correct, this may fail for reasons which are less than obvious from the error messages. Error: "
+			debug('Unable to retrieve prior grade from LMS. Note that if your server time is not correct, '
+					. 'this may fail for reasons which are less than obvious from the error messages. Error: '
 					. $response->message);
-			debug($response->content);
+			debug($response->body);
 			return 0;
 		}
 	}
 
 	if ($lti_do_send) {
-
 		# Send the LMS the new grade
 
 		# This is boilerplate XML used to submit the $score for $sourcedid
@@ -450,22 +402,21 @@ EOS
 			$bodyhash .= '=';
 		}
 		my $message2 = '';
-		$message2 .= "mass_update: " if $self->{post_processing_mode};
-		$message2 .= "Submitting grade using sourcedid: $sourcedid and score: $score\n";
-		warn($message2) if $ce->{debug_lti_grade_passback};
+		$message2 .= 'mass_update: ' if $self->{post_processing_mode};
+		$message2 .= "Submitting grade using sourcedid: $sourcedid and score: $score";
+		$self->warning($message2) if $ce->{debug_lti_grade_passback};
 
-		$requestGen = Net::OAuth->request("consumer");
+		$requestGen = Net::OAuth->request('consumer');
 		debug("obtained requestGen $requestGen");
 
 		$requestGen->add_required_message_params('body_hash');
-		debug("add required message params");
 
 		# Change the time dependent portion of the nonce for the second stage
-		$uuid_p2 .= "-step2";
+		$uuid_p2 .= '-step2';
 
 		$gradeRequest = $requestGen->new(
 			request_url      => $request_url,
-			request_method   => "POST",
+			request_method   => 'POST',
 			consumer_secret  => $ce->{LTIBasicConsumerSecret},
 			consumer_key     => $consumer_key,
 			signature_method => $signature_method,
@@ -473,71 +424,59 @@ EOS
 			timestamp        => time(),
 			body_hash        => $bodyhash
 		);
-		debug("created grade request " . $gradeRequest);
-		$gradeRequest->sign();
-		debug("signed grade request");
+		debug("created grade request $gradeRequest");
+		$gradeRequest->sign;
+		debug('signed grade request');
 
-		$HTTPRequest = HTTP::Request->new(
-			$gradeRequest->request_method,
+		$response = Mojo::UserAgent->new->post(
 			$gradeRequest->request_url,
-			[
-				'Authorization' => $gradeRequest->to_authorization_header,
-				'Content-Type'  => 'application/xml',
-			],
-			$replaceResultXML,
-		);
-		debug("posting grade request: $HTTPRequest");
-
-		$response = eval { LWP::UserAgent->new->request($HTTPRequest); };
-		if ($@) {
-			warn "error sending HTTP request to LMS, $@";
-		}
+			{ 'Authorization' => $gradeRequest->to_authorization_header, 'Content-Type' => 'application/xml' },
+			$replaceResultXML
+		)->result;
 
 		# debug section
-		if ($ce->{debug_lti_grade_passback} and $ce->{debug_lti_parameters}) {
-			warn "The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest)));
-			warn "The nonce used is ${uuid_p1}__${uuid_p2}\n";
-			warn "The response is:\n " . ($self->local_escape_html(join(" ", %$response)));
-			warn "The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest)));
-			debug("The request was:\n " . ($self->local_escape_html(join(" ", %$HTTPRequest))));
-			debug("The nonce used is ${uuid_p1}__${uuid_p2}\n");
-			debug("The response is:\n " . ($self->local_escape_html(join(" ", %$response))));
+		if ($ce->{debug_lti_grade_passback} && $ce->{debug_lti_parameters}) {
+			$self->warning("The request was:\n " . $self->local_escape_html($replaceResultXML));
+			$self->warning("The nonce used is ${uuid_p1}__${uuid_p2}");
+			$self->warning("The response is:\n " . $self->local_escape_html($response->to_string));
+			debug("The request was:\n " . $replaceResultXML);
+			debug("The nonce used is ${uuid_p1}__${uuid_p2}");
+			debug("The response is:\n " . $response->to_string);
 		}
 
 		if ($response->is_success) {
-			$response->content =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
+			$response->body =~ /<imsx_codeMajor>\s*(\w+)\s*<\/imsx_codeMajor>/;
 			my $message = $1;
-			warn("result is: $message\n") if $ce->{debug_lti_grade_passback};
+			$self->warning("result is: $message") if $ce->{debug_lti_grade_passback};
 			if ($message ne 'success') {
-				debug("Unable to update LMS grade $sourcedid . LMS responded with message: " . $message);
+				debug("Unable to update LMS grade $sourcedid . LMS responded with message: $message");
 				return 0;
 			} else {
-				# if we got here we got successes from both the post and the lms
-				debug("Successfully updated LMS grade $sourcedid. LMS responded with message: " . $message);
+				# If we got here, we got successes from both the post and the lms.
+				debug("Successfully updated LMS grade $sourcedid. LMS responded with message: $message");
 			}
 		} else {
-			debug("Unable to update LMS grade $sourcedid. Error: " . ($response->message));
-			debug($self->local_escape_html($response->content));
+			debug("Unable to update LMS grade $sourcedid. Error: " . $response->message);
+			debug($response->body);
 			return 0;
 		}
-		debug("Success submitting grade using sourcedid: $sourcedid and score: $score\n");
+		debug("Success submitting grade using sourcedid: $sourcedid and score: $score");
 
-		return 1;    # success
+		return 1;
 	}
-	return 0;        # failure as a fallback value
+
+	return 0;
 }
 
-# does a mass update of all grades.  This is all user grades for
-# course grade mode and all user set grades for homework grade mode.
+# Perform a mass update of all grades.  This is all user grades for course grade mode and all user set grades for
+# homework grade mode if $manual_update is false.  Otherwise what is updated is determined by a combination of the grade
+# mode and the useriD and setID parameters.  Note that this is not a class method and the only required parameter is $c.
 sub mass_update {
-	my ($self, $update, $name, $name2) = @_;
-	$name  ||= '';
-	$name2 ||= '';
-	my $c  = $self->{c};
+	my ($c, $manual_update, $userID, $setID) = @_;
 	my $ce = $c->ce;
 	my $db = $c->db;
 
-	# sanity check
+	# Sanity check.
 	unless (ref($ce)) {
 		warn('course environment is not defined');
 		return;
@@ -548,71 +487,29 @@ sub mass_update {
 	}
 
 	# Only run an automatic update if the time interval has passed.
-	if ($update eq 'auto') {
+	if (!$manual_update) {
 		my $lastUpdate     = $db->getSettingValue('LTILastUpdate') || 0;
-		my $updateInterval = $ce->{LTIMassUpdateInterval}          || -1;    # Never update
+		my $updateInterval = $ce->{LTIMassUpdateInterval} // -1;
 		return unless ($updateInterval != -1 && time - $lastUpdate > $updateInterval);
-		$update = 'all';
+		$db->setSettingValue('LTILastUpdate', time);
 	}
-
-	$self->{post_processing_mode} = 1;
-	$db->setSettingValue('LTILastUpdate', time()) if $update eq 'all';
 
 	# Send warning if debug_lti_grade_passback is set.
 	if ($ce->{debug_lti_grade_passback}) {
-		if ($update eq 'all') {
-			warn "starting mass_update of all sets and users via LTI";
-		} elsif ($update eq 'set' && $ce->{LTIGradeMode} eq 'homework') {
-			warn "starting mass_update of set $name for all users via LTI";
-		} elsif ($update eq 'user') {
-			warn "starting mass_update of all sets for user $name via LTI";
-		} elsif ($update eq 'user_set' && $ce->{LTIGradeMode} eq 'homework') {
-			warn "starting mass_update of user $name and set $name2 via LTI";
+		if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+			warn "LTI Mass Update: Queueing grade update for user $userID and set $setID.\n";
+		} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+			warn "LTI Mass Update: Queueing grade update for all users assigned to set $setID.\n";
+		} elsif ($userID) {
+			warn "LTI Mass Update: Queueing grade update of all sets assigned to user $userID.\n";
+		} else {
+			warn "LTI Mass Update: Queueing grade update for all sets and users.\n";
 		}
 	}
 
-	# Start update loop.
-	Mojo::IOLoop->timer(
-		1 => sub {
-			eval {
-				# Determine what needs to be updated.
-				my %updateUsers;
-				if ($update eq 'all') {
-					if ($ce->{LTIGradeMode} eq 'course') {
-						%updateUsers = map { $_ => 'update_course_grade' } $db->listUsers;
-					} elsif ($ce->{LTIGradeMode} eq 'homework') {
-						%updateUsers = map { $_ => [ $db->listUserSets($_) ] } $db->listUsers;
-					}
-				} elsif ($update eq 'set' && $ce->{LTIGradeMode} eq 'homework') {
-					%updateUsers = map { $_ => [$name] } $db->listSetUsers($name);
-				} elsif ($update eq 'user') {
-					if ($ce->{LTIGradeMode} eq 'course') {
-						$updateUsers{$name} = 'update_course_grade';
-					} elsif ($ce->{LTIGradeMode} eq 'homework') {
-						$updateUsers{$name} = [ $db->listUserSets($name) ];
-					}
-				} elsif ($update eq 'user_set' && $ce->{LTIGradeMode} eq 'homework') {
-					$updateUsers{$name} = [$name2];
-				}
+	$c->minion->enqueue(lti_mass_update => [ $ce->{courseName}, $userID, $setID ]);
 
-				for my $user (keys %updateUsers) {
-					if (ref($updateUsers{$user}) eq 'ARRAY') {
-						for my $set (@{ $updateUsers{$user} }) {
-							$self->submit_set_grade($user, $set);
-						}
-					} elsif ($updateUsers{$user} eq 'update_course_grade') {
-						$self->submit_course_grade($user);
-					}
-				}
-			};
-			if ($@) {
-				# Write errors to the Mojolicious log.
-				$c->log->error("An error occured while trying to mass_update grades via LTI: $@\n");
-			}
-			$self->{post_processing_mode} = 0;
-		}
-	);
-	Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+	return;
 }
 
 1;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -47,7 +47,6 @@ use MIME::Base64;
 use Scalar::Util qw(weaken);
 use HTML::Entities;
 use Encode;
-use Email::Sender::Transport::SMTP;
 
 use WeBWorK::File::Scoring qw(parse_scoring_file);
 use WeBWorK::PG;
@@ -108,12 +107,10 @@ The method content() is called to send the page content to client.
 async sub go ($c) {
 	my $ce = $c->ce;
 
-	# If grades are begin passed back to the LTI then we peroidically update all of the grades because things can get
-	# out of sync if instructors add or modify sets.
-	if ($ce->{LTIGradeMode} && ref $c->db) {
-		my $grader = WeBWorK::Authen::LTIAdvanced::SubmitGrade->new($c);
-		$grader->mass_update('auto');
-	}
+	# If grades are being passed back to the lti, then peroidically update all of the
+	# grades because things can get out of sync if instructors add or modify sets.
+	WeBWorK::Authen::LTIAdvanced::SubmitGrade::mass_update($c)
+		if $c->stash('courseID') && ref($c->db) && $ce->{LTIGradeMode};
 
 	# Check to determine if this is a problem set response.  Individual content generators must check
 	# $c->{invalidSet} and react appropriately.
@@ -1279,42 +1276,6 @@ prepends the path to the scoring directory.
 sub read_scoring_file ($c, $fileName) {
 	return {} if $fileName eq "None";    # callers expect a hashref in all cases
 	return parse_scoring_file($c->ce->{courseDirs}{scoring} . "/$fileName");
-}
-
-=item createEmailSenderTransportSMTP
-
-Wrapper that creates an Email::Sender::Transport::SMTP object
-
-=cut
-
-# this function abstracts the process of creating a transport layer for SendMail
-# it is used in Feedback.pm, SendMail.pm and Utils/ProblemProcessing.pm (for JITAR messages)
-
-sub createEmailSenderTransportSMTP ($c) {
-	my $ce = $c->ce;
-	my $transport;
-	if (defined $ce->{mail}{smtpPort}) {
-		$transport = Email::Sender::Transport::SMTP->new({
-			host    => $ce->{mail}{smtpServer},
-			ssl     => $ce->{mail}{tls_allowed} // 0,    ## turn off ssl security by default
-			port    => $ce->{mail}{smtpPort},
-			timeout => $ce->{mail}{smtpTimeout},
-			# debug => 1,
-		});
-	} else {
-		$transport = Email::Sender::Transport::SMTP->new({
-			host    => $ce->{mail}{smtpServer},
-			ssl     => $ce->{mail}{tls_allowed} // 0,    ## turn off ssl security by default
-			timeout => $ce->{mail}{smtpTimeout},
-			# debug => 1,
-		});
-	}
-	#warn "port is ", $transport->port();
-	#warn "ssl is ", $transport->ssl();
-	#warn "tls_allowed is ", $ce->{mail}->{tls_allowed}//'';
-	#warn "smtpPort is set to ", $ce->{mail}->{smtpPort}//'';
-
-	return $transport;
 }
 
 =back

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -28,7 +28,7 @@ use Try::Tiny;
 use Text::Wrap qw(wrap);
 
 use WeBWorK::Upload;
-use WeBWorK::Utils qw/decodeAnswers/;
+use WeBWorK::Utils qw/decodeAnswers createEmailSenderTransportSMTP/;
 
 # request paramaters used
 #
@@ -246,7 +246,7 @@ $emailableURL
 		try {
 			$email->send_or_die({
 				# createEmailSenderTransportSMTP is defined in ContentGenerator
-				transport => $c->createEmailSenderTransportSMTP(),
+				transport => createEmailSenderTransportSMTP($ce),
 				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 			});
 		} catch {

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -40,6 +40,7 @@ use Storable;
 use Carp;
 use Storable qw(nfreeze thaw);
 use JSON;
+use Email::Sender::Transport::SMTP;
 
 use open IO => ':encoding(UTF-8)';
 
@@ -117,6 +118,8 @@ our @EXPORT_OK = qw(
 	jitar_problem_adjusted_status
 	jitar_problem_finished
 	fetchEmailRecipients
+	processEmailMessage
+	createEmailSenderTransportSMTP
 	generateURLs
 	getAssetURL
 	x
@@ -1822,6 +1825,65 @@ sub fetchEmailRecipients {
 			&& defined $sender
 			&& defined $sender->section ? (section => $sender->section) : (),
 		});
+}
+
+sub processEmailMessage {
+	my ($text, $user_record, $STATUS, $merge_data, $for_preview) = @_;
+
+	# User macros that can be used in the email message
+	my $SID        = $user_record->student_id;
+	my $FN         = $user_record->first_name;
+	my $LN         = $user_record->last_name;
+	my $SECTION    = $user_record->section;
+	my $RECITATION = $user_record->recitation;
+	my $EMAIL      = $user_record->email_address;
+	my $LOGIN      = $user_record->user_id;
+
+	# Get record from merge data.
+	my @COL = defined($merge_data->{$SID}) ? @{ $merge_data->{$SID} } : ();
+	unshift(@COL, '');    # This makes COL[1] the first column.
+
+	# For safety, only evaluate special variables.
+	my $msg = $text;
+	$msg =~ s/\$SID/$SID/g;
+	$msg =~ s/\$LN/$LN/g;
+	$msg =~ s/\$FN/$FN/g;
+	$msg =~ s/\$STATUS/$STATUS/g;
+	$msg =~ s/\$SECTION/$SECTION/g;
+	$msg =~ s/\$RECITATION/$RECITATION/g;
+	$msg =~ s/\$EMAIL/$EMAIL/g;
+	$msg =~ s/\$LOGIN/$LOGIN/g;
+
+	if (defined $COL[1]) {
+		$msg =~ s/\$COL\[(\-?\d+)\]/$COL[$1]/g;
+	} else {
+		$msg =~ s/\$COL\[(\-?\d+)\]//g;
+	}
+
+	$msg =~ s/\r//g;
+
+	if ($for_preview) {
+		my @preview_COL = @COL;
+		shift @preview_COL;    # Shift of the added empty string for preview.
+		return $msg,
+			join(' ',
+				'', (map { "COL[$_]" . '&nbsp;' x (3 - length $_) } 1 .. $#COL),
+				'<br>', (map { $_ =~ s/\s/&nbsp;/gr } map { sprintf('%-8.8s', $_); } @preview_COL));
+	} else {
+		return $msg;
+	}
+}
+
+# This function abstracts the process of creating a transport layer for SendMail.
+# It is used in Feedback.pm, SendMail.pm and Utils/ProblemProcessing.pm (for JITAR messages).
+sub createEmailSenderTransportSMTP {
+	my $ce = shift;
+	return Email::Sender::Transport::SMTP->new({
+		host => $ce->{mail}{smtpServer},
+		ssl  => $ce->{mail}{tls_allowed} // 0,
+		defined $ce->{mail}->{smtpPort} ? (port => $ce->{mail}{smtpPort}) : (),
+		timeout => $ce->{mail}{smtpTimeout},
+	});
 }
 
 # Requires a CG object.

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -29,8 +29,8 @@ use Try::Tiny;
 use Mojo::JSON qw(encode_json decode_json);
 
 use WeBWorK::Debug;
-use WeBWorK::Utils
-	qw(writeLog writeCourseLogGivenTime encodeAnswers before after jitar_problem_adjusted_status jitar_id_to_seq);
+use WeBWorK::Utils qw(writeLog writeCourseLogGivenTime encodeAnswers before after jitar_problem_adjusted_status
+	jitar_id_to_seq createEmailSenderTransportSMTP);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
 
 use Caliper::Sensor;
@@ -434,8 +434,7 @@ Comment:    $comment
 	#  https://metacpan.org/pod/Email::Sender::Manual::QuickStart#envelope-information
 	try {
 		$email->send_or_die({
-			# createEmailSenderTransportSMTP is defined in ContentGenerator
-			transport => $c->createEmailSenderTransportSMTP(),
+			transport => createEmailSenderTransportSMTP($ce),
 			$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 		});
 		debug('Successfully sent JITAR alert message');

--- a/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
+++ b/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
@@ -51,7 +51,7 @@
 		<div class="col-auto">
 			<%= select_field updateUserID => [
 					[
-						maketext('All Users') => 'All Users',
+						maketext('All Users') => '',
 						selected             => undef,
 						$ce->{LTIGradeMode} eq 'homework' ? (data => { sets => join(':', @$sets) }) : (),
 					],
@@ -68,7 +68,7 @@
 			<div class="col-auto">
 				<%= select_field updateSetID => [
 						[
-							maketext('All Sets') => 'All Sets',
+							maketext('All Sets') => '',
 							selected             => undef,
 							data                 => { users => join(':', @$users) }
 						],

--- a/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
@@ -1,10 +1,17 @@
-<div class="mb-3" dir="ltr"><pre><%= $preview_header %></pre></div>
-<h3><%= maketext('This sample mail would be sent to [_1]', $ur->email_address) %></h3>
+<h2 class="fs-3"><%= maketext('This sample mail would be sent to [_1]', $ur->email_address) %></h2>
 <div class="mb-3" dir="ltr"><pre><%= $msg %></pre></div>
-% if ($recipients) {
-	<h3><%= maketext('Emails to be sent to the following:') %></h3>
-	<div class="mb-3"><%= $recipients || maketext('No recipients selected.') %></div>
+<h2 class="fs-3"><%= maketext('Merge file data:') %></h2>
+<div class="mb-3" dir="ltr"><pre><%== $preview_header %></pre></div>
+% if (@{ $c->{ra_send_to} }) {
+	<h2 class="fs-3"><%= maketext('Emails to be sent to the following:') %></h2>
+	<div class="mb-3">
+		<ul>
+			% for (@{ $c->{ra_send_to} }) {
+				<li><%= $_ %></li>
+			% }
+		</ul>
+	</div>
 % } else {
-	<h3><%= maketext('No recipients selected.') %></h3>
+	<h2 class="fs-3"><%= maketext('No recipients selected.') %></h2>
 % }
-<p><%= maketext('Use browser back button to return from preview mode.') %></p>
+<div class="alert alert-info p-1 mt-3"><%= maketext('Use browser back button to return from preview mode.') %></div>


### PR DESCRIPTION
This is used for LTI mass grade updates and sending instructor emails.

A special warnings method is added to submit grade that sends debugging warnings to the log instead of using a native warn.  During a mass update those warn statements fall on deaf ears in production deployment with hypnotoad.

The code is generally cleaned up in that file.  Replace CGI::escapeHTML with HTML::Entities::encode_entities which does the same thing (for the most part).  Also, replace LWP::UserAgent with Mojo::UserAgent.

For this to work with the Minion::Backend::SQLite module, you will need to install version 3.002 of the Mojo::SQLite package.  Newer versions of that module cause issues.  Note that by default the sqlite database file is "$webwork_dir/DATA/webwork2_job_queue.db".

Other backends that can be used are the Minion::Backend::Pg module with postgres, and the Minion::Backend::mysql module with mysql.  Setting those up takes a little more work though.  The SQLite backend is much simpler.

The usage is documented in conf/README.md.

In short, for development you can run the job queue with `./bin/webwork2 minion worker`,
and for production copy conf/webwork2-job-queue.dist.service to conf/webwork2-job-queue.service and run
`sudo systemctl enable /opt/webwork/webwork2/conf/webwork2-job-queue.service` and
`sudo systemctl start webwork2-job-queue`

This is #1858 which will shortly be closed.  I accidentally pushed to origin.  My bad.