### PR TITLE
Add commented out lines to enable show-source.cgi to the apache2 config

### DIFF
--- a/conf/webwork2.apache2.4.dist.conf
+++ b/conf/webwork2.apache2.4.dist.conf
@@ -1,3 +1,19 @@
+# Uncomment the following lines to allow access to show-source.cgi.  This allows the "show source" button that is added
+# by the "source.pl" macro to work for demonstration "courses".  It requires that a show-source.cgi script be customized
+# and placed in the courses html directory.  You will also need to enable the apache2 cgi module with `sudo a2enmod cgi`
+# for this to work.  Note that if you have the mpm_event module enabled instead of mpm_worker, then you will need the
+# cgid module instead.  Apache2 will automatically select this module if the given command is used.  The "show source"
+# button is most useful for webwork "courses" used to train new authors.  It is not desirable to expose the code of
+# regular homework questions to students.
+
+#<DirectoryMatch /opt/webwork/courses/[^/]*/html/>
+#	Options -MultiViews +SymLinksIfOwnerMatch
+#	AllowOverride None
+#	Require all granted
+#</DirectoryMatch>
+#ScriptAliasMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) /opt/webwork/courses/$1/html/show-source.cgi/$2
+#ProxyPassMatch /webwork2_course_files/([^/]*)/show-source.cgi/(.*) !
+
 <Proxy /webwork2/*>
 	Require all granted
 </Proxy>

--- a/htdocs/show-source.cgi
+++ b/htdocs/show-source.cgi
@@ -1,72 +1,76 @@
 #!/usr/bin/env perl
 
-print "Content-type:  text/HTML\n\n";
+use strict;
+use warnings;
 
-$file = $ENV{PATH_INFO};
+print "Content-type: text/html\n\n";
 
-Error("Can't load specified file") if ($file =~ m!(\.\./|//|:|~)!);
-Error("Can't load specified file") if ($file !~ m!\.p[lg]$!);
+my $file = $ENV{PATH_INFO};
 
+Error(q{Can't load specified file.}) if $file =~ m!(\.\./|//|:|~)! || $file !~ m!\.p[lg]$!;
 
-#$root = '/usr/local/WeBWorK';
-$root = '/opt/webwork/';
-$filedir = $file; $filedir =~ s!/[^/]+$!!;
+my $root    = '/opt/webwork';
+my $filedir = $file =~ s!/[^/]+$!!r;
 $file =~ s!.*/!!;
 
-@PGdirs = (
-  "../templates$filedir",
-  "../templates/macros",
-#  "$root/local/macros",
-  "$root/pg/macros",
+my @PGdirs = (
+	"../templates$filedir",  '../templates/macros',      "$root/pg/macros",      "$root/pg/macros/answers",
+	"$root/pg/macros/capa",  "$root/pg/macros/contexts", "$root/pg/macros/core", "$root/pg/macros/deprecated",
+	"$root/pg/macros/graph", "$root/pg/macros/math",     "$root/pg/macros/misc", "$root/pg/macros/parsers",
+	"$root/pg/macros/ui",
 );
 
-foreach $dir (@PGdirs) {ShowSource("$dir/$file") if (-e "$dir/$file")}
+for my $dir (@PGdirs) { ShowSource("$dir/$file") if (-e "$dir/$file") }
 
-Error("Can't find specified file",join(",",@PGdirs).": ".$file);
+Error(qq{Can't find file "$file" in the following allowed locations:\n}, @PGdirs);
 
 sub Error {
-  print "<HTML>\n<HEAD>\n<TITLE>Show-Source Error</TITLE>\n</HEAD>\n";
-  print "<BODY>\n\n<H1>Show-Source Error:</H1>\n\n";
-  print join("\n",@_),"\n";
-  print "</BODY>\n</HTML>";
-  exit;
+	my @errors = @_;
+
+	print '<!DOCTYPE html><html lang="en-US"><head><meta charset="utf-8"><title>Show-Source Error</title></head>';
+	print '<body><h1>Show-Source Error:</h1><pre>';
+	print join("\n", @errors);
+	print '</pre></body></html>';
+
+	exit;
 }
 
 sub ShowSource {
-  my $file = shift;
-  my $name = $file; $name =~ s!.*/!!;
+	my $file = shift;
+	my $name = $file;
+	$name =~ s!.*/!!;
 
-  open(PGFILE,$file);
-  $program = join('',<PGFILE>);
-  close(PGFILE);
+	open(my $pg_file, '<', $file);
+	my $program = join('', <$pg_file>);
+	close($pg_file);
 
-  $program =~ s/&/\&amp;/g;
-  $program =~ s/</\&lt;/g;
-  $program =~ s/>/\&gt;/g;
-  $program =~ s/\t/        /g;
-  print "<HTML>\n<HEAD>\n<TITLE>Problem Source Code</TITLE>\n</HEAD>\n";
-  print "<BODY>\n\n<H1>Source Code for <CODE>$name</CODE>:</H1>\n\n";
-  print "<HR>\n<BLOCKQUOTE>\n";
-  print "<PRE>";
-  print MarkSource($program);
-  print "</PRE>\n";
-  print "</BLOCKQUOTE>\n<HR>\n";
-  print "</BODY>\n</HTML>\n";
-  exit;
+	$program =~ s/&/\&amp;/g;
+	$program =~ s/</\&lt;/g;
+	$program =~ s/>/\&gt;/g;
+
+	print '<!DOCTYPE html><html lang="en-US"><head><meta charset="utf-8"><title>Problem Source Code</title></head>';
+	print "<body><h1>Source Code for <code>$name</code>:</h1>";
+	print '<hr><blockquote>';
+	print '<pre style="tab-size:4;">';
+	print MarkSource($program);
+	print '</pre>';
+	print '</blockquote><hr>';
+	print '</body></html>';
+
+	exit;
 }
 
 sub MarkSource {
-  my $program = shift;
-  local $cgi = $ENV{SCRIPT_NAME};
-  $program =~ s/loadMacros *\(([^\)]*)\)/MakeLinks($1)/ge;
-  return $program;
+	my $program = shift;
+	$program =~ s/loadMacros *\(([^\)]*)\)/MakeLinks($1)/ge;
+	return $program;
 }
 
 sub MakeLinks {
-  my $macros = shift;
-  $macros =~ s!"([^\"<]*)"!"<A HREF="$cgi$filedir/\1">\1</A>"!g;
-  $macros =~ s!'([^\'<]*)'!'<A HREF="$cgi$filedir/\1">\1</A>'!g;
-  return 'loadMacros('.$macros.')';
+	my $macros = shift;
+	$macros =~ s!"([^\"<]*)"!"<a href="$ENV{SCRIPT_NAME}$filedir/$1">$1</a>"!g;
+	$macros =~ s!'([^\'<]*)'!'<a href="$ENV{SCRIPT_NAME}$filedir/$1">$1</a>'!g;
+	return "loadMacros($macros)";
 }
 
 1;


### PR DESCRIPTION
When proxying the webwork2 app via apache2 these lines can be uncommented and a link made to htdocs/show-source.cgi in the courses html directory to enable the "Show Problem Source" button that is added to a problem by loading the source.pl macro.

The show-source.cgi script is updated to also search for macros in the new pg/macros subdirectories. It is also perltidy-ed, strictures and warnings enabled, and generally cleaned up.