### PR TITLE
Archived course location

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1260,7 +1260,7 @@ sub do_unarchive_course ($c) {
 	unarchiveCourse(
 		newCourseID => $new_courseID,
 		oldCourseID => $unarchive_courseID =~ s/\.tar\.gz$//r,
-		archivePath => "$ce->{webworkDirs}{courses}/$unarchive_courseID",
+		archivePath => "$ce->{webworkDirs}{courses}/admin/archives/$unarchive_courseID",
 		ce          => $ce,
 	);
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -103,9 +103,9 @@ sub downloadFile ($c, $filename, $directory = '') {
 
 # First time through
 sub Init ($c) {
-	$c->param('unpack',     1);
-	$c->param('autodelete', 1);
-	$c->param('format',     'Automatic');
+	$c->param('unpack',     1)           unless defined($c->param('unpack'));
+	$c->param('autodelete', 1)           unless defined($c->param('autodelete'));
+	$c->param('format',     'Automatic') unless defined($c->param('format'));
 	return $c->Refresh;
 }
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -52,7 +52,7 @@ sub pre_header_initialize ($c) {
 
 	$c->downloadFile($c->param('download')) if defined $c->param('download');
 
-	if ($c->param('archiveCourse')) {
+	if ($action && ($action eq 'Archive Course' || $action eq $c->maketext('Archive Course'))) {
 		my $ce       = $c->ce;
 		my $courseID = $c->stash('courseID');
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -132,7 +132,8 @@ Lists the courses which have been archived (end in .tar.gz).
 
 sub listArchivedCourses {
 	my ($ce) = @_;
-	my $coursesDir = "$ce->{webworkDirs}->{courses}/admin/archives";
+	my $coursesDir = "$ce->{webworkDirs}{courses}/admin/archives";
+	surePathToFile($ce->{webworkDirs}{courses}, "$coursesDir/test");    # Ensure archives directory exists.
 	return grep {m/\.tar\.gz$/} readDirectory($coursesDir);
 }
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -767,6 +767,7 @@ sub archiveCourse {
 		$archive_path = $options{archive_path};
 	} else {
 		$archive_path = "$ce->{webworkDirs}{courses}/admin/archives/$courseID.tar.gz";
+		surePathToFile($ce->{webworkDirs}{courses}, $archive_path);
 	}
 
 	# fail if the source course does not exist
@@ -823,8 +824,6 @@ sub archiveCourse {
 	##### step 3: cleanup -- remove database dump files from course directory #####
 
 	unless (-e $archive_path) {
-		# Make sure any missing directories are creates.
-		surePathToFile($ce->{webworkDirs}{courses}, $archive_path);
 		unless (move($tmp_archive_path, $archive_path)) {
 			unlink($tmp_archive_path);    #clean up
 			croak "Failed to rename archived file to '$archive_path': $!";

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -37,7 +37,7 @@ use File::Spec;
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(runtime_use readDirectory pretty_print_rh surePathToFile);
+use WeBWorK::Utils qw(runtime_use readDirectory surePathToFile);
 
 our @EXPORT_OK = qw(
 	listCourses

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -132,9 +132,9 @@ Lists the courses which have been archived (end in .tar.gz).
 
 sub listArchivedCourses {
 	my ($ce) = @_;
-	my $coursesDir = "$ce->{webworkDirs}{courses}/admin/archives";
-	surePathToFile($ce->{webworkDirs}{courses}, "$coursesDir/test");    # Ensure archives directory exists.
-	return grep {m/\.tar\.gz$/} readDirectory($coursesDir);
+	my $archivesDir = "$ce->{webworkDirs}{courses}/admin/archives";
+	surePathToFile($ce->{webworkDirs}{courses}, "$archivesDir/test");    # Ensure archives directory exists.
+	return grep {m/\.tar\.gz$/} readDirectory($archivesDir);
 }
 
 ################################################################################

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -42,7 +42,12 @@
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
+	<li class="list-group-item list-group-item-primary nav-item">
+		<%= $makelink->(
+			'instructor_file_manager',
+			systemlink_params => { pwd => '.', unpack => 0, autodelete => 0 }
+		) %>
+	</li>
 	<li class="list-group-item list-group-item-primary nav-item">
 		<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
 	</li>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -264,21 +264,6 @@
 				<%= $c->helpMacro('instructor_links',
 					{ label => maketext('Help'), class => 'nav-link' }) %>
 			</li>
-			% # Show the archive course link only on the FileManager page
-			% if (
-				% $authz->hasPermissions($userID, 'manage_course_files')
-				% && current_route eq 'instructor_file_manager'
-			% )
-			% {
-				<li class="list-group-item nav-item">
-					<%= $makelink->(
-						'instructor_file_manager',
-						text              => maketext('Archive this Course'),
-						systemlink_params => { archiveCourse => 1 },
-						active            => 0
-					) %>
-				</li>
-			% }
 		% }
 		%
 		% if (exists $ce->{webworkURLs}{bugReporter}

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -59,6 +59,12 @@
 	</ol>
 	%
 	<h2><%= maketext('Archived Courses') =%></h2>
+	<p>
+		<%= link_to maketext('Download/upload archived courses') => $c->systemLink(
+			url_for('instructor_file_manager'),
+			params => { pwd => 'archives' },
+		) =%>
+	</p>
 	<ol>
 		% for (sort { lc($a) cmp lc($b) } listArchivedCourses($ce)) {
 			<li><%= $_ %></li>

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -62,7 +62,7 @@
 	<p>
 		<%= link_to maketext('Download/upload archived courses') => $c->systemLink(
 			url_for('instructor_file_manager'),
-			params => { pwd => 'archives' },
+			params => { pwd => 'archives', unpack => 0, autodelete => 0 },
 		) =%>
 	</p>
 	<ol>

--- a/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
@@ -70,7 +70,7 @@
 	% if ($all_tables_ok && $directories_ok) {
 		% # No missing tables, missing fields, or directories
 		% # Warn about overwriting an existing archive
-		% my $archive_path = "$ce2->{webworkDirs}{courses}/$archive_courseID.tar.gz";
+		% my $archive_path = "$ce2->{webworkDirs}{courses}/admin/archives/$archive_courseID.tar.gz";
 		% if (-e $archive_path && -w $archive_path) {
 			<p class="text-danger fw-bold">
 				<%= maketext(

--- a/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
@@ -1,12 +1,4 @@
 <h2><%= maketext('Archive Course') %> <%= $c->helpMacro('AdminArchiveCourse') %></h2>
-<p>
-	<%= maketext(
-		'Creates a gzipped tar archive (.tar.gz) of a course in the WeBWorK courses directory. '
-			. 'Before archiving, the course database is dumped into a subdirectory of the course\'s DATA directory. '
-			. 'Currently the archive facility is only available for mysql databases. It depends on the mysqldump '
-			. 'application.'
-	) =%>
-</p>
 %
 % if (@$courseIDs) {
 	<p>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -1,13 +1,6 @@
 % use WeBWorK::Utils::CourseManagement qw(listArchivedCourses);
 %
 <h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
-<p>
-	<%= maketext(
-		'Restores a course from a gzipped tar archive (.tar.gz). After unarchiving, the course database is '
-			. "restored from a subdirectory of the course's DATA directory. Currently the archive facility is only "
-			. 'available for mysql databases. It depends on the mysqldump application.'
-	) =%>
-</p>
 %
 % # Find courses which have been archived.
 % my @courseIDs = sort { lc($a) cmp lc($b) } listArchivedCourses($ce);

--- a/templates/ContentGenerator/Instructor/FileManager.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager.html.ep
@@ -43,6 +43,7 @@
 		% "\\"                => 'ParentDir',
 		% x('Make Archive')   => 'MakeArchive',
 		% x('Unpack Archive') => 'UnpackArchive',
+		% x('Archive Course') => 'Refresh',
 	% );
 	%
 	% # Add translated action names to the method map.

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -47,7 +47,9 @@
 					unarchive_text => maketext('Unpack Archive')
 				},
 				%button =%>
-			<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
+			% unless ($c->{courseName} eq 'admin') {
+				<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
+			% }
 			<div style="height: 10px"></div>
 			<%= submit_button maketext('New File'), id => 'NewFile', %button =%>
 			<%= submit_button maketext('New Folder'), id => 'NewFolder', %button =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -47,6 +47,7 @@
 					unarchive_text => maketext('Unpack Archive')
 				},
 				%button =%>
+			<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
 			<div style="height: 10px"></div>
 			<%= submit_button maketext('New File'), id => 'NewFile', %button =%>
 			<%= submit_button maketext('New Folder'), id => 'NewFolder', %button =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -109,13 +109,13 @@
 		<div class="input-group input-group-sm">
 			<div class="input-group-text">
 				<label class="form-check-label">
-					<%= check_box unpack => 1, checked => undef, class => 'form-check-input me-2' =%>
+					<%= check_box unpack => 1, class => 'form-check-input me-2' =%>
 					<%= maketext('Unpack archives automatically') =%>
 				</label>
 			</div>
 			<div class="input-group-text flex-grow-1">
 				<label class="form-check-label">
-					<%= check_box autodelete => 1, checked => undef, class => 'form-check-input me-2' =%>
+					<%= check_box autodelete => 1, class => 'form-check-input me-2' =%>
 					<%= maketext('then delete them') =%>
 				</label>
 			</div>

--- a/templates/HelpFiles/AdminArchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminArchiveCourse.html.ep
@@ -23,6 +23,5 @@
 </p>
 <p class="mb-0">
 	<%= maketext('Archived courses are located inside the "archives" directory of the "admin" course.  Use the '
-		. '"File Manager" to access the .tar.gz files.  The "archives" directory is found by first going up one '
-		. 'level to the "admin" course root directory.') =%>
+		. '"File Manager" to access the .tar.gz files.') =%>
 </p>

--- a/templates/HelpFiles/AdminArchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminArchiveCourse.html.ep
@@ -16,8 +16,13 @@
 % layout 'help_macro';
 % title maketext('Archive Course Help');
 %
-<p class="mb-0">
+<p>
 	<%= maketext('Select a course to create a .tar.gz archive of, which contains a dump of the database and all '
 		. 'course files (templates, configuration files, etc).  Each course can only have a single archive.  '
 		. 'Creating an archive of a previously archived course will delete the old archive.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('Archived courses are located inside the "archives" directory of the "admin" course.  Use the '
+		. '"File Manager" to access the .tar.gz files.  The "archives" directory is found by first going up one '
+		. 'level to the "admin" course root directory.') =%>
 </p>

--- a/templates/HelpFiles/AdminUnarchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminUnarchiveCourse.html.ep
@@ -24,6 +24,5 @@
 </p>
 <p class="mb-0">
 	<%= maketext('Archived courses are located inside the "archives" directory of the "admin" course.  Use '
-		. 'the "File Manager" to upload additional .tar.gz files to be unarchived.  The "archives" directory '
-		. 'is found by first going up one level to the "admin" course root directory.') =%>
+		. 'the "File Manager" to upload additional .tar.gz files to be unarchived.') =%>
 </p>

--- a/templates/HelpFiles/AdminUnarchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminUnarchiveCourse.html.ep
@@ -16,9 +16,14 @@
 % layout 'help_macro';
 % title maketext('Unarchive Course Help');
 %
-<p class="mb-0">
+<p>
 	<%= maketext('Select an archive to restore.  You cannot restore an archive into an existing course. '
 		. 'Instead, either rename or delete the old course, or restore the archive with a new name.  When '
 		. 'restoring a course with a new name, the name is used as the course ID, and must contain only '
 		. 'letters, numbers, hyphens, and underscores, and may have at most 40 characters.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('Archived courses are located inside the "archives" directory of the "admin" course.  Use '
+		. 'the "File Manager" to upload additional .tar.gz files to be unarchived.  The "archives" directory '
+		. 'is found by first going up one level to the "admin" course root directory.') =%>
 </p>


### PR DESCRIPTION
Moves the archived courses into the admin course's `archives` directory so they can be accessed via the file manager.   Adds a direct link to the `archives` directory above the archived courses list in the main admin course page.  Adds help statements stating where the archives are located.  Removes some old text describing the internals of the archive process which isn't needed.  Moves the `Archive This Course` link from the instructor menu to a button inside the file manager.

I was considering also looking in the old location when listing archives and when unarchive archives, use the old location if the course doesn't exist in the new location to make it so old archives are still shown, just not accessible via the file manager.  I have left that off for now, part of the upgrade process should include moving the old archive files. Just mentioning the thought if others think it is worth pursing.