### PR TITLE
Make renaming a course or unarchiving a course to a new name work again.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1233,6 +1233,10 @@ sub unarchive_course_validate ($c) {
 		push @errors, $c->maketext('Course ID cannot exceed [_1] characters.', $ce->{maxCourseIdLength});
 	}
 
+	unless ($courseID =~ /^[\w-]*$/) {    # regex copied from CourseAdministration.pm
+		push @errors, $c->maketext('Course ID may only contain letters, numbers, hyphens, and underscores.');
+	}
+
 	return @errors;
 }
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -505,11 +505,7 @@ sub renameCourse {
 	}
 
 	# get new course environment
-	my $newCE = $oldCE->new(
-		$oldCE->{webworkDirs}->{root},
-		$oldCE->{webworkURLs}->{root},
-		$oldCE->{pg}->{directories}->{root}, $newCourseID,
-	);
+	my $newCE = $oldCE->new({ courseName => $newCourseID });
 
 	# find the course dirs that still exist in their original locations
 	# (i.e. are not subdirs of $courseDir)


### PR DESCRIPTION
This was using the old four argument form of the CourseEnvironment constructor.  I missed that in #1985.

To test this rename a course or unarchive a course to a new name.  On the current release candidate branch you will get an error.  With this pull request it will work.

Note that if you test this on the release candidate branch and rename a course, the course directory will be renamed.  So you will need to manually rename that back to what it was.  The database tables will still be under the old course name.  If you attempt to unarchive to a new name, then the course directory will be created with the new name, but the database tables will not be.  So you will need to manually delete that new course directory.