### PR TITLE
Pgeditor, option to backup up files when saving.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -995,6 +995,9 @@ $options{useContribDefFiles} = 1;
 # just a textarea
 $options{PGCodeMirror} = 1;
 
+# Number of backups to keep when saving problems in the problem editor.
+$options{editorNumberOfBackups} = 0;
+
 ###########################################################################################
 #### Default settings for the PG translator
 #### This section controls the display of equations, HINTS, answers, SOLUTIONS,
@@ -1566,6 +1569,17 @@ $ConfigValues = [
 			),
 			type    => 'number',
 			hashVar => '{pg}->{answersOpenAfterDueDate}'
+		},
+		{
+			var  => 'options{editorNumberOfBackups}',
+			doc  => x('Number of backups to keep in the PG editor (0 to disable backups)'),
+			doc2 => x(
+					'If this is greater than zero, two additional options become available when saving files with '
+					. 'the problem editor, backup previous file and delete oldest backup. This sets the number of backups '
+					. 'to keep before suggesting to delete the oldest backup. Backup files can be either restored or '
+					. 'deleted under the "Revert" tab. Setting to 0 disables all backup features.'
+			),
+			type => 'number'
 		},
 	],
 	[

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -995,9 +995,6 @@ $options{useContribDefFiles} = 1;
 # just a textarea
 $options{PGCodeMirror} = 1;
 
-# Number of backups to keep when saving problems in the problem editor.
-$options{editorNumberOfBackups} = 0;
-
 ###########################################################################################
 #### Default settings for the PG translator
 #### This section controls the display of equations, HINTS, answers, SOLUTIONS,
@@ -1569,17 +1566,6 @@ $ConfigValues = [
 			),
 			type    => 'number',
 			hashVar => '{pg}->{answersOpenAfterDueDate}'
-		},
-		{
-			var  => 'options{editorNumberOfBackups}',
-			doc  => x('Number of backups to keep in the PG editor (0 to disable backups)'),
-			doc2 => x(
-					'If this is greater than zero, two additional options become available when saving files with '
-					. 'the problem editor, backup previous file and delete oldest backup. This sets the number of backups '
-					. 'to keep before suggesting to delete the oldest backup. Backup files can be either restored or '
-					. 'deleted under the "Revert" tab. Setting to 0 disables all backup features.'
-			),
-			type => 'number'
 		},
 	],
 	[

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -195,12 +195,14 @@ sub pre_header_initialize ($c) {
 	$c->{editFilePath}  = '';
 	$c->{tempFilePath}  = '';
 	$c->{inputFilePath} = '';
+	$c->{backBasePath}  = '';
 
 	# Determine the paths for the file.
 	# getFilePath defines:
 	#   $c->{editFilePath}:  path to the permanent file to be edited
 	#   $c->{tempFilePath}:  path to the temporary file to be edited with .tmp suffix
 	#   $c->{inputFilePath}: path to the file for input, (this is either the editFilePath or the tempFilePath)
+	#   $c->{backBasePath}:  base path to the backup files
 	$c->getFilePaths;
 
 	# Default problem contents
@@ -465,9 +467,11 @@ sub isTempEditFilePath ($c, $path) {
 #   $c->{editFilePath}  -- path to permanent file
 #   $c->{tempFilePath}  -- temporary file name to use (may not exist)
 #   $c->{inputFilePath} -- actual file to read and edit (will be one of the above)
+#   $c->{backBasePath}  -- base path to backup files
 sub getFilePaths ($c) {
-	my $ce = $c->ce;
-	my $db = $c->db;
+	my $ce   = $c->ce;
+	my $db   = $c->db;
+	my $user = $c->param('user');
 
 	my $editFilePath;
 
@@ -551,6 +555,7 @@ sub getFilePaths ($c) {
 	# The path to the permanent file is now verified and stored in $editFilePath
 	$c->{editFilePath} = $editFilePath;
 	$c->{tempFilePath} = $c->determineTempEditFilePath($editFilePath);
+	$c->{backBasePath} = $c->{tempFilePath} =~ s/.$user.tmp/.bak/r;
 
 	# $c->{inputFilePath} is $c->{tempFilePath} if it is exists and is readable.
 	# Otherwise it is the original $c->{editFilePath}.
@@ -559,11 +564,44 @@ sub getFilePaths ($c) {
 	return;
 }
 
-sub saveFileChanges ($c, $outputFilePath, $problemContents = undef) {
-	my $ce = $c->ce;
+sub getBackupTimes ($c) {
+	my $backBasePath = $c->{backBasePath};
+	return reverse(map { $_ =~ s/$backBasePath//r } glob("$backBasePath*"));
+}
 
-	$problemContents = $$problemContents if defined $problemContents && ref $problemContents;
-	$problemContents = ${ $c->{r_problemContents} } unless not_blank($problemContents);
+sub backupFile ($c, $outputFilePath) {
+	my $ce = $c->ce;
+	return unless $ce->{options}{editorNumberOfBackups} && $ce->{options}{editorNumberOfBackups} > 0;
+
+	my $backupTime   = time;
+	my $backFilePath = $c->{backBasePath} . $backupTime;
+
+	# Make sure any missing directories are created.
+	surePathToFile($ce->{courseDirs}{templates}, $backFilePath);
+	copy($outputFilePath, $backFilePath);
+	$c->addgoodmessage($c->maketext(
+		'Backup created on [_1]',
+		$c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat})
+	));
+
+	# Delete oldest backup if option is present.
+	if ($c->param('deleteBackup')) {
+		my @backupTimes    = $c->getBackupTimes;
+		my $backupTime     = @backupTimes[$#backupTimes];
+		my $backFilePath   = $c->{backBasePath} . $backupTime;
+		my $formatBackTime = $c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat});
+		if (-e $backFilePath) {
+			unlink($backFilePath);
+			$c->addgoodmessage($c->maketext('Deleted backup from [_1].', $formatBackTime));
+		} else {
+			$c->addbadmessage($c->maketext('Unable to delete backup from [_1].', $formatBackTime));
+		}
+	}
+}
+
+sub saveFileChanges ($c, $outputFilePath, $backup = undef) {
+	my $ce              = $c->ce;
+	my $problemContents = ${ $c->{r_problemContents} };
 
 	# Read and update the targetFile and targetFile.tmp files in the directory.
 	# If a .tmp file already exists use that, unless the revert button has been pressed.
@@ -584,6 +622,9 @@ sub saveFileChanges ($c, $outputFilePath, $problemContents = undef) {
 
 	# Make sure any missing directories are created.
 	surePathToFile($ce->{courseDirs}{templates}, $outputFilePath);
+
+	# Backup file if asked.
+	$c->backupFile($outputFilePath) if $backup;
 
 	# Actually save the file.
 	if (open my $outfile, '>:encoding(UTF-8)', $outputFilePath) {
@@ -906,7 +947,7 @@ sub save_handler ($c) {
 				. 'The problem set may have changed. Please reopen this file from the homework sets editor.'
 		));
 	} else {
-		$c->saveFileChanges($c->{editFilePath});
+		$c->saveFileChanges($c->{editFilePath}, $c->param('backupFile'));
 	}
 
 	# Don't redirect unless it was requested to open in a new window.
@@ -1181,9 +1222,8 @@ sub save_as_handler ($c) {
 }
 
 sub revert_handler ($c) {
-	my $ce = $c->ce;
-
-	$c->{inputFilePath} = $c->{editFilePath};
+	my $ce   = $c->ce;
+	my $user = $c->param('user');
 
 	unless (path_is_subdir($c->{tempFilePath}, $ce->{courseDirs}{templates}, 1)) {
 		$c->addbadmessage($c->maketext(
@@ -1193,14 +1233,48 @@ sub revert_handler ($c) {
 		return;
 	}
 
-	# Unlink the temp files;
-	unlink($c->{tempFilePath});
-	$c->addgoodmessage($c->maketext('Deleted temporary file [_1].', $c->shortPath($c->{tempFilePath})));
+	# Determine revert action
+	my $revertType = $c->param('action.revert.type') || 'do_not_revert';
+
+	if ($revertType eq 'revert') {
+		$c->{inputFilePath} = $c->{editFilePath};
+		unlink($c->{tempFilePath});
+		$c->addgoodmessage($c->maketext('Deleted temporary file "[_1]".',    $c->shortPath($c->{tempFilePath})));
+		$c->addgoodmessage($c->maketext('Reverted to original file "[_1]".', $c->shortPath($c->{editFilePath})));
+	} elsif ($revertType eq 'backup') {
+		my $backupTime   = $c->param('action.revert.backup.time') || '';
+		my $backFilePath = $c->{backBasePath} . $backupTime;
+		$c->{inputFilePath} = $c->{tempFilePath};
+
+		if (-r $backFilePath) {
+			copy($backFilePath, $c->{tempFilePath});
+			$c->addgoodmessage($c->maketext(
+				'Restored backup from [_1].',
+				$c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat})
+			));
+		} else {
+			$c->addbadmessage($c->maketext('Unable to read backup file "[_1]".', $c->shortPath($backFilePath)));
+		}
+	} elsif ($revertType eq 'delete') {
+		my $delTime     = $c->param('action.revert.delete.time');
+		my $delFilePath = $c->{backBasePath} . $delTime;
+
+		if (-e $delFilePath) {
+			unlink($delFilePath);
+			$c->addgoodmessage($c->maketext(
+				'Deleted backup from [_1].',
+				$c->formatDateTime($delTime, undef, $ce->{studentDateDisplayFormat})
+			));
+		} else {
+			$c->addbadmessage($c->maketext('Unable to delete backup file "[_1]".', $c->shortPath($delFilePath)));
+		}
+		return;
+	} else {
+		return;
+	}
 
 	$c->{r_problemContents} = \'';
 	$c->param('problemContents', undef);
-
-	$c->addgoodmessage($c->maketext('Reverted to original file "[_1]".', $c->shortPath($c->{editFilePath})));
 
 	return;
 }

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -572,9 +572,7 @@ sub getBackupTimes ($c) {
 }
 
 sub backupFile ($c, $outputFilePath) {
-	my $ce = $c->ce;
-	return unless $ce->{options}{editorNumberOfBackups} && $ce->{options}{editorNumberOfBackups} > 0;
-
+	my $ce             = $c->ce;
 	my $backupTime     = time;
 	my $backupFilePath = $c->{backupBasePath} . $backupTime;
 
@@ -589,7 +587,7 @@ sub backupFile ($c, $outputFilePath) {
 	# Delete oldest backup if option is present.
 	if ($c->param('deleteBackup')) {
 		my @backupTimes      = $c->getBackupTimes;
-		my $backupTime       = @backupTimes[$#backupTimes];
+		my $backupTime       = $backupTimes[-1];
 		my $backupFilePath   = $c->{backupBasePath} . $backupTime;
 		my $formatBackupTime = $c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat});
 		if (-e $backupFilePath) {
@@ -599,6 +597,7 @@ sub backupFile ($c, $outputFilePath) {
 			$c->addbadmessage($c->maketext('Unable to delete backup from [_1].', $formatBackupTime));
 		}
 	}
+	return;
 }
 
 sub saveFileChanges ($c, $outputFilePath, $backup = 0) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -120,8 +120,8 @@ use constant ACTION_FORM_TITLES => {
 	view        => x('View/Reload'),
 	hardcopy    => x('Generate Hardcopy'),
 	add_problem => x('Append'),
-	save        => x('Update'),
-	save_as     => x('New Version'),
+	save        => x('Save'),
+	save_as     => x('Save As'),
 	revert      => x('Revert'),
 };
 

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -1,5 +1,86 @@
-% if ($c->{file_type} ne 'course_info' && !-r $c->{editFilePath}) {
-	<%= maketext('Error: The original file [_1] cannot be read.', $c->{editFilePath}) =%>
-% } elsif (defined $c->{tempFilePath} && -e $c->{tempFilePath}) {
-	<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
-%}
+% # Don't show the revert form when editing an existing course info file.
+% next if $c->{file_type} eq 'course_info';
+%
+% if (!-r $c->{editFilePath}) {
+	<%== maketext(
+		'Error: The original file [_1] cannot be read.',
+		tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))
+	) =%>
+	% next;
+% }
+%
+% # Build list of backup files.
+% my $foundTempFile = defined($c->{tempFilePath}) && -e $c->{tempFilePath};
+% my @backupTimes   = $c->getBackupTimes;
+% if (@backupTimes) {
+	<div>
+		<div class="mb-2">
+			<%= maketext('Select action:') %>
+		</div>
+
+		% if ($foundTempFile) {
+			<div class="form-check mb-2">
+				<%= radio_button 'action.revert.type' => 'revert', id => 'action_revert_type_revert_id',
+					checked => undef, class => 'form-check-input' =%>
+				<%= label_for 'action_revert_type_revert_id', class => 'form-check-label', begin =%>
+					<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
+				<% end =%>
+			</div>
+		% }
+
+		<div class="row align-items-center mb-2">
+			<div class="col-auto">
+				<%= radio_button 'action.revert.type' => 'backup', id => 'action_revert_type_backup_id',
+					class => 'form-check-input', $foundTempFile ? () : (checked => undef) =%>
+				<%= label_for 'action_revert_type_backup_id', class => 'form-check-label ms-2', begin =%>
+					<%= scalar(@backupTimes) == 1
+						? maketext(
+							'Restore backup from [_1]',
+							$c->formatDateTime($backupTimes[0], undef, $ce->{studentDateDisplayFormat})
+						) : maketext('Restore backup from') =%>
+				<% end =%>
+			</div>
+			% if (scalar(@backupTimes) == 1) {
+				<%= hidden_field 'action.revert.backup.time' => $backupTimes[0] =%>
+			% } else {
+				<div class="col-auto">
+					<%= select_field 'action.revert.backup.time' => [
+						map { [ $c->formatDateTime($_, undef, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
+					],
+					id    => 'action_revert_backup_time_id',
+					class => 'form-select form-select-sm d-inline w-auto' =%>
+				</div>
+			% }
+		</div>
+
+		<div class="row align-items-center mb-2">
+			<div class="col-auto">
+				<%= radio_button 'action.revert.type' => 'delete', id => "action_revert_type_delete_id",
+					class => 'form-check-input' =%>
+				<%= label_for "action_revert_type_delete_id", class => 'form-check-label ms-2', begin =%>
+					<%= scalar(@backupTimes) == 1
+						? maketext(
+							'Delete backup from [_1]',
+							$c->formatDateTime($backupTimes[0], undef, $ce->{studentDateDisplayFormat})
+						) : maketext('Delete backup from') =%>
+				<% end =%>
+			</div>
+			% if (scalar(@backupTimes) == 1) {
+				<%= hidden_field 'action.revert.delete.time' => $backupTimes[0] =%>
+			% } else {
+				<div class="col-auto">
+					<%= select_field 'action.revert.delete.time' => [
+						map { [ $c->formatDateTime($_, undef, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
+					],
+					id    => 'action_revert_delete_number_id',
+					class => 'form-select form-select-sm d-inline w-auto' =%>
+				</div>
+			% }
+		</div>
+	</div>
+% } elsif ($foundTempFile) {
+	<div class="mb-2">
+		<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
+	</div>
+	<%= hidden_field 'action.revert.type' => 'revert' =%>
+% }

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
@@ -11,4 +11,23 @@
 		<%= label_for newWindowSave => maketext('Open in new window'), class => 'form-check-label' =%>
 	</div>
 	<%= hidden_field 'action.save.source_file' => $c->{editFilePath} =%>
+
+	% # Backup options
+	% my $backupMax = $c->ce->{options}{editorNumberOfBackups};
+	% if ($backupMax > 0) {
+		<div class="form-check mb-2">
+			<%= check_box backupFile => 1, id => 'backupFile', class => 'form-check-input', checked => undef =%>
+			<%= label_for backupFile => maketext('Create backup'), class => 'form-check-label' =%>
+		</div>
+
+		% # Show option to delete oldest backup if it exists. Check option if at backup capacity.
+		% my @backupTimes = $c->getBackupTimes;
+		% if (@backupTimes) {
+			<div class="form-check mb-2">
+				<%= check_box deleteBackup => 1, id => 'deleteBackup', class => 'form-check-input',
+					scalar(@backupTimes) < $backupMax ? () : (checked => undef) =%>
+				<%= label_for deleteBackup => maketext('Delete oldest backup'), class => 'form-check-label' =%>
+			</div>
+		% }
+	% }
 </div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
@@ -13,20 +13,18 @@
 	<%= hidden_field 'action.save.source_file' => $c->{editFilePath} =%>
 
 	% # Backup options
-	% my $backupMax = $c->ce->{options}{editorNumberOfBackups};
-	% if ($backupMax > 0) {
-		<div class="form-check mb-2">
-			% param('backupFile', 1) unless defined param('backupFile');
-			<%= check_box backupFile => 1, id => 'backupFile', class => 'form-check-input' =%>
-			<%= hidden_field backupFile => 0 =%>
-			<%= label_for backupFile => maketext('Create backup'), class => 'form-check-label' =%>
-		</div>
+	<div class="form-check mb-2">
+		% param('backupFile', 1) unless defined param('backupFile');
+		<%= check_box backupFile => 1, id => 'backupFile', class => 'form-check-input' =%>
+		<%= hidden_field backupFile => 0 =%>
+		<%= label_for backupFile => maketext('Create backup'), class => 'form-check-label' =%>
+	</div>
 
-		% # Show option to delete oldest backup if it exists. Check option if at backup capacity.
-		% my @backupTimes = $c->getBackupTimes;
+	% # Show option to delete oldest backup if it exists.
+	% my @backupTimes = $c->getBackupTimes;
+	% if (@backupTimes) {
 		<div class="form-check mb-2">
-			<%= check_box deleteBackup => 1, id => 'deleteBackup', class => 'form-check-input',
-				@backupTimes < $backupMax ? () : (checked => undef), @backupTimes ? () : (disabled => undef) =%>
+			<%= check_box deleteBackup => 1, id => 'deleteBackup', class => 'form-check-input' =%>
 			<%= label_for deleteBackup => maketext('Delete oldest backup'), class => 'form-check-label' =%>
 		</div>
 	% }


### PR DESCRIPTION
When saving a file with the PG editor, a backup can be made that could be reverted to if desired. This is done by first setting the number of backups to keep. Then each time a problem is saved there is an option to create a backup of the previous saved file (defaults to yes). Backups are numbered 1, 2, 3, ..., with 1 being the most recent. Backups are saved in the `tmpEdit` directory next to the temp files.

The revert tab then has an additional option to allow users to revert to either the current live version or one of the backups. If a user selects to revert to a backup, only the temporary file is reverted, and the user will still need to save the file to make it available to students.

In addition rename "Update" as "Save" and "New Version" as "Save As" to be more standard.