### PR TITLE
Fix an incorrect route name on the stats page

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -176,7 +176,8 @@ sub set_stats ($c) {
 
 		# Link to individual problem stats page.
 		$problem->{statsLink} =
-			$c->systemLink($c->url_for('instructor_set_statistics', setID => $c->stash('setID'), problemID => $probID),
+			$c->systemLink(
+				$c->url_for('instructor_problem_statistics', setID => $c->stash('setID'), problemID => $probID),
 				params => $c->param('filter') ? { filter => $c->param('filter') } : {});
 
 		$showGraderRow = 1 if $problem->flags =~ /essay/;

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -86,7 +86,7 @@ sub page_title ($c) {
 		return $c->maketext('Statistics for [_1]', $c->tag('span', dir => 'ltr', format_set_name_display($setID)));
 	} elsif ($c->current_route eq 'instructor_problem_statistics') {
 		return $c->maketext(
-			'Statsitcs for [_1] problem [_2]',
+			'Statistics for [_1] problem [_2]',
 			$c->tag('span', dir => 'ltr', format_set_name_display($setID)),
 			$c->{prettyID}
 		);


### PR DESCRIPTION
The problem links on a set statistics page were not going to the correct place because the route name was wrong.  The prolem links were going to the general set stats page instead of the problem stats page because the instructor_set_statistics route was accidentally used instead of the instructor_problem_statics route.

To see the problem on the develop branch open the stats page for a set, and click on the problem numbers in either the "Percent of Users" table near the end.  That will just open the page you are currently viewing instead of the stats page for the problem you click on.

There was also a typo in the title of the problem stats page from before that is fixed.