### PR TITLE
Update the tag widget.

### DIFF
--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -293,7 +293,8 @@
 
 			if (currentValue && !select.value) {
 				showMessage(`Provided ${category} "${currentValue}" is not in the taxonomy.`);
-				select.add(new Option(currentValue, currentValue, false, true));
+				select.remove(0);
+				select.add(new Option(currentValue, currentValue, false, true), 0);
 			}
 		}
 

--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -1,275 +1,307 @@
+'use strict';
+
 (async () => {
-	// Load the library taxonomy from the JSON file.
 	const tagWidgetScript = document.getElementById('tag-widget-script');
-	if (!tagWidgetScript || !tagWidgetScript.dataset.taxo) return;
+	if (!tagWidgetScript || !tagWidgetScript.dataset.taxonomy) return;
 
-	const response = await fetch(tagWidgetScript.dataset.taxo);
-	if (!response.ok) {
-		alert('Could not load the OPL taxonomy from the server.')
-		return;
-	}
+	// Add a container for message toasts.
+	const toastContainer = document.createElement('div');
+	toastContainer.classList.add('toast-container', 'position-fixed', 'bottom-0', 'end-0', 'p-3');
+	toastContainer.style.zIndex = 1060;
+	document.body.append(toastContainer);
 
-	const taxo = await response.json();
+	// Convenience method for showing messages in a Bootstrap toast.
+	const showMessage = (message, success = false) => {
+		if (!message) return;
 
-	const basicWebserviceURL = `${webworkConfig?.webwork_url ?? '/webwork2'}/instructor_rpc`;
+		const toast = document.createElement('div');
+		toast.classList.add('toast', 'align-items-center', 'border-0');
+		toast.setAttribute('role', 'alert');
+		toast.setAttribute('aria-live', success ? 'polite' : 'assertive');
+		toast.setAttribute('aria-atomic', 'true');
 
-	function readfromtaxo(who, valarray) {
-		var mytaxo = taxo;
-		if (who == 'subjects') {
-			return mytaxo.map(function(z) {return z['name'];} );
+		const alert = document.createElement('div');
+		alert.classList.add('d-flex', 'alert', success ? 'alert-success' : 'alert-danger', 'p-0');
+		toast.append(alert);
+
+		const toastBody = document.createElement('div');
+		toastBody.classList.add('toast-body');
+		toastBody.textContent = message;
+
+		const closeButton = document.createElement('button');
+		closeButton.classList.add('btn-close', 'me-2', 'm-auto');
+		closeButton.type = 'button';
+		closeButton.dataset.bsDismiss = 'toast';
+		closeButton.setAttribute('aria-label', 'Close');
+
+		alert.append(toastBody, closeButton);
+
+		toastContainer.append(toast);
+
+		const bsToast = new bootstrap.Toast(toast, { delay: toastContainer.childElementCount * 5000 });
+		toast.addEventListener('hidden.bs.toast', () => {
+			bsToast.dispose();
+			toast.remove();
+		});
+		bsToast.show();
+	};
+
+	// Load the library taxonomy from the JSON file.
+	const response = await fetch(tagWidgetScript.dataset.taxonomy).catch(
+		(err) => `Could not load the OPL taxonomy from the server: ${err.messsage ?? err}`
+	);
+	if (typeof response === 'string') return showMessage(response);
+	if (!response.ok) return showMessage('Could not load the OPL taxonomy from the server.');
+
+	const taxonomy = await response.json();
+
+	const webServiceURL = `${webworkConfig?.webwork_url ?? '/webwork2'}/instructor_rpc`;
+
+	const readFromTaxonomy = (category, values) => {
+		const subjectTaxonomy = taxonomy;
+		if (category === 'subject') return subjectTaxonomy.map((subject) => subject.name);
+
+		const chapterTaxonomy = subjectTaxonomy.find((value) => value.name === values[0])?.subfields;
+		if (!chapterTaxonomy) return [];
+		if (category === 'chapter') return chapterTaxonomy.map((chapter) => chapter.name);
+
+		const sectionTaxonomy = chapterTaxonomy.find((value) => value.name === values[1])?.subfields;
+		if (!sectionTaxonomy) return [];
+		if (category === 'section') return sectionTaxonomy.map((section) => section['name']);
+
+		return []; // Should not get here
+	};
+
+	const createWebServiceObject = (command, values = {}) => {
+		return {
+			rpc_command: command,
+			library_name: 'Library',
+			command: 'searchLib',
+			user: document.getElementById('hidden_user')?.value,
+			courseID: document.getElementById('hidden_courseID')?.value,
+			key: document.getElementById('hidden_key')?.value,
+			...values
+		};
+	};
+
+	class TagWidget {
+		constructor(filePath) {
+			this.filePath = filePath;
 		}
-		var failed = true;
-		for(var i=0; i<mytaxo.length; i++) {
-			if(mytaxo[i]['name'] == valarray[0]) {
-				mytaxo = mytaxo[i]['subfields'];
-				failed=false;
-				break;
+
+		async show() {
+			await this.getTags();
+
+			if (!this.tags) return;
+
+			if (this.tags.DBsubject && /ZZZ/.test(this.tags.DBsubject)) {
+				showMessage('Problem file is a pointer to another file', true);
+				return;
+			}
+
+			const modal = document.createElement('div');
+			modal.classList.add('modal');
+			modal.ariaLabelledby = 'tag-editor';
+			modal.setAttribute('aria-hidden', 'true');
+			modal.tabIndex = -1;
+
+			const dialog = document.createElement('div');
+			dialog.classList.add('modal-dialog', 'modal-dialog-centered');
+			modal.append(dialog);
+
+			const content = document.createElement('div');
+			content.classList.add('modal-content');
+			dialog.append(content);
+
+			const header = document.createElement('div');
+			header.classList.add('modal-header');
+
+			const headerTitle = document.createElement('h1');
+			headerTitle.classList.add('modal-title', 'fs-4');
+			headerTitle.id = 'tag-editor';
+			headerTitle.textContent = 'Tag Editor';
+
+			const headerCloseButton = document.createElement('button');
+			headerCloseButton.type = 'button';
+			headerCloseButton.classList.add('btn-close');
+			headerCloseButton.dataset.bsDismiss = 'modal';
+			headerCloseButton.setAttribute('aria-label', 'Close');
+
+			header.append(headerTitle, headerCloseButton);
+
+			const body = document.createElement('div');
+			body.classList.add('modal-body');
+
+			this.subjectSelect = document.createElement('select');
+			this.subjectSelect.classList.add('form-select', 'mb-2');
+			this.subjectSelect.setAttribute('aria-label', 'Select subject');
+			this.subjectSelect.add(new Option('All Subjects', '', true));
+			this.subjectSelect.addEventListener('change', () =>
+				this.update('chapter', { DBsubject: '', DBchapter: '', DBsection: '' })
+			);
+			body.append(this.subjectSelect);
+
+			this.chapterSelect = document.createElement('select');
+			this.chapterSelect.classList.add('form-select', 'mb-2');
+			this.chapterSelect.setAttribute('aria-label', 'Select chapter');
+			this.chapterSelect.add(new Option('All Chapters', '', true));
+			this.chapterSelect.addEventListener('change', () =>
+				this.update('section', { DBsubject: '', DBchapter: '', DBsection: '' })
+			);
+			body.append(this.chapterSelect);
+
+			this.sectionSelect = document.createElement('select');
+			this.sectionSelect.classList.add('form-select', 'mb-2');
+			this.sectionSelect.setAttribute('aria-label', 'Select section');
+			this.sectionSelect.add(new Option('All Sections', '', true));
+			body.append(this.sectionSelect);
+
+			this.levelSelect = document.createElement('select');
+			this.levelSelect.classList.add('form-select');
+			this.levelSelect.setAttribute('aria-label', 'Select level');
+			this.levelSelect.add(new Option('Level', '', true));
+			for (const j of Array(6).keys()) {
+				this.levelSelect.add(new Option(j + 1));
+			}
+			body.append(this.levelSelect);
+
+			// Show the status menu if this is a problem in "Pending".
+			if (/^Pending\//.test(this.filePath.replace(/^.*templates\//, ''))) {
+				this.statusSelect = document.createElement('select');
+				this.statusSelect.classList.add('form-select', 'mt-2');
+				this.statusSelect.setAttribute('aria-label', 'Change status');
+				for (const value of [
+					['Accept', 'A'],
+					['Review', '0', true, true],
+					['Reject', 'R'],
+					['Further', 'F'],
+					['Needs Resource', 'N']
+				]) {
+					this.statusSelect.add(new Option(...value));
+				}
+				body.append(this.statusSelect);
+			}
+
+			const footer = document.createElement('div');
+			footer.classList.add('modal-footer');
+
+			this.saveButton = document.createElement('button');
+			this.saveButton.type = 'button';
+			this.saveButton.classList.add('btn', 'btn-primary');
+			this.saveButton.textContent = 'Save';
+			this.saveButton.addEventListener('click', () => this.savetags());
+
+			const closeButton = document.createElement('button');
+			closeButton.type = 'button';
+			closeButton.classList.add('btn', 'btn-secondary');
+			closeButton.dataset.bsDismiss = 'modal';
+			closeButton.textContent = 'Close';
+
+			footer.append(this.saveButton, closeButton);
+
+			content.append(header, body, footer);
+
+			modal.addEventListener('shown.bs.modal', () => this.update('subject', this.tags));
+			modal.addEventListener('hidden.bs.modal', () => {
+				this.bsModal.dispose();
+				modal.remove();
+			});
+
+			this.bsModal = new bootstrap.Modal(modal);
+			this.bsModal.show();
+		}
+
+		async getTags() {
+			const response = await fetch(webServiceURL, {
+				method: 'post',
+				mode: 'same-origin',
+				body: new URLSearchParams(createWebServiceObject('getProblemTags', { command: this.filePath }))
+			}).catch((err) => `Error requesting problem tags: ${err.message ?? err}`);
+			if (typeof response === 'string') return showMessage(response);
+			if (!response.ok) return showMessage('Unable to obtain problem tags.');
+			const data = await response.json();
+			if (data.error) return showMessage(data.error);
+			this.tags = data.result_data;
+		}
+
+		update(category, values, clear = false) {
+			if (category === 'level') {
+				if (values.Level) this.levelSelect.value = values.Level;
+				return this.update('status', values);
+			}
+			if (category === 'status') {
+				if (this.statusSelect && values.Status) this.statusSelect.value = values.Status;
+				return;
+			}
+
+			const child = {
+				subject: 'chapter',
+				chapter: 'section',
+				section: 'level'
+			};
+
+			const allText = `All ${category.charAt(0).toUpperCase() + category.slice(1)}s`;
+
+			if (clear) {
+				this.setSelect(category, allText);
+				return this.update(child[category], values);
+			}
+
+			const subject = values.DBsubject || this.subjectSelect.value;
+			const chapter = values.DBchapter || this.chapterSelect.value;
+			const section = values.DBsection || this.sectionSelect.value;
+
+			if (category === 'chapter' && subject === '') return this.update(category, values, true);
+			if (category === 'section' && chapter === '') return this.update(category, values, true);
+
+			this.setSelect(category, allText, readFromTaxonomy(category, [subject, chapter, section]), values);
+
+			this.update(child[category], values);
+		}
+
+		setSelect(category, allText, options = [], values = {}) {
+			const select = this[`${category}Select`];
+			while (select.lastChild) select.firstChild.remove();
+
+			const currentValue = values[`DB${category}`];
+
+			select.add(new Option(allText, '', true, !!currentValue));
+
+			for (const option of options) {
+				select.add(new Option(option, option, false, option === currentValue));
+			}
+
+			if (currentValue && !select.value) {
+				showMessage(`Provided ${category} "${currentValue}" is not in the taxonomy.`)
+				select.add(new Option(currentValue, currentValue, false, true));
 			}
 		}
-		if(failed) {
-			alert('Provided value "' + valarray[0] + '" is not in my subject taxonomy. ' );
-			return([]);
+
+		async savetags() {
+			const response = await fetch(webServiceURL, {
+				method: 'post',
+				mode: 'same-origin',
+				body: new URLSearchParams(
+					createWebServiceObject('setProblemTags', {
+						library_subjects: this.subjectSelect.value,
+						library_chapters: this.chapterSelect.value,
+						library_sections: this.sectionSelect.value,
+						library_levels: this.levelSelect.value,
+						library_status: this.statusSelect?.value ?? '0',
+						command: this.filePath
+					})
+				)
+			}).catch((err) => `Error saving problem tags: ${err.message ?? err}`);
+			if (typeof response === 'string') return showMessage(response);
+			if (!response.ok) return showMessage('Unable to save problem tags.');
+			const data = await response.json();
+			if (data.error) return showMessage(data.error);
+			showMessage(data.server_response);
 		}
-		if(who == 'chapters') {
-			return(mytaxo.map(function(z) {return(z['name']);} ));
-		}
-		failed = true;
-		for(var i=0; i<mytaxo.length; i++) {
-			if(mytaxo[i]['name'] == valarray[1]) {
-				mytaxo = mytaxo[i]['subfields'];
-				failed=false;
-				break;
-			}
-		}
-		if(failed) {
-			alert('Provided value "'+ valarray[1] + '" is not in my chapter taxonomy. ' );
-			return([]);
-		}
-		if(who == 'sections') {
-			return mytaxo.map(function(z) {return(z['name']);} );
-		}
-		return([]); // Should not get here
 	}
 
-	function init_webservice(command) {
-		const myUser = $('#hidden_user').val();
-		const myCourseID = $('#hidden_courseID').val();
-		const mySessionKey = $('#hidden_key').val();
-		const requestObject = {
-			'rpc_command': 'listLib',
-			'library_name': 'Library',
-			'command': 'searchLib'
-		};
-		if (myUser && mySessionKey && myCourseID) {
-			requestObject.user = myUser;
-			requestObject.key = mySessionKey;
-			requestObject.courseID = myCourseID;
-		} else {
-			alert("missing hidden credentials: user "
-				+ myUser + " session_key " + mySessionKey+ " courseID "
-				+ myCourseID, "alert-danger");
-			return null;
-		}
-		requestObject.rpc_command = command;
-		return requestObject;
+	for (const tagEditButton of document.querySelectorAll('.tag-edit-btn')) {
+		if (!tagEditButton.dataset.sourceFile) return;
+		tagEditButton.addEventListener('click', () => new TagWidget(tagEditButton.dataset.sourceFile).show());
 	}
-
-
-	// New object
-	function tag_widget(el, path) {
-		const id = el.id;
-
-		var nodata = {'DBsubject': '', 'DBchapter': '', 'DBsection': ''};
-
-		var $el = $(el);
-		$el.html('<b>Edit tags:</b> ');
-		$el.append('<select id="'+id+'subjects"></select>');
-		var subj = $('#'+id+'subjects');
-		subj.append('<option value="All Subjects">All Subjects</option>');
-		$el.append('<select id="'+id+'chapters"></select>');
-		var chap = $('#'+id+'chapters');
-		chap.append('<option value="All Chapters">All Chapters</option>');
-		$el.append('<select id="'+id+'sections"></select>');
-		var sect = $('#'+id+'sections');
-		sect.append('<option value="All Sections">All Sections</option>');
-		$el.append('<select id="'+id+'level"></select>');
-		var levels = $('#'+id+'level');
-		levels.append('<option value="">Level</option>');
-		for (var j=1; j<7; j++) {
-			levels.append('<option value="'+j+'">'+j+'</option>');
-		}
-		// Only show the status menu if we are looking at something in Pending
-		var shortpath = path.replace(/^.*templates\//,'');
-		if(/^Pending\//.test(shortpath)) {
-
-			$el.append('<select id="'+id+'stat"></select>');
-			var stat = $('#'+id+'stat');
-			stat.append('<option value="A">Accept</option>');
-			stat.append('<option value="0">Review</option>');
-			stat.append('<option value="R">Reject</option>');
-			stat.append('<option value="F">Further review</option>');
-			stat.append('<option value="N">Needs resource</option>');
-		}
-		subj.on('change', function() {tag_widget_clear_message(id);tag_widget_update('chapters', 'get', id, nodata);});
-		chap.on('change', function() {tag_widget_clear_message(id);tag_widget_update('sections', 'get', id, nodata);});
-		sect.on('change', function() {tag_widget_clear_message(id);});
-		this.tw_gettags(path, id);
-		$el.append('<button id="'+id+'Save">Save</button>');
-		$('#'+id+'Save').on('click', function() {tag_widget_savetags(id, path);return false;});
-		$el.append('<span id="'+id+'result"></span>');
-		return false;
-	}
-
-	tag_widget.prototype.tw_gettags = function(path, id) {
-		var requestObject = init_webservice('getProblemTags');
-		// console.log("In tw_gettags");
-		if(requestObject == null) {
-			// We failed
-			return false;
-		}
-		requestObject.command = path;
-		// console.log(requestObject);
-		return $.post(basicWebserviceURL, requestObject, function (data) {
-			tag_widget_update('subjects', 'get', id, data.result_data);
-		});
-	}
-
-	tag_widget_savetags = function(id, path) {
-		var requestObject = init_webservice('setProblemTags');
-		if(requestObject == null) {
-			// We failed
-			return false;
-		}
-		var subj = $('#'+id+'subjects').find(':selected').text();
-		var chap = $('#'+id+'chapters').find(':selected').text();
-		var sect = $('#'+id+'sections').find(':selected').text();
-		var level = $('#'+id+'level').find(':selected').text();
-		var stat = $('#'+id+'stat').find(':selected').val();
-		if(subj == 'All Subjects') { subj = '';};
-		if(chap == 'All Chapters') { chap = '';};
-		if(sect == 'All Sections') { sect = '';};
-		if(level == 'Level') { level = '';};
-		requestObject.library_subjects = subj;
-		requestObject.library_chapters = chap;
-		requestObject.library_sections = sect;
-		requestObject.library_levels = level;
-		requestObject.library_status = stat;
-		requestObject.command = path;
-		// console.log(requestObject);
-		return $.post(basicWebserviceURL, requestObject, function (data) {
-			$('#'+id+'result').text(data.server_response);
-		});
-	}
-
-	tag_widget_clear_message = function(id) {
-		$('#'+id+'result').text('');
-	}
-
-	tag_widget_update = function(who, what, where, values) {
-		// where is the start of the id's for the parts
-		const child = {
-			subjects: 'chapters',
-			chapters: 'sections',
-			sections: 'level',
-			level: 'stat',
-			stat: 'count'
-		};
-
-		// console.log({"who": who, "what": what, "where":where, "values": values});
-		var all = 'All ' + capFirstLetter(who);
-		if(who=='level') {
-			all = 'Level';
-		}
-
-		if(who=='count') {
-			return false;
-		}
-		if(!values.DBsubject && values.DBsubject.match(/ZZZ/)) {
-			$('#'+where+'subjects').remove();
-			$('#'+where+'chapters').remove();
-			$('#'+where+'sections').remove();
-			$('#'+where+'level').remove();
-			$('#'+where+'stat').remove();
-			$('#'+where+'Save').remove();
-			$('#'+where+'result').text(' Problem file is a pointer to another file');
-			return false;
-		}
-		var requestObject = init_webservice('searchLib');
-		if(requestObject == null) {
-			// We failed
-			return false;
-		}
-		var subj = $('#'+where+'subjects').find(':selected').text();
-		var chap = $('#'+where+'chapters').find(':selected').text();
-		var sect = $('#'+where+'sections').find(':selected').text();
-		var level = $('#'+where+'level').find(':selected').text();
-		var stat = $('#'+where+'stat').find(':selected').val();
-		if(subj == 'All Subjects') { subj = '';};
-		if(chap == 'All Chapters') { chap = '';};
-		if(sect == 'All Sections') { sect = '';};
-		if(level == 'Level') { level = '';};
-		// Now override in case we were fed values
-		if(values.DBsubject) { subj = values.DBsubject;}
-		if(values.DBchapter) { chap = values.DBchapter;}
-		if(values.DBsection) { sect = values.DBsection;}
-		if(values.Level) { level = values.Level;}
-		if(values.Status) { stat = values.Status;} else { stat = "0" }
-		requestObject.library_subjects = subj;
-		requestObject.library_chapters = chap;
-		requestObject.library_sections = sect;
-		var subcommand = "getAllDBsubjects";
-		if(who == 'level') {
-			$('#'+where+who).val(level);
-			return tag_widget_update('stat','get',where,values);
-		}
-		if(who == 'stat') {
-			$('#'+where+who).val(stat);
-			return true;
-		}
-		if(what == 'clear') {
-			setselectbyid(where+who, [all]);
-			return tag_widget_update(child[who], 'clear',where, values);
-		}
-		if(who=='chapters' && subj=='') { return tag_widget_update(who, 'clear', where, values); }
-		if(who=='sections' && chap=='') { return tag_widget_update(who, 'clear', where, values); }
-		if(who=='chapters') { subcommand = "getAllDBchapters";}
-		if(who=='sections') { subcommand = "getSectionListings";}
-		requestObject.command = subcommand;
-		// console.log("Setting menu "+where+who);
-		// console.log(requestObject);
-		var arr = readfromtaxo(who, [subj, chap, sect]);
-		arr.splice(0,0,all);
-		setselectbyid(where+who, arr);
-		if(values.DBsubject && who=='subjects') {
-			$('#'+where+who).val(values.DBsubject);
-		}
-		if(values.DBchapter && who=='chapters') {
-			$('#'+where+who).val(values.DBchapter);
-		}
-		if(values.DBsection && who=='sections') {
-			$('#'+where+who).val(values.DBsection);
-		}
-		tag_widget_update(child[who], 'get',where, values);
-		return true;
-	}
-
-	// Two utility functions
-	function setselectbyid(id, newarray) {
-		var sel = $('#'+id);
-		// console.log("Setting "+id);
-		sel.empty();
-		$.each(newarray, function(_i,val) {
-			sel.append($("<option></option>").val(val).html(val));
-		});
-	}
-
-	function capFirstLetter(string) {
-		return string.charAt(0).toUpperCase() + string.slice(1);
-	}
-
-	document.querySelectorAll('.tag-widget').forEach(
-		(tagger) => {
-			if (!tagger.dataset.sourceFilePath) return;
-			new tag_widget(tagger, tagger.dataset.sourceFilePath);
-		});
 })();

--- a/htdocs/js/apps/TagWidget/tagwidget.js
+++ b/htdocs/js/apps/TagWidget/tagwidget.js
@@ -106,7 +106,7 @@
 			modal.tabIndex = -1;
 
 			const dialog = document.createElement('div');
-			dialog.classList.add('modal-dialog', 'modal-dialog-centered');
+			dialog.classList.add('modal-dialog', 'modal-dialog-centered', 'modal-lg');
 			modal.append(dialog);
 
 			const content = document.createElement('div');
@@ -132,44 +132,62 @@
 			const body = document.createElement('div');
 			body.classList.add('modal-body');
 
-			this.subjectSelect = document.createElement('select');
-			this.subjectSelect.classList.add('form-select', 'mb-2');
-			this.subjectSelect.setAttribute('aria-label', 'Select subject');
-			this.subjectSelect.add(new Option('All Subjects', '', true));
+			for (const [select, label] of [
+				['subjectSelect', 'Subject'],
+				['chapterSelect', 'Chapter'],
+				['sectionSelect', 'Section'],
+				['levelSelect', 'Level']
+			]) {
+				const row = document.createElement('div');
+				row.classList.add('row', 'mb-2');
+
+				const labelEl = document.createElement('label');
+				labelEl.classList.add('col-sm-2', 'col-form-label');
+				labelEl.textContent = `${label}:`;
+				labelEl.setAttribute('for', select);
+
+				const selectColumn = document.createElement('div');
+				selectColumn.classList.add('col-sm-10');
+				row.append(labelEl, selectColumn);
+
+				this[select] = document.createElement('select');
+				this[select].id = select;
+				this[select].classList.add('form-select');
+				this[select].add(new Option(`Select ${label}`, '', true));
+				selectColumn.append(this[select]);
+
+				body.append(row);
+			}
+
 			this.subjectSelect.addEventListener('change', () =>
 				this.update('chapter', { DBsubject: '', DBchapter: '', DBsection: '' })
 			);
-			body.append(this.subjectSelect);
 
-			this.chapterSelect = document.createElement('select');
-			this.chapterSelect.classList.add('form-select', 'mb-2');
-			this.chapterSelect.setAttribute('aria-label', 'Select chapter');
-			this.chapterSelect.add(new Option('All Chapters', '', true));
 			this.chapterSelect.addEventListener('change', () =>
 				this.update('section', { DBsubject: '', DBchapter: '', DBsection: '' })
 			);
-			body.append(this.chapterSelect);
 
-			this.sectionSelect = document.createElement('select');
-			this.sectionSelect.classList.add('form-select', 'mb-2');
-			this.sectionSelect.setAttribute('aria-label', 'Select section');
-			this.sectionSelect.add(new Option('All Sections', '', true));
-			body.append(this.sectionSelect);
-
-			this.levelSelect = document.createElement('select');
-			this.levelSelect.classList.add('form-select');
-			this.levelSelect.setAttribute('aria-label', 'Select level');
-			this.levelSelect.add(new Option('Level', '', true));
 			for (const j of Array(6).keys()) {
 				this.levelSelect.add(new Option(j + 1));
 			}
-			body.append(this.levelSelect);
 
 			// Show the status menu if this is a problem in "Pending".
 			if (/^Pending\//.test(this.filePath.replace(/^.*templates\//, ''))) {
+				const statusRow = document.createElement('div');
+				statusRow.classList.add('row', 'mt-2');
+
+				const statusLabel = document.createElement('label');
+				statusLabel.classList.add('col-sm-2', 'col-form-label');
+				statusLabel.textContent = 'Status:';
+				statusLabel.setAttribute('for', 'statusSelect');
+
+				const statusColumn = document.createElement('div');
+				statusColumn.classList.add('col-sm-10');
+				statusRow.append(statusLabel, statusColumn);
+
 				this.statusSelect = document.createElement('select');
-				this.statusSelect.classList.add('form-select', 'mt-2');
-				this.statusSelect.setAttribute('aria-label', 'Change status');
+				this.statusSelect.id = 'statusSelect';
+				this.statusSelect.classList.add('form-select');
 				for (const value of [
 					['Accept', 'A'],
 					['Review', '0', true, true],
@@ -179,7 +197,9 @@
 				]) {
 					this.statusSelect.add(new Option(...value));
 				}
-				body.append(this.statusSelect);
+				statusColumn.append(this.statusSelect);
+
+				body.append(statusRow);
 			}
 
 			const footer = document.createElement('div');
@@ -240,10 +260,10 @@
 				section: 'level'
 			};
 
-			const allText = `All ${category.charAt(0).toUpperCase() + category.slice(1)}s`;
+			const defaultOption = `Select ${category.charAt(0).toUpperCase() + category.slice(1)}`;
 
 			if (clear) {
-				this.setSelect(category, allText);
+				this.setSelect(category, defaultOption);
 				return this.update(child[category], values);
 			}
 
@@ -254,25 +274,25 @@
 			if (category === 'chapter' && subject === '') return this.update(category, values, true);
 			if (category === 'section' && chapter === '') return this.update(category, values, true);
 
-			this.setSelect(category, allText, readFromTaxonomy(category, [subject, chapter, section]), values);
+			this.setSelect(category, defaultOption, readFromTaxonomy(category, [subject, chapter, section]), values);
 
 			this.update(child[category], values);
 		}
 
-		setSelect(category, allText, options = [], values = {}) {
+		setSelect(category, defaultOption, options = [], values = {}) {
 			const select = this[`${category}Select`];
 			while (select.lastChild) select.firstChild.remove();
 
 			const currentValue = values[`DB${category}`];
 
-			select.add(new Option(allText, '', true, !!currentValue));
+			select.add(new Option(defaultOption, '', true, !!currentValue));
 
 			for (const option of options) {
 				select.add(new Option(option, option, false, option === currentValue));
 			}
 
 			if (currentValue && !select.value) {
-				showMessage(`Provided ${category} "${currentValue}" is not in the taxonomy.`)
+				showMessage(`Provided ${category} "${currentValue}" is not in the taxonomy.`);
 				select.add(new Option(currentValue, currentValue, false, true));
 			}
 		}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1130,6 +1130,22 @@ sub page_title ($c) {
 		)->join('');
 	}
 
+	# Add the tag edit button to the sub header if the user has permission to edit tags.
+	if ($c->authz->hasPermissions($c->param('user'), 'modify_tags')) {
+		$subheader = $c->c(
+			$subheader,
+			$c->tag(
+				'button',
+				id    => 'tagger',
+				type  => 'button',
+				class => 'tag-edit-btn btn btn-secondary btn-sm ms-2',
+				data  => { source_file => $c->ce->{courseDirs}{templates} . '/' . $c->{problem}{source_file} },
+				$c->maketext('Edit Tags')
+			),
+			$c->hidden_field(courseID => $c->stash('courseID'), id => 'hidden_courseID')
+		)->join('');
+	}
+
 	return $c->c($header, $c->tag('span', class => 'problem-sub-header d-block', $subheader))->join('');
 }
 
@@ -1592,24 +1608,6 @@ sub output_achievement_message ($c) {
 		&& $c->{problem}->set_id ne 'Undefined_Set')
 	{
 		return checkForAchievements($c->{problem}, $c->{pg}, $c);
-	}
-
-	return '';
-}
-
-# Puts the tags in the page
-sub output_tag_info ($c) {
-	if ($c->authz->hasPermissions($c->param('user'), 'modify_tags')) {
-		return $c->c(
-			$c->tag(
-				'div',
-				id    => 'tagger',
-				class => 'tag-widget',
-				data  => { source_file_path => $c->ce->{courseDirs}{templates} . '/' . $c->{problem}{source_file} },
-				''
-			),
-			$c->hidden_field(courseID => $c->stash('courseID'), id => 'hidden_courseID')
-		)->join('');
 	}
 
 	return '';

--- a/lib/WebworkWebservice/LibraryActions.pm
+++ b/lib/WebworkWebservice/LibraryActions.pm
@@ -395,6 +395,8 @@ sub getProblemTags {
 	return $out;
 }
 
+# FIXME: Why are library_subjects, library_chapters, library_sections plural?  Each has a value that is a single
+# subject, chapter, or section.  This is also done in many places above.
 sub setProblemTags {
 	my ($invocant, $self, $rh) = @_;
 	my $path   = $rh->{command};

--- a/templates/ContentGenerator/Instructor/SetMaker.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker.html.ep
@@ -6,7 +6,7 @@
 	%
 	% if ($authz->hasPermissions(scalar(param('user')), 'modify_tags')) {
 		<%= javascript "$ce->{webworkURLs}{htdocs}/js/apps/TagWidget/tagwidget.js", id => 'tag-widget-script',
-			defer => undef, data => { taxo => "$ce->{webworkURLs}{htdocs}/DATA/tagging-taxonomy.json" } =%>
+			defer => undef, data => { taxonomy => "$ce->{webworkURLs}{htdocs}/DATA/tagging-taxonomy.json" } =%>
 	% }
 % end
 %

--- a/templates/ContentGenerator/Instructor/SetMaker/problem_row.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/problem_row.html.ep
@@ -162,9 +162,15 @@
 			<div class="lb-problem-add d-flex align-items-center mb-1">
 				<button class="add_me btn btn-primary btn-sm" type="button"
 					data-bs-title="<%= maketext('Add problem to target set') %>"
-					data-source-file="<%= $sourceFileName %>" data-bs-toggle="tooltip" data-bs-placement="top">
+					data-source-file-path="<%= $sourceFileName %>" data-bs-toggle="tooltip" data-bs-placement="top">
 					<%= maketext('Add') %>
 				</button>
+				% if ($authz->hasPermissions(param('user'), 'modify_tags')) {
+					<button id="tagger<%= $cnt %>" class="tag-edit-btn btn btn-secondary btn-sm ms-2" type="button"
+						data-source-file="<%= "$ce->{courseDirs}{templates}/$sourceFileName" %>">
+						<%= maketext('Edit Tags') =%>
+					</button>
+				% }
 			</div>
 			<div class="d-flex flex-wrap align-items-center mb-1 gap-2">
 				<%= content "global-problem-stats-$cnt" =%>
@@ -258,11 +264,6 @@
 			</div>
 		</div>
 		<%= hidden_field "filetrial$cnt" => $sourceFileName =%>
-		% if ($authz->hasPermissions(param('user'), 'modify_tags')) {
-			<div id="tagger<%= $cnt %>" class="tag-widget"
-				data-source-file-path="<%= "$ce->{courseDirs}{templates}/$sourceFileName" %>">
-			</div>
-		% }
 		<div>
 			<div class="psr_render_area" id="psr_render_area_<%= $cnt %>" data-pg-file="<%= $pg_file %>"></div>
 		</div>

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -35,7 +35,7 @@
 	% # This is for tagging menus (if allowed)
 	% if ($authz->hasPermissions(param('user'), 'modify_tags')) {
 		<%= javascript getAssetURL($ce, 'js/apps/TagWidget/tagwidget.js'), id => 'tag-widget-script', defer => undef,
-			data => { taxo => "$ce->{webworkURLs}{htdocs}/DATA/tagging-taxonomy.json" } =%>
+			data => { taxonomy => "$ce->{webworkURLs}{htdocs}/DATA/tagging-taxonomy.json" } =%>
 	% }
 	%
 	% # This is for the problem grader
@@ -68,7 +68,6 @@
 % }
 %
 <%== $c->post_header_text =%>
-<div class="row"><div id="tag_info" class="col-12"><%= $c->output_tag_info %></div></div>
 <div id="custom_edit_message" class="row"><div class="col-lg-10"><%= $c->output_custom_edit_message %></div></div>
 <div class="row"><div id="output_summary" class="col-lg-10"><%= $c->output_summary %></div></div>
 <div class="row">


### PR DESCRIPTION
The javascript is updated with javascript that does not use jQuery.

Furthermore, the old widget that was directly displayed in the page and was ugly as hell has been replaced with a button.  When the button is clicked a dialog opens with a dialog which contains the tag editor.

If a problem has invalid tags, instead of those intrusive native alert dialogs a toast is shown.  The user can continue to interact with the page even while the toast is present.  The toast disappears after five seconds on its own.

Note for self:  This has conflicts with #1884.