### PR TITLE
Fix a couple of encoding issues with the render_rpc endpoint.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -231,7 +231,7 @@ sub formatRenderedProblem {
 		$output->{pg_version} = $ce->{PG_VERSION};
 
 		# Convert to JSON and render.
-		$ws->c->render(data => JSON->new->utf8(0)->encode($output));
+		$ws->c->render(data => JSON->new->utf8(1)->encode($output));
 	}
 
 	# Setup arnd render the appropriate template in the templates/RPCRenderFormats folder depending on the outputformat.
@@ -285,7 +285,7 @@ sub formatRenderedProblem {
 
 	return $ws->c->render(%template_params) if $formatName eq 'json' || !$ws->{inputs_ref}{send_pg_flags};
 	return $ws->c->render(
-		json => { html => $ws->c->render_to_string(%template_params), pg_flags => $rh_result->{flags} });
+		json => { html => $ws->c->render_to_string(%template_params)->to_string, pg_flags => $rh_result->{flags} });
 }
 
 sub saveGradeToLTI {


### PR DESCRIPTION
First the output of render_to_string is a Mojo::ByteStream object.  As such when it is then passed as the html key of the json object in `render` of FormatRenderedProblem, it is not encoded.  So the `to_string` method needs to be called on that to make sure it is encoded properly for the json output.

Second, the raw output now needs to be utf8 encoded since Mojolicious does not encode data output.

The attached problem can be used to test this.
[hebrew.pg.txt](https://github.com/openwebwork/webwork2/files/10808290/hebrew.pg.txt)

Add that problem to a homework set, and then on the problem set detail page render it directly in the page.  Also, open the file in the problem editor.  In both cases for the develop branch the Hebrew in the problem and in the warning the problem emits will be mojibake.  With this pull request the Hebrew will render correctly.  This is for the first case above.

The second case above is a little harder to test.  You can use a link of the form
`http://localhost:3000/webwork2/render_rpc?courseID=your_course_id&user=your_user&passwd=your_password&displayMode=MathJax&outputformat=raw&problemSeed=42&sourceFilePath=path/in/templates_dir/to/hebrew.pg`.  This link assumes that your user has at least proctor login permission and you are serving via morbo on port 3000.