### PR TITLE
initialize two variables

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -1004,7 +1004,7 @@ sub readSetDef ($c, $fileName) {
 		$restrictLoc,         $emailInstructor,    $restrictProbProgression, $countsParentGrade,
 		$attToOpenChildren,   $problemID,          $showMeAnother,           $showHintsAfter,
 		$prPeriod,            $listType
-	) = ('') x 16;    # initialize these to ''
+	) = ('') x 18;    # initialize these to ''
 	my ($timeCap, $restrictIP, $relaxRestrictIP) = (0, 'No', 'No');
 	# additional fields currently used only by gateways; later, the world?
 	my ($hideScore, $hideScoreByProblem, $hideWork,) = ('N', 'N', 'N');


### PR DESCRIPTION
The last two variables here were not being initialized. It led to a warning when I imported a set.