### PR TITLE
Fix the stats and progress index page siblings

### DIFF
--- a/templates/ContentGenerator/Instructor/Stats/siblings.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/siblings.html.ep
@@ -33,7 +33,8 @@
 						defined stash('setID') && $_ eq stash('setID') ? (class => 'nav-link active')
 						: (
 							href => $c->systemLink(
-								url_for(current_route, setID => $_, problemID => ''),
+								url_for(current_route =~ s/instructor_(progress|statistics)/instructor_set_$1/r,
+									setID => $_, problemID => ''),
 								params => param('filter') ? { filter => param('filter') } : {}
 							),
 							class => 'nav-link'


### PR DESCRIPTION
There was another issue with the incorrect route being used.  If viewing the index page of either Statistics or Progress then the siblings links for all sets listed just take you back to the index page instead of to the statistics or progress page for that set.