### PR TITLE
Fix for file manager directory dropdown menu.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -581,6 +581,7 @@ sub directoryMenu ($c, $dir) {
 		push(@values, [ $dir => $pwd ]);
 	}
 	push(@values, [ $c->{courseName} => '.' ]);
+	$c->param('directory', $values[0][0]);
 	return \@values;
 }
 


### PR DESCRIPTION
When opening a new directory with the file manager, update the directory drop down menu to ensure the current directory is selected.