### PR TITLE
Fix some issues with Achievements.pm

### DIFF
--- a/htdocs/themes/math4/achievements.scss
+++ b/htdocs/themes/math4/achievements.scss
@@ -20,7 +20,7 @@
 }
 
 .levelinnerbar {
-	height: 16px;
+	height: 100%;
 	background-color: var(--ww-achievement-level-color, #88D);
 }
 
@@ -46,7 +46,7 @@
 }
 
 .cheevoinnerbar {
-	height: 6px;
+	height: 100%;
 	background-color: var(--ww-achievement-level-color, #88D);
 }
 

--- a/templates/ContentGenerator/Achievements/achievement_badges.html.ep
+++ b/templates/ContentGenerator/Achievements/achievement_badges.html.ep
@@ -1,8 +1,7 @@
 <h2 class="my-3"><%= maketext('Badges') %></h2>
 %
-% my $previousCategory = $achievements->[0]->category;
-%
 % if (@$achievements) {
+	% my $previousCategory = $achievements->[0]->category;
 	% for my $achievement (@$achievements) {
 		% # Separate categories with whitespace.
 		% if ($achievement->category ne $previousCategory) {

--- a/templates/ContentGenerator/Instructor/AchievementList/edit_table_row.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/edit_table_row.html.ep
@@ -8,7 +8,7 @@
 	<%= hidden_field $fieldName => 0 =%>
 % } elsif ($fieldName =~ /\.assignment_type$/) {
 	% my @allowedTypes = split(',', $value);
-	% for my $type ([ default => 'homework' ], [ gateway => 'gateways' ], [ jitar => 'just-in-time' ]) {
+	% for my $type ([ default => 'homework' ], [ gateway => 'tests' ], [ jitar => 'just-in-time' ]) {
 		<label class="form-check-label me-1">
 			<%= $type->[1] =%>
 			<%= check_box $fieldName => $type->[0], class => 'form-check-input me-1',


### PR DESCRIPTION
This includes two fixes.

The first is that if a student has global achievement data but is not assigned to any visible achievement badges, the page errors out due to calling a method on an undefined achievement. Here is the error:

```
Error messages

Can't call method "category" on an undefined value at template
ContentGenerator/Achievements/achievement_badges.html.ep line 3.

Context

    1: <h2 class="my-3"><%= maketext('Badges') %></h2>

    2: %

    3: % my $previousCategory = $achievements->[0]->category;

    4: %

    5: % if (@$achievements) {

    6: 	% for my $achievement (@$achievements) {
```

This fixes the issue by moving the definition of `$previousCategory` inside the if block which first checks that visible achievements exist.

The second is the achievement progress bars height of the inner div can be one pixel too big or too small (probably due to rounding issues) when viewing the achievements on certain resolutions/zoom sizes.

This fixes the issue by making the height of the inner bars all `100%` instead of a set pixel size, which ensures the height always matches the size of the outside div. Though this fix also makes the `.levelinnerbar` and `.cheevoinnerbar` classes the same (should these be combined into a single class or left as is?).