### PR TITLE
Fix a typo in WeBWorK/Utils/Rendering.pm.

### DIFF
--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -226,7 +226,7 @@ async sub renderProblem {
 		effectivePermissionLevel => $rh->{effectivePermissionLevel} || $rh->{permissionLevel} || 0,
 		useMathQuill             => $ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill',
 		useMathView              => $ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView',
-		useWiris                 => $ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'WIRIS',
+		useWirisEditor           => $ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'WIRIS',
 		isInstructor             => $rh->{isInstructor}       // 0,
 		forceScaffoldsOpen       => $rh->{forceScaffoldsOpen} // 0,
 		debuggingOptions         => {


### PR DESCRIPTION
This typo has the effect that if the course settings are to use no entry assist method, then when rendering a problem in the homework sets editor or in the pg problem editor (or anything that uses WeBWorK/Utils/Rendering.pm), then instead of no entry assist, you get wiris.