### PR TITLE
Add the PGML lab problem to the modelCourse and render locally for the PG problem editor

### DIFF
--- a/courses.dist/modelCourse/templates/PGMLLab/PGML-lab.pg
+++ b/courses.dist/modelCourse/templates/PGMLLab/PGML-lab.pg
@@ -1,0 +1,716 @@
+DOCUMENT();
+
+loadMacros('PGstandard.pl', 'PGML.pl', 'parserMultiAnswer.pl', 'PGcourse.pl');
+
+# Hide the score summary and show past answers and email instructor buttons.
+HEADER_TEXT(MODES(
+	HTML => tag('style', '.problemFooter, #score_summary {display: none}'),
+	TeX  => ''
+));
+
+sub EscapeHTML {
+	my $s = shift;
+	$s =~ s/&/~~&amp;/g;
+	$s =~ s/</~~&lt;/g;
+	$s =~ s/>/~~&gt;/g;
+	$s =~ s/"/~~&quot;/g;
+	return $s;
+}
+
+# Make a reference menu
+sub Menu {
+	return tag(
+		'select',
+		aria_labelledby => 'reference-label',
+		style           => 'width:15em',
+		join('', map { tag('option', $_) } @_)
+	);
+}
+
+# Make an example menu
+sub Examples {
+	my ($title, @examples) = @_;
+
+	return tag(
+		'select',
+		class           => 'example-selector',
+		id              => $title,
+		aria_labelledby => 'examples-label',
+		style           => 'width:15em',
+		tag('option', value => '', $title) . join(
+			'',
+			map {
+				tag(
+					'option',
+					value     => $_->[0],
+					data_vars => EscapeHTML($_->[1][0]),
+					data_pgml => EscapeHTML($_->[1][1]),
+					$_->[0]
+				)
+			} @examples
+		)
+	);
+}
+
+TEXT(MODES(
+	HTML => tag('div', style => 'text-align:center', tag('b', 'Interactive PGML Lab:')),
+	TeX  => $BCENTER . $BBOLD . 'Interactive PGML Lab:' . $EBOLD . $ECENTER
+));
+
+$vars   = $inputs_ref->{vars} // '';
+$pgml   = ($inputs_ref->{pgml} // '') =~ s/~~r?~~n/~~n/gr;
+$result = '';
+
+if ($vars ne '') {
+	($vresult, $verror) = PG_restricted_eval($vars);
+	if ($verror) {
+		$verror =~ s/ at ~~(eval ~~d+~~) line ~~d+(, at EOF)?//;
+		$verror = EscapeHTML($verror);
+		$verror =~ s/~~n/<br>/g;
+		$verror = tag('span', style => 'color:#c00', 'Error processing variables: ' . tag('i', $verror));
+	}
+} else {
+	$vars = '';
+}
+
+if ($pgml ne '') {
+	$PGML::warningsFatal = 1;
+	($result, $error) = PG_restricted_eval('PGML::Format($pgml)');
+	if ($error) {
+		$result = $error;
+		$result =~ s/ at ~~(eval ~~d+~~) line ~~d+//;
+		$result = EscapeHTML($result);
+		$result =~ s/~~n/<br>/g;
+		$result = tag('span', style => 'color:#c00', $result);
+	}
+	warn join('', @PGML::warnings) . "~~n" if scalar(@PGML::warnings);
+	if ($inputs_ref->{showTeX}) {
+		$oldDisplay  = $displayMode;
+		$displayMode = 'TeX';
+
+		# The variables need to be processed again before processing the problem.  This redefines all of the variables
+		# as new objects.  If this is not done, then errors occur for many of the examples with MathObjects because the
+		# the problem has already been processed above.  Ignore the errors this time.  Those have already been caught
+		# above.
+		PG_restricted_eval($vars) if $vars ne '';
+
+		($tex, $error) = PG_restricted_eval('PGML::Format($pgml)');
+		if ($error) {
+			$result = $error;
+			$result =~ s/ at ~~(eval ~~d+~~) line ~~d+//;
+			$result = EscapeHTML($result);
+			$result =~ s/~~n/<br>/g;
+			$result = tag('span', style => 'color:#c00', 'TeX Error: ' . tag('i', $result));
+		}
+		$displayMode = $oldDisplay;
+	}
+	$pgml  = EscapeHTML($pgml);
+} else {
+	$pgml = '';
+}
+
+$prows = scalar(split(/~~n/, $pgml));
+$prows = 8 unless $prows >= 8;
+$vrows = scalar(split(/~~n/, $vars));
+$vrows = 2 unless $vrows >= 2;
+
+RECORD_FORM_LABEL('vars');
+RECORD_FORM_LABEL('pgml');
+RECORD_FORM_LABEL('showHTML');
+RECORD_FORM_LABEL('showTeX');
+
+TEXT(MODES(HTML => '<div id="resultsBox">', TeX => ''));
+TEXT($HR . $verror . $HR) if $verror;
+TEXT(MODES(
+	HTML => tag(
+		'div',
+		style => 'margin:1rem auto;width:fit-content;padding:1rem;'
+			. 'border:1px solid black;border-radius:4px;background-color:#e8e8e8;',
+		$result
+	),
+	TeX => $result
+))
+	if defined $result && $result ne '';
+
+if ($inputs_ref->{showHTML}) {
+	$result = EscapeHTML($result);
+	$result =~ s!~~n!<br>!g;
+	TEXT(tag('hr') . tag('small', tag('pre', $result)) . tag('hr'));
+}
+if ($inputs_ref->{showTeX}) {
+	$tex = EscapeHTML($tex);
+	$tex =~ s!~~n!<br>!g;
+	TEXT(tag('hr') . tag('small', tag('pre', $tex)) . tag('hr'));
+}
+TEXT(MODES(HTML => '</div>', TeX => ''));
+
+TEXT(MODES(
+	HTML => tag(
+		'div',
+		style => 'width:fit-content;max-width:100%;text-align:left;margin:auto',
+		tag('label', for => 'vars', tag('small', tag('i', style => 'color:#555', 'Variable definitions:')))
+			. tag('textarea', name => 'vars', id => 'vars', rows => $vrows, cols => 60, style => 'display:block', $vars)
+			. tag('label',    for  => 'pgml', tag('small', tag('i', style => 'color:#555', 'Text of problem:')))
+			. tag('textarea', name => 'pgml', id => 'pgml', rows => $prows, cols => 60, style => 'display:block', $pgml)
+			. tag(
+				'div',
+				style => 'margin-top:0.25rem;display:flex;justify-content:space-between;align-items:center',
+				tag(
+					'div',
+					tag(
+						'div',
+						tag(
+							'label',
+							tag(
+								'input',
+								type  => 'checkbox',
+								name  => 'showHTML',
+								value => 1,
+								$inputs_ref->{showHTML} ? (checked => undef) : ()
+							)
+							. ' Show HTML code '
+						)
+					)
+					. tag(
+						'div',
+						tag(
+							'label',
+							tag(
+								'input',
+								type  => 'checkbox',
+								name  => 'showTeX',
+								value => 1,
+								$inputs_ref->{showTeX} ? (checked => undef) : ()
+							)
+							. ' Show TeX code'
+						)
+					)
+				)
+				. tag('div', tag('input', type => 'submit', name => 'action', value => 'Process this Text'))
+			)
+	),
+	TeX => "Variable definitions:$BR"
+		. qq!\hbox to .8\hsize{\hrulefill}$BR!
+		. "Text of problem:$BR"
+		. qq!\hbox to .8\hsize{\hrulefill}$BR$SPACE!
+		. "Show HTML code$BR$SPACE"
+		. "Show TeX code$BR"
+		. '[Process this Text]'
+));
+
+if ($displayMode ne 'TeX') {
+	$SP = "&#x2423;";
+	TEXT(tag('script', << 'END_SCRIPT'));
+window.addEventListener('DOMContentLoaded', () => {
+	const unescapeHTML = (html) => {
+		return html
+			.replace(/&gt;/g, '>')
+			.replace(/&lt;/g, '<')
+			.replace(/&amp;/g, '&')
+			.replace(/&quot;/g, '"')
+			.replace(/\n/g, '~~n')
+			.replace(/\\/g, '\');
+	};
+	for (const select of document.querySelectorAll('.example-selector')) {
+		select.addEventListener('change', () => {
+			if (select.value === '') return;
+			const selectedExample = select.options[select.selectedIndex];
+			const dataType = { vars: 2, pgml: 8 };
+			for (const id in dataType) {
+				const el = document.getElementById(id);
+				el.value = unescapeHTML(selectedExample.dataset[id]);
+				el.rows = Math.max(dataType[id], selectedExample.dataset[id].split(/\n/).length);
+			}
+			document.getElementById('resultsBox').style.display = 'none';
+			window.scrollTo(0, 0);
+		});
+	}
+});
+END_SCRIPT
+
+	TEXT(tag(
+		'div',
+		style => 'margin:1rem auto 0;width:fit-content;'
+			. 'display:flex;justify-content:space-between;align-items:flex-start;flex-wrap:wrap;gap:1rem;',
+		tag(
+			'fieldset',
+			style => 'border:1px solid #5555;border-radius:4px;padding:1rem;'
+				. 'display:flex;flex-direction:column;gap:0.25rem',
+			join(
+				'',
+				tag('legend', id => 'examples-label', style => 'font-size:20px', 'Examples:'),
+				Examples(
+					'Math',
+					[
+						'TeX math' => [
+							'',
+							'In-line math: [`\\frac{x+1}{x-1}`], display math: [``\\frac{x+1}{x-1}``]'
+								. "\n\n"
+								. '    [``\\frac{x+1}{x-1}``] (indented)'
+								. "\n\n"
+								. '>>[``\\frac{x+1}{x-1}``] (centered)<<'
+						]
+					],
+					[
+						'Parsed math' => [
+							'',
+							'In-line math: [:(x+1)/(x-1):], display math: [::(x+1)/(x-1)::]'
+								. "\n\n"
+								. '    [::(x+1)/(x-1)::] (indented)'
+								. "\n\n"
+								. '>>[::(x+1)/(x-1)::] (centered)<<'
+						]
+					],
+					[
+						'Specify context' => [
+							'$context = Context("Vector");',
+							'Use vector context: [:<1,2x>:]{"Vector"}  '
+								. "\n"
+								. 'Use context object: [:<1,2x>:]{$context}  '
+								. "\n"
+								. 'Use current context: [:<1,2x>:]*'
+						]
+					],
+				),
+				Examples(
+					'Answers',
+					[ Numeric => [ '', 'The number twelve is [_______]{12}' ] ],
+					[ Formula => [ '', 'The formula is [__________]{"1+x"}' ] ],
+					[
+						'From variable' => [
+							'$f=Formula("1+x^2"); $Df = $f->D;',
+							q!Suppose [`f(x) = [$f]`].  Then [`f'(x) =`] [____________]{$Df}!
+						]
+					],
+					[ MathObject     => [ '', 'Twelve is [______]{Real(12)}' ] ],
+					[ 'MathObject 2' => [ '', '2 mod 10 is [______]{Real(2)->with(period=>10)}' ] ],
+					[
+						'MathObject 3' =>
+							[ '$f = Formula("sqrt(x^2-1)")->with(limits=>[1,2]);', 'The answer is: [_____]{$f}' ]
+					],
+					[ Traditional => [ '', 'Twelve is [______]{num_cmp(12)}' ] ],
+					[
+						'Checker Options' =>
+							[ '', '[::Int(x,2x)::] = [________]{Formula("x^2")->cmp(upToConstant=>1)} [`+C`]' ]
+					],
+					[
+						'Checker Options 1' => [
+							'$cmp = Formula("x^2")->cmp(upToConstant=>1);',
+							'[::Int(x,2x)::] = [________]{$cmp} [`+C`]'
+						]
+					],
+					[ 'Answer Array' => [ '$M = Matrix([1,2],[3,4])', '[`[$M] =`] [___]*{$M}' ] ],
+					[
+						'MultiAnswer' => [
+							'$mp = MultiAnswer(12,6)->with(checker=>sub {1}, singleResult=>1)',
+							'[_____]{$mp} and [_____]{$mp}'
+						]
+					],
+					[ 'Option Form' => [ '', 'The number 12 is [____]{answer=>12,width=>10}' ] ],
+					[
+						'External ANS' => [
+							'Context("Vector"); ANS(Vector(1,2,3)->cmp(showCoodinateHints=>0));',
+							"[:<1,2,3>:]* = [__________]"
+						]
+					],
+				),
+				Examples(
+					'Lists',
+					[
+						Numeric => [
+							'',
+							"Here is a list:\n"
+								. "1.  This is the first list item\n"
+								. "    continued on the next line.\n"
+								. "2.  Additional items are easy to add.\n"
+								. "3.  Continuation need not be indented,\n"
+								. "such as this line.\n\n"
+								. "A paragraph break ends the list...\n"
+								. "1.  Unless you indent the paragraph...\n\n"
+								. "    ...in which case it is part of the list item.\n"
+								. "2.  See?"
+						]
+					],
+					[
+						Alphabetic => [
+							'',
+							"A list with alphabetic markers:\n"
+								. "a)  You can use dots\n"
+								. "b)  or parens to indicate the items\n\n"
+								. "A paragraph break ends the list.\n\n"
+								. "A list with roman numeral markers:\n"
+								. "i.  Item 1\n"
+								. "ii. Item 2   \n"
+								. "Ending with three spaces also ends the list"
+						]
+					],
+					[
+						'Bullet lists' => [
+							'',
+							"A list can be with stars:\n"
+								. "* Item 1\n"
+								. "* Item 1\n\n"
+								. "Or with plus or minus:\n"
+								. "+ Item 1\n"
+								. "+ Item 2\n\n"
+								. "Paragraphs can be used between items:\n\n"
+								. "o Item 1\n\n"
+								. "o Item 2\n\n"
+								. "End of lists."
+						]
+					],
+					[
+						'Sub-lists' => [
+							'',
+							"1.  A list\n"
+								. "    -  with a sub-list\n"
+								. "    -  of three items\n"
+								. "    -  (indent the sub list)\n"
+								. "2.  Back to the main list\n"
+						]
+					],
+				),
+				Examples(
+					'Substitutions',
+					[
+						Variables => [
+							'$a = 1; $f = Formula("(x+1)/(x-1)");',
+							'a = [$a], f = [$f].  In math: [`f = [$f]`] (TeX inserted automatically),' . "\n"
+								. 'parsed: [:f = [$f]:] (string inserted automatically).'
+						]
+					],
+					[ Commands => [ 'sub F {return (shift)+1}; $x = 5;', 'Add one to five: [@ F($x) @]' ] ],
+					[
+						Comments => [
+							'',
+							"This [% text %] is removed.  \n"
+								. "So are these [% partial [@ and incomplete %] commands.  \n"
+								. "Comments can be nested: [% one [% and two %] and three %]\n"
+						]
+					],
+					[
+						'No Escape' => [
+							'$x = "has math: [:x+1:] and ${BBOLD}bold${EBOLD}";',
+							"Contents of substitutions will be escaped, unless\n"
+								. "followed by a star:  \n"
+								. 'Escaped: [$BSMALL] not small [$ESMALL]  ' . "\n"
+								. 'Verbatim: [$BSMALL]* small [$ESMALL]*'
+								. "\n\n"
+								. "Two stars forces the contents to be processed further:  \n"
+								. 'Escaped: [$x]  ' . "\n"
+								. 'Verbatim: [$x]*  ' . "\n"
+								. 'Processed: [$x]**' . "\n"
+						]
+					],
+				),
+				Examples(
+					'Formatting',
+					[
+						'Line breaks' => [
+							'',
+							"Force line break by  \n"
+								. "ending a line with two spaces\n\n"
+								. "## even in a header ##  \n"
+								. "## that runs over two lines ##\n"
+						]
+					],
+					[
+						'Par break' => [
+							'',
+							'A blank line is a paragraph break\n    \nEven if it just contains white space\n'
+						]
+					],
+					[
+						Indentation => [
+							'',
+							"Indent a section by using four spaces or a tab\n"
+								. "    This is indented,\n"
+								. "    and continues on a second line.\n"
+								. "        Another four spaces indents again.\n"
+								. "    Go back to four to end the inner indenting.\n"
+								. "Note, however, that you only need to indent\n"
+								. "the first line of a paragraph to have all of it\n"
+								. "be indented.  (That may need to be changed.)\n\n"
+								. "End the paragraph to go back to no indenting\n"
+								. "    or use _three_ spaces to end the line   \n"
+								. "and that will end the indenting"
+						]
+					],
+					[
+						Centering => [
+							'',
+							"Use angle brackets to center a phrase:\n\n"
+								. ">> This is centered <<\n\n"
+								. "You can center several lines as a paragraph:\n"
+								. ">> These lines will <<\n"
+								. ">> be combined <<\n\n"
+								. "Or you can force line breaks with two spaced at the end:\n"
+								. ">> These lines will <<  \n"
+								. ">> be centered separately <<\n\n"
+								. "A whole paragraph can be centered:\n"
+								. ">> This is a paragraph\n"
+								. "that will be centered <<\n"
+						]
+					],
+					[
+						'Right justify' => [
+							'',
+							"Use right angle brackets to force a line or paragraph\n"
+								. "to be right-justified:\n"
+								. ">> At the right\n\n"
+								. ">> Several lines combined\n"
+								. ">> right justfied\n\n"
+								. ">> Or a whole paragaph\n"
+								. "that is pushed to the right\n\n"
+								. ">> Or two lines  \n"
+								. ">> justified separately."
+						]
+					],
+					[
+						Headings => [
+							'',
+							"# Heading size 1 #\n"
+								. "## Heading size 2 ##\n"
+								. "### Heading size 3 ###\n"
+								. "#### Heading size 4 ####\n"
+								. "##### Heading size 5 #####\n"
+								. "###### Heading size 6 ######\n\n"
+								. "### Two separate lines ###\n"
+								. "### are combined ###\n\n"
+								. "### A whole paragraph\n"
+								. "can be a heading ###\n\n"
+								. "### End with two spaces ###  \n"
+								. "### for two lines separately ###\n\n"
+								. "### The trailing hashes are optional.\n\n"
+								. ">> ## centered heading ## <<\n"
+								. ">> ## right-justified ##"
+						]
+					],
+					[
+						Rules => [
+							'',
+							"Three or more dashes or equals on a line by itself forms a rule\n\n"
+								. "-----\n"
+								. "You can specify the width and size if you want:\n"
+								. "----{200}\n----{'50%'}\n===={200}{5}\n===={size=>5}\n\n"
+								. "You can center and right-justify rules:\n>> ----{100} <<\n>> ----{100}\n"
+						]
+					],
+					[
+						Emphasis => [
+							'',
+							"These words are in *bold* or _italic_.\n\n"
+								. "Stars can be used in*side* a word,\n"
+								. "but underlines_don't_work_that_way."
+						]
+					],
+					[
+						'Smart Quotes' => [
+							'',
+							"Quotes are ~~"smart~~" (~~"even here~~"), and don't forget about 'other' quotes.\n\n"
+								. "You can quote a quote: ~~\\"dumb quotes~~\\"."
+						]
+					],
+					[
+						Preformatted => [
+							'',
+							"Preformatted text starts with a colon and three spaces:\n"
+								. ":   This is preformatted,\n"
+								. ":       and can include any text, e.g., <, >, ~~$, etc.,\n"
+								. ":       but [@ ~~"commands~~" @] and other *mark up* are performed normally.\n"
+								. ":   Use [|verbatim mode|] if you want to include commands literally,\n"
+								. ":   or use a slash to escape them:  \\[~~$x].\n\n"
+								. "The formatting can be indented, too:\n"
+								. "    Here is some indenting\n"
+								. "    :   with preformatting\n"
+								. "    :   on several lines.\n"
+								. "    Now back to normal, but indented.\n"
+						]
+					],
+					[
+						Verbatim => [
+							'',
+							"Text that includes commands can be enclosed\n"
+								. "to prevent interpretation:  \n"
+								. "[|This is not math [`x+1`] in here.|]\n\n"
+								. "You can use more vertical bars to make verbatim verbatims:  \n"
+								. "[||This is [|verbatim|].||]\n\n"
+								. "Use backslashes to escape command characters if you need to:  \n"
+								. "This occurred in the year\n"
+								. "1\\.  (Prevent accidental list).\n\n"
+								. "Don't do comment: \\[% you will see this %]."
+						]
+					],
+					[
+						'Other Chars' =>
+							[ '', 'Other characters quote themselves on their own: <, >, &, %, $, ^, etc.' ]
+					],
+				),
+				Examples(
+					'Problems',
+					[
+						Algebra => [
+							'Context("Interval"); $a = random(1,8,1); $b = random(8,15,1); $min = $a-$b; $max = $a+$b;',
+							"Solve the following inequality and enter your answer using interval notation:\n\n"
+								. '    [``|x-[$a]| > [$b]``]'
+								. "\n\n"
+								. 'Answer: [`x`] must be in [____________________________]{"(-inf,$min)U($max,inf)"}'
+						]
+					],
+					[
+						Composition => [
+							'$b=non_zero_random(-3,1,1)+1; # b=1 makes answers equal' . "\n"
+								. '$f = Formula("x+$b"); $g = Formula("(x-2)^2");' . "\n"
+								. '$F = "$f for x in [-1,5] using color:blue and weight:2";' . "\n"
+								. '$G = "$g for x in [0,4] using color:red and weight:2";'
+								. "\n\n"
+								. 'loadMacros("PGgraphmacros.pl");' . "\n"
+								. '$graph = init_graph(-2,-4,6,8,axes=>[0,0],grid=>[8,12],size=>[200,200]);' . "\n"
+								. 'plot_functions($graph,$F,$G);' . "\n"
+								. '$lf = new Label (5.3,$f->eval(x=>5)+.3,"f","blue","left","bottom");' . "\n"
+								. '$lg = new Label (.3,$g->eval(x=>0)+.3,"g","red","left","bottom");' . "\n"
+								. '$graph->lb($lf,$lg);',
+							"Let [`f`] be the linear function (in blue) and let [`g`] be the\n"
+								. "parabolic function (in red) below.\n\n"
+								. '    [@ image(insertGraph($graph),' . "\n"
+								. '             width=>200,height=>200,tex_size=>480) @]*'
+								. "\n\n"
+								. '    1.  [:(f o g)(2):] = [____]{$b}' . "\n"
+								. '    2.  [:(g o f)(2):] = [____]{$b**2}' . "\n"
+								. '    3.  [:(f o f)(2):] = [____]{2+2*$b}' . "\n"
+								. '    4.  [:(g o g)(2):] = [____]{4}'
+								. "\n\n"
+						]
+					],
+					[
+						Derivative => [
+							'$aa = random(3,8,1);' . "\n"
+								. '$f = Formula("atan(sqrt(${aa}x^2-1))");' . "\n"
+								. '$Df = $f->D->with(limits=>[1/sqrt($aa),1]);',
+							q!Let [`f(x) = [$f]`]. Find [`f'(x)`].!
+								. "\n\n"
+								. q![`f'(x)`] = [____________________________________]{$Df}!
+						]
+					],
+					[
+						Logarithm => [
+							'$a = random(3,5,1); $b = random(2,20,1); $c = random(2,20,1);',
+							'Use the laws of logarithms to rewrite the expression'
+								. "\n\n"
+								. '    [::ln(root [$a] of xy)::]'
+								. "\n\n"
+								. 'in a form that does not contain any logarithm of a product,' . "\n"
+								. 'quotient or power.'
+								. "\n\n"
+								. 'After rewriting, we have'
+								. "\n\n"
+								. '    [::ln(root [$a] of xy) = A ln x + B ln y::]'
+								. "\n\n"
+								. 'with constants'
+								. "\n\n"
+								. '    [`A`] = [_______________]{1/$a} and  ' . "\n"
+								. '    [`B`] = [_______________]{1/$b}.'
+								. "\n\n"
+						]
+					],
+					[
+						Optimization => [
+							'$a = random(200, 320, 10); $b = random(3, 6, 1); $c = random(12, 16, 1);'
+								. "\n\n"
+								. '$length = sqrt($a*($b+$c)/(2*$b)); $width = sqrt(2*$b*$a/($b+$c));'
+								. "\n\n"
+								. '$mp = MultiAnswer(Real($length), Real($width))->with(' . "\n"
+								. '  singleResult => 1, separator => " x ", tex_separator => "\\\\times",'
+								. "\n"
+								. '  checker => sub {' . "\n"
+								. '    my ($correct, $student) = @_;' . "\n"
+								. '    my ($a,$b) = @$correct; my ($A,$B) = @$student;' . "\n"
+								. '    return ($a == $A && $b == $B) || ($a == $B && $b == $A);' . "\n" . '  }'
+								. "\n" . ');',
+							'A fence is to be built to enclose a rectangular area of [$a] square' . "\n"
+								. 'feet.  The fence along three sides is to be made of material that' . "\n"
+								. 'costs [$b] dollars per foot, and the material for the fourth side' . "\n"
+								. 'costs [$c] dollars per foot.  Find the dimensions of the enclosure' . "\n"
+								. 'that is most economical to construct.'
+								. "\n\n"
+								. 'Dimensions: [___________]{$mp} x [___________]{$mp} feet'
+						]
+					],
+				)
+			)
+			)
+			. tag(
+				'fieldset',
+				style => 'border:1px solid #5555;border-radius:4px;padding:1rem;'
+				. 'display:flex;flex-direction:column;gap:0.25rem',
+				join(
+					'',
+					tag('legend', id => 'reference-label', style => 'font-size:20px', 'For reference only:'),
+					Menu(
+						'- Math -',                  '[`tex`]',
+						'[``display-tex``]',         '[:parsed-math:]',
+						'[::parsed-display-math::]', '[:parsed-math:]{context}',
+						'[:parsed-math:]*  (uses current context)',
+					),
+					Menu(
+						'- Answers -',                '[______] (# of _ is width)',
+						'[___]{answer}',              '[___]{answer}{width}',
+						'[___]{answer}{width}{name}', '[___]{answer=>...,width=>...,name=>...}',
+						'[___]*   (ans_array not ans_rule)',
+					),
+					Menu(
+						'- Lists -',
+						'1. (numeric list)',
+						'a. (alpha list)',
+						'A. (capital alphas)',
+						'i. (roman numerals)',
+						'I. (capital roman)',
+						'*  (bullet list)',
+						'-  (bullet list)',
+						'+  (square bullets)',
+						'o  (circle bullets)',
+					),
+					Menu(
+						'- Substitutions -',
+						'[$variable]',
+						'[$variable]* (no escaping)',
+						'[$variable]** (parse results)',
+						'[@ perl-command @]',
+						'[@ perl-command @]* (no escaping)',
+						'[@ perl-command @]** (parse results)',
+						'[% comment %]',
+						'[&lt;url&gt;] (not implemented)',
+						'[!image!] (not implemented)',
+					),
+					Menu(
+						'- Formatting -',
+						"$SP$SP\n     (line break)",
+						"$SP$SP$SP\n  (format break)",
+						'blankline  (par break)',
+						"$SP$SP$SP$SP or \t  (indent)",
+						'>> ... &lt;&lt;  (center)',
+						'>> ...     (right justify)',
+						'---        (hrule)',
+						'---{width}',
+						'---{width}{size}',
+						'*bold*',
+						'_italic_',
+						'*_bold-italic_*',
+						":$SP$SP$SP    (preformatted)",
+						'[|verbatim|]',
+					),
+					Menu(
+						'- Headings -',
+						'# heading 1 #',
+						'## heading 2 ##',
+						'### heading 3 ###',
+						'#### heading 4 ####',
+						'##### heading 5 #####',
+						'###### heading 6 ######',
+					)
+				)
+			)
+	));
+}
+
+ENDDOCUMENT();

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -95,15 +95,25 @@
 			),
 			class  => 'reference-link btn btn-sm btn-info',
 			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # https://courses1.webwork.maa.org/webwork2/cervone_course/PGML/1/?login_practice_user=true
-		<%= link_to maketext('PGML') => $ce->{webworkURLs}{PGMLHelpURL},
-			target => 'PGML',
-			title  => maketext(
-				'PG mark down syntax used to format WeBWorK questions. '
-				. 'This interactive lab can help you to learn the techniques.'
-			),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+		% # PGML lab problem rendered as an unattached problem in a new window.
+		% if (-e "$ce->{courseDirs}{templates}/PGMLLab/PGML-lab.pg") {
+			<%= link_to maketext('PGML') => $c->systemLink(
+					url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
+					params => {
+						displayMode    => $ce->{pg}{options}{displayMode},
+						problemSeed    => 1234,
+						editMode       => 'temporaryFile',
+						sourceFilePath => 'PGMLLab/PGML-lab.pg'
+					}
+				),
+				target => 'PGML',
+				title  => maketext(
+					'PG markdown syntax used to format WeBWorK questions. '
+					. 'This interactive lab can help you to learn the techniques.'
+				),
+				class  => 'reference-link btn btn-sm btn-info',
+				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+		% }
 		% # http://webwork.maa.org/wiki/Category:Authors
 		<%= link_to maketext('Author Info') => $ce->{webworkURLs}{AuthorHelpURL},
 			target => 'author_info',


### PR DESCRIPTION
The Rochester course that contains the PGML lab problem linked to for the PG Problem Editor is not working anymore.  So the PGML lab link in the problem editor needs to be handled differently.  This adds the problem to the modelCourse so it will be copied into newly created courses.  Then the PG problem editor checks to see if the file exists in the course templates directory, and if so adds a link that opens the problem in an undefined set and a new window.

This means that system administrators will need to update their local modelCourse copy, and then newly created courses will get the file.  Old coursed will need the file to be copied into their templates directory. If the file PGMLLab/PGML-lab.pg is not present in the course templates directory, the link will simply not be shown (better than a dead link to a server that isn't operational).

To test this on an existing course, you will need to recursively copy the `webwork2/courses.dist/modelCourse/PGMLLab` directory into the courses templates directory.

Another option would be to add this problem to the OPL.  Then the problem would be available for old courses assuming the OPL is updated.