### PR TITLE
Update user information in cached list when saving a user in the Classlist Editor.

### DIFF
--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -73,7 +73,7 @@
 				<%= include 'ContentGenerator/Instructor/UserList/user_row',
 					user         => $c->{allUsers}{$_},
 					userSelected => exists $c->{selectedUserIDs}{$_},
-					editable     => exists $c->{userIsEditable}{$_} 
+					editable     => exists $c->{userIsEditable}{$_}
 				=%>
 			% }
 		</tbody>


### PR DESCRIPTION
Since the database is not queried to retrieve updated information after actions are performed the data for saved users needs to be updated in the cached lists so that the updated information is displayed when the templates are loaded later.

This fixes #1933.

Also fix sorting that was also broken in #1888.  The fallback methods are needed in order for sorting to work correctly in case the first three do not sort thing properly.  Currently, if you load the page with users that do not have the information that the first three methods sort on, then the users end up in a different order each time you load the page.  For example, if using the default sort and users do not have first or last names.