### PR TITLE
When deleting the user currently being acted as, stop acting.

### DIFF
--- a/templates/ContentGenerator/Base/login_status.html.ep
+++ b/templates/ContentGenerator/Base/login_status.html.ep
@@ -6,31 +6,26 @@
 	% my $effectiveUserID = param('effectiveUser');
 	% my $userName        = $user->full_name || $user->user_id;
 	%
-	% if ($effectiveUserID eq $userID) {
-		<%= maketext('Logged in as [_1].', $userName) %>
-		<%= link_to $c->systemLink(url_for 'logout'), class => 'btn btn-light btn-sm ms-2', begin %>
-		<%= maketext('Log Out') %> <i class="icon fas fa-sign-out-alt" aria-hidden="true" data-alt="signout"></i>
-		<% end %>
-	% } else {
-		% # This will contain any extra parameters which are needed to make
-		% # the page function properly.  This will normally be empty.
-		% my $extraStopActingParams = $c->{extraStopActingParams} // {};
-		% $extraStopActingParams->{effectiveUser} = $userID;
-		%
+	<%= maketext('Logged in as [_1].', $userName) %>
+	<%= link_to $c->systemLink(url_for 'logout'), class => 'btn btn-light btn-sm ms-2', begin %>
+	<%= maketext('Log Out') %> <i class="icon fas fa-sign-out-alt" aria-hidden="true" data-alt="signout"></i>
+	<% end %>
+	%
+	% if ($effectiveUserID ne $userID) {
 		% my $effectiveUser = $db->getUser($effectiveUserID);
+		% unless ($effectiveUser) {
+			% param('effectiveUser', $userID);
+			% next;
+		% }
 		% my $effectiveUserName =
 			% $effectiveUser->full_name
 			% ? join(' ', $effectiveUser->full_name, '(' . $effectiveUser->user_id . ')')
 			% : $effectiveUser->user_id;
 		%
-		<%= maketext('Logged in as [_1].', $userName) %>
-		<%= link_to $c->systemLink(url_for 'logout'), class => 'btn btn-light btn-sm ms-2', begin %>
-		<%= maketext('Log Out') %> <i class="icon fas fa-sign-out-alt" aria-hidden="true" data-alt="signout"></i>
-		<% end %>
 		<br>
 		<%= maketext('Acting as [_1].', $effectiveUserName) %>
-		<%= link_to $c->systemLink(url_for, params => $extraStopActingParams), class => 'btn btn-light btn-sm ms-2',
-			begin %>
+		<%= link_to $c->systemLink(url_for, params => { effectiveUser => $userID }),
+			class => 'btn btn-light btn-sm ms-2', begin %>
 		<%= maketext('Stop Acting') %> <i class="icon fas fa-sign-out-alt" aria-hidden="true" data-alt="signout"></i>
 		<% end %>
 	% }


### PR DESCRIPTION
If you delete the user that you are currently acting as, the confirmation page fails to load and an error is shown.  This makes it so that if the effectiveUser no longer exists, it automatically stops acting as that user.  This is detected in
templates/ContentGenerator/Base/login_status.html.ep, and in that case it simply changes the effectiveUser parameter back to the current user id.

This is a long standing bug from what I can see in the code history, but haven't tested this with previous versions of webwork2.  It is probably not something that happens much.