### PR TITLE
Remove overwriting of login error message

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -217,17 +217,6 @@ sub verify {
 		if (defined $log_error) {
 			$self->write_log_entry("LOGIN FAILED $log_error");
 		}
-		if (defined($error) and $error =~ /\S/) {    # if error message has a least one non-space character.
-			if (defined($log_error) and $log_error eq "inactivity timeout") {
-				# We don't want to override the localized inactivity timeout message.
-				# so do not check next "if" in this case.
-			} elsif (defined($c->param("user")) or defined($c->param("user_id"))) {
-				$error = $c->maketext(
-					"Your authentication failed.  Please try again. Please speak with your instructor if you need help."
-				);
-			}
-
-		}
 		#warn "LOGIN FAILED: log_error: $log_error; user error: $error";
 		$self->maybe_kill_cookie;
 		# if error message has a least one non-space character.


### PR DESCRIPTION
I don't know what the intention of this block of code was, but as far as I can tell all it does is overwrite any login error message with a generic message.

With this PR error messages that are set during the authentication process are preserved and displayed to the user.  For example, when trying to log in with an empty username you now get the message "You must specify a user ID."

This means that most failed logins will now get the message in `$GENERIC_ERROR_MESSAGE`, which is "Invalid user ID or password", rather than "Your authentication failed. Please try again. Please speak with your instructor if you need help."  I never liked having "Please speak with your instructor if you need help.", as it will depend on the WW implementation as to who you should contact for login issues.