### PR TITLE
Add Observer status

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -548,6 +548,10 @@ $default_status = "Enrolled";
 		abbrevs => [qw/ A a audit /],
 		behaviors => [qw/ allow_course_access include_in_assignment include_in_stats include_in_email /],
 	},
+	Observer => {
+		abbrevs => [qw/ O o observer /],
+		behaviors => [qw/ allow_course_access include_in_assignment /],
+	},
 	Drop => {
 		abbrevs => [qw/ D d drop withdraw /],
 		behaviors => [qw/  /],

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -732,6 +732,7 @@ input.changed[type=text] { /* orange */
 .Audit { font-style: normal; color: purple; background-color: inherit; }
 .Enrolled { font-weight: normal; color: black; background-color: inherit; }
 .Drop { font-style: italic; color: #555; background-color: inherit; }
+.Observer { font-style: normal; color: green; background-color: inherit; }
 
 /* Styles for the PGProblemEditor Page */
 

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -335,6 +335,7 @@ sub do_add_course ($c) {
 			$PermissionLevel->permission($ce->{userRoles}{admin});
 			my $User     = $db->getUser($userID);
 			my $Password = $db->getPassword($userID);
+			$User->status('O');    # Add admin user as an observer.
 
 			push @users, [ $User, $Password, $PermissionLevel ]
 				if $authz->hasPermissions($userID, 'create_and_delete_courses');
@@ -349,7 +350,7 @@ sub do_add_course ($c) {
 			last_name     => $add_initial_lastName,
 			student_id    => $add_initial_userID,
 			email_address => $add_initial_email,
-			status        => 'C',
+			status        => 'O',
 		);
 		my $Password = $db->newPassword(
 			user_id  => $add_initial_userID,

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -116,8 +116,7 @@ sub filter_students ($c) {
 	for my $student (@{ $c->{student_records} }) {
 		# Only include current/auditing students in stats.
 		next
-			unless ($ce->status_abbrev_has_behavior($student->status, 'include_in_stats')
-				&& $db->getPermissionLevel($student->user_id)->permission == $ce->{userRoles}{student});
+			unless ($ce->status_abbrev_has_behavior($student->status, 'include_in_stats'));
 
 		my $section = $student->section;
 		$filters{"section:$section"} = $c->maketext('Section [_1]', $section)


### PR DESCRIPTION
Add a new observer status for instructors/teaching assistants/users who have access to the course and the assignments, but are not included in any stats, grades, or emails. Add a style so Observer users are green in the classlist editor.