### PR TITLE
Add customized menu for the admin course.

### DIFF
--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,0 +1,48 @@
+<h2 class="navbar-brand mb-0"><%= maketext('Admin Menu') %></h2>
+<ul class="nav flex-column">
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
+	</li>
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= $makelink->(
+			'set_list',
+			text   => maketext('Course Administration'),
+			active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
+		) %>
+	</li>
+	% for (
+		% [
+		% 	'add_course',
+		% 	maketext('Add Course'),
+		% 	{
+		% 		add_admin_users      => 1,
+		% 		add_config_file      => 1,
+		% 		add_dbLayout         => 'sql_single',
+		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
+		% 	}
+		% ],
+		% [ 'rename_course',        maketext('Rename Course') ],
+		% [ 'delete_course',        maketext('Delete Course') ],
+		% [ 'archive_course',       maketext('Archive Course') ],
+		% [ 'unarchive_course',     maketext('Unarchive Course') ],
+		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
+		% [ 'manage_locations',     maketext('Manage Locations') ],
+		% [ 'hide_inactive_course', maketext('Hide Courses') ],
+	% )
+	% {
+		<li class="list-group-item list-group-item-primary nav-item">
+			<%= $makelink->(
+				'set_list',
+				text              => $_->[1],
+				systemlink_params => { subDisplay => $_->[0], %{ $_->[2] // {} } },
+				active            => (param('subDisplay') // '') eq $_->[0],
+			) %>
+		</li>
+	% }
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
+	</li>
+</ul>

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -42,6 +42,7 @@
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
 	<li class="list-group-item list-group-item-primary nav-item">
 		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 	</li>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -1,5 +1,9 @@
 % use WeBWorK::Utils qw(jitar_id_to_seq);
 %
+% if ($ce->{courseName} eq 'admin') {
+	<%= include 'ContentGenerator/Base/admin_links' =%>
+	% next;
+% }
 <h2 class="navbar-brand mb-0"><%= maketext('Main Menu') %></h2>
 <ul class="nav flex-column">
 	% unless ($restricted_navigation) {
@@ -13,12 +17,7 @@
 			% if ($restricted_navigation) {
 				<span class="nav-link disabled"><%= maketext('Homework Sets') %></span>
 			% } else {
-				<%= $makelink->(
-					'set_list',
-					text => $ce->{courseName} eq 'admin'
-						? maketext('Course Administration')
-						: maketext('Homework Sets'),
-				) %>
+				<%= $makelink->('set_list', text => maketext('Homework Sets')) %>
 			% }
 		</li>
 		%

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -286,7 +286,7 @@
 			% && $authz->hasPermissions($userID, 'report_bugs'))
 		% {
 			<li class="list-group-item list-group-item-primary nav-item">
-				%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link'
+				<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 			</li>
 		% }
 	% }

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -12,37 +12,6 @@
 	% last;
 % }
 %
-<ul class="nav nav-pills justify-content-center my-2">
-	% for (
-		% [
-		% 	'add_course',
-		% 	maketext('Add Course'),
-		% 	{
-		% 		add_admin_users      => 1,
-		% 		add_config_file      => 1,
-		% 		add_dbLayout         => 'sql_single',
-		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
-		% 	}
-		% ],
-		% [ 'rename_course',        maketext('Rename Course') ],
-		% [ 'delete_course',        maketext('Delete Course') ],
-		% [ 'archive_course',       maketext('Archive Course') ],
-		% [ 'unarchive_course',     maketext('Unarchive Course') ],
-		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
-		% [ 'manage_locations',     maketext('Manage Locations') ],
-		% [ 'hide_inactive_course', maketext('Hide Courses') ],
-	% )
-	% {
-		<li class="nav-item">
-			<%= link_to $_->[1] =>
-				$c->systemLink(url_for, params => { subDisplay => $_->[0], %{ $_->[2] // {} } }),
-				class => 'nav-link' . ((param('subDisplay') // '') eq $_->[0] ? ' active' : '') =%>
-		</li>
-	% }
-</ul>
-%
-<hr class="mt-0">
-%
 <%= include 'ContentGenerator/CourseAdmin/registration_form' %>
 %
 % if (@{ $c->{errors} }) {


### PR DESCRIPTION
  Move the links (nav menu) from the top of the admin page over to
  the main menu.  Also remove most of the course links since they
  don't really do much on the admin page.  Label this new menu
  'Admin Menu'.

The only old menu items used are the user settings to be able to change the password, class list editor, and email since the admin users may want to email various instructors or manage them (since they are created automatically with new courses).  There was also some discussion of maybe the file manager being useful, but not added here. I had wondered if the admin file manager could go up one more directory to the courses directory root, so admin users have access to all course files.