### PR TITLE
No more "Take Action!" button.  Stop taking action.  Just sleep.

### DIFF
--- a/htdocs/js/apps/ActionTabs/actiontabs.js
+++ b/htdocs/js/apps/ActionTabs/actiontabs.js
@@ -1,6 +1,12 @@
-document.querySelectorAll('.action-link').forEach((actionLink) => {
-	actionLink.addEventListener('click', () => {
-		actionLink.blur();
-		document.getElementById("current_action").value = actionLink.dataset.action;
+(() => {
+	const takeAction = document.getElementById('take_action');
+
+	document.querySelectorAll('.action-link').forEach((actionLink) => {
+		const currentAction = document.getElementById('current_action');
+		actionLink.addEventListener('click', () => {
+			actionLink.blur();
+			if (takeAction) takeAction.value = actionLink.textContent;
+			if (currentAction) currentAction.value = actionLink.dataset.action;
+		});
 	});
-});
+})();

--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -89,7 +89,7 @@
 			?.addEventListener('change', () => deleteBackupCheck.checked = true);
 	}
 
-	document.getElementById('submit_button_id')?.addEventListener('click', async (e) => {
+	document.getElementById('take_action')?.addEventListener('click', async (e) => {
 		const actionView = document.getElementById('view');
 		const editorForm = document.getElementById('editor');
 
@@ -287,7 +287,7 @@
 		})).then(() => resolve());
 	});
 
-	// This is used to protect against rapid successive clicks on the "Randomize Seed" or "Take Action" buttons.
+	// This is used to protect against rapid successive clicks on the "Randomize Seed" or "View/Reload" buttons.
 	let rendering = false;
 
 	const renderProblem = (body) => new Promise((resolve) => {

--- a/htdocs/js/apps/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/apps/ProblemSetList/problemsetlist.js
@@ -1,5 +1,5 @@
 (() => {
-	// Show the filter error message if the 'Take Action' button is clicked when matching set IDs without having entered
+	// Show the filter error message if the 'Filter' button is clicked when matching set IDs without having entered
 	// a text to filter on.
 	document.getElementById('take_action')?.addEventListener('click',
 		(e) => {

--- a/templates/ContentGenerator/Instructor/AchievementEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementEditor.html.ep
@@ -61,5 +61,8 @@
 		<ul class="nav nav-tabs mb-2" role="tablist"><%= content 'tab-list' =%></ul>
 		<div class="tab-content"><%= content 'tab-content' %></div>
 	</div>
-	<div><%= submit_button maketext('Take Action!'), name => 'submit', class => 'btn btn-primary' %></div>
+	<div>
+		<%= submit_button maketext($actionFormTitles->{$default_choice}),
+			name => 'submit', id => 'take_action', class => 'btn btn-primary' %>
+	</div>
 <% end =%>

--- a/templates/ContentGenerator/Instructor/AchievementList.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList.html.ep
@@ -59,7 +59,8 @@
 			% }
 		</div>
 	</div>
-	<%= submit_button maketext('Take Action!'), id => 'take_action', class => 'btn btn-primary mb-3' =%>
+	<%= submit_button maketext($formTitles->{ $formsToShow->[0] }),
+		id => 'take_action', class => 'btn btn-primary mb-3' =%>
 	% if ($c->{exportMode}) {
 		<%= include 'ContentGenerator/Instructor/AchievementList/export_table' =%>
 	% } elsif ($c->{editMode}) {

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -190,7 +190,7 @@
 		<div class="tab-content"><%= content 'tab-content' %></div>
 	</div>
 	<div>
-		<%= submit_button maketext('Take Action!'), name => 'submit', id => 'submit_button_id',
+		<%= submit_button maketext($actionFormTitles->{$default_choice}), name => 'submit', id => 'take_action',
 			class => 'btn btn-primary' =%>
 	</div>
 <% end =%>

--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -125,7 +125,8 @@
 		<div class="tab-content"><%= content 'tab-content' %></div>
 	</div>
 	<div>
-		<%= submit_button maketext('Take Action!'), id => 'take_action', class => 'btn btn-primary mb-3' =%>
+		<%= submit_button maketext($formTitles->{$default_choice}),
+			id => 'take_action', class => 'btn btn-primary mb-3' =%>
 	</div>
 	%
 	<p class="mb-2">

--- a/templates/ContentGenerator/Instructor/UserList.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList.html.ep
@@ -95,7 +95,7 @@
 	</div>
 	%
 	<div class="mb-3">
-		<%= submit_button maketext('Take Action!'), id => 'take_action', class => 'btn btn-primary' =%>
+		<%= submit_button maketext($formTitles->{$default_choice}), id => 'take_action', class => 'btn btn-primary' =%>
 	</div>
 	%
 	<p class="mb-0"><%= maketext('Showing [_1] out of [_2] users',


### PR DESCRIPTION
On the pages that utilize action tabs, instead of the button reading "Take Action!" it now has the text of the currently active tab.

Note that some of the help files reference the "Take Action!" button. That will be changed in #1967.

Also, there are "Take Action!" buttons on the location management pages in the course administration course.  Those are left for now.  Those pages do not use the action tab javascript.