### PR TITLE
Minor improvements and fixes for the attempts table.

### DIFF
--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -87,7 +87,7 @@
 	);
 
 	// Set up popovers in the attemptResults table.
-	document.querySelectorAll('table.attemptResults td span.answer-preview').forEach((popover) => {
+	document.querySelectorAll('table.attemptResults td div.answer-preview').forEach((popover) => {
 		if (popover.dataset.bsContent) new bootstrap.Popover(popover, {trigger: 'click', html: true, sanitize: false});
 	});
 

--- a/lib/WeBWorK/HTML/AttemptsTable.pm
+++ b/lib/WeBWorK/HTML/AttemptsTable.pm
@@ -295,7 +295,11 @@ sub answerTemplate ($self) {
 		$self->showHeadline
 		? $c->tag('h2', class => 'attemptResultsHeader', $c->maketext('Results for this submission'))
 		: '',
-		$c->tag('table', class => 'attemptResults table table-sm table-bordered', $tableRows->join('')),
+		$c->tag(
+			'div',
+			class => 'table-responsive',
+			$c->tag('table', class => 'attemptResults table table-sm table-bordered', $tableRows->join(''))
+		),
 		$self->showSummary ? $self->createSummary : ''
 	)->join('');
 }
@@ -317,7 +321,7 @@ sub previewAnswer ($self, $answerResult) {
 	} elsif ($displayMode eq 'images') {
 		return $imgGen->add($tex);
 	} elsif ($displayMode eq 'MathJax') {
-		return $self->c->tag('script', type => 'math/tex', mode => 'display', $self->c->b($tex));
+		return $self->c->tag('script', type => 'math/tex; mode=display', $self->c->b($tex));
 	}
 }
 
@@ -339,7 +343,7 @@ sub previewCorrectAnswer ($self, $answerResult) {
 	} elsif ($displayMode eq 'images') {
 		return $imgGen->add($tex);
 	} elsif ($displayMode eq 'MathJax') {
-		return $self->c->tag('script', type => 'math/tex', mode => 'display', $self->c->b($tex));
+		return $self->c->tag('script', type => 'math/tex; mode=display', $self->c->b($tex));
 	}
 }
 
@@ -443,7 +447,7 @@ sub formatToolTip ($self, $answer, $formattedAnswer) {
 	return $self->c->tag(
 		'td',
 		$self->c->tag(
-			'span',
+			'div',
 			class => 'answer-preview',
 			data  => {
 				bs_toggle    => 'popover',


### PR DESCRIPTION
Change the preview span to a preview div.  We make that a span, but set it as display `block`.  If you want display block, generally you should be using a div.  Furthermore, many answer previews now use divs for layout which results in invalid html inside a span.  (This requires a change to the PG problem css.  See https://github.com/openwebwork/pg/pull/796.)

Also wrap the attempts table in a `table-responsive` div.  This cleans up the page size on narrow screens or when the results table becomes excessively large (as can quite frequently occur with messages and correct answers).

Also fix display mode for MathJax equations in answer previews.  This fixes issue #1921.