### PR TITLE
Admin course help

### DIFF
--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -44,6 +44,9 @@
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
 	<li class="list-group-item list-group-item-primary nav-item">
+		<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
+	</li>
+	<li class="list-group-item list-group-item-primary nav-item">
 		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 	</li>
 </ul>

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,0 +1,48 @@
+<h2 class="navbar-brand mb-0"><%= maketext('Admin Menu') %></h2>
+<ul class="nav flex-column">
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
+	</li>
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= $makelink->(
+			'set_list',
+			text   => maketext('Course Administration'),
+			active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
+		) %>
+	</li>
+	% for (
+		% [
+		% 	'add_course',
+		% 	maketext('Add Course'),
+		% 	{
+		% 		add_admin_users      => 1,
+		% 		add_config_file      => 1,
+		% 		add_dbLayout         => 'sql_single',
+		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
+		% 	}
+		% ],
+		% [ 'rename_course',        maketext('Rename Course') ],
+		% [ 'delete_course',        maketext('Delete Course') ],
+		% [ 'archive_course',       maketext('Archive Course') ],
+		% [ 'unarchive_course',     maketext('Unarchive Course') ],
+		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
+		% [ 'manage_locations',     maketext('Manage Locations') ],
+		% [ 'hide_inactive_course', maketext('Hide Courses') ],
+	% )
+	% {
+		<li class="list-group-item list-group-item-primary nav-item">
+			<%= $makelink->(
+				'set_list',
+				text              => $_->[1],
+				systemlink_params => { subDisplay => $_->[0], %{ $_->[2] // {} } },
+				active            => (param('subDisplay') // '') eq $_->[0],
+			) %>
+		</li>
+	% }
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
+	</li>
+</ul>

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -42,6 +42,7 @@
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
 	<li class="list-group-item list-group-item-primary nav-item">
 		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 	</li>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -1,5 +1,9 @@
 % use WeBWorK::Utils qw(jitar_id_to_seq);
 %
+% if ($ce->{courseName} eq 'admin') {
+	<%= include 'ContentGenerator/Base/admin_links' =%>
+	% next;
+% }
 <h2 class="navbar-brand mb-0"><%= maketext('Main Menu') %></h2>
 <ul class="nav flex-column">
 	% unless ($restricted_navigation) {
@@ -13,12 +17,7 @@
 			% if ($restricted_navigation) {
 				<span class="nav-link disabled"><%= maketext('Homework Sets') %></span>
 			% } else {
-				<%= $makelink->(
-					'set_list',
-					text => $ce->{courseName} eq 'admin'
-						? maketext('Course Administration')
-						: maketext('Homework Sets'),
-				) %>
+				<%= $makelink->('set_list', text => maketext('Homework Sets')) %>
 			% }
 		</li>
 		%

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -286,7 +286,7 @@
 			% && $authz->hasPermissions($userID, 'report_bugs'))
 		% {
 			<li class="list-group-item list-group-item-primary nav-item">
-				%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link'
+				<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 			</li>
 		% }
 	% }

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -12,37 +12,6 @@
 	% last;
 % }
 %
-<ul class="nav nav-pills justify-content-center my-2">
-	% for (
-		% [
-		% 	'add_course',
-		% 	maketext('Add Course'),
-		% 	{
-		% 		add_admin_users      => 1,
-		% 		add_config_file      => 1,
-		% 		add_dbLayout         => 'sql_single',
-		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
-		% 	}
-		% ],
-		% [ 'rename_course',        maketext('Rename Course') ],
-		% [ 'delete_course',        maketext('Delete Course') ],
-		% [ 'archive_course',       maketext('Archive Course') ],
-		% [ 'unarchive_course',     maketext('Unarchive Course') ],
-		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
-		% [ 'manage_locations',     maketext('Manage Locations') ],
-		% [ 'hide_inactive_course', maketext('Hide Courses') ],
-	% )
-	% {
-		<li class="nav-item">
-			<%= link_to $_->[1] =>
-				$c->systemLink(url_for, params => { subDisplay => $_->[0], %{ $_->[2] // {} } }),
-				class => 'nav-link' . ((param('subDisplay') // '') eq $_->[0] ? ' active' : '') =%>
-		</li>
-	% }
-</ul>
-%
-<hr class="mt-0">
-%
 <%= include 'ContentGenerator/CourseAdmin/registration_form' %>
 %
 % if (@{ $c->{errors} }) {

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -1,6 +1,6 @@
 % use WeBWorK::Utils::CourseManagement qw(listCourses);
 %
-<h2><%= maketext('Add Course') %></h2>
+<h2><%= maketext('Add Course') %> <%= $c->helpMacro('AdminAddCourse') %></h2>
 %
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>

--- a/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Archive Course') =%></h2>
+<h2><%= maketext('Archive Course') %> <%= $c->helpMacro('AdminArchiveCourse') %></h2>
 % # Report on databases
 <h3 class="my-3"><%= maketext('Report on database structure for course [_1]:', $archive_courseID) %></h3>
 % if (@$upgrade_report) {

--- a/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Archive Course') =%></h2>
+<h2><%= maketext('Archive Course') %> <%= $c->helpMacro('AdminArchiveCourse') %></h2>
 <p>
 	<%= maketext(
 		'Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses directory. '

--- a/templates/ContentGenerator/CourseAdmin/delete_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/delete_course_confirm.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Delete Course') %></h2>
+<h2><%= maketext('Delete Course') %> <%= $c->helpMacro('AdminDeleteCourse') %></h2>
 <p>
 	<%== maketext(
 		'Are you sure you want to delete the course [_1]? All course files and data will be destroyed. '

--- a/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Delete Course') =%></h2>
+<h2><%= maketext('Delete Course') %> <%= $c->helpMacro('AdminDeleteCourse') %></h2>
 %
 % if (@$courseIDs) {
 	<%= form_for current_route, method => 'POST', begin =%>

--- a/templates/ContentGenerator/CourseAdmin/edit_location_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/edit_location_form.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Editing location [_1]', $locationID) %></h2>
+<h2><%= maketext('Editing location [_1]', $locationID) %> <%= $c->helpMacro('AdminManageLocations') %></h2>
 <p>
 	<%= maketext(
 		'Edit the current value of the location description, if desired, then add and select addresses to delete, '

--- a/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Hide Courses') %></h2>
+<h2><%= maketext('Hide Courses') %> <%= $c->helpMacro('AdminHideCourses') %></h2>
 <p>
 	<%= maketext(
 		'Select the course(s) you want to hide (or unhide) and then click "Hide Courses" (or "Unhide Courses"). '

--- a/templates/ContentGenerator/CourseAdmin/manage_location_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/manage_location_form.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Manage Locations') %></h2>
+<h2><%= maketext('Manage Locations') %> <%= $c->helpMacro('AdminManageLocations') %></h2>
 <p><strong><%= maketext('Currently defined locations are listed below.') %></strong></p>
 <%= form_for current_route, method => 'POST', begin =%>
 	% my @locationIDs = map  { $_->location_id } @$locations;

--- a/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Rename Course') =%></h2>
+<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
 % # Report on databases
 <h3 class="my-3"><%= maketext('Report on database structure for course [_1]:', $rename_oldCourseID) %></h3>
 % if (@$upgrade_report) {

--- a/templates/ContentGenerator/CourseAdmin/rename_course_confirm_short.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_confirm_short.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Rename Course') =%></h2>
+<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields('subDisplay') =%>

--- a/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
@@ -1,6 +1,6 @@
 % use WeBWorK::Utils::CourseManagement qw(listCourses);
 %
-<h2><%= maketext('Rename Course') %></h2>
+<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
 %
 % my @courseIDs = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
 %

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
@@ -1,4 +1,4 @@
-<h2><%= maketext('Unarchive Course') %></h2>
+<h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<div class="row mb-2">
 		<%= label_for new_courseID => maketext('Unarchive [_1] to course:', $unarchive_courseID),

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -1,6 +1,6 @@
 % use WeBWorK::Utils::CourseManagement qw(listArchivedCourses);
 %
-<h2><%= maketext('Unarchive Course') %></h2>
+<h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
 <p>
 	<%= maketext(
 		'Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, the course database is '

--- a/templates/ContentGenerator/CourseAdmin/upgrade_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/upgrade_course_confirm.html.ep
@@ -1,3 +1,4 @@
+<h2><%= maketext('Upgrade Courses') %> <%= $c->helpMacro('AdminUpgradeCourses') %></h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<% my $checkALLs = begin =%>
 		% if ($extra_database_tables_exist) {

--- a/templates/ContentGenerator/CourseAdmin/upgrade_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/upgrade_course_form.html.ep
@@ -4,7 +4,7 @@
 %
 % my @courseIDs = sort { lc($a) cmp lc($b) } listCourses($ce);
 %
-<h2><%= maketext('Upgrade Courses') %></h2>
+<h2><%= maketext('Upgrade Courses') %> <%= $c->helpMacro('AdminUpgradeCourses') %></h2>
 <div class="mb-2"><%= maketext('Update the checked directories?') %></div>
 <%= form_for current_route, method => 'POST', id => 'courselist', name => 'courselist', begin =%>
 	<div class="mb-2">

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -1,0 +1,37 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Add Course Help');
+%
+<p>
+	<%= maketext('Create a new course.  The "Course ID" is used as the course name and is used in course links.  '
+		. 'Underscores appear as spaces when displaying the course name.  The "Course Title" is used as the title '
+		. 'on the course home page.') =%>
+</p>
+<p>
+	<%= maketext('The WeBWorK administrators need to be added to the course in order for them to access the course.  '
+		. 'Unchecking this option will make it so WeBWorK administrators cannot directly login to the course.') =%>
+</p>
+<p>
+	<%= maketext('The simple configuration file is the name of the configuration file created when using the "Course '
+		. 'Configuration" page to configure course options.  This option sets if this configuration file is copied '
+		. 'from the old course or not and instead use the server defaults.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('Enter the details of the course instructor to be added when the course is created.  This user '
+		. 'will also be added to the admin course with the username "userID_courseID" so you can manage and '
+		. 'email the instructors of the courses on the server.') =%>
+</p>

--- a/templates/HelpFiles/AdminArchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminArchiveCourse.html.ep
@@ -1,0 +1,23 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Archive Course Help');
+%
+<p class="mb-0">
+	<%= maketext('Select a course to create a .tar.gz archive of, which contains a dump of the database and all '
+		. 'course files (templates, configuration files, etc).  Each course can only have a single archive.  '
+		. 'Creating an archive of a previously archived course will delete the old archive.') =%>
+</p>

--- a/templates/HelpFiles/AdminDeleteCourse.html.ep
+++ b/templates/HelpFiles/AdminDeleteCourse.html.ep
@@ -1,0 +1,22 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Delete Course Help');
+%
+<p class="mb-0">
+	<%= maketext('Select a course to delete.  Warning, all data will be deleted and this cannot be undone.  '
+		. 'This will not delete any course archives.') =%>
+</p>

--- a/templates/HelpFiles/AdminHideCourses.html.ep
+++ b/templates/HelpFiles/AdminHideCourses.html.ep
@@ -1,0 +1,25 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Hide Course Help');
+%
+<p class="mb-0">
+	<%= maketext('Select the course(s) you want to hide (or unhide) and then click "Hide Courses" (or "Unhide '
+		. 'Courses"). Hiding a course that is already hidden does no harm (the action is skipped). Likewise unhiding '
+		. 'a course that is already visible does no harm (the action is skipped). Hidden courses are still active '
+		. 'but are not listed in the list of WeBWorK courses on the opening page. To access the course, an '
+		. 'instructor or student must know the full URL address for the course.') =%>
+</p>

--- a/templates/HelpFiles/AdminManageLocations.html.ep
+++ b/templates/HelpFiles/AdminManageLocations.html.ep
@@ -1,0 +1,34 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Manage Locations Help');
+%
+<p>
+	<%= maketext('Fill out the form below to add, edit, or delete locations.  Locations are used to restrict access '
+		. 'to sets based on ip address.  Locations are configured here in the administration course, then used in a '
+		. 'normal course.  When configuring a set to use a restricted ip address, the instructor can choose to '
+		. 'either restrict access to the location or deny access from a location, which are identified by their '
+		. 'name.  Instructors can select multiple locations to restrict access to.') =%>
+</p>
+<p>
+	<%= maketext('Locations are a list of ip addresses.  Ip addresses can be a single address (e.g. 192.168.1.101), '
+		. 'a range of ip address (e.g. 192.168.1.101-192.168.1.150), or an ip address mask (e.g. 192.168.1.0/24). '
+		. 'Enter one ip address per line, using as many lines as needed for each location.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('Locations are edited by adding new ip addresses to the location, or deleting existing address.  '
+		. 'You must select the confirm checkbox when deleting a location, and this cannot be undone.') =%>
+</p>

--- a/templates/HelpFiles/AdminRenameCourse.html.ep
+++ b/templates/HelpFiles/AdminRenameCourse.html.ep
@@ -1,0 +1,23 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Rename Course Help');
+%
+<p class="mb-0">
+	<%= maketext('Select the course to change its Course ID, Course Title, or Institution.  Note that changing a '
+		. q{course's ID will change the URL of all links to the course, and could break links from external sites }
+		. 'such as an LMS.') =%>
+</p>

--- a/templates/HelpFiles/AdminUnarchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminUnarchiveCourse.html.ep
@@ -1,0 +1,24 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Unarchive Course Help');
+%
+<p class="mb-0">
+	<%= maketext('Select an archive to restore.  You cannot restore an archive into an existing course. '
+		. 'Instead, either rename or delete the old course, or restore the archive with a new name.  When '
+		. 'restoring a course with a new name, the name is used as the course ID, and must contain only '
+		. 'letters, numbers, hyphens, and underscores, and may have at most 40 characters.') =%>
+</p>

--- a/templates/HelpFiles/AdminUpgradeCourses.html.ep
+++ b/templates/HelpFiles/AdminUpgradeCourses.html.ep
@@ -1,0 +1,24 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Upgrade Courses Help');
+%
+<p class="mb-0">
+	<%= maketext('Select which courses to upgrade from a previous version of WeBWorK.  The upgrade process can add '
+		. 'missing database columns, delete unused database columns, and check the course file structure.  Be sure '
+		. 'to read over the changes before confirming the upgrade.  You may want to create an archive of the course '
+		. 'before upgrading.  Only courses that need upgraded will be selectable.') =%>
+</p>

--- a/templates/HelpFiles/admin_links.html.ep
+++ b/templates/HelpFiles/admin_links.html.ep
@@ -1,0 +1,55 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Course Administration Help');
+%
+<%== maketext('Click the icon [_1] for page and item specific help.',
+	'<a href="#"><i class="fas fa-question-circle"></i></a>') =%>
+<hr>
+<p>
+	<%= maketext('This is the administration course which is used to manage courses on this server.  Use the '
+		. '"Admin Menu" to select the desired action.') =%>
+</p>
+
+<dl>
+	<dt><%= maketext('Add Course') %></dt>
+	<dd><%= maketext('Create a new course on this server.') =%></dd>
+	<dt><%= maketext('Rename Course') %></dt>
+	<dd><%= maketext(q{Change a course's ID, Title, or Institution.}) =%></dd>
+	<dt><%= maketext('Delete Course') %></dt>
+	<dd><%= maketext('Delete a course and all associated data.') =%></dd>
+	<dt><%= maketext('Archive Course') %></dt>
+	<dd><%= maketext(q{Create a .tar.gz archive which includes the course's database and all course files.}) =%></dd>
+	<dt><%= maketext('Unarchive Course') %></dt>
+	<dd><%= maketext(q{Restore a .tar.gz archive.}) =%></dd>
+	<dt><%= maketext('Upgrade Courses') %></dt>
+	<dd><%= maketext('Upgrade courses from a previous version of WeBWorK.') =%></dd>
+	<dt><%= maketext('Manage Locations') %></dt>
+	<dd><%= maketext('Configure ip ranges (locations) that can used to restrict set access.') =%></dd>
+	<dt><%= maketext('Hide Courses') %></dt>
+	<dd><%= maketext('Configure which course links appear on the main "Courses" page.') =%></dd>
+	<dt><%= maketext('User Settings') %></dt>
+	<dd><%= maketext('Use this page to change your password.') =%></dd>
+	<dt><%= maketext('Classlist Editor') %></dt>
+	<dd>
+		<%= maketext('Manage instructors.  When instructors are added to a newly created course, they are also '
+			. 'added to the admin course with username "userID_courseID".') =%>
+	</dd>
+	<dt><%= maketext('Email') %></dt>
+	<dd><%= maketext('Send emails to selected instructors.') %></dd>
+	<dt><%= maketext('File Manager') %></dt>
+	<dd><%= maketext('Manage administration course files.') %></dd>
+</dl>


### PR DESCRIPTION
This adds some help popups to the admin page as suggested in #2009. This is also built on top of #2009 so needs to be merged after.

This only adds short help items to the admin pages as there is already a lot of info on each page and I couldn't think of what else might be needed in some of the help pages.  I also noticed that some of the info on the page might be outdated (talks about mysql in archiving courses, is this still needed?)

Anyways, I think there is some more cleanup that could be done, but here is a start by adding some help popups as suggested.  If anyone wants to help add more to the help or think it is worth cleaning up the text on some of the pages, please make a PR against my branch.