### PR TITLE
Add set status message to ProblemSet and StudentProgress pages.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -536,7 +536,7 @@ sub links ($c) {
 		# Do not use HTML::Entities::encode_entities on the link text.
 		# Mojolicious has already encoded html entities at this point.
 		return $c->link_to(
-			($options{text} // route_title($c, $route_name)) => $c->systemLink(
+			($options{text} // route_title($c, $route_name, 1)) => $c->systemLink(
 				$new_url, params => { %systemlink_params, %{ $options{systemlink_params} // {} } }
 			),
 			class => 'nav-link' . ($active ? ' active' : ''),
@@ -691,7 +691,7 @@ sub page_title ($c) {
 		return $db->getSettingValue('courseTitle');
 	} else {
 		# Display the route name
-		return route_title($c, $c->current_route);
+		return route_title($c, $c->current_route, 1);
 	}
 }
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -69,13 +69,11 @@ sub page_title ($c) {
 	return '' unless $c->authz->hasPermissions($c->param('user'), 'access_instructor_tools');
 
 	if ($c->current_route eq 'instructor_user_progress') {
-		return $c->maketext('Student Progress for [_1] student [_2]', $c->ce->{courseName}, $c->{studentID});
+		return $c->maketext('Student Progress for [_1]', $c->{studentID});
 	} elsif ($c->current_route eq 'instructor_set_progress') {
 		return $c->maketext(
-			'Student Progress for [_1] set [_2]. Closes [_3]',
-			$c->ce->{courseName},
+			'Student Progress for set [_1]',
 			$c->tag('span', dir => 'ltr', format_set_name_display($c->stash('setID'))),
-			$c->formatDateTime($c->{setRecord}->due_date)
 		);
 	}
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -116,14 +116,6 @@ sub nav ($c, $args) {
 	);
 }
 
-sub page_title ($c) {
-	my $ce = $c->ce;
-
-	# Using the url path parameters won't break if the set/problem are invalid.
-	my $setID = $c->stash('setID');
-	return $c->tag('span', dir => 'ltr', format_set_name_display($setID));
-}
-
 sub siblings ($c) {
 	my $db    = $c->db;
 	my $ce    = $c->ce;

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -121,32 +121,7 @@ sub page_title ($c) {
 
 	# Using the url path parameters won't break if the set/problem are invalid.
 	my $setID = $c->stash('setID');
-
-	my $title = $c->tag('span', dir => 'ltr', format_set_name_display($setID));
-
-	# Put either due date or reduced scoring date in the title.
-	my $set = $c->db->getMergedSet($c->param('effectiveUser'), $setID);
-	if (defined($set) && between($set->open_date, $set->due_date)) {
-		if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
-			&& $set->enable_reduced_scoring
-			&& $set->reduced_scoring_date
-			&& $set->reduced_scoring_date != $set->due_date
-			&& before($set->reduced_scoring_date))
-		{
-			$title .= ' - '
-				. $c->maketext(
-					'Due [_1], after which reduced scoring is available until [_2]',
-					$c->formatDateTime($set->reduced_scoring_date, undef, $ce->{studentDateDisplayFormat}),
-					$c->formatDateTime($set->due_date,             undef, $ce->{studentDateDisplayFormat})
-				);
-		} elsif ($set->due_date) {
-			$title .= ' - '
-				. $c->maketext('Closes [_1]',
-					$c->formatDateTime($set->due_date, undef, $ce->{studentDateDisplayFormat}));
-		}
-	}
-
-	return $title;
+	return $c->tag('span', dir => 'ltr', format_set_name_display($setID));
 }
 
 sub siblings ($c) {

--- a/templates/ContentGenerator/Base/set_status.html.ep
+++ b/templates/ContentGenerator/Base/set_status.html.ep
@@ -7,7 +7,7 @@
 	% && $set->reduced_scoring_date != $set->due_date
 % );
 % 
-<div class="alert alert-warning mb-3">
+<div class="alert alert-info mb-3">
 	<%== $useReducedScoring ? '<p>' : '<p class="mb-0">' =%> 
 		<strong>
 			% if (before($set->open_date)) {

--- a/templates/ContentGenerator/Base/set_status.html.ep
+++ b/templates/ContentGenerator/Base/set_status.html.ep
@@ -1,0 +1,52 @@
+% use WeBWorK::Utils qw(after before between);
+%
+% my $useReducedScoring = ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+	% && after($set->open_date)
+	% && $set->enable_reduced_scoring
+	% && $set->reduced_scoring_date
+	% && $set->reduced_scoring_date != $set->due_date
+% );
+% 
+<div class="alert alert-warning mb-3">
+	<%== $useReducedScoring ? '<p>' : '<p class="mb-0">' =%> 
+		<strong>
+			% if (before($set->open_date)) {
+				<%= maketext('Set opens on [_1].', $c->formatDateTime($set->open_date)) %>
+			% } elsif ($useReducedScoring && before($set->reduced_scoring_date)) {
+				<%= maketext('Set is due on [_1].', $c->formatDateTime($set->reduced_scoring_date)) %>
+			% } elsif (before($set->due_date)) {
+				<%= maketext('Set closes on [_1].', $c->formatDateTime($set->due_date)) %>
+			% } else {
+				<%= maketext('Set is closed.') %>
+			% }
+		</strong>
+	</p>
+	%
+	% if ($useReducedScoring) {
+		% my $reduced_scoring_date  = $set->reduced_scoring_date;
+		% my $reducedScoringPerCent = int(100 * $ce->{pg}{ansEvalDefaults}{reducedScoringValue} + .5);
+		%
+		<p class="mb-0">
+			% if (before($reduced_scoring_date)) {
+				<%= maketext(
+					'After the due date this set enters a reduced scoring period until it closes on [_1].  All work '
+						. 'completed during the reduced scoring period counts for [_2]% of its value.',
+					$c->formatDateTime($set->due_date), $reducedScoringPerCent
+				) =%>
+			% } elsif (between($reduced_scoring_date, $set->due_date)) {
+				<%= maketext(
+					'This set is in its reduced scoring period.  All work counts for [_1]% of its value.',
+					$reducedScoringPerCent
+				) =%>
+			% } else {
+				<%= maketext(
+					'This set had a reduced scoring period that started on [_1] and ended on [_2].  '
+						. 'During that period all work counted for [_3]% of its value.',
+					$c->formatDateTime($reduced_scoring_date),
+					$c->formatDateTime($set->due_date),
+					$reducedScoringPerCent
+				) =%>
+			% }
+		</p>
+	% }
+</div>

--- a/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
@@ -1,3 +1,5 @@
+<%= include 'ContentGenerator/Base/set_status', set => $c->{setRecord} =%>
+%
 % # In the case of gateway tests, add a form with checkboxes that allow customization of what is included in the
 % # display.
 % if ($setIsVersioned) {

--- a/templates/ContentGenerator/ProblemSet.html.ep
+++ b/templates/ContentGenerator/ProblemSet.html.ep
@@ -19,39 +19,9 @@
 % }
 %
 % my $set = $c->{set};
-%
-% if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
-	% && $set->enable_reduced_scoring
-	% && $set->reduced_scoring_date
-	% && $set->reduced_scoring_date != $set->due_date
-% ) {
-	% my $reduced_scoring_date  = $set->reduced_scoring_date;
-	% my $reducedScoringPerCent = int(100 * $ce->{pg}{ansEvalDefaults}{reducedScoringValue} + .5);
-	%
-	% if (before($reduced_scoring_date)) {
-		<div class="alert alert-warning mb-3">
-			<%= maketext(
-				'After the reduced scoring period begins all work counts for [_1]% of its value.',
-				$reducedScoringPerCent
-			) =%>
-		</div>
-	% } elsif (between($reduced_scoring_date, $set->due_date)) {
-		<div class="alert alert-warning mb-3">
-			<%= maketext(
-				'This set is in its reduced scoring period.  All work counts for [_1]% of its value.',
-				$reducedScoringPerCent
-			) =%>
-		</div>
-	% } else {
-		<div class="alert alert-warning mb-3">
-			<%= maketext(
-				'This set had a reduced scoring period that started on [_1] and ended on [_2].  '
-					. 'During that period all work counted for [_3]% of its value.',
-				$c->formatDateTime($reduced_scoring_date), $c->formatDateTime($set->due_date), $reducedScoringPerCent
-			) =%>
-		</div>
-	% }
-% }
+% 
+% # Stats message displays the current status of the set and states the next important date.
+<%= include 'ContentGenerator/Base/set_status', set => $set =%>
 %
 <%= $set->assignment_type =~ /gateway/ ? $c->gateway_body : $c->problem_list =%>
 %

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -143,12 +143,10 @@
 		% }
 	% }
 	%
-	% # Is it past due date?
-	% if ($timeNow >= $set->due_date) {
-		% $msg = maketext('This test is closed.');
+	% # Only print status message if the set is open.
+	% if ($timeNow < $set->due_date) {
+		<div class="alert alert-dark"><strong><%= $msg %></strong></div>
 	% }
-	%
-	<div class="alert alert-dark"><strong><%= $msg %></strong></div>
 % }
 %
 % if (@$setVersions) {


### PR DESCRIPTION
  This removes the due dates from the main page title on the ProblemSet
  and StudentProgress for sets pages and instead puts that information
  into a status alert (similar to where the reduced scoring information
  was already) that states when a set will open, is due (enters reduced
  scoring period), or is closed.  If the set uses reduced scoring the
  reduced reduced scoring message is included in the alert.