### PR TITLE
Fix issue with generating a single hardcopy test version.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -435,8 +435,6 @@ sub display_form ($c) {
 			$canShowCorrectAnswers = $perm_view_answers
 				|| (defined($mergedSet) && after($mergedSet->answer_date));
 		}
-		# Make display for versioned sets a bit nicer
-		$selected_set_id =~ s/,v(\d+)$/ (version $1)/;
 	}
 
 	return $c->include(

--- a/templates/ContentGenerator/Hardcopy/form.html.ep
+++ b/templates/ContentGenerator/Hardcopy/form.html.ep
@@ -55,7 +55,7 @@
 		<p>
 			<%== maketext(
 				'Download hardcopy of set [_1] for [_2]?',
-				tag('span', dir => 'ltr', format_set_name_display($selected_set_id)),
+				tag('span', dir => 'ltr', format_set_name_display($selected_set_id =~ s/,v(\d+)$/ (version $1)/r)),
 				join(' ', $user->first_name, $user->last_name)
 			) =%>
 		</p>


### PR DESCRIPTION
The `$selected_set_id` name was updated to be displayed, but was still being used as the set id parameter. This moves the display change to the line it is being used to ensure the set id parameter is unchanged.

Fixes #1930