### PR TITLE
Fix and update Email page.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -99,11 +99,10 @@ $mail{feedbackVerbosity}     = 1;
 # The default is yes
 $blockStudentIDinFeedback = 0;
 
-# Defines the size of the Mail Merge editor window
+# Defines the initial height of the Mail Merge editor window
 # FIXME: should this be here? it's UI, not mail
 # FIXME: replace this with the auto-size method that TWiki uses
 $mail{editor_window_rows}    = 15;
-$mail{editor_window_columns} = 100;
 
 ##################################################################################
 # Customizing the action of the "Email your instructor" button

--- a/htdocs/js/apps/SendMail/sendmail.js
+++ b/htdocs/js/apps/SendMail/sendmail.js
@@ -8,4 +8,20 @@
 			else previewUserNameSpan.textContent = previewUserNameSpan.dataset.default;
 		});
 	}
+
+	for (const select of [
+		['openfilename', 'openMessage'],
+		['merge_file', 'viewMergeFile']
+	]) {
+		document.getElementById(select[0])?.addEventListener('change', () => {
+			const mailForm = document.forms['mail-main-form'];
+			if (!mailForm) return;
+			const submit = document.createElement('input');
+			submit.type = 'submit';
+			submit.name = select[1];
+			submit.style.display = 'none';
+			mailForm.append(submit);
+			submit.click();
+		});
+	}
 })();

--- a/htdocs/js/apps/SendMail/sendmail.js
+++ b/htdocs/js/apps/SendMail/sendmail.js
@@ -1,0 +1,11 @@
+(() => {
+	const previewUserNameSpan = document.getElementById('preview-user');
+	if (previewUserNameSpan) {
+		const classListSelect = document.getElementById('classList');
+		classListSelect?.addEventListener('change', () => {
+			if (classListSelect.selectedIndex !== -1)
+				previewUserNameSpan.textContent = classListSelect.options[classListSelect.selectedIndex].textContent;
+			else previewUserNameSpan.textContent = previewUserNameSpan.dataset.default;
+		});
+	}
+})();

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -441,31 +441,23 @@ sub read_input_file ($c, $filePath) {
 	my $header = '';
 	my ($subject, $from, $replyTo);
 
-	if (-e "$filePath" and -r "$filePath") {
-		open my $FILE, "<:encoding(UTF-8)", $filePath
-			or do { $c->addbadmessage($c->maketext(q{Can't open [_1]}, $filePath)); return };
-		while ($header !~ s/Message:\s*$//m and not eof($FILE)) {
-			$header .= <$FILE>;
-		}
-		$text = join('', <$FILE>);
-		close $FILE;
-
-		$text   =~ s/^\s*//;           # remove initial white space if any.
-		$header =~ /^From:\s(.*)$/m;
-		$from = $1 or $from = $c->{defaultFrom};
-
-		$header =~ /^Reply-To:\s(.*)$/m;
-		$replyTo = $1 or $replyTo = $c->{defaultReply};
-
-		$header =~ /^Subject:\s(.*)$/m;
-		$subject = $1;
-
-	} else {
-		$from    = $c->{defaultFrom};
-		$replyTo = $c->{defaultReply};
-		$text    = (-e "$filePath") ? "FIXME file $filePath can't be read" : "FIXME file $filePath doesn't exist";
-		$subject = $c->{defaultSubject};
+	open my $FILE, "<:encoding(UTF-8)", $filePath
+		or do { $c->addbadmessage($c->maketext(q{Can't open [_1]}, $filePath)); return };
+	while ($header !~ s/Message:\s*$//m and not eof($FILE)) {
+		$header .= <$FILE>;
 	}
+	$text = join('', <$FILE>);
+	close $FILE;
+
+	$text   =~ s/^\s*//;           # remove initial white space if any.
+	$header =~ /^From:\s(.*)$/m;
+	$from = $1 || $c->{defaultFrom};
+
+	$header =~ /^Reply-To:\s(.*)$/m;
+	$replyTo = $1 || $c->{defaultReply};
+
+	$header =~ /^Subject:\s(.*)$/m;
+	$subject = $1 || $c->{defaultSubject};
 
 	return ($from, $replyTo, $subject, \$text);
 }

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -408,12 +408,16 @@ sub print_preview ($c) {
 		"\n"
 	);
 
+	# Associate usernames to student ids to test if merge data is found.
+	my %student_ids = map { $_->user_id => $_->student_id } @{ $c->{ra_user_records} };
+
 	return $c->include(
 		'ContentGenerator/Instructor/SendMail/preview',
 		preview_header => $preview_header,
 		ur             => $c->{preview_user},
 		msg            => $msg,
-		recipients     => join(" ", @{ $c->{ra_send_to} })
+		merge_data     => $rh_merge_data,
+		student_ids    => \%student_ids,
 	);
 }
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -475,7 +475,7 @@ sub data_format ($c, @data) {
 }
 
 sub data_format2 ($c, @data) {
-	return map { $_ =~ s/\s/&nbsp;/gr } map { sprintf('%-8.8s', $_) } @data;
+	return map { $_ =~ s/\s/&nbsp;/gr } map { sprintf('%-8.7s', $_) } @data;
 }
 
 1;

--- a/templates/ContentGenerator/Instructor/SendMail.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail.html.ep
@@ -1,3 +1,9 @@
+% use WeBWorK::Utils qw(getAssetURL);
+%
+% content_for js => begin
+	<%= javascript getAssetURL($ce, 'js/apps/SendMail/sendmail.js'), defer => undef =%>
+% end
+%
 % unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
 	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to access instructor tools') %></div>
 	% last;

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -14,30 +14,24 @@
 						<%= label_for 'openfilename', class => 'input-group-text', begin =%>
 							<strong><%= maketext('Message file:') %></strong>
 						<% end =%>
-						<span class="input-group-text"><%= $c->{input_file} %></span>
-					</div>
-					<div class="input-group input-group-sm mb-2">
-						<%= submit_button maketext('Open'), name => 'openMessage', class => 'btn btn-secondary' =%>
 						<%= select_field openfilename => [
 								map { [ $_ => $_, $_ eq $c->{input_file} ? (selected => undef) : () ] }
 								$c->get_message_file_names
 							],
 							id => 'openfilename', class => 'form-select form-select-sm' =%>
-					</div>
-					<div class="input-group input-group-sm mb-2">
-						<span class="input-group-text"><strong><%= maketext('Save file to:') %></strong></span>
-						<span class="input-group-text"><%= $c->{output_file} %></span>
+						<%= submit_button maketext('Open'), name => 'openMessage', class => 'btn btn-secondary' =%>
 					</div>
 					<div class="input-group input-group-sm mb-2">
 						<%= label_for 'merge_file', class => 'input-group-text', begin =%>
 							<strong><%= maketext('Merge file:') %></strong>
 						<% end =%>
-						<span class="input-group-text"><%= $merge_file %></span>
+						<%= select_field merge_file => [
+								map { [ $_ => $_, $_ eq $merge_file ? (selected => undef) : () ] }
+								$c->get_merge_file_names
+							],
+							id => 'merge_file', class => 'form-select form-select-sm' =%>
+						<%= submit_button maketext('View'), name => 'viewMergeFile', class => 'btn btn-secondary' =%>
 					</div>
-					<%= select_field merge_file => [
-							map { [ $_ => $_, $_ eq $merge_file ? (selected => undef) : () ] } $c->get_merge_file_names
-						],
-						id => 'merge_file', class => 'form-select form-select-sm mb-2' =%>
 					<div class="row mb-1">
 						<%= label_for from => maketext('From:'),
 							class => 'col-sm-3 col-form-label col-form-label-sm' =%>
@@ -62,27 +56,63 @@
 								class => 'form-control form-control-sm' =%>
 						</div>
 					</div>
-					<div class="row mb-2">
-						<%= label_for rows => maketext('Editor rows:'),
-							class => 'col-3 col-form-label col-form-label-sm' =%>
-						<div class="col-9">
-							<%= text_field rows => $c->{rows}, id => 'rows', size => 3,
-								class => 'form-control form-control-sm d-inline w-auto' =%>
-						</div>
-					</div>
-					<%= submit_button maketext('Update settings and refresh page'),
-						name => 'updateSettings', class => 'btn btn-secondary btn-sm' =%>
-				</div>
-				<div class="col-md-6 mb-2">
 					<div class="form-check">
 						<%= radio_button send_to => 'all_students', id => 'send_to_all', class => 'form-check-input' =%>
 						<%= label_for send_to_all => maketext('Send to all students'), class => 'form-check-label' =%>
 					</div>
-					<div class="form-check">
+					<div class="form-check mb-2">
 						<%= radio_button send_to => 'studentID', id => 'send_to_selected', class => 'form-check-input',
 							checked => undef =%>
-							<%= label_for send_to_selected => maketext('Send to the students selected below'),
+							<%= label_for send_to_selected => maketext('Send to selected students'),
 								class => 'form-check-label' =%>
+					</div>
+					<div class="mb-2">
+						<%= submit_button maketext('Preview Message'),
+								name => 'previewMessage', class => 'btn btn-secondary btn-sm' =%>
+					</div>
+					<div class="mb-2">
+						<%= submit_button maketext('Send Email'), name => 'sendEmail',
+							class => 'btn btn-secondary btn-sm d-inline w-auto' =%>
+					</div>
+					% # Insert a toast containing a list of available macros.
+					<div class="mb-0">
+						<button id="insertable-macros-btn" class="btn btn-secondary btn-sm" type="button">
+							<%= maketext('List of insertable macros') =%>
+						</button>
+					</div>
+					<div class="position-fixed top-0 end-0 p-3" style="z-index: 21">
+						<div id="insertable-macros" class="toast bg-white" role="alert" aria-live="polite"
+								aria-atomic="true">
+							<div class="toast-header">
+								<strong class="me-auto"><%= maketext('List of insertable macros') %></strong>
+								<button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close">
+								</button>
+							</div>
+							<div class="toast-body">
+								<table class="table table-bordered table-sm align-middle w-auto mb-0 mx-auto">
+									<thead>
+										<tr><th><%= maketext('Macro') %></th><th><%= maketext('Value') %></th></tr>
+									</thead>
+									<tbody class="table-group-divider">
+										<tr><td>$SID</td><td><%= maketext('Student ID') %></td></tr>
+										<tr><td>$FN</td><td><%= maketext('First name') %></td></tr>
+										<tr><td>$LN</td><td><%= maketext('Last name') %></td></tr>
+										<tr><td>$SECTION</td><td><%= maketext('Section') %></td></tr>
+										<tr><td>$RECITATION</td><td><%= maketext('Recitation') %></td></tr>
+										<tr><td>$STATUS</td><td><%= maketext('Enrolled, Drop, etc.') %></td></tr>
+										<tr><td>$EMAIL</td><td><%= maketext('Email address') %></td></tr>
+										<tr><td>$LOGIN</td><td><%= maketext('Login') %></td></tr>
+										<tr><td>$COL[n]</td><td><%= maketext('nth colum of merge file') %></td></tr>
+										<tr><td>$COL[-1]</td><td><%= maketext('Last column of merge file') %></td></tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="col-md-6 mb-0">
+					<div class="mb-2">
+						<strong><%= maketext('Students') %></strong>
 					</div>
 					<div class="mb-2">
 						<%= scrollingRecordList(
@@ -92,56 +122,11 @@
 								default_sort        => 'lnfn',
 								default_format      => 'lnfn_uid',
 								default_filters     => ['all'],
-								refresh_button_name => maketext('Update settings and refresh page'),
+								refresh_button_name => maketext('Change Display Settings'),
 								attrs               => { size => 5, multiple => undef }
 							},
 							@{ $c->{ra_user_records} }
 						) =%>
-					</div>
-					% my $preview_record = $db->getUser($c->{preview_user});
-					% if ($preview_record) {
-						<div class="input-group input-group-sm mb-2">
-							<%= submit_button maketext('Preview Message'),
-								name => 'previewMessage', class => 'btn btn-secondary btn-sm' =%>
-							<span class="input-group-text text-nowrap">
-								<strong><%= maketext('for') %></strong>
-								&nbsp;<%= $preview_record->last_name %>, <%= $preview_record->first_name %>
-								(<%= $preview_record->user_id %>)
-							</span>
-						</div>
-					% }
-				</div>
-			</div>
-			% # Insert a toast containing a list of available macros.
-			<div class="d-flex justify-content-center">
-				<button id="insertable-macros-btn" class="btn btn-secondary btn-sm" type="button">
-					<%= maketext('List of insertable macros') =%>
-				</button>
-			</div>
-			<div class="position-fixed top-0 end-0 p-3" style="z-index: 21">
-				<div id="insertable-macros" class="toast bg-white" role="alert" aria-live="polite" aria-atomic="true">
-					<div class="toast-header">
-						<strong class="me-auto"><%= maketext('List of insertable macros') %></strong>
-						<button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-					</div>
-					<div class="toast-body">
-						<table class="table table-bordered table-sm align-middle w-auto mb-0 mx-auto">
-							<thead>
-								<tr><th><%= maketext('Macro') %></th><th><%= maketext('Value') %></th></tr>
-							</thead>
-							<tbody class="table-group-divider">
-								<tr><td>$SID</td><td><%= maketext('Student ID') %></td></tr>
-								<tr><td>$FN</td><td><%= maketext('First name') %></td></tr>
-								<tr><td>$LN</td><td><%= maketext('Last name') %></td></tr>
-								<tr><td>$SECTION</td><td><%= maketext('Section') %></td></tr>
-								<tr><td>$RECITATION</td><td><%= maketext('Recitation') %></td></tr>
-								<tr><td>$STATUS</td><td><%= maketext('Enrolled, Drop, etc.') %></td></tr>
-								<tr><td>$EMAIL</td><td><%= maketext('Email address') %></td></tr>
-								<tr><td>$LOGIN</td><td><%= maketext('Login') %></td></tr>
-								<tr><td>$COL[n]</td><td><%= maketext('nth colum of merge file') %></td></tr>
-								<tr><td>$COL[-1]</td><td><%= maketext('Last column of merge file') %></td></tr>
-							</tbody>
-						</table>
 					</div>
 				</div>
 			</div>
@@ -149,10 +134,15 @@
 	</div>
 	%
 	% # Merge file fragment and message text area field
+	% if ($merge_file ne 'None') {
+		<div class="mb-2">
+			<%= maketext('Viewing data from merge file [_1] for user [_2].', $merge_file, $c->{preview_user}) =%>
+		</div>
+	% }
 	% my $rh_merge_data = $c->read_scoring_file($merge_file);
 	% my @merge_data = eval { @{ $rh_merge_data->{ $db->getUser($c->{preview_user})->student_id } } };
 	% if ($@ && $merge_file ne 'None') {
-		<div class="mb-3"><%= "No merge data for $c->{preview_user} in merge file: $merge_file" =%></div>
+		<div class="mb-3"><%= maketext('No merge data found.') =%></div>
 	% } elsif (@merge_data) {
 		<pre><%== join('', ' ', $c->data_format(1 .. ($#merge_data + 1))) =%>\
 			<br><% =%>\
@@ -171,16 +161,12 @@
 		<% end =%>
 		<%= text_area body =>
 			defined $c->{r_text} ? ${ $c->{r_text} } : 'FIXME no text was produced by initialization!',
-			id => 'email-body', rows => $c->{rows}, class => 'form-control' %>
+			id => 'email-body', rows => $ce->{mail}->{editor_window_rows}, class => 'form-control' %>
 	</div>
 	%
 	% # Action buttons
 	<div class="card">
 		<div class="card-body p-1 d-md-flex flex-wrap justify-content-evenly">
-			<div class="input-group input-group-sm w-auto m-1">
-				<%= submit_button maketext('Send Email'), name => 'sendEmail',
-					class => 'btn btn-secondary btn-sm d-inline w-auto' =%>
-			</div>
 			<div class="input-group input-group-sm w-auto m-1">
 				<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
 				<span class="input-group-text"><%= maketext('to') . ' ' . $c->{output_file} %></span>

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -66,10 +66,21 @@
 							<%= label_for send_to_selected => maketext('Send to selected students'),
 								class => 'form-check-label' =%>
 					</div>
-					<div class="mb-2">
-						<%= submit_button maketext('Preview Message'),
+					% if ($c->{preview_user}) {
+						<div class="input-group input-group-sm mb-2">
+							<%= submit_button maketext('Preview Message'),
 								name => 'previewMessage', class => 'btn btn-secondary btn-sm' =%>
-					</div>
+							<span class="input-group-text text-nowrap">
+								<strong><%= maketext('for') %></strong>&nbsp;
+								<span id="preview-user" data-default="<%=
+									$c->{defaultPreviewUser}->last_name . ', ' . $c->{defaultPreviewUser}->first_name
+									. ' (' . $c->{defaultPreviewUser}->user_id . ')' %>">
+									<%= $c->{preview_user}->last_name . ', ' . $c->{preview_user}->first_name
+										. ' (' . $c->{preview_user}->user_id . ')' =%>
+								</span>
+							</span>
+						</div>
+					% }
 					<div class="mb-2">
 						<%= submit_button maketext('Send Email'), name => 'sendEmail',
 							class => 'btn btn-secondary btn-sm d-inline w-auto' =%>
@@ -136,11 +147,12 @@
 	% # Merge file fragment and message text area field
 	% if ($merge_file ne 'None') {
 		<div class="mb-2">
-			<%= maketext('Viewing data from merge file [_1] for user [_2].', $merge_file, $c->{preview_user}) =%>
+			<%= maketext('Viewing data from merge file [_1] for user [_2].',
+				$merge_file, $c->{preview_user}->user_id) =%>
 		</div>
 	% }
 	% my $rh_merge_data = $c->read_scoring_file($merge_file);
-	% my @merge_data = eval { @{ $rh_merge_data->{ $db->getUser($c->{preview_user})->student_id } } };
+	% my @merge_data = eval { @{ $rh_merge_data->{ $c->{preview_user}->student_id } } };
 	% if ($@ && $merge_file ne 'None') {
 		<div class="mb-3"><%= maketext('No merge data found.') =%></div>
 	% } elsif (@merge_data) {
@@ -159,8 +171,7 @@
 		<%= label_for 'email-body', class => 'form-label', begin =%>
 			<%= maketext("Email Body:") %><span class="required-field">*</span>
 		<% end =%>
-		<%= text_area body =>
-			defined $c->{r_text} ? ${ $c->{r_text} } : 'FIXME no text was produced by initialization!',
+		<%= text_area body => $c->{r_text} // 'FIXME no text was produced by initialization!',
 			id => 'email-body', rows => $ce->{mail}->{editor_window_rows}, class => 'form-control' %>
 	</div>
 	%

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -2,7 +2,7 @@
 %
 % my $merge_file = $c->{merge_file} // 'None';
 %
-<%= form_for current_route, method => 'post', begin =%>
+<%= form_for current_route, id => 'mail-main-form', method => 'post', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%
 	% # Email settings
@@ -19,7 +19,6 @@
 								$c->get_message_file_names
 							],
 							id => 'openfilename', class => 'form-select form-select-sm' =%>
-						<%= submit_button maketext('Open'), name => 'openMessage', class => 'btn btn-secondary' =%>
 					</div>
 					<div class="input-group input-group-sm mb-2">
 						<%= label_for 'merge_file', class => 'input-group-text', begin =%>
@@ -30,7 +29,6 @@
 								$c->get_merge_file_names
 							],
 							id => 'merge_file', class => 'form-select form-select-sm' =%>
-						<%= submit_button maketext('View'), name => 'viewMergeFile', class => 'btn btn-secondary' =%>
 					</div>
 					<div class="row mb-1">
 						<%= label_for from => maketext('From:'),

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -181,7 +181,9 @@
 			% if ($c->{input_file}) {
 				<div class="input-group input-group-sm w-auto m-1">
 					<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
-					<span class="input-group-text"><%= maketext('to') . ' ' . $c->{output_file} %></span>
+					<span class="input-group-text">
+						<strong><%= maketext('to') %></strong>&nbsp;<%= $c->{output_file} %>
+					</span>
 				</div>
 			% }
 			<div class="input-group input-group-sm w-auto m-1">

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -15,8 +15,10 @@
 							<strong><%= maketext('Message file:') %></strong>
 						<% end =%>
 						<%= select_field openfilename => [
-								map { [ $_ => $_, $_ eq $c->{input_file} ? (selected => undef) : () ] }
-								$c->get_message_file_names
+								map { [
+									$_ => $_, ($_ eq 'None' || $_ eq $c->{input_file}) ? (selected => undef) : ()
+								] }
+								($c->{input_file} ? () : 'None', $c->get_message_file_names)
 							],
 							id => 'openfilename', class => 'form-select form-select-sm' =%>
 					</div>
@@ -169,26 +171,24 @@
 		<%= label_for 'email-body', class => 'form-label', begin =%>
 			<%= maketext("Email Body:") %><span class="required-field">*</span>
 		<% end =%>
-		<%= text_area body => $c->{r_text} // 'FIXME no text was produced by initialization!',
+		<%= text_area body => $c->{r_text},
 			id => 'email-body', rows => $ce->{mail}->{editor_window_rows}, class => 'form-control' %>
 	</div>
 	%
 	% # Action buttons
 	<div class="card">
 		<div class="card-body p-1 d-md-flex flex-wrap justify-content-evenly">
-			<div class="input-group input-group-sm w-auto m-1">
-				<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
-				<span class="input-group-text"><%= maketext('to') . ' ' . $c->{output_file} %></span>
-			</div>
+			% if ($c->{input_file}) {
+				<div class="input-group input-group-sm w-auto m-1">
+					<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
+					<span class="input-group-text"><%= maketext('to') . ' ' . $c->{output_file} %></span>
+				</div>
+			% }
 			<div class="input-group input-group-sm w-auto m-1">
 				<%= submit_button maketext('Save as') . ':', name => 'saveAs', id => 'saveAs',
 					class => 'btn btn-secondary btn-sm' =%>
-				<%= text_field savefilename => $c->{output_file}, size => 20,
-					class => 'form-control form-control-sm', 'aria-labelledby' => 'saveAs' =%>
-			</div>
-			<div class="input-group input-group-sm w-auto m-1">
-				<%= submit_button maketext('Save as Default'), name => 'saveDefault',
-					class => 'btn btn-secondary btn-sm' =%>
+				<%= text_field savefilename => $c->{output_file} ? $c->{output_file} : 'default.msg',
+					size => 20, class => 'form-control form-control-sm', 'aria-labelledby' => 'saveAs' =%>
 			</div>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -1,7 +1,5 @@
 % use WeBWorK::HTML::ScrollingRecordList qw/scrollingRecordList/;
 %
-% my $merge_file = $c->{merge_file} // 'None';
-%
 <%= form_for current_route, id => 'mail-main-form', method => 'post', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%
@@ -15,10 +13,8 @@
 							<strong><%= maketext('Message file:') %></strong>
 						<% end =%>
 						<%= select_field openfilename => [
-								map { [
-									$_ => $_, ($_ eq 'None' || $_ eq $c->{input_file}) ? (selected => undef) : ()
-								] }
-								($c->{input_file} ? () : 'None', $c->get_message_file_names)
+								map { [ $_ => $_, $_ eq $c->{input_file} ? (selected => undef) : () ] }
+								('None', $c->get_message_file_names)
 							],
 							id => 'openfilename', class => 'form-select form-select-sm' =%>
 					</div>
@@ -27,7 +23,7 @@
 							<strong><%= maketext('Merge file:') %></strong>
 						<% end =%>
 						<%= select_field merge_file => [
-								map { [ $_ => $_, $_ eq $merge_file ? (selected => undef) : () ] }
+								map { [ $_ => $_, $_ eq $c->{merge_file} ? (selected => undef) : () ] }
 								$c->get_merge_file_names
 							],
 							id => 'merge_file', class => 'form-select form-select-sm' =%>
@@ -145,16 +141,21 @@
 	</div>
 	%
 	% # Show valid rows of selected merge file.
-	% if ($merge_file ne 'None') {
-		<div class="mb-2"><%= maketext('Showing data from merge file: [_1]', $merge_file) =%></div>
-		% my $rh_merge_data = $c->read_scoring_file($merge_file);
+	% if ($c->{merge_file} ne 'None') {
+		<div class="mb-2"><%= maketext('Showing data from merge file: [_1]', $c->{merge_file}) =%></div>
+		% my $rh_merge_data = $c->read_scoring_file($c->{merge_file});
 		% my @rows;
+		% my $cols = 0;
 		% for my $user (@{ $c->{ra_user_records} }) {
-			% push(@rows, $rh_merge_data->{$user->student_id}) if $rh_merge_data->{$user->student_id};
+			% if ($rh_merge_data->{$user->student_id}) {
+				% my $this_row = $rh_merge_data->{$user->student_id};
+				% push(@rows, $this_row);
+				% $cols = scalar(@$this_row) if scalar(@$this_row) > $cols;
+			% }
 		% }
 		% if (@rows) {
 			<pre class="overflow-scroll" style="max-height: 100px;"><% =%>\
-				<%== join('', ' ', $c->data_format(1 .. scalar(@{ $rows[0] }))) =%><br><% =%>\
+				<%== join('', ' ', $c->data_format(1 .. $cols)) =%><br><% =%>\
 				<%== join('<br>', map { join('', ' ', $c->data_format2(@$_)) } @rows) =%>\
 			</pre>
 		% } else {
@@ -162,23 +163,18 @@
 		% }
 	% }
 	%
-	% # Create a textbox with the subject and a textarea with the message.
-	% # Print the actual body of message.
-	% if (defined $c->{message}) {
-		<div class="alert alert-info p-1 my-2"><%= $c->{message} %></div>
-	% }
 	<div class="mb-2">
 		<%= label_for 'email-body', class => 'form-label', begin =%>
 			<%= maketext("Email Body:") %><span class="required-field">*</span>
 		<% end =%>
 		<%= text_area body => $c->{r_text},
-			id => 'email-body', rows => $ce->{mail}->{editor_window_rows}, class => 'form-control' %>
+			id => 'email-body', rows => $ce->{mail}{editor_window_rows}, class => 'form-control' %>
 	</div>
 	%
-	% # Action buttons
+	% # Save buttons
 	<div class="card">
 		<div class="card-body p-1 d-md-flex flex-wrap justify-content-evenly">
-			% if ($c->{input_file}) {
+			% if ($c->{input_file} ne 'None') {
 				<div class="input-group input-group-sm w-auto m-1">
 					<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
 					<span class="input-group-text">

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -144,22 +144,22 @@
 		</div>
 	</div>
 	%
-	% # Merge file fragment and message text area field
+	% # Show valid rows of selected merge file.
 	% if ($merge_file ne 'None') {
-		<div class="mb-2">
-			<%= maketext('Viewing data from merge file [_1] for user [_2].',
-				$merge_file, $c->{preview_user}->user_id) =%>
-		</div>
-	% }
-	% my $rh_merge_data = $c->read_scoring_file($merge_file);
-	% my @merge_data = eval { @{ $rh_merge_data->{ $c->{preview_user}->student_id } } };
-	% if ($@ && $merge_file ne 'None') {
-		<div class="mb-3"><%= maketext('No merge data found.') =%></div>
-	% } elsif (@merge_data) {
-		<pre><%== join('', ' ', $c->data_format(1 .. ($#merge_data + 1))) =%>\
-			<br><% =%>\
-			<%== join('', ' ', $c->data_format2(@merge_data)) =%>\
-		</pre>
+		<div class="mb-2"><%= maketext('Showing data from merge file: [_1]', $merge_file) =%></div>
+		% my $rh_merge_data = $c->read_scoring_file($merge_file);
+		% my @rows;
+		% for my $user (@{ $c->{ra_user_records} }) {
+			% push(@rows, $rh_merge_data->{$user->student_id}) if $rh_merge_data->{$user->student_id};
+		% }
+		% if (@rows) {
+			<pre class="overflow-scroll" style="max-height: 100px;"><% =%>\
+				<%== join('', ' ', $c->data_format(1 .. scalar(@{ $rows[0] }))) =%><br><% =%>\
+				<%== join('<br>', map { join('', ' ', $c->data_format2(@$_)) } @rows) =%>\
+			</pre>
+		% } else {
+			<div class="mb-3"><%= maketext('No merge data found.') =%></div>
+		% }
 	% }
 	%
 	% # Create a textbox with the subject and a textarea with the message.

--- a/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
@@ -1,6 +1,7 @@
 <h2 class="fs-3"><%= maketext('This sample mail would be sent to [_1]', $ur->email_address) %></h2>
 <div class="mb-3" dir="ltr"><pre><%= $msg %></pre></div>
 <h2 class="fs-3"><%= maketext('Merge file data:') %></h2>
+<p><%= maketext('Showing data from merge file: [_1]', $c->{merge_file}) %></p>
 <div class="mb-3" dir="ltr"><pre><%== $preview_header %></pre></div>
 % if (@{ $c->{ra_send_to} }) {
 	<h2 class="fs-3"><%= maketext('Emails to be sent to the following:') %></h2>

--- a/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/preview.html.ep
@@ -1,14 +1,23 @@
 <h2 class="fs-3"><%= maketext('This sample mail would be sent to [_1]', $ur->email_address) %></h2>
 <div class="mb-3" dir="ltr"><pre><%= $msg %></pre></div>
-<h2 class="fs-3"><%= maketext('Merge file data:') %></h2>
-<p><%= maketext('Showing data from merge file: [_1]', $c->{merge_file}) %></p>
-<div class="mb-3" dir="ltr"><pre><%== $preview_header %></pre></div>
+% if ($c->{merge_file}) {
+	<h2 class="fs-3"><%= maketext('Merge file data:') %></h2>
+	<p><%= maketext('Showing data from merge file [_1] for user [_2]:', $c->{merge_file}, $ur->user_id) %></p>
+	<div class="mb-3" dir="ltr"><pre><%== $preview_header %></pre></div>
+% } else {
+	<h2 class="fs-3"><%= maketext('No merge file selected.') %></h2>
+% }
 % if (@{ $c->{ra_send_to} }) {
 	<h2 class="fs-3"><%= maketext('Emails to be sent to the following:') %></h2>
 	<div class="mb-3">
 		<ul>
 			% for (@{ $c->{ra_send_to} }) {
-				<li><%= $_ %></li>
+				<li>
+					<%= $_ %>
+					% if ($c->{merge_file} && !$merge_data->{$student_ids->{$_}}) {
+						<span class="text-danger">(<%= maketext('No merge data found') %>)</span>
+					% }
+				</li>
 			% }
 		</ul>
 	</div>


### PR DESCRIPTION
In looking to write help for the Email page I noticed that due to mojolicious caching of parameters, some of the buttons didn't correctly work on the email page.  I also felt that the page could be organized a bit better.  This restructures the Email page along with address the issues I originally noticed (main one was the open button didn't show the new file it opened). Summary of changes:

+ Removed the option to set the editor rows, since the email body text input can be resized.
+ Removed one of the refresh page buttons. It was mostly used for the editor row setting which was removed.
+ Renamed the student list refresh button to 'Change Display Settings' to match what is said on the instructor tools page.
+ Combined the message and merge file names into a single row.  I don't think we need to state what the last used selection was on the page.
+ Removed an error message about the user not found in the merge file from the editor page.  This message is also on the preview page and just checked the status of the professor which might not be in the CSV. Instead just show this message when they try to preview a message.
+ Don't state the professors name next to the preview button. It will preview the first selected student, and fall back to using the professor if no student was selected. Selecting a student didn't change the name next to the preview button, so it was at best misleading.
+ Move the elements around to better make use of the space.

If this gets approved, I'll update the help file in #1967 to match.