### PR TITLE
Fix an issue on the problem set detail page with user problem versions.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1880,7 +1880,7 @@ sub initialize ($c) {
 		if ($editingSetVersion) {
 			$c->stash->{mergedProblems} = {
 				map { $_->problem_id => $_ } $db->getMergedProblemVersionsWhere(
-					{ user_id => $editForUser[0], set_id => { like => "$setID,v\%" } }, 'problem_id'
+					{ user_id => $editForUser[0], set_id => "$setID,v$editingSetVersion" }, 'problem_id'
 				)
 			};
 		} else {


### PR DESCRIPTION
The where clause was incorrect when obtaining all merged problem versions for a fixed version of a gateway quiz.  It was selecting merged problems where the version was allowed to be anything when it should have been selecting only the specified version.

The result of this error is that if you edit a set version for a user (by going to the classlist editor, clicking on the sets for a user, and clicking on a particular test version on that page), then the data that is displayed for that set version is actually a mix of data from multiple versions.  Fortunately the data is saved to the correct version, but this leads to very unexpected results in viewing.

To see this in action on the develop branch (or webwork2 2.17) create a gateway quiz with at least two problems and take two versions of the quiz.  Then go edit version 2 and change the source_file for problem 2 on that version (choose a source_file name that doesn't exist to make this really evident).  Then go edit version 1 of the quiz.  You will see the source_file that you just picked displayed for problem 2.  If you look in the database you will see that none of the data for version 1 has changed, and the data for version 2 has changed as was intended.

This gets worse with more quiz versions.

This was my mistake when I made all of the database changes in the last release.

This may be a rather dangerous bug, and I would say should be considered for a hotfix.