### PR TITLE
Fix two column hardcopy themes to actually be two columns.

### DIFF
--- a/bin/check_latex.tex
+++ b/bin/check_latex.tex
@@ -30,8 +30,6 @@
 
 \begin{document}
 \voffset=-0.8in
-\newpage
-\setcounter{page}{1}
 \begin{multicols}{2}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-oneColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-oneColumn/hardcopyPreamble.tex
@@ -45,5 +45,3 @@
 \input{PGML.tex}
 
 \begin{document}
-\newpage
-\setcounter{page}{1}

--- a/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-twoColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-Hebrew-twoColumn/hardcopyPreamble.tex
@@ -46,5 +46,4 @@
 
 \begin{document}
 \voffset=-0.8in
-\newpage
-\setcounter{page}{1}
+\twocolumn

--- a/conf/snippets/hardcopyThemes/XeLaTeX-oneColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-oneColumn/hardcopyPreamble.tex
@@ -47,5 +47,3 @@
 \input{PGML.tex}
 
 \begin{document}
-\newpage
-\setcounter{page}{1}

--- a/conf/snippets/hardcopyThemes/XeLaTeX-twoColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/XeLaTeX-twoColumn/hardcopyPreamble.tex
@@ -47,5 +47,4 @@
 \input{PGML.tex}
 
 \begin{document}
-\newpage
-\setcounter{page}{1}
+\twocolumn

--- a/conf/snippets/hardcopyThemes/oneColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/oneColumn/hardcopyPreamble.tex
@@ -19,5 +19,3 @@
 \input{PGML.tex}
 
 \begin{document}
-\newpage
-\setcounter{page}{1}

--- a/conf/snippets/hardcopyThemes/twoColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/twoColumn/hardcopyPreamble.tex
@@ -18,5 +18,4 @@
 \input{PGML.tex}
 
 \begin{document}
-\newpage
-\setcounter{page}{1}
+\twocolumn


### PR DESCRIPTION
If the hardcopy set header happens to have the BEGIN_ONE_COLUMN/END_ONE_COLUMN calls this is done by calling `\twocolumn` with its header text starting and ending a `@twocolumnfalse` section.  But if the set header does not call BEGIN_ONE_COLUMN/END_ONE_COLUMN there is no `\twocolumn` call to start two column mode.  To fix that the `\twocolumn` call needs to occur in the hardcopyPreamble.tex file.

This fixes #1973.

Also it is time to remove that `\newpage` call at the beginning of the document in all themes.  That is clearly added by someone that doesn't know what they are doing with TeX.  There is no point in ending the current page at the beginning of the document.

Additionally, there is no need to set the page number to 1 on the first page of the document.  TeX does that anyway.

(Recreated as I accidentally pushed to origin)