### PR TITLE
Change the authentication failure message when accessing the webservice endpoints.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/InstructorRPCHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/InstructorRPCHandler.pm
@@ -41,7 +41,7 @@ use WebworkWebservice;
 
 async sub pre_header_initialize ($c) {
 	unless ($c->authen->was_verified) {
-		$c->{output} = 'instructor_rpc: authentication failed.';
+		$c->{output} = $c->maketext('Authentication failed. Log in again to continue.');
 		return;
 	}
 

--- a/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
@@ -39,7 +39,9 @@ async sub pre_header_initialize ($c) {
 
 	unless ($c->authen->was_verified) {
 		$c->{output} =
-			$c->{wantsjson} ? { error => 'render_rpc: authentication failed.' } : 'render_rpc: authentication failed.';
+			$c->{wantsjson}
+			? { error => $c->maketext('Authentication failed. Log in again to continue.') }
+			: $c->maketext('Authentication failed. Log in again to continue.');
 		return;
 	}
 


### PR DESCRIPTION
Try to make the message a bit clearer as to what is happening when the session times out.  Note the endpoints can not distinguish in any valid way a session timeout from a failed authentication attempt.  So only one message can be sent in both cases.

Is this wording better?  I can't remember the exact wording we discussed.

Note that these messages are now translatable and the "render_rpc: " prefix of the message has been dropped.