### PR TITLE
Pass the options isInstructor and forceScaffoldsOpen through with the render_rpc endpoint.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -272,6 +272,8 @@ sub formatRenderedProblem {
 		uriEncodedProblemSource  => $ws->{inputs_ref}{uriEncodedProblemSource} // '',
 		fileName                 => $ws->{inputs_ref}{fileName}                // '',
 		formLanguage             => $formLanguage,
+		isInstructor             => $ws->{inputs_ref}{isInstructor}       // '',
+		forceScaffoldsOpen       => $ws->{inputs_ref}{forceScaffoldsOpen} // '',
 		showSummary              => $showSummary,
 		showHints                => $ws->{inputs_ref}{showHints}     // '',
 		showSolutions            => $ws->{inputs_ref}{showSolutions} // '',

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -78,6 +78,8 @@
 					%= hidden_field outputformat             => $formatName
 					%= hidden_field theme                    => $theme
 					%= hidden_field language                 => $formLanguage
+					%= hidden_field isInstructor             => $isInstructor
+					%= hidden_field forceScaffoldsOpen       => $forceScaffoldsOpen
 					%= hidden_field showSummary              => $showSummary
 					%= hidden_field showHints                => $showHints
 					%= hidden_field showSolutions            => $showSolutions


### PR DESCRIPTION
Since these options are not passed on through the form in the default template, they are not preserved after submitting answers.  As such problems with scaffolds come back after submitting with the latter scaffolds grayed out and unable to be opened when a problem is rendered on the set detail page, the problem sets editor page, or on the library browser page.