### PR TITLE
Add a link to the set assigner page in the site nav.

### DIFF
--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -129,6 +129,8 @@
 							</ul>
 						</li>
 					% }
+					% # Set assigner
+					<li class="nav-item"><%= $makelink->('instructor_set_assigner') %></li>
 					% # Library Browser
 					<li class="nav-item"><%= $makelink->('instructor_set_maker') %></li>
 					% # Statistics


### PR DESCRIPTION
Previously this page could only be accessed from the "Instructor Tools" page when using the "Assign" button, and when you get to the page the job of assigning the selected sets to the selected users is already done.  Although this page also allows mass unassigning.