### PR TITLE
Update the masthead layout.

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -58,11 +58,12 @@ $masthead-height: 70px !default;
 $layout-divider-color: #aaa !default;
 
 /* Banner */
-#masthead {
+.masthead {
 	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
+	display: flex;
 	height: $masthead-height;
 	background-color: var(--bs-primary, #038);
 	border-bottom: 1px solid $layout-divider-color;
@@ -72,6 +73,7 @@ $layout-divider-color: #aaa !default;
 
 	@media only screen and (max-width: 768px) {
 		position: static;
+		flex-direction: column;
 		height: unset;
 	}
 
@@ -83,13 +85,14 @@ $layout-divider-color: #aaa !default;
 		}
 	}
 
-	.webwork_logo {
+	.webwork-logo {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		padding: 5px 0;
 		background-color: var(--ww-logo-background-color, #104aad);
 		z-index: 20;
+		width: 20%;
 
 		img {
 			max-height: $masthead-height - 15px;
@@ -99,6 +102,7 @@ $layout-divider-color: #aaa !default;
 		@media only screen and (max-width: 768px) {
 			height: 0.75 * $masthead-height;
 			position: fixed;
+			width: 100%;
 
 			img {
 				max-height: 0.75 * $masthead-height - 11px;
@@ -111,8 +115,9 @@ $layout-divider-color: #aaa !default;
 		}
 	}
 
-	.institution_logo {
+	.institution-logo {
 		display: flex;
+		flex-grow: 1;
 		align-items: center;
 		padding: 8px 0;
 		max-height: $masthead-height - 1px;
@@ -133,7 +138,8 @@ $layout-divider-color: #aaa !default;
 		}
 	}
 
-	#login-status {
+	.login-status {
+		flex-shrink: 1;
 		height: $masthead-height - 1px;
 		padding: 4px 10px 4px 0;
 		color: var(--ww-primary-foreground-color, white);

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -65,8 +65,8 @@
 	class => 'visually-hidden-focusable bg-white p-2 m-3 position-absolute' =%>
 %
 % # Header
-<div id="masthead" class="row" role="banner">
-	<div class="col-md-3 col-lg-2 webwork_logo">
+<div class="masthead" role="banner">
+	<div class="webwork-logo">
 		% if ($c->can('links') || $c->can('siblings') || $c->can('options')) {
 			<button type="button" class="navbar-toggler ms-3 me-2 p-0 fa-2x" id="toggle-sidebar"
 				aria-controls="site-navigation">
@@ -78,8 +78,8 @@
 		% }
 		<%= $c->webwork_logo %>
 	</div>
-	<div class="col-lg-6 col-md-5 institution_logo"><%= $c->institution_logo %></div>
-	<div id="login-status" class="col-md-4"><%= include 'ContentGenerator/Base/login_status' %></div>
+	<div class="institution-logo"><%= $c->institution_logo %></div>
+	<div class="login-status"><%= include 'ContentGenerator/Base/login_status' %></div>
 </div>
 % # Navigation
 % if ($c->can('links') || $c->can('siblings') || $c->can('options')) {


### PR DESCRIPTION
This removes the masthead from bootstrap's grid layout, and instead used display flex.  The div containing the webwork logo and sidebar menu button has a width of 20%, the same as the sidebar.  The institution logo is allowed to take up any space left from the login status to the right.

Since the sidebar and this div have the same width, the sidebar no longer overlaps with the institution logo part of the masthead giving a better appearance with the new coloring of the "MAIN MENU" navbar brand.

Note that on narrow screens there should be no difference from before.