### PR TITLE
Prevent multiple auto submits of gateway tests.

### DIFF
--- a/htdocs/js/apps/GatewayQuiz/gateway.js
+++ b/htdocs/js/apps/GatewayQuiz/gateway.js
@@ -66,6 +66,7 @@
 			const alertStatus = sessionStorage.getItem('gatewayAlertStatus');
 
 			if (remainingTime <= 10 - gracePeriod) {
+				if (!alertStatus) return;
 				sessionStorage.removeItem('gatewayAlertStatus');
 				actuallySubmit = true;
 				submitAnswers.click();
@@ -106,9 +107,13 @@
 
 		if (!timerDiv.dataset.acting) {
 			if (remainingTime <= 10 - gracePeriod) {
-				// Submit the test if time is expired and near the end of grace period.
-				actuallySubmit = true;
-				submitAnswers.click();
+				if (sessionStorage.getItem('gatewayAlertStatus')) {
+					sessionStorage.removeItem('gatewayAlertStatus');
+
+					// Submit the test if time is expired and near the end of grace period.
+					actuallySubmit = true;
+					submitAnswers.click();
+				}
 			} else {
 				// Set the timer text and check alerts at page load.
 				updateTimer();


### PR DESCRIPTION
When the gateway test option "Number of Graded Submissions per Test" is set something more than one or even worse to 0, then the javascript auto submit submits continuously until all submissions are used up or the full grace period expires.  That can crash a server.

To test this create a gateway quiz and just use the default setting of 0 for that option.  I recommend setting the test time limit to something small (I used 0.05 for 3 seconds), and setting `$gatewayGracePeriod = 11;` in localOverrides.conf.  When the time is up on the develop branch you will see the quiz start submitting, and continue to do so for the next 10 seconds and the full gatewayGracePeriod is expired.

With this pull request, you will see the test only submit once.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8228.