### PR TITLE
Fix issues with tests that have questions with a weight of 0

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1316,7 +1316,7 @@ async sub pre_header_initialize ($c) {
 	if ($will{recordAnswers} || $will{checkAnswers}) {
 		my $i = 0;
 		for my $pg (@pg_results) {
-			my $pValue = $problems[$i]->value ? $problems[$i]->value : 1;
+			my $pValue = $problems[$i]->value // 1;
 			my $pScore = 0;
 			if (ref $pg) {
 				# If a pg object is available, then use the pg recorded score and save it in the @probStatus array.

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -268,7 +268,7 @@ sub scoreSet ($c, $setID, $format, $showIndex, $UsersRef, $sortedUserIDsRef) {
 					my $score = 0;
 					foreach (values(%versionUserProblems)) {
 						my $status = $_->status || 0;
-						my $value  = $_->value  // 1;
+						my $value  = $_->value // 1;
 						# some of these are coming in null; I'm not
 						# why, or if this should be necessary
 						$_->status($status);

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -268,7 +268,7 @@ sub scoreSet ($c, $setID, $format, $showIndex, $UsersRef, $sortedUserIDsRef) {
 					my $score = 0;
 					foreach (values(%versionUserProblems)) {
 						my $status = $_->status || 0;
-						my $value  = $_->value  || 1;
+						my $value  = $_->value  // 1;
 						# some of these are coming in null; I'm not
 						# why, or if this should be necessary
 						$_->status($status);


### PR DESCRIPTION
In gateway tests if a question has weight of 0 then the score is reported incorrectly on both the quiz page and the scoring download.

To test:

- Create a test with two questions, and set the weight of the second question to 0
- Take the test and get both questions correct.  Before this PR the message will say "Your score on this attempt is 2/1".  With the change it will correctly report "Your score on this attempt is 1/1".
- From the scoring tools page download the scores for the above test.  Before the PR your score in the csv will be listed as "2".  With the patch the score will be listed as "1".

Can Scoring.pm be refactored to use `grade_set` from Utils.pm?  It seems like there is a lot of duplicated code here.