### PR TITLE
Update the docker build with missing modules.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,11 @@ RUN apt-get update \
 	libarray-utils-perl \
 	libc6-dev \
 	libcapture-tiny-perl \
-	libcgi-pm-perl \
 	libclass-tiny-antlers-perl \
 	libclass-tiny-perl \
 	libcpanel-json-xs-perl \
-	libcrypt-ssleay-perl \
+	libcrypt-jwt-perl \
+	libcryptx-perl \
 	libdata-dump-perl \
 	libdata-structure-util-perl \
 	libdatetime-perl \
@@ -90,6 +90,9 @@ RUN apt-get update \
 	libemail-sender-perl \
 	libemail-stuffer-perl \
 	libexception-class-perl \
+	libextutils-config-perl \
+	libextutils-helpers-perl \
+	libextutils-installpaths-perl \
 	libextutils-xsbuilder-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
@@ -107,6 +110,7 @@ RUN apt-get update \
 	libmail-sender-perl \
 	libmail-sender-perl \
 	libmariadb-dev \
+	libmath-random-secure-perl \
 	libmime-tools-perl \
 	libminion-backend-sqlite-perl \
 	libminion-perl \
@@ -178,7 +182,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install Statistics::R::IO Mojolicious::Plugin::NotYAMLConfig DBD::MariaDB \
+RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -37,11 +37,11 @@ RUN apt-get update \
 	libarray-utils-perl \
 	libc6-dev \
 	libcapture-tiny-perl \
-	libcgi-pm-perl \
 	libclass-tiny-antlers-perl \
 	libclass-tiny-perl \
 	libcpanel-json-xs-perl \
-	libcrypt-ssleay-perl \
+	libcrypt-jwt-perl \
+	libcryptx-perl \
 	libdata-dump-perl \
 	libdata-structure-util-perl \
 	libdatetime-perl \
@@ -52,6 +52,9 @@ RUN apt-get update \
 	libemail-sender-perl \
 	libemail-stuffer-perl \
 	libexception-class-perl \
+	libextutils-config-perl \
+	libextutils-helpers-perl \
+	libextutils-installpaths-perl \
 	libextutils-xsbuilder-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
@@ -69,6 +72,7 @@ RUN apt-get update \
 	libmail-sender-perl \
 	libmail-sender-perl \
 	libmariadb-dev \
+	libmath-random-secure-perl \
 	libmime-tools-perl \
 	libminion-backend-sqlite-perl \
 	libminion-perl \
@@ -140,7 +144,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n Statistics::R::IO Mojolicious::Plugin::NotYAMLConfig DBD::MariaDB Mojo::SQLite@3.002 \
+RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================


### PR DESCRIPTION
When I added the LTI 1.3 authentication, I forgot to add the modules for that.

Remove the libcgi-pm-perl package.  That is not needed anymore!

Remove the libcrypt-ssleay-perl package as that is not needed.

Add the dependencies of Mojo::SQLite as that speeds up the cpan installation.

Don't install Mojolicious::Plugin::NotYAMLConfig as that is now part of Mojolicious directly, and so is included in the libmojolicious-perl pacakge which is already installed.