### PR TITLE
Change syntax highlighting for non PG files in PGCodeMirror.

### DIFF
--- a/htdocs/js/apps/PGCodeMirror/pgeditor.js
+++ b/htdocs/js/apps/PGCodeMirror/pgeditor.js
@@ -69,7 +69,7 @@
 	};
 
 	const cm = webworkConfig.pgCodeMirror = CodeMirror.fromTextArea(document.querySelector('.codeMirrorEditor'), {
-		mode: 'PG',
+		mode: document.querySelector('.codeMirrorEditor')?.dataset.mode ?? 'PG',
 		indentUnit: 4,
 		tabMode: 'spaces',
 		lineNumbers: true,

--- a/lib/WeBWorK/HTML/CodeMirrorEditor.pm
+++ b/lib/WeBWorK/HTML/CodeMirrorEditor.pm
@@ -63,10 +63,10 @@ use constant CODEMIRROR_ADDONS_JS => [
 	'scroll/annotatescrollbar.js', 'edit/matchbrackets.js'
 ];
 
-sub generate_codemirror_html ($c, $name, $contents = '') {
+sub generate_codemirror_html ($c, $name, $contents = '', $mode = 'PG') {
 	# Output the textarea that will be used by CodeMirror.
 	# If CodeMirror is disabled, then this is directly the editing area.
-	return $c->text_area($name => $contents, id => $name, class => 'codeMirrorEditor');
+	return $c->text_area($name => $contents, id => $name, class => 'codeMirrorEditor', data => { mode => $mode });
 }
 
 sub generate_codemirror_controls_html ($c) {
@@ -89,11 +89,12 @@ sub generate_codemirror_controls_html ($c) {
 	return $c->include('HTML/CodeMirrorEditor/controls', themeValues => $themeValues, keymapValues => $keymapValues);
 }
 
-sub output_codemirror_static_files ($c) {
+sub output_codemirror_static_files ($c, $mode = 'PG') {
 	return $c->include(
 		'HTML/CodeMirrorEditor/js',
 		codemirrorAddonsCSS => CODEMIRROR_ADDONS_CSS(),
-		codemirrorAddonsJS  => CODEMIRROR_ADDONS_JS()
+		codemirrorAddonsJS  => CODEMIRROR_ADDONS_JS(),
+		codemirrorModesJS   => $mode eq 'htmlmixed' ? [ 'xml', 'css', 'javascript', 'htmlmixed' ] : [$mode]
 	);
 }
 

--- a/templates/ContentGenerator/Instructor/AchievementEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementEditor.html.ep
@@ -3,7 +3,7 @@
 	% qw(generate_codemirror_html generate_codemirror_controls_html output_codemirror_static_files);
 %
 % content_for js => begin
-	<%= output_codemirror_static_files($c) =%>
+	<%= output_codemirror_static_files($c, 'perl') =%>
 	<%= javascript getAssetURL($ce, 'js/apps/ActionTabs/actiontabs.js'), defer => undef =%>
 % end
 %
@@ -23,7 +23,7 @@
 		<%= hidden_field sourceFilePath => $c->{sourceFilePath} =%>
 	% }
 	%
-	<div class="mb-2"><%= generate_codemirror_html($c, 'achievementContents', $achievementContents) =%></div>
+	<div class="mb-2"><%= generate_codemirror_html($c, 'achievementContents', $achievementContents, 'perl') =%></div>
 	<%= generate_codemirror_controls_html($c) =%>
 	%
 	% # Output action forms

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -2,8 +2,9 @@
 % use WeBWorK::HTML::CodeMirrorEditor
 	% qw(generate_codemirror_html generate_codemirror_controls_html output_codemirror_static_files);
 %
+% my $codemirrorMode = $c->{file_type} eq 'course_info' ? 'htmlmixed' : 'PG';
 % content_for js => begin
-	<%= output_codemirror_static_files($c) =%>
+	<%= output_codemirror_static_files($c, $codemirrorMode) =%>
 	<%= javascript getAssetURL($ce, 'js/apps/ActionTabs/actiontabs.js'),           defer => undef =%>
 	<%= javascript getAssetURL($ce, 'js/apps/PGProblemEditor/pgproblemeditor.js'), defer => undef =%>
 % end
@@ -126,7 +127,7 @@
 	</div>
 	<div class="row mb-2">
 		<div class="col-lg-6 col-md-12 order-last order-lg-first">
-			<%= generate_codemirror_html($c, 'problemContents', $problemContents) =%>
+			<%= generate_codemirror_html($c, 'problemContents', $problemContents, $codemirrorMode) =%>
 		</div>
 		<div class="col-lg-6 col-md-12 mb-lg-0 mb-2 order-first order-lg-last">
 			<div class="p-0" id="pgedit-render-area">

--- a/templates/HTML/CodeMirrorEditor/js.html.ep
+++ b/templates/HTML/CodeMirrorEditor/js.html.ep
@@ -16,8 +16,13 @@
 		% for my $addon (@$codemirrorAddonsJS) {
 			<%= javascript getAssetURL($ce, "node_modules/codemirror/addon/$addon"), defer => undef =%>
 		% }
+		% for my $mode (@$codemirrorModesJS) {
+			<%= javascript getAssetURL(
+					$ce,
+					$mode eq 'PG' ? 'js/apps/PGCodeMirror/PG.js' : "node_modules/codemirror/mode/$mode/$mode.js"
+				), defer => undef =%>
+		% }
 		%
-		<%= javascript getAssetURL($ce, 'js/apps/PGCodeMirror/PG.js'), defer => undef =%>
 		<%= javascript getAssetURL($ce, 'js/apps/PGCodeMirror/pgeditor.js'), defer => undef =%>
 	% end
 % }


### PR DESCRIPTION
When using PGCodeMirror to edit course_info pages, use the htmlmixed to highlight html, and when editing achivement files the base perl mode is used.