### PR TITLE
Fix a possible division by zero issue with achievements.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Achievements.pm
+++ b/lib/WeBWorK/ContentGenerator/Achievements.pm
@@ -76,7 +76,7 @@ sub getAchievementLevelData ($c) {
 			$level_progress   = $c->{globalData}->achievement_points - $prev_level;
 			$level_progress   = 0           if $level_progress < 0;
 			$level_progress   = $level_goal if $level_progress > $level_goal;
-			$level_percentage = int(100 * $level_progress / $level_goal);
+			$level_percentage = $level_goal ? int(100 * $level_progress / $level_goal) : 0;
 		}
 	}
 


### PR DESCRIPTION
I keep seeing this occur.  I am not entirely sure how it happens, but in some cases the previous level points and the next level points end up being the same.  This results in the computed level goal being zero in Achievements.pm, and that causes a division by zero error.  There should always be protection against division by zero in any case.