### PR TITLE
Use column headers on user detail set dates table

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -573,8 +573,8 @@ sub fieldTable ($c, $userID, $setID, $problemID, $globalRecord, $userRecord = un
 				'tr',
 				$c->c(
 					$c->tag('td', colspan => '3', ''),
-					$c->tag('th', $c->maketext('User Value')),
-					$c->tag('th', $c->maketext('Class value'))
+					$c->tag('th', $c->maketext('User overrides')),
+					$c->tag('th', $c->maketext('Set values'))
 				)->join('')
 			)
 		);

--- a/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
@@ -8,6 +8,14 @@
 % }
 %
 <table>
+	<tr>
+		<th scope="col" colspan="3">
+			<%= maketext("User overrides") =%>
+		</th>
+		<th scope="col">
+			<%= maketext("Set defaults") =%>
+		</th>
+	</tr>
 	% for my $field (@$fields) {
 		% # Skip reduced credit dates for sets which don't have them.
 		% next

--- a/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
@@ -13,7 +13,7 @@
 			<%= maketext("User overrides") =%>
 		</th>
 		<th scope="col">
-			<%= maketext("Set defaults") =%>
+			<%= maketext("Set values") =%>
 		</th>
 	</tr>
 	% for my $field (@$fields) {


### PR DESCRIPTION
This morning an instructor was confused why they were changing dates for a student on a set, but the "date wouldn't change". They didn't understand that they were seeing the set's global dates alongside the override they were applying to a student.  So I added column headers to the tables that are made for the dates. See pic.

Note that I do not think it is appropriate to split up the table into two columns of the larger table. It is appropriate for a user to be able to keyboard navigate quickly from the override input to the default date and back.

<img width="1059" alt="Screen Shot 2023-05-30 at 12 19 55 PM" src="https://github.com/openwebwork/webwork2/assets/4732672/094ec99f-bae0-4164-bd8f-0af88ea1be47">
