### PR TITLE
Render empty problems via the render_rpc and deprecated html2xml endpoints.

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -300,8 +300,6 @@
 				if (data.error) throw data.error;
 				// This generally shouldn't happen.
 				if (!data.html) throw 'A server error occured.  The response had no content';
-				// Give a nicer file not found error.
-				if (/this problem file was empty/i.test(data.html)) throw 'No Such File or Directory!';
 
 				renderArea.replaceChildren(iframe);
 				iframe.srcdoc = data.html;

--- a/htdocs/js/apps/RenderProblem/renderproblem.js
+++ b/htdocs/js/apps/RenderProblem/renderproblem.js
@@ -51,8 +51,7 @@
 				if (data.error) throw data.error;
 				// This shouldn't happen if the error is not set.
 				if (!data.html) throw 'A server error occured.  The response had no content.';
-				// Give nicer file not found error
-				if (/this problem file was empty/i.test(data.html)) throw 'No Such File or Directory!';
+				if (/this problem file was empty/i.test(data.html)) throw 'No such file or file was empty!';
 				// Give nicer problem rendering error
 				if (
 					(data.pg_flags && data.pg_flags.error_flag) ||

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -52,11 +52,8 @@ sub formatRenderedProblem {
 
 	my $renderErrorOccurred = 0;
 
-	my $problemText = '';
-	if ($rh_result->{text}) {
-		$problemText = $rh_result->{text};
-	} else {
-		$problemText .= "Unable to decode problem text:<br>$ws->{error_string}<br>" . format_hash_ref($rh_result);
+	my $problemText = $rh_result->{text} // '';
+	if ($rh_result->{flags}{error_flag}) {
 		$rh_result->{problem_result}{score} = 0;    # force score to 0 for such errors.
 		$renderErrorOccurred                = 1;
 		$forbidGradePassback                = 1;    # due to render error
@@ -398,13 +395,6 @@ EOS
 	$LTIGradeMessage .= $ws->c->hidden_field(lis_result_sourcedid    => $sourcedid)->to_string;
 
 	return $LTIGradeMessage;
-}
-
-# Error formatting
-sub format_hash_ref {
-	my $hash = shift;
-	warn 'Use a hash reference' unless ref($hash) =~ /HASH/;
-	return join(' ', map { $_ // '--' } %$hash) . "\n";
 }
 
 # Nice output for debugging

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -41,7 +41,7 @@ sub hardcopyRenderedProblem {
 	# Deal with PG errors
 	return $rh_result->{errors} if $rh_result->{flags}{error_flag};
 
-	return 'Unable to decode problem text.' unless $rh_result->{text};
+	return 'This problem has no content.' unless $rh_result->{text};
 
 	my @errors;
 

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -192,7 +192,7 @@ async sub renderProblem {
 	if ($rh->{problemSource}) {
 		$r_problem_source = \(decode_utf8_base64($rh->{problemSource}) =~ tr/\r/\n/r);
 		$problemRecord->source_file(defined $rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
-	} elsif ($rh->{rawProblemSource}) {
+	} elsif (defined $rh->{rawProblemSource}) {
 		$r_problem_source = \$rh->{rawProblemSource};
 		$problemRecord->source_file(defined $rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
 	} elsif ($rh->{uriEncodedProblemSource}) {


### PR DESCRIPTION
Instead of failing to render when the body text is the empty string, just render the empty problem.  Only fail if the error_flag is set.

This means that a problem like
```perlcritic
DOCUMENT();
loadMacros('PGstandard.pl');
ENDDOCUMENT();
```
will now render, but will have not content.

Note that this is consistent with how problems are rendered in an actual set.

The message about not being able to "decode" the problem text was removed because that is not valid.  There is no decoding of the problem text anymore.  Also the ugly `format_hash_ref` call and the method itself was removed as that is no longer serving its purpose.

Also remove the "nicer file not found error".  In that case the error_flag is set, so just let that come through.  This happens for files that actually have no content as well as for files that don't exist.  The error message was changed for the general problem renderer used elsewhere to better say what actually causes the message.