### PR TITLE
Fetch feedback mail recipients only when needed.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -994,6 +994,8 @@ sub feedbackMacro ($c, %params) {
 		return $c->link_to(($c->maketext($c->ce->{feedback_button_name}) || $c->maketext('Email instructor')) =>
 				$c->ce->{courseURLs}{feedbackURL});
 	} elsif ($c->ce->{courseURLs}{feedbackFormURL}) {
+		$params{notifyAddresses} =
+			join(';', $c->fetchEmailRecipients('receive_feedback', $c->db->getUser($c->param('user'))));
 		return $c->include(
 			'ContentGenerator/Base/feedback_macro_form',
 			params          => \%params,

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1660,15 +1660,16 @@ sub output_past_answer_button ($c) {
 sub output_email_instructor ($c) {
 	my $user = $c->db->getUser($c->param('user'));
 
+	# FIXME: Most of what is passed here is only needed by the feedback form, and should be extracted in the
+	# feedbackMacro method and only for that case.
 	return $c->feedbackMacro(
-		route           => $c->current_route,
-		courseId        => $c->stash('courseID'),
-		set             => $c->{set}->set_id,
-		problem         => $c->{problem}->problem_id,
-		problemPath     => $c->{problem}->source_file,
-		randomSeed      => $c->{problem}->problem_seed,
-		notifyAddresses => join(';', $c->fetchEmailRecipients('receive_feedback', $user)),
-		emailableURL    => $c->generateURLs(
+		route        => $c->current_route,
+		courseId     => $c->stash('courseID'),
+		set          => $c->{set}->set_id,
+		problem      => $c->{problem}->problem_id,
+		problemPath  => $c->{problem}->source_file,
+		randomSeed   => $c->{problem}->problem_seed,
+		emailableURL => $c->generateURLs(
 			url_type   => 'absolute',
 			set_id     => $c->{set}->set_id,
 			problem_id => $c->{problem}->problem_id

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -1807,22 +1807,26 @@ ID: foreach my $id (@problemIDs) {
 	return 1;
 }
 
-# requires a CG object, and a permission type
-# a user may also be submitted, in case we need to filter by section
-
+# Requires a ContentGenerator object, and a permission type.
+# If the optional sender argument is provided, then filter on the section of the given sender.
 sub fetchEmailRecipients {
-	my ($c, $permissionType, $sender) = @_;    # sender argument is optional
+	my ($c, $permissionType, $sender) = @_;
 	my $db    = $c->db;
 	my $ce    = $c->ce;
 	my $authz = $c->authz;
 
-	return unless $permissionType;
+	return
+		unless $permissionType
+		&& defined $ce->{permissionLevels}{$permissionType}
+		&& defined $ce->{userRoles}{ $ce->{permissionLevels}{$permissionType} };
 
-	# FIXME:  This is a very expensive and slow process.  It retrieves all users from the database that have email
-	# addresses, and then proceeds to check permissions for all of those users.  For large classes this can be extremely
-	# slow.  Fixing this would require completely reworking the way that feedback recipients are determined.
 	my @recipients =
-		map { $_->rfc822_mailbox } grep { $authz->hasPermissions($_->user_id, $permissionType) } $db->getUsersWhere({
+		map { $_->rfc822_mailbox } $db->getUsersWhere({
+			user_id => [
+				map { $_->user_id } $db->getPermissionLevelsWhere(
+					{ permission => { '>=' => $ce->{userRoles}{ $ce->{permissionLevels}{$permissionType} } } }
+				)
+			],
 			email_address => { '!=', undef },
 			$ce->{feedback_by_section}
 			&& defined $sender


### PR DESCRIPTION
This moves the call to fetchEmailRecipients out of Problem.pm and into the feedbackMacro method, and only in the case the the feedback form is used.  That is the only case that needs the list, and that expensive call makes changing problems very slow for large classes.

This fixes the issue observed in
https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8214.  Note that this regression was introduced in WeBWorK 2.16.

Also make the Feedback.pm module use the Utils.pm fetchEmailRecipients method, and improve that method to add in the course environemnt $mail{feedbackRecipients} values as the previous Feedback.pm getFeedbackRecipients method did.

There is a larger problem here though.  The method that we use to determine feedback recipients requires retrieving all users from the database.  That is an expensive query, and should not be done for something as simple as determining email feedback recipients.