### PR TITLE
Bump yaml and cssnano (#1955 for the release candidate)

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -22,7 +22,7 @@
             "devDependencies": {
                 "autoprefixer": "^10.4.13",
                 "chokidar": "^3.5.3",
-                "cssnano": "^5.1.14",
+                "cssnano": "^6.0.0",
                 "postcss": "^8.4.21",
                 "rtlcss": "^4.0.0",
                 "sass": "^1.57.1",
@@ -385,9 +385,9 @@
             }
         },
         "node_modules/css-declaration-sorter": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-            "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
+            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
             "dev": true,
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -397,15 +397,15 @@
             }
         },
         "node_modules/css-select": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
             "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.0.1",
-                "domhandler": "^4.3.1",
-                "domutils": "^2.8.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
                 "nth-check": "^2.0.1"
             },
             "funding": {
@@ -413,16 +413,16 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
             "dev": true,
             "dependencies": {
-                "mdn-data": "2.0.14",
-                "source-map": "^0.6.1"
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
         },
         "node_modules/css-what": {
@@ -450,17 +450,16 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "5.1.14",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
-            "integrity": "sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.0.tgz",
+            "integrity": "sha512-RGlcbzGhzEBCHuQe3k+Udyj5M00z0pm9S+VurHXFEOXxH+y0sVrJH2sMzoyz2d8N1EScazg+DVvmgyx0lurwwA==",
             "dev": true,
             "dependencies": {
-                "cssnano-preset-default": "^5.2.13",
-                "lilconfig": "^2.0.3",
-                "yaml": "^1.10.2"
+                "cssnano-preset-default": "^6.0.0",
+                "lilconfig": "^2.1.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -471,81 +470,102 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "5.2.13",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
-            "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.0.tgz",
+            "integrity": "sha512-BDxlaFzObRDXUiCCBQUNQcI+f1/aX2mgoNtXGjV6PG64POcHoDUoX+LgMWw+Q4609QhxwkcSnS65YFs42RA6qQ==",
             "dev": true,
             "dependencies": {
                 "css-declaration-sorter": "^6.3.1",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-calc": "^8.2.3",
-                "postcss-colormin": "^5.3.0",
-                "postcss-convert-values": "^5.1.3",
-                "postcss-discard-comments": "^5.1.2",
-                "postcss-discard-duplicates": "^5.1.0",
-                "postcss-discard-empty": "^5.1.1",
-                "postcss-discard-overridden": "^5.1.0",
-                "postcss-merge-longhand": "^5.1.7",
-                "postcss-merge-rules": "^5.1.3",
-                "postcss-minify-font-values": "^5.1.0",
-                "postcss-minify-gradients": "^5.1.1",
-                "postcss-minify-params": "^5.1.4",
-                "postcss-minify-selectors": "^5.2.1",
-                "postcss-normalize-charset": "^5.1.0",
-                "postcss-normalize-display-values": "^5.1.0",
-                "postcss-normalize-positions": "^5.1.1",
-                "postcss-normalize-repeat-style": "^5.1.1",
-                "postcss-normalize-string": "^5.1.0",
-                "postcss-normalize-timing-functions": "^5.1.0",
-                "postcss-normalize-unicode": "^5.1.1",
-                "postcss-normalize-url": "^5.1.0",
-                "postcss-normalize-whitespace": "^5.1.1",
-                "postcss-ordered-values": "^5.1.3",
-                "postcss-reduce-initial": "^5.1.1",
-                "postcss-reduce-transforms": "^5.1.0",
-                "postcss-svgo": "^5.1.0",
-                "postcss-unique-selectors": "^5.1.1"
+                "postcss-colormin": "^6.0.0",
+                "postcss-convert-values": "^6.0.0",
+                "postcss-discard-comments": "^6.0.0",
+                "postcss-discard-duplicates": "^6.0.0",
+                "postcss-discard-empty": "^6.0.0",
+                "postcss-discard-overridden": "^6.0.0",
+                "postcss-merge-longhand": "^6.0.0",
+                "postcss-merge-rules": "^6.0.0",
+                "postcss-minify-font-values": "^6.0.0",
+                "postcss-minify-gradients": "^6.0.0",
+                "postcss-minify-params": "^6.0.0",
+                "postcss-minify-selectors": "^6.0.0",
+                "postcss-normalize-charset": "^6.0.0",
+                "postcss-normalize-display-values": "^6.0.0",
+                "postcss-normalize-positions": "^6.0.0",
+                "postcss-normalize-repeat-style": "^6.0.0",
+                "postcss-normalize-string": "^6.0.0",
+                "postcss-normalize-timing-functions": "^6.0.0",
+                "postcss-normalize-unicode": "^6.0.0",
+                "postcss-normalize-url": "^6.0.0",
+                "postcss-normalize-whitespace": "^6.0.0",
+                "postcss-ordered-values": "^6.0.0",
+                "postcss-reduce-initial": "^6.0.0",
+                "postcss-reduce-transforms": "^6.0.0",
+                "postcss-svgo": "^6.0.0",
+                "postcss-unique-selectors": "^6.0.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/cssnano-utils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
+            "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/csso": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
             "dev": true,
             "dependencies": {
-                "css-tree": "^1.1.2"
+                "css-tree": "~2.2.0"
             },
             "engines": {
-                "node": ">=8.0.0"
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
             }
         },
-        "node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
             "dev": true,
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "dev": true
+        },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
@@ -564,12 +584,12 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -579,14 +599,14 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
             "dev": true,
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -605,10 +625,13 @@
             "dev": true
         },
         "node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -770,9 +793,9 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-            "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -804,9 +827,9 @@
             "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw=="
         },
         "node_modules/mdn-data": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
             "dev": true
         },
         "node_modules/nanoid": {
@@ -843,18 +866,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/normalize-url": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/nth-check": {
@@ -925,361 +936,360 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-            "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
+            "integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.16.6",
+                "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
                 "colord": "^2.9.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
-            "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
+            "integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
+            "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-discard-duplicates": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
+            "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-discard-empty": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
+            "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-discard-overridden": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
+            "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-merge-longhand": {
-            "version": "5.1.7",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
-            "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
+            "integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^5.1.1"
+                "stylehacks": "^6.0.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
-            "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.0.tgz",
+            "integrity": "sha512-rCXkklftzEkniyv3f4mRCQzxD6oE4Quyh61uyWTUbCJ26Pv2hoz+fivJSsSBWxDBeScR4fKCfF3HHTcD7Ybqnw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-selector-parser": "^6.0.5"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-minify-font-values": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-            "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
+            "integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-minify-gradients": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
-            "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
+            "integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
             "dev": true,
             "dependencies": {
                 "colord": "^2.9.1",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-minify-params": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
-            "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
+            "integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-minify-selectors": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
-            "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
+            "integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
             "dev": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.5"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-charset": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
+            "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-display-values": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-            "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
+            "integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-positions": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
-            "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
+            "integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-repeat-style": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
-            "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
+            "integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-string": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-            "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
+            "integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-timing-functions": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-            "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
+            "integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
-            "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
+            "integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-url": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-            "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
+            "integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
             "dev": true,
             "dependencies": {
-                "normalize-url": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-normalize-whitespace": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
-            "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
+            "integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-ordered-values": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
-            "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
+            "integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
             "dev": true,
             "dependencies": {
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
-            "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
+            "integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-reduce-transforms": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-            "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
+            "integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
@@ -1299,31 +1309,31 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-            "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
+            "integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^2.7.0"
+                "svgo": "^3.0.2"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >= 18"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
-            "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
+            "integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
             "dev": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.5"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
@@ -1429,13 +1439,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/stable": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-            "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-            "dev": true
-        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1475,40 +1478,43 @@
             }
         },
         "node_modules/stylehacks": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
-            "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
+            "integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
                 "postcss-selector-parser": "^6.0.4"
             },
             "engines": {
-                "node": "^10 || ^12 || >=14.0"
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.15"
             }
         },
         "node_modules/svgo": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
             "dev": true,
             "dependencies": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
-                "css-select": "^4.1.3",
-                "css-tree": "^1.1.3",
-                "csso": "^4.2.0",
-                "picocolors": "^1.0.0",
-                "stable": "^0.1.8"
+                "css-select": "^5.1.0",
+                "css-tree": "^2.2.1",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0"
             },
             "bin": {
                 "svgo": "bin/svgo"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
             }
         },
         "node_modules/terser": {
@@ -1603,15 +1609,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/yargs": {
@@ -1877,33 +1874,33 @@
             "dev": true
         },
         "css-declaration-sorter": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-            "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
+            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
             "dev": true,
             "requires": {}
         },
         "css-select": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.0.1",
-                "domhandler": "^4.3.1",
-                "domutils": "^2.8.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
                 "nth-check": "^2.0.1"
             }
         },
         "css-tree": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
             "dev": true,
             "requires": {
-                "mdn-data": "2.0.14",
-                "source-map": "^0.6.1"
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
             }
         },
         "css-what": {
@@ -1919,78 +1916,95 @@
             "dev": true
         },
         "cssnano": {
-            "version": "5.1.14",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.14.tgz",
-            "integrity": "sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.0.tgz",
+            "integrity": "sha512-RGlcbzGhzEBCHuQe3k+Udyj5M00z0pm9S+VurHXFEOXxH+y0sVrJH2sMzoyz2d8N1EScazg+DVvmgyx0lurwwA==",
             "dev": true,
             "requires": {
-                "cssnano-preset-default": "^5.2.13",
-                "lilconfig": "^2.0.3",
-                "yaml": "^1.10.2"
+                "cssnano-preset-default": "^6.0.0",
+                "lilconfig": "^2.1.0"
             }
         },
         "cssnano-preset-default": {
-            "version": "5.2.13",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
-            "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.0.tgz",
+            "integrity": "sha512-BDxlaFzObRDXUiCCBQUNQcI+f1/aX2mgoNtXGjV6PG64POcHoDUoX+LgMWw+Q4609QhxwkcSnS65YFs42RA6qQ==",
             "dev": true,
             "requires": {
                 "css-declaration-sorter": "^6.3.1",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-calc": "^8.2.3",
-                "postcss-colormin": "^5.3.0",
-                "postcss-convert-values": "^5.1.3",
-                "postcss-discard-comments": "^5.1.2",
-                "postcss-discard-duplicates": "^5.1.0",
-                "postcss-discard-empty": "^5.1.1",
-                "postcss-discard-overridden": "^5.1.0",
-                "postcss-merge-longhand": "^5.1.7",
-                "postcss-merge-rules": "^5.1.3",
-                "postcss-minify-font-values": "^5.1.0",
-                "postcss-minify-gradients": "^5.1.1",
-                "postcss-minify-params": "^5.1.4",
-                "postcss-minify-selectors": "^5.2.1",
-                "postcss-normalize-charset": "^5.1.0",
-                "postcss-normalize-display-values": "^5.1.0",
-                "postcss-normalize-positions": "^5.1.1",
-                "postcss-normalize-repeat-style": "^5.1.1",
-                "postcss-normalize-string": "^5.1.0",
-                "postcss-normalize-timing-functions": "^5.1.0",
-                "postcss-normalize-unicode": "^5.1.1",
-                "postcss-normalize-url": "^5.1.0",
-                "postcss-normalize-whitespace": "^5.1.1",
-                "postcss-ordered-values": "^5.1.3",
-                "postcss-reduce-initial": "^5.1.1",
-                "postcss-reduce-transforms": "^5.1.0",
-                "postcss-svgo": "^5.1.0",
-                "postcss-unique-selectors": "^5.1.1"
+                "postcss-colormin": "^6.0.0",
+                "postcss-convert-values": "^6.0.0",
+                "postcss-discard-comments": "^6.0.0",
+                "postcss-discard-duplicates": "^6.0.0",
+                "postcss-discard-empty": "^6.0.0",
+                "postcss-discard-overridden": "^6.0.0",
+                "postcss-merge-longhand": "^6.0.0",
+                "postcss-merge-rules": "^6.0.0",
+                "postcss-minify-font-values": "^6.0.0",
+                "postcss-minify-gradients": "^6.0.0",
+                "postcss-minify-params": "^6.0.0",
+                "postcss-minify-selectors": "^6.0.0",
+                "postcss-normalize-charset": "^6.0.0",
+                "postcss-normalize-display-values": "^6.0.0",
+                "postcss-normalize-positions": "^6.0.0",
+                "postcss-normalize-repeat-style": "^6.0.0",
+                "postcss-normalize-string": "^6.0.0",
+                "postcss-normalize-timing-functions": "^6.0.0",
+                "postcss-normalize-unicode": "^6.0.0",
+                "postcss-normalize-url": "^6.0.0",
+                "postcss-normalize-whitespace": "^6.0.0",
+                "postcss-ordered-values": "^6.0.0",
+                "postcss-reduce-initial": "^6.0.0",
+                "postcss-reduce-transforms": "^6.0.0",
+                "postcss-svgo": "^6.0.0",
+                "postcss-unique-selectors": "^6.0.0"
             }
         },
         "cssnano-utils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
+            "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
             "dev": true,
             "requires": {}
         },
         "csso": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
             "dev": true,
             "requires": {
-                "css-tree": "^1.1.2"
+                "css-tree": "~2.2.0"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+                    "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+                    "dev": true,
+                    "requires": {
+                        "mdn-data": "2.0.28",
+                        "source-map-js": "^1.0.1"
+                    }
+                },
+                "mdn-data": {
+                    "version": "2.0.28",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+                    "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+                    "dev": true
+                }
             }
         },
         "dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             }
         },
         "domelementtype": {
@@ -2000,23 +2014,23 @@
             "dev": true
         },
         "domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "requires": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             }
         },
         "domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
             "dev": true,
             "requires": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
             }
         },
         "electron-to-chromium": {
@@ -2032,9 +2046,9 @@
             "dev": true
         },
         "entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true
         },
         "escalade": {
@@ -2146,9 +2160,9 @@
             }
         },
         "lilconfig": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-            "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
             "dev": true
         },
         "lodash.memoize": {
@@ -2174,9 +2188,9 @@
             "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw=="
         },
         "mdn-data": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
             "dev": true
         },
         "nanoid": {
@@ -2201,12 +2215,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-            "dev": true
-        },
-        "normalize-url": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true
         },
         "nth-check": {
@@ -2252,21 +2260,21 @@
             }
         },
         "postcss-colormin": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-            "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
+            "integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.16.6",
+                "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
                 "colord": "^2.9.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-convert-values": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
-            "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
+            "integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
@@ -2274,151 +2282,151 @@
             }
         },
         "postcss-discard-comments": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
+            "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-duplicates": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
+            "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-empty": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
+            "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-overridden": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
+            "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
             "dev": true,
             "requires": {}
         },
         "postcss-merge-longhand": {
-            "version": "5.1.7",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
-            "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
+            "integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^5.1.1"
+                "stylehacks": "^6.0.0"
             }
         },
         "postcss-merge-rules": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
-            "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.0.tgz",
+            "integrity": "sha512-rCXkklftzEkniyv3f4mRCQzxD6oE4Quyh61uyWTUbCJ26Pv2hoz+fivJSsSBWxDBeScR4fKCfF3HHTcD7Ybqnw==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-selector-parser": "^6.0.5"
             }
         },
         "postcss-minify-font-values": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
-            "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
+            "integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-gradients": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
-            "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
+            "integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
             "dev": true,
             "requires": {
                 "colord": "^2.9.1",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-params": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
-            "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
+            "integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-selectors": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
-            "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
+            "integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
             "dev": true,
             "requires": {
                 "postcss-selector-parser": "^6.0.5"
             }
         },
         "postcss-normalize-charset": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
+            "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
             "dev": true,
             "requires": {}
         },
         "postcss-normalize-display-values": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
-            "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
+            "integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-positions": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
-            "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
+            "integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-repeat-style": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
-            "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
+            "integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-string": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
-            "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
+            "integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-timing-functions": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
-            "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
+            "integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-unicode": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
-            "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
+            "integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
@@ -2426,38 +2434,37 @@
             }
         },
         "postcss-normalize-url": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
-            "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
+            "integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
             "dev": true,
             "requires": {
-                "normalize-url": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-whitespace": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
-            "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
+            "integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-ordered-values": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
-            "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
+            "integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
             "dev": true,
             "requires": {
-                "cssnano-utils": "^3.1.0",
+                "cssnano-utils": "^4.0.0",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-reduce-initial": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
-            "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
+            "integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
@@ -2465,9 +2472,9 @@
             }
         },
         "postcss-reduce-transforms": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
-            "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
+            "integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
@@ -2484,19 +2491,19 @@
             }
         },
         "postcss-svgo": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
-            "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
+            "integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^2.7.0"
+                "svgo": "^3.0.2"
             }
         },
         "postcss-unique-selectors": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
-            "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
+            "integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
             "dev": true,
             "requires": {
                 "postcss-selector-parser": "^6.0.5"
@@ -2578,12 +2585,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "stable": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-            "dev": true
-        },
         "string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2611,9 +2612,9 @@
             "dev": true
         },
         "stylehacks": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
-            "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
+            "integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
@@ -2621,18 +2622,17 @@
             }
         },
         "svgo": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
             "dev": true,
             "requires": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
-                "css-select": "^4.1.3",
-                "css-tree": "^1.1.3",
-                "csso": "^4.2.0",
-                "picocolors": "^1.0.0",
-                "stable": "^0.1.8"
+                "css-select": "^5.1.0",
+                "css-tree": "^2.2.1",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0"
             }
         },
         "terser": {
@@ -2695,12 +2695,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
-        },
-        "yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true
         },
         "yargs": {

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -26,7 +26,7 @@
     "devDependencies": {
         "autoprefixer": "^10.4.13",
         "chokidar": "^3.5.3",
-        "cssnano": "^5.1.14",
+        "cssnano": "^6.0.0",
         "postcss": "^8.4.21",
         "rtlcss": "^4.0.0",
         "sass": "^1.57.1",


### PR DESCRIPTION
Fix security vulnerabilities that npm warns about.