### PR TITLE
move primary coloring in navbar to student-accessible menu items

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -193,7 +193,6 @@ $layout-divider-color: #aaa !default;
 		color: black;
 		font-weight: bold;
 		font-size: 0.9rem;
-		opacity: 0.7;
 		background-color: var(--bs-primary, #038);
 		color: var(--ww-primary-foreground-color, white);
 	}

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -193,7 +193,9 @@ $layout-divider-color: #aaa !default;
 		color: black;
 		font-weight: bold;
 		font-size: 0.9rem;
-		opacity: 0.6;
+		opacity: 0.7;
+		background-color: var(--bs-primary, #038);
+		color: var(--ww-primary-foreground-color, white);
 	}
 
 	.info-box {

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -3,13 +3,13 @@
 <h2 class="navbar-brand mb-0"><%= maketext('Main Menu') %></h2>
 <ul class="nav flex-column">
 	% unless ($restricted_navigation) {
-		<li class="list-group-item nav-item">
+		<li class="list-group-item list-group-item-primary nav-item">
 			<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
 		</li>
 	% }
 	% if (defined $courseID && $authen->was_verified) {
 		% # Homework Sets or Course Administration
-		<li class="list-group-item nav-item">
+		<li class="list-group-item list-group-item-primary nav-item">
 			% if ($restricted_navigation) {
 				<span class="nav-link disabled"><%= maketext('Homework Sets') %></span>
 			% } else {
@@ -23,7 +23,7 @@
 		</li>
 		%
 		% if (defined $setID) {
-			<li class="list-group-item nav-item">
+			<li class="list-group-item list-group-item-primary nav-item">
 				<ul class="nav flex-column">
 					% # Set link. The set record is needed to determine the assignment type.
 					% my $setRecord = $db->getGlobalSet($setID =~ s/,v\d+$//r);
@@ -81,26 +81,26 @@
 			% || $authz->hasPermissions($userID, 'change_email_address')
 			% || $authz->hasPermissions($userID, 'change_pg_display_settings'))
 		% {
-			<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
+			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
 		% }
 		%
 		% unless ($restricted_navigation || $courseID eq 'admin') {
-			<li class="list-group-item nav-item"><%= $makelink->('grades') %></li>
+			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('grades') %></li>
 		% }
 		%
 		% if ($ce->{achievementsEnabled}) {
-			<li class="list-group-item nav-item"><%= $makelink->('achievements') %></li>
+			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('achievements') %></li>
 		% }
 		%
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_tools') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
 			% # Class list editor
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
 			% # Homework Set Editor
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_set_list') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_list') %></li>
 			% # Editor link.  Only shown for non-versioned sets
 			% if (defined $setID && $setID !~ /,v\d+$/) {
-				<li class="list-group-item list-group-item-primary nav-item">
+				<li class="list-group-item nav-item">
 					<ul class="nav flex-column">
 						<li class="nav-item">
 							<%= $makelink->(
@@ -129,11 +129,11 @@
 			% }
 
 			% # Set assigner
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_set_assigner') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_assigner') %></li>
 			% # Library Browser
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_set_maker') %></li>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_maker') %></li>
 			% # Statistics
-			<li class="list-group-item list-group-item-primary nav-item">
+			<li class="list-group-item nav-item">
 				<%= $makelink->('instructor_statistics') %>
 				% if ($userID ne $eUserID || defined $setID || defined $urlUserID) {
 				<ul class="nav flex-column">
@@ -187,7 +187,7 @@
 				% }
 			</li>
 			% # Student Progress
-			<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_progress') %>
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_progress') %>
 				% if ($userID ne $eUserID || defined $setID || defined $urlUserID) {
 					<ul class="nav flex-column">
 						% if (defined $urlUserID) {
@@ -225,11 +225,11 @@
 			</li>
 			% # Scoring
 			% if ($authz->hasPermissions($userID, 'score_sets')) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_scoring') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_scoring') %></li>
 			% }
 			% # Achievment Editor
 			% if ($ce->{achievementsEnabled} && $authz->hasPermissions($userID, 'edit_achievements')) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_achievement_list') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_achievement_list') %></li>
 				% if (defined $achievementID) {
 					<li class="nav-item">
 						<ul class="nav flex-column">
@@ -246,22 +246,22 @@
 			% }
 			% # Email
 			% if ($authz->hasPermissions($userID, 'send_mail')) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
 			% }
 			% # File Manager
 			% if ($authz->hasPermissions($userID, 'manage_course_files')) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_file_manager') %></li>
 			% }
 			% # LTI Grade Update
 			% if ($ce->{LTIGradeMode} && $authz->hasPermissions($userID, 'score_sets')) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_lti_update') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_lti_update') %></li>
 			% }
 			% # Course Configuration
 			% if ($authz->hasPermissions($userID, "manage_course_files")) {
-				<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_config') %></li>
+				<li class="list-group-item nav-item"><%= $makelink->('instructor_config') %></li>
 			% }
 			% # Instructor links help
-			<li class="list-group-item list-group-item-primary nav-item">
+			<li class="list-group-item nav-item">
 				<%= $c->helpMacro('instructor_links',
 					{ label => maketext('Help'), class => 'nav-link' }) %>
 			</li>
@@ -271,7 +271,7 @@
 				% && current_route eq 'instructor_file_manager'
 			% )
 			% {
-				<li class="list-group-item list-group-item-primary nav-item">
+				<li class="list-group-item nav-item">
 					<%= $makelink->(
 						'instructor_file_manager',
 						text              => maketext('Archive this Course'),
@@ -286,7 +286,7 @@
 			% && $ce->{webworkURLs}{bugReporter} ne ''
 			% && $authz->hasPermissions($userID, 'report_bugs'))
 		% {
-			<li class="list-group-item list-group-item-primary nav-item">
+			<li class="list-group-item nav-item">
 				%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link'
 			</li>
 		% }


### PR DESCRIPTION
This changes the navbar coloring so the student-accessible menu items get the primary coloring instead of the others below.

Also the "MAIN MENU" h2 gets coloring with the primary color. That h2 had `opacity: 0.6` and it looked a bit too light to me, so I changed it to 0.7. (I also tried removing the opacity setting so it was as dark as the main banner and active item, but that looked bad.)

Note that if this is a good way to go, then #2008 should be closed unmerged.

Here are some screenshots. One of them has a set and problem number opened so you can confirm the coloring applies to nested things in the nav tree. "Achievements" is gray in one of them because the mouse was hovering over it when I took the screen shot.

<img width="912" alt="Screen Shot 2023-05-30 at 11 50 25 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/6500ec78-744b-4e75-9067-42fe45732760">

<img width="912" alt="Screen Shot 2023-05-30 at 11 50 03 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/56fe7ed2-5206-48f1-b798-cda59ba6d500">

<img width="912" alt="Screen Shot 2023-05-30 at 11 49 23 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/7ea1c794-14a5-4ff6-a713-5a5a9fa873e8">

<img width="912" alt="Screen Shot 2023-05-30 at 11 51 44 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/ce422d9c-5b92-49ef-a404-319cac1229da">


