### PR TITLE
Fix saving a change of the permission level in the Classlist Editor.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -509,11 +509,9 @@ sub save_edit_handler ($c) {
 			}
 		}
 
-		foreach my $field ($PermissionLevel->NONKEYFIELDS()) {
-			my $param = "permission.$userID.$field";
-			if (defined $c->param($param) && $c->param($param) <= $editorUserPermission) {
-				$PermissionLevel->$field($c->param($param));
-			}
+		my $param = "user.$userID.permission";
+		if (defined $c->param($param) && $c->param($param) <= $editorUserPermission) {
+			$PermissionLevel->permission($c->param($param));
 		}
 
 		$db->putUser($User);

--- a/templates/ContentGenerator/Hardcopy/form.html.ep
+++ b/templates/ContentGenerator/Hardcopy/form.html.ep
@@ -82,26 +82,26 @@
 					</div>
 					<div class="input-group-text">
 						<label class="form-check-label">
-							<%= check_box showComments => 0, class => 'form-check-input me-2' =%>
+							<%= check_box showComments => 1, class => 'form-check-input me-2' =%>
 							<%= maketext('Comments') =%>
 						</label>
 					</div>
 					% if ($canShowCorrectAnswers) {
 						<div class="input-group-text">
 							<label class="form-check-label">
-								<%= check_box showCorrectAnswers => 0, class => 'form-check-input me-2' =%>
+								<%= check_box showCorrectAnswers => 1, class => 'form-check-input me-2' =%>
 								<%= maketext('Correct answers') =%>
 							</label>
 						</div>
 						<div class="input-group-text">
 							<label class="form-check-label">
-								<%= check_box showHints => 0, class => 'form-check-input me-2' =%>
+								<%= check_box showHints => 1, class => 'form-check-input me-2' =%>
 								<%= maketext('Hints') =%>
 							</label>
 						</div>
 						<div class="input-group-text">
 							<label class="form-check-label">
-								<%= check_box showSolutions => 0, class => 'form-check-input me-2' =%>
+								<%= check_box showSolutions => 1, class => 'form-check-input me-2' =%>
 								<%= maketext('Solutions') =%>
 							</label>
 						</div>

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -2,7 +2,6 @@
 	% qw(sortByName listFilesRecursive jitar_id_to_seq seq_to_jitar_id format_set_name_display getAssetURL);
 %
 % content_for css => begin
-	% log->info('hello');
 	<%= stylesheet getAssetURL($ce, 'node_modules/flatpickr/dist/flatpickr.min.css') =%>
 	<%= stylesheet getAssetURL($ce, 'node_modules/flatpickr/dist/plugins/confirmDate/confirmDate.css') =%>
 % end


### PR DESCRIPTION
I change the parameter name of the permission select for edit mode on the Classlist Editor page, but forgot to change the handling of that parameter when "Take Action" is clicked.  As a result permissions can not be changed for users.  This fixes that.

This also fixes another similar issue on the hardcopy generator page.  The checkboxes on that page weren't working.