### PR TITLE
PGProblemEditor bugfix and add hot key to render problem

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -149,6 +149,15 @@
 	// CodeMirror is disabled in localOverrides.conf.
 	const editorArea = document.querySelector('.CodeMirror') ?? document.getElementById('problemContents');
 
+	// Add hot key, ctrl-enter, to render the problem
+	editorArea.addEventListener('keydown', async (e) => {
+		if (e.ctrlKey && e.code === 'Enter') {
+			e.preventDefault();
+			await render();
+			saveTempFile();
+		}
+	});
+
 	// Synchronize the heights of the render area and the editor area for wide windows.
 	if (editorArea && renderArea) {
 		const codeMirrorResizeObserver = new ResizeObserver((entries) => {

--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -39,7 +39,8 @@
 
 		request_object.rpc_command = 'saveFile';
 		request_object.outputFilePath = document.getElementsByName('temp_file_path')[0]?.value ?? '';
-		request_object.fileContents = webworkConfig?.pgCodeMirror?.getValue() ?? '';
+		request_object.fileContents = webworkConfig?.pgCodeMirror?.getValue()
+			?? document.getElementById('problemContents')?.value ?? '';
 
 		if (!request_object.outputFilePath) return;
 


### PR DESCRIPTION
Added `Ctrl-Enter` as a hot key to re-render the problem from inside the editor's text area.

Also found and fixed a bug that re-rendering the problem when codeMirror was disabled would cause erase the temp file with a blank file.