### PR TITLE
Fix invalid course logins.

### DIFF
--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -124,7 +124,8 @@
 				<div class="col-12">
 					<h1 id="page-title" class="page-title">
 						<%== $c->page_title %>
-						% if (param('user') && $authz->hasPermissions(param('user'), 'access_instructor_tools')) {
+						% if ($authen->{was_verified}
+							% && $authz->hasPermissions(param('user'), 'access_instructor_tools')) {
 							<%= $c->help({ label_size => 'fa-xs' }) %>
 						% }
 					</h1>


### PR DESCRIPTION
Checking the param('user') isn't good enough to determine when to show the help icon by the title.  When an invalid user attempts to sign in that parameter will be set.  However, a user corresponding to that parameter does not exist, and so the Authz hasPermissions call errors out.  It is enough to check the `$authen->{was_verified}`.  If that is true then there is a valid user as check_user has been called and found a valid user from the value of param('user').

To test this just enter the username for a non-existent user on a course login page.  You will get an error without this pull request, and with this pull request it will just say "Invalid user ID or password."