### PR TITLE
The ContentGenerator helpMacro needs a default value for the args parameter.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -970,7 +970,7 @@ $args->{label} is the displayed label, and $args->{class} is added to the html c
 
 =cut
 
-sub helpMacro ($c, $name, $args) {
+sub helpMacro ($c, $name, $args = {}) {
 	my $label = $args->{label}
 		// $c->tag('i', class => 'icon fas fa-question-circle', 'aria-hidden' => 'true', data => { alt => ' ? ' }, '');
 	delete $args->{label};


### PR DESCRIPTION
This causes an error when clicking on "Advanced Search" in the library browser (and perhaps other places).

This fix is in #1884, but is unrelated to that pull request.  So I will add this separately.