### PR TITLE
Change to a new method for computing the server/browser time zone adjustment

### DIFF
--- a/htdocs/js/apps/DatePicker/datepicker.js
+++ b/htdocs/js/apps/DatePicker/datepicker.js
@@ -46,15 +46,14 @@
 
 			luxon.Settings.defaultLocale = rule.dataset.locale ?? 'en';
 
-			// Compute the time difference between the current browser timezone and the the course timezone.
+			// Compute the time difference between the current browser timezone and the course timezone.
 			// flatpickr gives the time in the browser's timezone, and this is used to adjust to the course timezone.
-			// Note that this is converted to seconds.
-			const timezoneAdjustment =
-				parseInt(Intl.DateTimeFormat('en-US', { timeZoneName: 'shortOffset' })
-					.format(new Date).split(' ')[1].slice(3) || '0') * 3600000
-				- parseInt(Intl.DateTimeFormat('en-US',
-					{ timeZone: rule.dataset.timezone ?? 'America/New_York', timeZoneName: 'shortOffset' })
-					.format(new Date).split(' ')[1].slice(3) || '0') * 3600000;
+			// Note that this is in seconds.
+			const timezoneAdjustment = (
+				(new Date((new Date).toLocaleString('en-US'))).getTime() -
+				(new Date((new Date).toLocaleString('en-US',
+					{ timeZone: rule.dataset.timezone ?? 'America/New_York' }))).getTime()
+			);
 
 			const fp = flatpickr(rule.parentNode, {
 				allowInput: true,

--- a/htdocs/js/apps/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/apps/ProblemSetList/problemsetlist.js
@@ -67,15 +67,14 @@
 
 		luxon.Settings.defaultLocale = importDateShift.dataset.locale ?? 'en';
 
-		// Compute the time difference between the current browser timezone and the the course timezone.
+		// Compute the time difference between the current browser timezone and the course timezone.
 		// flatpickr gives the time in the browser's timezone, and this is used to adjust to the course timezone.
-		// Note that this is converted to microseconds.
-		const timezoneAdjustment =
-			parseInt(Intl.DateTimeFormat('en-US', { timeZoneName: 'shortOffset' })
-				.format(new Date).split(' ')[1].slice(3) || '0') * 3600000
-			- parseInt(Intl.DateTimeFormat('en-US',
-				{ timeZone: importDateShift.dataset.timezone ?? 'UTC', timeZoneName: 'shortOffset' })
-				.format(new Date).split(' ')[1].slice(3) || '0') * 3600000
+		// Note that this is in seconds.
+		const timezoneAdjustment = (
+			(new Date((new Date).toLocaleString('en-US'))).getTime() -
+			(new Date((new Date).toLocaleString('en-US',
+				{ timeZone: importDateShift.dataset.timezone ?? 'America/New_York' }))).getTime()
+		);
 
 		const fp = flatpickr(importDateShift.parentNode, {
 			allowInput: true,


### PR DESCRIPTION
This method is simpler and just uses Date object methods directly and not the Intl.DateTimeFormat method.

This should fix issue #1873.  Safari users please test.  Most importantly someone using an older version of Safari.