### PR TITLE
Don't display due dates on the users assigned to set page if not set.

### DIFF
--- a/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
+++ b/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
@@ -61,8 +61,10 @@
 						<td class="text-center"><%= $user->section %></td>
 						% if (defined $userSet) {
 							<td>
-								<%= $c->formatDateTime($userSet->due_date, '',
-									'datetime_format_short', $ce->{language}) =%>
+								% if ($userSet->due_date) {
+									<%= $c->formatDateTime($userSet->due_date, '',
+										'datetime_format_short', $ce->{language}) =%>
+								% }
 							</td>
 							<td>
 								<%= link_to maketext('Edit data for [_1]', $userID) => $c->systemLink(


### PR DESCRIPTION
This is how this was with webwork 2.17 and how it should still be.  A check was forgotten in the conversion to Mojolicious templates.

This fixes issue #1902.