### PR TITLE
Fix a pluralization translation issue.

### DIFF
--- a/templates/ContentGenerator/Problem/messages.html.ep
+++ b/templates/ContentGenerator/Problem/messages.html.ep
@@ -28,12 +28,12 @@
 	<p>
 		<b><%= maketext('Note') %>:</b>
 		<i>
-			<%= maketext(
-				$showHintsAfter == -1
-				? 'The hint shown is an instructor preview and will not be shown to students.'
-				: 'The hint shown is an instructor preview and will be shown to students after '
-					. "$showHintsAfter attempts."
-			) =%>
+			<%= $showHintsAfter == -1
+				? maketext('The hint shown is an instructor preview and will not be shown to students.')
+				: maketext(
+					'The hint shown is an instructor preview and will be shown to students after [quant,_1,attempt].',
+					$showHintsAfter
+				) =%>
 		</i>
 	</p>
 % }


### PR DESCRIPTION
The hints message is not correctly pluralized.  If you have `showHintsAfter` set to 1, then you get the message "The hint shown is an instructor preview and will be shown to students after 1 attempts.".  Furthermore the maketext usage was incorrect, and the current code would fail to translate in any case.