### PR TITLE
Add the equation editor to the manual problem grader instructor comment boxes.

### DIFF
--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -1,26 +1,6 @@
 'use strict';
 
 (() => {
-	// Comment preview popovers.
-	document.querySelectorAll('.preview').forEach((el) => {
-		el.addEventListener('click', () => {
-			el.dataset.bsContent =
-				el.parentNode.querySelector('textarea')?.value.replace(/</g, '< ').replace(/>/g, ' >');
-			if (el.dataset.bsContent) {
-				const popover = new bootstrap.Popover(el, {
-					html: true, trigger: 'focus', placement: 'bottom', delay: { show: 0, hide: 200 }
-				});
-				el.addEventListener('hidden.bs.popover', () => popover.dispose(), { once: true });
-				popover.show();
-				if (window.MathJax) {
-					MathJax.startup.promise = MathJax.startup.promise.then(
-						() => MathJax.typesetPromise(['.popover-body'])
-					);
-				}
-			}
-		});
-	});
-
 	const setPointInputValue = (pointInput, score) =>
 		pointInput.value = (Math.round(score * pointInput.max / 100 / pointInput.step) * pointInput.step).toFixed(2);
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -954,6 +954,14 @@ td.alt-source {
 		margin-bottom: 2px;
 		padding-bottom: 5px;
 	}
+
+	.restricted-width-col {
+		width: 0.1%;
+	}
+
+	.grader-comment-col {
+		min-width: 300px;
+	}
 }
 
 .problem-grader-table {
@@ -984,12 +992,10 @@ td.alt-source {
 	}
 }
 
-/* Equation editor bugfixes */
-#eqEditorDiv {
-	overflow: visible;
-}
-
-#openEqEditor {
-	min-height: 35px;
-	min-width: 43px;
+#problem-grader-form,
+.problem-grader-table {
+	.mv-container .mv-inner-container,
+	.mq-latex-editor-container .mq-latex-editor-inner-container {
+		width: 100%;
+	}
 }

--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -6,10 +6,24 @@
 	<%= javascript getAssetURL($ce, 'js/apps/RenderProblem/renderproblem.js'), defer => undef =%>
 	<%= javascript getAssetURL($ce, 'js/apps/ProblemGrader/problemgrader.js'), defer => undef =%>
 	<%= javascript getAssetURL($ce, 'node_modules/iframe-resizer/js/iframeResizer.min.js') =%>
+	<%= javascript getAssetURL($ce, 'js/apps/Essay/essay.js'), defer => undef =%>
+	% if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
+		<%= javascript getAssetURL($ce, 'node_modules/mathquill/dist/mathquill.js'), defer => undef =%>
+		<%= javascript getAssetURL($ce, 'js/apps/MathQuill/mqeditor.js'), defer => undef =%>
+	% } elsif ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
+		<%= javascript getAssetURL($ce, "js/apps/MathView/$ce->{pg}{options}{mathViewLocale}"), defer => undef =%>
+		<%= javascript getAssetURL($ce, 'js/apps/MathView/mathview.js'), defer => undef =%>
+	% }
 % end
 %
 % content_for css => begin
 	<%= stylesheet getAssetURL($ce, 'js/apps/Problem/problem.css') =%>
+	% if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
+		<%= stylesheet getAssetURL($ce, 'node_modules/mathquill/dist/mathquill.css') =%>
+		<%= stylesheet getAssetURL($ce, 'js/apps/MathQuill/mqeditor.css') =%>
+	% } elsif ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
+		<%= stylesheet getAssetURL($ce, 'js/apps/MathView/mathview.css') =%>
+	% }
 % end
 %
 % unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
@@ -104,7 +118,7 @@
 					<th><%= maketext('Latest Answers') %></th>
 					<th id="mark-all-correct-header" class="text-center">
 						<%= label_for 'select-all' => maketext('Mark Correct') =%>
-					   	<br>
+						<br>
 						<%= check_box 'select-all' => 'on', id => 'select-all', class => 'select-all form-check-input',
 							data => { select_group => 'mark_correct' } =%>
 					</th>
@@ -138,7 +152,7 @@
 						% }
 						<tr>
 							% if ($haveSections) {
-								<td class="text-center"><%= $user->section %></td>
+								<td class="text-center restricted-width-col"><%= $user->section %></td>
 							% }
 							% $problemNeedsGrading = 1 if $_->{problem}->flags =~ /:needs_grading$/;
 							<td class="<%= $_->{problem}->flags =~ /:needs_grading$/ ? 'needs-grading' : ''%>">
@@ -182,28 +196,29 @@
 									<%= 'There are no answers for this student.' =%>
 								% }
 							</td>
-							<td class="text-center">
+							<td class="text-center restricted-width-col">
 								% param("$userID.$versionID.mark_correct", undef);
 								<%= check_box "$userID.$versionID.mark_correct" => '1',
 									class             => 'mark_correct form-check-input',
 									'aria-labelledby' => 'mark-all-correct-header' =%>
 							</td>
-							<td>
+							<td class="restricted-width-col">
 								% param("$userID.$versionID.score", undef);
 								<%= number_field "$userID.$versionID.score" =>
 										wwRound(0, $_->{problem}->status * 100),
-									class => 'score-selector form-control form-control-sm', style => 'width:6.5rem;',
-									min => 0, max => 100, autocomplete => 'off',
-								   	'aria-labelledby' => 'score-header' =%>
+									class => 'score-selector form-control form-control-sm restricted-width-col',
+									style => 'width:6.5rem;', min => 0, max => 100, autocomplete => 'off',
+									'aria-labelledby' => 'score-header' =%>
 							</td>
-							<td>
+							<td class="grader-comment-column">
 								% if (defined $_->{past_answer}) {
 									<%= text_area "$userID.$versionID.comment" => $_->{past_answer}->comment_string,
-										rows  => 3, class => 'form-control', 'aria-labelledby' => 'comment-header' =%>
-									<br>
-									<button class="preview btn btn-secondary btn-sm" type="button">
-										<%= maketext('Preview') =%>
-									</button>
+										id => "${userID}_${versionID}_comment",
+										rows  => 3, class => 'form-control latexentryfield',
+										'aria-labelledby' => 'comment-header' =%>
+									<%= hidden_field "MaThQuIlL_${userID}_${versionID}_comment" => '',
+										id => "MaThQuIlL_${userID}_${versionID}_comment",
+										data => { eqn_editor_btn_after => 'true' } =%>
 								% }
 							</td>
 						</tr>
@@ -215,7 +230,7 @@
 			<div class='mb-3'>
 				<span class='needs-grading fw-bold p-2'><%= maketext('Name') %></span>
 				\( = \)
- 				<%= maketext('Problem has an essay answer that needs to be graded.') =%>
+				<%= maketext('Problem has an essay answer that needs to be graded.') =%>
 			</div>
 		% }
 		<div id="alt-source-key" class='mb-3 d-none'>

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -180,12 +180,11 @@
 					% param('grader-instructor-comment', $grader->{comment_string});
 					<%= text_area 'grader-instructor-comment' => '',
 						id    => "comment_problem$grader->{problem_id}",
-						class => 'grader-problem-comment form-control d-inline',
+						class => 'grader-problem-comment form-control d-inline latexentryfield',
 						data  => { problem_id => $grader->{problem_id} },
 						rows  => 3 =%>
-					<button class="preview btn btn-secondary mt-1" type="button">
-						<%= maketext('Preview Comment') %>
-					</button>
+					<%= hidden_field "MaThQuIlL_comment_problem$grader->{problem_id}" => '',
+						id => "MaThQuIlL_comment_problem$grader->{problem_id}" =%>
 				</div>
 			</div>
 		% }
@@ -193,7 +192,7 @@
 		% # Save button
 		<div class="row align-items-center">
 			<div class="col-fixed mt-2">
-				<button class="save-grade btn btn-secondary" type="button"
+				<button class="save-grade btn btn-sm btn-secondary" type="button"
 					id="<%= "save_grade_problem$grader->{problem_id}" %>"
 					data-course-id="<%= $grader->{course_id} %>"
 					data-student-id="<%= $grader->{student_id} %>"


### PR DESCRIPTION
This just adds the latexentryfield class and a hidden MathQuill input corresponding to the instructor comment box.  Thus if MathQuill is enabled, then the mqeditor activates for the textarea, and if MathView is enabled then the mathviewer activates for the textarea.

For this to work well a few changes to the MathQuill and Mathview equation editors are needed.  Those are in a PG pull request (https://github.com/openwebwork/pg/pull/822).