### PR TITLE
Remove a debugging log I accidentally left in.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -247,8 +247,6 @@ sub pre_header_initialize ($c) {
 		grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
 	];
 
-	for (@{ $c->{sortedUserIDs} }) { $c->log->info($_); }
-
 	return;
 }
 


### PR DESCRIPTION
Probably don't want all users being displayed dumped to the log everytime an instructor opens the classlist editor.