### PR TITLE
Change events for changing actions for the action tabs.

### DIFF
--- a/htdocs/js/apps/ActionTabs/actiontabs.js
+++ b/htdocs/js/apps/ActionTabs/actiontabs.js
@@ -3,8 +3,7 @@
 
 	document.querySelectorAll('.action-link').forEach((actionLink) => {
 		const currentAction = document.getElementById('current_action');
-		actionLink.addEventListener('click', () => {
-			actionLink.blur();
+		actionLink.addEventListener('show.bs.tab', () => {
 			if (takeAction) takeAction.value = actionLink.textContent;
 			if (currentAction) currentAction.value = actionLink.dataset.action;
 		});


### PR DESCRIPTION
The click event is not triggered when tabs are changed via the keyboard. Thus in that case the text of the action button and the action set in the hidden input are not correctly changed to the current action.  This can result in odd behavior as well as the incorrect text on the action button.

Also, the blur call was messing with the natural tab order of the page. So that just had to be removed.

To test this use the keyboard to navigate to a tab (for example in the Classlist Editor), and then use the left/right arrow keys to change tabs.  The action button text will not change.  Furthermore, if you click on that button, the action that is performed will be the action the button says, even though that tab is not visible.  That is the behavior on the develop/WeBWorK-2.18 branches.  With this pull request the button text will change correctly, and the correct action will be performed.

Also, if you click on a tab on initial page order the focus shold be set on that tab.  It is not on the develop/WeBWorK-2.18 branch.  In fact focus falls back to where it wasy at the beginning of the page.