### PR TITLE
Fix the perltidy linter workflow.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,9 +14,9 @@ on:
 jobs:
   perltidy:
     name: Run perltidy on Perl Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
-      image: perl:5.32
+      image: perl:5.34
     steps:
       - uses: actions/checkout@v3
       - name: perl -V
@@ -28,5 +28,6 @@ jobs:
       - name: Run perltidy
         shell: bash
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           shopt -s extglob globstar nullglob
           perltidy --pro=./.perltidyrc -b -bext='/' ./**/*.p[lm] ./**/*.t && git diff --exit-code


### PR DESCRIPTION
It seems there has been a change to either the version of `git` in the container image or to the `actions/checkout@v3` workflow.  This requires that the workspace be added as a safe directory in order for git commands to work.

Note that all perltidy workflow jobs will fail until this is merged.  This includes all new pull requests or changes to existing pull requests.

Note that the runner image is switched to ubuntu-22.04.  That is actually what ubuntu-latest currently is, but it is probably good to lock the version and change manually to avoid unexpected surprises.

Also the perl container version is updated to 5.34.  This is the same version we are using for pg and is the default version on Ubuntu 22.04.