### PR TITLE
Bugfix: Errors when adding problems to set with assigned users

### DIFF
--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -2148,15 +2148,17 @@ sub addUserMultipleProblems {
 	my @collectedProblemList;
 
 	for my $problemListRef (@problemLists) {
-		my $user_id = $problemListRef->[0]->user_id;
+		my $user_id    = $problemListRef->[0]->user_id;
+		my $problem_id = $problemListRef->[0]->problem_id;
 		croak "addMultipleUserProblems: user set $set_id for user $user_id not found"
 			unless $self->{set_user}->exists($user_id, $set_id);
 
 		# Test whether there are already problem records for this user in this set, as in that case
 		# inserting multiple records at once would trigger an error.
-		my $where = [ user_id_eq_set_id_eq => $user_id, $set_id ];
+		my $where = [ user_id_eq_set_id_eq_problem_id_eq => $user_id, $set_id, $problem_id ];
 
-		croak "addMultipleUserProblems cannot be run as set $set_id already contains some problems for user $user_id"
+		croak
+			"addMultipleUserProblems cannot be run as set $set_id already contains one of the requested problems for user $user_id"
 			if $self->{problem_user}->count_where($where);
 		# If we got here, we can add this list of problems to those to insert into the database
 		push(@collectedProblemList, @{$problemListRef});


### PR DESCRIPTION
## Add Problem Error #1960 

### Description

An error is thrown, and database corruption occurs, whenever problems are added to a set (with assigned users) from the Library Browser. This is caused by counting too many records from the problem_user table, querying for any assigned problems rather than the specific problem(s) being added to the set.

### Resolution

Restrict the database query to match set, user, *and problem*

Suggestions for updating the error message are welcome, but this is a situation that "should" never happen...

### Testing

Create a set with at least one problem, assign it to at least one user, then visit the library browser and try to add a problem to the set. See #1960 for details. Warning: this causes database issues!

After applying this fix, problems will be added to the set and they will add a UserProblem for each assigned user, as expected.