### PR TITLE
Remove the allowedRecipients option.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -42,26 +42,16 @@ include("VERSION");  # get WW version
 # Mail Settings
 ################################################################################
 
-# AllowedRecipients defines addresses that the PG system is allowed to send mail
-# to. this prevents subtle PG exploits. This should be set in course.conf to the
-# addresses of professors of each course. Sending mail from the PG system (i.e.
-# questionaires, essay questions) will fail if this is not set somewhere (either
-# here or in course.conf).
-$mail{allowedRecipients}     = [
-	#'prof1@yourserver.yourdomain.edu',
-	#'prof2@yourserver.yourdomain.edu',
-];
-
 # By default, feedback is sent to all users who have permission to
-# receive_feedback. If this list is non-empty, feedback is also sent to the
-# addresses specified here.
+# receive_feedback in a course. If this list is non-empty, feedback is also sent
+# to the addresses specified here.
 #
 # * If you want to disable feedback altogether, leave this empty and set
-#   submit_feedback => $nobody in %permissionLevels below. This will cause the
+#   $permissionLevels{submit_feedback} = 'nobody'. This will cause the
 #   feedback button to go away as well.
 #
 # * If you want to send email ONLY to addresses in this list, set
-#   receive_feedback => $nobody in %permissionLevels below.
+#   $permissionLevels{receive_feedback} = 'nobody'.
 #
 # It's often useful to set this in the course.conf to change the behavior of
 # feedback for a specific course.
@@ -70,7 +60,7 @@ $mail{allowedRecipients}     = [
 #   'Joe User <joe.user@example.com>'
 # The advantage of this form is that the resulting email will include the name
 # of the recipient in the "To" field of the email.
-#
+
 $mail{feedbackRecipients}    = [
 	#'prof1@yourserver.yourdomain.edu',
 	#'prof2@yourserver.yourdomain.edu',
@@ -2039,16 +2029,6 @@ $ConfigValues = [
 			values => [qw(0 1 2)],
 			type   => 'popuplist'
 
-		},
-		{
-			var  => 'mail{allowedRecipients}',
-			doc  => x('E-mail addresses which can receive e-mail from a pg problem'),
-			doc2 => x(
-				'List of e-mail addresses to which e-mail can be sent by a problem. Professors need to be added to '
-					. 'this list if questionaires are used, or other WeBWorK problems which send e-mail as part of '
-					. 'their answer mechanism.'
-			),
-			type => 'list'
 		},
 		{
 			var  => 'permissionLevels{receive_feedback}',

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -38,11 +38,21 @@
 # Additional mail settings in defaults.config can be overridden here
 ################################################################################
 
-# This setting is only used if you need to send email from within a PG problem
-# (e.g. surveys, essay questions).  It is not necessary for using the email
-# tools in WeBWorK.  You can set email addresses here for users who need to
-# receive email from problems in all courses, or in course.conf for professors
-# who will receive email from problems in a single course.
+# By default, feedback is sent to all users who have permission to
+# receive_feedback in a course. If this list is non-empty, feedback is also sent
+# to the addresses specified here.
+#
+# * If you want to disable feedback altogether, leave this empty and set
+#   $permissionLevels{submit_feedback} = 'nobody'. This will cause the
+#   feedback button to go away as well.
+#
+# * If you want to send email ONLY to addresses in this list, set
+#   $permissionLevels{receive_feedback} = 'nobody'.
+#
+# Items in this list may be bare addresses, or RFC822 mailboxes, like:
+#   'Joe User <joe.user@example.com>'
+# The advantage of this form is that the resulting email will include the name
+# of the recipient in the "To" field of the email.
 
 $mail{feedbackRecipients}    = [
 	#'prof1@yourserver.yourdomain.edu',

--- a/courses.dist/modelCourse/course.conf
+++ b/courses.dist/modelCourse/course.conf
@@ -1,96 +1,39 @@
 #!perl
-################################################################################
-# WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
-#
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of either: (a) the GNU General Public License as published by the
-# Free Software Foundation; either version 2, or (at your option) any later
-# version, or (b) the "Artistic License" which comes with this package.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
-# Artistic License for more details.
-################################################################################
 
-# This file is used to override the global WeBWorK course environment for
-# requests to this course. All package variables set in this file are added to
-# the course environment. If you wish to set a variable here but omit it from
-# the course environment,  use the "my" keyword. Commonly changed configuration
-# options are noted below.
+# This file is used to override the global WeBWorK course environment for this course.
 
 # Database Layout (global value typically defined in global.conf)
-#
 # Several database are defined in the file conf/database.conf and stored in the
 # hash %dbLayouts.
-#
 # The database layout is always set here, since one should be able to change the
 # default value in global.conf without disrupting existing courses.
-#
 # global.conf values:
 # 	$dbLayoutName = 'sql_single';
 # 	*dbLayout = $dbLayouts{$dbLayoutName};
-
 $dbLayoutName = 'sql_single';
 *dbLayout = $dbLayouts{$dbLayoutName};
 
-# Allowed Mail Recipients (global value typically not defined)
-#
-# Defines addresses to which the PG system is allowed to send mail. This should
-# probably be set to the addresses of professors of this course. Sending mail
-# from the PG system (i.e. questionaires, essay questions) will fail if this is
-# not set.
-#
-# $mail{allowedRecipients} = ['email@address.here'];
-
-
-# Feedback Mail Recipients (global value typically not defined)
-#
-# Defines recipients for feedback mail. If not defined, mail is sent to all
-# instructors and TAs.
-#
-# $mail{feedbackRecipients} = ['email@address.here'];
-
-
-
 # Users for whom to label problems with the PG file name
-#
 # For users in this list, PG will display the source file name when rendering a problem.
-#
-# $pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = ['user_id1'];
+#$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = ['user_id1'];
 
 # The following hashes control which users are allowed to see students from which
-# sections.  This is typically  used for large multi-section classes with many students, ta's and
+# sections.  This is typically used for large multi-section classes with many students, ta's and
 # professors.  When set users will only be allowed to see students from the appropriate section in the following:
-# -  Instructor Tools
-# -  Student Progress
-# -  Email
-# -  Problem Grader
-# -  Show Answers
+# - Instructor Tools
+# - Student Progress
+# - Email
+# - Problem Grader
+# - Show Answers
 # They will be able to see students from other sections on other pages.
 # These variables generally should be set here and not in defaults.conf.
-
-# $viewable_sections = { user_id1 => [1 ,2 ,3] , # list of viewable sections for user_id1
-#		       user_id2 => [1],
-#		     };
-
-# $viewable_recitations = { user_id1 => [1 ,2 ,3] , # list of viewable recitations for user_id1
-#			  user_id2 => [1],
-#		     };
-
-
-# controls if the Tagging features are displayed.  This is mainly used by library editors
-# $permissionLevels{modify_tags} = "professor";
-
-# For achievements you may set the preamble.at file as described at
-# https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4209 to exclude
-# certain sets or questions from achievement system.  However, these
-# questions still count to the score used to determine the level.  The
-# variable $achievementExcludeSet allows to exclude certain set completely
-# from the achievement system and these questions do not count to the level.
-# Remember that the names of the sets do not contain spaces.
-#
-# $achievementExcludeSet = ["00_Introduction","99_Summary","Sample_exam"];
+#$viewable_sections = {
+#    user_id1 => [1, 2, 3], # list of viewable sections for user_id1
+#    user_id2 => [1],
+#};
+#$viewable_recitations = {
+#    user_id1 => [1, 2, 3], # list of viewable recitations for user_id1
+#    user_id2 => [1],
+#};
 
 1;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -313,10 +313,6 @@ sub do_add_course ($c) {
 
 	my %courseOptions = (dbLayoutName => $add_dbLayout);
 
-	if ($add_initial_email ne '') {
-		$courseOptions{allowedRecipients} = [$add_initial_email];
-	}
-
 	my @users;
 
 	# copy users from current (admin) course if desired

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -162,12 +162,9 @@ environment.
 $courseOptions is a reference to a hash containing the following options:
 
  dbLayoutName         => $dbLayoutName
- allowedRecipients    => $mail{allowedRecipients}
- feedbackRecipients   => $mail{feedbackRecipients}
  PRINT_FILE_NAMES_FOR => $pg{specialPGEnvironmentVars}->{PRINT_FILE_NAMES_FOR}
 
-C<dbLayoutName> is required. C<allowedRecipients>, C<feedbackRecipients>, and
-C<PRINT_FILE_NAMES_FOR> are references to arrays.
+C<dbLayoutName> is required. C<PRINT_FILE_NAMES_FOR> is a reference to an array.
 
 $dbOptions is a reference to a hash containing information required to create a
 database for the course. Current database layouts do not require additional
@@ -1350,119 +1347,32 @@ sub writeCourseConf {
 
 	print $fh <<'EOF';
 #!perl
-################################################################################
-# WeBWorK Online Homework Delivery System
-# Copyright 2000-2016 The WeBWorK Project, http://openwebwork.sf.net/
-#
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of either: (a) the GNU General Public License as published by the
-# Free Software Foundation; either version 2, or (at your option) any later
-# version, or (b) the "Artistic License" which comes with this package.
-#
-# This program is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
-# Artistic License for more details.
-################################################################################
 
-# This file is used to override the global WeBWorK course environment for
-# requests to this course. All package variables set in this file are added to
-# the course environment. If you wish to set a variable here but omit it from
-# the course environment,  use the "my" keyword. Commonly changed configuration
-# options are noted below.
+# This file is used to override the global WeBWorK course environment for this course.
 
 EOF
 
 	print $fh <<'EOF';
 # Database Layout (global value typically defined in defaults.config)
-#
 # Several database are defined in the file conf/database.conf and stored in the
 # hash %dbLayouts.
-#
 # The database layout is always set here, since one should be able to change the
 # default value in localOverrides.conf without disrupting existing courses.
-#
 # defaults.config values:
 EOF
 
 	print $fh "# \t", '$dbLayoutName = \'', protectQString($ce->{dbLayoutName}), '\';', "\n";
 	print $fh "# \t", '*dbLayout = $dbLayouts{$dbLayoutName};', "\n";
-	print $fh "\n";
 
 	if (defined $options{dbLayoutName}) {
 		print $fh '$dbLayoutName = \'', protectQString($options{dbLayoutName}), '\';', "\n";
 		print $fh '*dbLayout = $dbLayouts{$dbLayoutName};', "\n";
-		print $fh "\n";
-	} else {
-		print $fh "\n\n\n";
-	}
-
-	print $fh <<'EOF';
-# Allowed Mail Recipients (global value typically not defined)
-#
-# Defines addresses to which the PG system is allowed to send mail. This should
-# probably be set to the addresses of professors of this course. Sending mail
-# from the PG system (i.e. questionaires, essay questions) will fail if this is
-# not set.
-#
-# defaults.config values:
-EOF
-
-	if (defined $ce->{mail}->{allowedRecipients}) {
-		print $fh "# \t", '$mail{allowedRecipients} = [',
-			join(", ", map { "'" . protectQString($_) . "'" } @{ $ce->{mail}->{allowedRecipients} }), '];', "\n";
-	} else {
-		print $fh "# \t", '$mail{allowedRecipients} = [  ];', "\n";
 	}
 	print $fh "\n";
-
-	if (defined $options{allowedRecipients}) {
-		print $fh '$mail{allowedRecipients} = [',
-			join(", ", map { "'" . protectQString($_) . "'" } @{ $options{allowedRecipients} }), '];', "\n";
-		print $fh "\n";
-	} else {
-		print $fh "\n\n\n";
-	}
-
-	print $fh <<'EOF';
-# By default, feedback is sent to all users who have permission to
-# receive_feedback. If this list is non-empty, feedback is also sent to the
-# addresses specified here.
-#
-# * If you want to disable feedback altogether, leave this empty and set
-#   $permissionLevels{submit_feedback} = undef;
-#   This will cause the
-#   feedback button to go away as well.
-#
-# * If you want to send email ONLY to addresses in this list, set
-#   $permissionLevels{receive_feedback} = undef;
-#
-# It's often useful to set this in the course.conf to change the behavior of
-# feedback for a specific course.
-# defaults.config values:
-EOF
-
-	if (defined $ce->{mail}->{feedbackRecipients}) {
-		print $fh "# \t", '$mail{feedbackRecipients} = [',
-			join(", ", map { "'" . protectQString($_) . "'" } @{ $ce->{mail}->{feedbackRecipients} }), '];', "\n";
-	} else {
-		print $fh "# \t", '$mail{feedbackRecipients} = [  ];', "\n";
-	}
-	print $fh "\n";
-
-	if (defined $options{feedbackRecipients}) {
-		print $fh '$mail{feedbackRecipients} = [',
-			join(", ", map { "'" . protectQString($_) . "'" } @{ $options{feedbackRecipients} }), '];', "\n";
-		print $fh "\n";
-	} else {
-		print $fh "\n\n\n";
-	}
 
 	print $fh <<'EOF';
 # Users for whom to label problems with the PG file name (global value typically "professor")
-#
 # For users in this list, PG will display the source file name when rendering a problem.
-#
 # defaults.config values:
 EOF
 
@@ -1472,16 +1382,12 @@ EOF
 			map { "'" . protectQString($_) . "'" } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} }),
 			'];', "\n";
 	} else {
-		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [  ];', "\n";
+		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [ ];', "\n";
 	}
-	print $fh "\n";
 
 	if (defined $options{PRINT_FILE_NAMES_FOR}) {
 		print $fh '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [',
 			join(", ", map { "'" . protectQString($_) . "'" } @{ $options{PRINT_FILE_NAMES_FOR} }), '];', "\n";
-		print $fh "\n";
-	} else {
-		print $fh "\n\n\n";
 	}
 }
 


### PR DESCRIPTION
This option no longer is used for anything now that PG problems can not send email anymore.
    
Also clean up the generated course.conf file.  The segment regarding $mail{feedbackRecipients} is also no longer added to the course.conf file.  That can be set from the course configuration (written to simple.conf), and is not needed here.  The actual setting is usually not set here anyway.  All the commentary about this course environment setting is certainly not needed here.  The copyright and license certainly do not need to be output to a generated file.  Also remove some excessive newlines and make the output more condensed.

The course.conf file in courses.dist/modelCourse is modified accordingly.  In addition, the commentary about the $achievementExcludeSet variable is removed.  Really this file should be deleted.  The file itself is not used for anything. The only thing that it has of value is the documentation on the $viewable_sections and $viewable_recitations hashes.  Those hashes should be able to be set from the course configuration, and the documenation added in defaults.config.

For now I left the dbLayoutName and dbLayout setting in the course.conf.  Does anyone actually use the sql_moodle layout?  Is it even valid anymore?  Should this be entirely removed from the code, and just have a fixed database layout?