### PR TITLE
Make the PGProblemEditor show the problem submit buttons for source paths

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -193,6 +193,8 @@
 			return;
 		}
 
+		const isProblem = fileType && /problem/.test(fileType) ? 1 : 0;
+
 		renderProblem(new URLSearchParams({
 			user: document.getElementById('hidden_user')?.value,
 			courseID: document.getElementsByName('courseID')[0]?.value,
@@ -213,9 +215,9 @@
 			isInstructor: 1,
 			noprepostambles: 1,
 			processAnswers: 0,
-			showPreviewButton: fileType && fileType === 'problem' ? 1 : 0,
-			showCheckAnswersButton: fileType && fileType === 'problem' ? 1 : 0,
-			showCorrectAnswersButton: fileType && fileType === 'problem' ? 1 : 0,
+			showPreviewButton: isProblem,
+			showCheckAnswersButton: isProblem,
+			showCorrectAnswersButton: isProblem,
 			showFooter: 0,
 			displayMode: document.getElementById('action_view_displayMode_id')?.value ?? 'MathJax',
 			language: document.querySelector('input[name="hidden_language"]')?.value ?? 'en',


### PR DESCRIPTION
Currently if you edit an OPL or Contrib problem from the library browser the submit buttons are not shown in the problem rendered in the page.

To fix this the javascript needs to check for both "problem" and "source_path_for_problem_file" to determine when to show the submit buttons. This actually just checks that the file type contains the string "problem" (so it also catches blank_problem, although I don't actually know how to get the PGProblemEditor to open a true blank problem).