### PR TITLE
Add a configuration option to redirect http to https.

### DIFF
--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -70,6 +70,12 @@ JSON_ERROR_LOG: 0
 server_user: www-data
 server_group: www-data
 
+# Change redirect_http_to_https to 1 to have all http requests redirected to
+# https.  You will also need to add "- http://*:80" as well as "- http://*:443"
+# to the hypnotoad listen values below for this to work.  This should only be
+# used when serving the webwork2 app directly.
+redirect_http_to_https: 0
+
 # hypnotoad server configuration
 # See https://docs.mojolicious.org/Mojo/Server/Daemon
 # Any of the attributes listed there can be set in this section.

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -114,6 +114,19 @@ sub startup ($app) {
 		);
 	}
 
+	# Add a hook that redirects http to https if configured to do so.
+	if ($config->{redirect_http_to_https}) {
+		$app->hook(
+			before_dispatch => sub ($c) {
+				my $request_url = $c->req->url->to_abs;
+				if ($request_url->scheme eq 'http') {
+					$request_url->scheme('https');
+					$c->redirect_to($request_url);
+				}
+			}
+		);
+	}
+
 	$app->hook(
 		around_action => async sub ($next, $c, $action, $last) {
 			return $next->() unless $c->isa('WeBWorK::ContentGenerator');


### PR DESCRIPTION
This should only be used when serving directly, and accomplishes what is typically done for servers that serve secure content in that case.

This builds on #1874 by the way.