### PR TITLE
Remove more of the null byte hack for gateway quizzes.

### DIFF
--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -596,8 +596,12 @@
 				% # Print out hidden fields with the current last answers.
 				% my $curr_prefix = 'Q' . sprintf('%04d', $problem_numbers->[ $probOrder->[$i] ]) . '_';
 				% for my $curr_field (grep {/^(?!previous).*$curr_prefix/} keys %{ $c->{formFields} }) {
-					% for (split(/\0/, $c->{formFields}{$curr_field} // '')) {
-						<%= hidden_field $curr_field => $_ =%>
+					% if (ref($c->{formFields}{$curr_field}) eq 'ARRAY') {
+						% for (@{ $c->{formFields}{$curr_field} }) {
+							<%= hidden_field $curr_field => $_ =%>
+						% }
+					% } else {
+						<%= hidden_field $curr_field => $c->{formFields}{$curr_field} // '' =%>
 					% }
 				% }
 				% # Store the problem status for continued attempts recording.


### PR DESCRIPTION
The null byte array concatentation was still being checked for in templates/ContentGenerator/GatewayQuiz.html.ep.  Instead of splitting on the null byte, this should check for an array reference and add a hidden field with the same name for each element of an array.

This fixes #1996.