### PR TITLE
Fix a typo in defaults.config.  dvipdfm should be dvisvgm.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1124,7 +1124,7 @@ $pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL} =
 $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;
 
 # Binary that the PGtikz.pl and PGlateximage.pl macros will use to create svg images.
-# This should be either 'pdf2svg' or 'dvipdfm'.
+# This should be either 'pdf2svg' or 'dvisvgm'.
 $pg{specialPGEnvironmentVars}{latexImageSVGMethod} = "pdf2svg";
 
 # When ImageMagick is used for image conversions, this sets the default options.


### PR DESCRIPTION
The LaTeXImage.pm macro doesn't use dvipdfm at all.  Fortunately, the comments in localOverrides.conf are correct.