### PR TITLE
Include number of incorrect attempts for sets in student progress table.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -177,14 +177,14 @@ sub displaySets ($c) {
 			$score = wwRound(2, $score);
 
 			my $version_data = {
-				version            => $vNum,
-				score              => $score,
-				total              => $total,
-				date               => $dateOfTest,
-				testtime           => $testTime,
-				timeleft           => $timeLeft,
-				problem_scores     => $problem_scores,
-				incorrect_attempts => ''
+				version                    => $vNum,
+				score                      => $score,
+				total                      => $total,
+				date                       => $dateOfTest,
+				testtime                   => $testTime,
+				timeleft                   => $timeLeft,
+				problem_scores             => $problem_scores,
+				problem_incorrect_attempts => $problem_incorrect_attempts
 			};
 
 			if ($showBestOnly) {


### PR DESCRIPTION
  This makes the problem table consistent with other uses of it on
  grades pages, and correctly displays the number which is mentioned
  in help text at the top of the table.