### PR TITLE
Make the renderProblem method not look up invalid problem numbers.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -231,7 +231,7 @@ sub formatRenderedProblem {
 		$output->{pg_version} = $ce->{PG_VERSION};
 
 		# Convert to JSON and render.
-		$ws->c->render(data => JSON->new->utf8(1)->encode($output));
+		return $ws->c->render(data => JSON->new->utf8(1)->encode($output));
 	}
 
 	# Setup arnd render the appropriate template in the templates/RPCRenderFormats folder depending on the outputformat.

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -98,7 +98,7 @@ async sub renderProblem {
 
 	my $setVersionId = $rh->{version_id} || 0;
 
-	my $problemNumber = $rh->{probNum}      // 1;
+	my $problemNumber = $rh->{probNum}      // 0;
 	my $psvn          = $rh->{psvn}         // 1234;
 	my $problemValue  = $rh->{problemValue} // 1;
 	my $lastAnswer    = '';
@@ -146,9 +146,9 @@ async sub renderProblem {
 
 	# obtain the merged problem for $effectiveUser
 	my $problemRecord =
-		$setVersionId
-		? $db->getMergedProblemVersion($effectiveUserName, $setName, $setVersionId, $problemNumber)
-		: $db->getMergedProblem($effectiveUserName, $setName, $problemNumber);
+		!$problemNumber ? undef
+		: $setVersionId ? $db->getMergedProblemVersion($effectiveUserName, $setName, $setVersionId, $problemNumber)
+		:                 $db->getMergedProblem($effectiveUserName, $setName, $problemNumber);
 
 	if (defined $problemRecord) {
 		# If a problem from the database is used, the passed in problem seed is ignored.
@@ -158,8 +158,8 @@ async sub renderProblem {
 		# If that is not yet defined obtain the global problem,
 		# convert it to a user problem, and add fake user data
 		my $userProblemClass = $db->{problem_user}{record};
-		my $globalProblem    = $db->getGlobalProblem($setName, $problemNumber);    # checked
-			# if the global problem doesn't exist either, bail!
+		my $globalProblem    = $db->getGlobalProblem($setName, $problemNumber);
+		# if the global problem doesn't exist either, bail!
 		if (not defined $globalProblem) {
 			$problemRecord = fake_problem($db);
 		} else {


### PR DESCRIPTION
When renderProblem is called with a problem number of 0, then don't look the problem up in the database, and instead use the passed parameters for the problem seed.

This fixes issue #1938.

This also adds a missing return statement to formatRenderedProblem when the raw output mode is used.  The lack of this return statement causes the method to continue and attempt to also render the default output template.  That causes an exception because a response has already been rendered.