### PR TITLE
Play the z-index game.

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -51,7 +51,7 @@ table caption {
 
 .visually-hidden-focusable:active,
 .visually-hidden-focusable:focus {
-	z-index: 4;
+	z-index: 21;
 }
 
 $masthead-height: 70px !default;
@@ -68,7 +68,7 @@ $layout-divider-color: #aaa !default;
 	border-bottom: 1px solid $layout-divider-color;
 	margin: 0;
 	padding: 0;
-	z-index: 3;
+	z-index: 20;
 
 	@media only screen and (max-width: 768px) {
 		position: static;
@@ -89,7 +89,7 @@ $layout-divider-color: #aaa !default;
 		justify-content: space-between;
 		padding: 5px 0;
 		background-color: var(--ww-logo-background-color, #104aad);
-		z-index: 3;
+		z-index: 20;
 
 		img {
 			max-height: $masthead-height - 15px;
@@ -404,7 +404,7 @@ h2.page-title {
 	gap: 0.5rem;
 	align-content: space-between;
 	justify-content: space-between;
-	z-index: 1;
+	z-index: 20;
 	position: sticky;
 	top: $masthead-height;
 	background-color: white;


### PR DESCRIPTION
There are many things that are being shown above the masthead and the sticky nav that should not be.  For example, the scrollbars for the codemirror editor on the PG editor page in Firefox (but not Chrome), and the MathJax elements of the graph for a graphtool problem (those are set to z-index 9). I am sure there are other things as well.  Those are just the two I notice right now.

This increases the z-index from 3 to 20 for the masthead, and from 1 to 20 for the sticky nav.  Note that the sticky nav no longer needs to have higher z-index than the masthead now that it never scrolls up that high.

Note that this is still well below the z-index of the mqeditor toolbar, and any of the bootstrap elements that are meant to be over other things, so those will still show over both the masthead and stick nav.