### PR TITLE
Fix hide_score, hide_score_by_problem, and hide_work default values

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -290,6 +290,7 @@ use constant FIELD_PROPERTIES => {
 			'N:Y'                => x('Totals only (not problem scores)'),
 			'BeforeAnswerDate:Y' => x('Totals only, only after answer date')
 		},
+		default => 'N:N',
 	},
 	hide_work => {
 		name     => x('Show Problems on Finished Tests'),
@@ -301,6 +302,7 @@ use constant FIELD_PROPERTIES => {
 			'Y'                => x('No'),
 			'BeforeAnswerDate' => x('Only after set answer date')
 		},
+		default => 'N',
 	},
 	use_grade_auth_proctor => {
 		name     => x('Require Proctor Authorization to'),


### PR DESCRIPTION
On the ProblemSetDetail page when changing from a "homework" set to a "test" set the defaults for hide_score, hide_score_by_problem, and hide_work are not being set.  This results in warnings being displayed and probably other bad results later.  This is because the defaults are not set in the FIELD_PROPERTIES constant.  These were not set before, and somehow it worked, but things have changed and now it doesn't.  Not sure why exactly.

To test this, create a set on the Hmwk Sets Editor page, then enter the set detail for the set and change it from a "homework" set to a "test" set.  On the current develop branch you will see the warnings.  With this pull request, no warnings.