### PR TITLE
Fix the library browser include OPL checkbox.

### DIFF
--- a/templates/ContentGenerator/Instructor/SetMaker/view_problems_line.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/view_problems_line.html.ep
@@ -30,8 +30,10 @@
 		% if ($contrib_exists) {
 			<div class="form-check form-check-inline ms-2">
 				<label class="form-check-label col-form-label-sm">
-					<%= check_box includeOPL => 'on', checked => undef, class => 'form-check-input me-1' =%>
+					% param('includeOPL', 'on') unless defined param('includeOPL');
+					<%= check_box includeOPL => 'on', class => 'form-check-input me-1' =%>
 					<%= maketext('Include OPL') =%>
+					<%= hidden_field includeOPL => 0 =%>
 				</label>
 			</div>
 			<div class="form-check form-check-inline ms-2">


### PR DESCRIPTION
A default hidden input is needed to properly distinguish between an initial page load, and a form submission.

This fixes #1914.