### PR TITLE
Another tweak to the pg htdocs url configuration.

### DIFF
--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -232,6 +232,9 @@ sub new {
 			keys %{ $self->{statuses} }
 	};
 
+	# Make sure that this is set in case it is not defined in site.conf.
+	$self->{pg_htdocs_url} //= '/pg_files';
+
 	# Fixup for courses that still have an underscore, 'heb', 'zh_hk', or 'en_us' saved in their settings files.
 	$self->{language} =~ s/_/-/g;
 	$self->{language} = 'he-IL' if $self->{language} eq 'heb';


### PR DESCRIPTION
If `$pg_htdocs_url` is not set in `site.conf`, then pages load due to a fallback in `lib/Mojolicious/WeBWorK.pm` .  However, if a problem uses pg javascript the problem fails to load and there are lots of errors. This adds a fallback to the course environment as well so that those problems still load.

This stems from https://github.com/openwebwork/webwork2/pull/2000#issuecomment-1569040247.