### PR TITLE
Don't allow renaming the current course (namely the admin course).

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -932,7 +932,7 @@ sub do_delete_course ($c) {
 sub archive_course_form ($c) {
 	my $ce = $c->ce;
 
-	my @courseIDs = listCourses($ce);
+	my @courseIDs = grep { $_ ne $c->stash('courseID') } listCourses($ce);
 	my %courseLabels;
 
 	if (@courseIDs) {

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -112,7 +112,7 @@
 		<%= maketext('To copy problem templates from an existing course, select the course below.') =%>
 	</div>
 	<div class="row mb-3">
-		% my @existingCourses = sort { lc($a) cmp lc($b) } listCourses($ce);
+		% my @existingCourses = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
 		% unshift(@existingCourses, sort { lc($a) cmp lc($b) } @{ $ce->{modelCoursesForCopy} });
 		%
 		<%= label_for add_templates_course => maketext('Copy templates from:'),

--- a/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
@@ -2,7 +2,7 @@
 %
 <h2><%= maketext('Rename Course') %></h2>
 %
-% my @courseIDs = sort { lc($a) cmp lc($b) } listCourses($ce);
+% my @courseIDs = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
 %
 % if (@courseIDs) {
 	<%= form_for current_route, method => 'POST', begin =%>


### PR DESCRIPTION
I have noticed that when in the admin course the admin course is listed on the "Rename Course" page.  So I tried it out.  I renamed the admin course, changing the courseID from admin to admin_blah.  The page returned from the rename and said this course does not exist.  The rename was of course successful, and the admin course no longer existed. I then had to manually put everything back (rename the tables in the database and rename the course directory).  This probably should not be something that the page allows.  So this pull request removes the current course (which would be the admin course) from the list.  This is the same way that this is done for the "Delete Course" page.