### PR TITLE
Show a message if invalid characters are used when creating a set instead of dying.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -478,7 +478,7 @@ sub create_handler ($c) {
 		class => 'alert alert-danger p-1 mb-0',
 		$c->maketext(
 			'Failed to create new set: Invalid characters in set name "[_1]". '
-				. 'A set name may only contain letters, numbers, hyphens, and spaces.',
+				. 'A set name may only contain letters, numbers, hyphens, periods, and spaces.',
 			$newSetID =~ s/_/ /gr
 		)
 	) unless $newSetID =~ m/^[-a-zA-Z0-9_.]*$/;

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -466,21 +466,30 @@ sub create_handler ($c) {
 	return $c->tag(
 		'div',
 		class => 'alert alert-danger p-1 mb-0',
-		$c->maketext("Failed to create new set: set name cannot exceed 100 characters.")
+		$c->maketext("Failed to create new set: Set name cannot exceed 100 characters.")
 	) if (length($newSetID) > 100);
 	return $c->tag(
 		'div',
 		class => 'alert alert-danger p-1 mb-0',
-		$c->maketext("Failed to create new set: no set name specified!")
+		$c->maketext("Failed to create new set: No set name specified.")
 	) unless $newSetID =~ /\S/;
 	return $c->tag(
 		'div',
 		class => 'alert alert-danger p-1 mb-0',
 		$c->maketext(
-			"The set name '[_1]' is already in use.  Pick a different name if you would like to start a new set.",
-			$newSetID)
-			. " "
-			. $c->maketext("No set created.")
+			'Failed to create new set: Invalid characters in set name "[_1]". '
+				. 'A set name may only contain letters, numbers, hyphens, and spaces.',
+			$newSetID =~ s/_/ /gr
+		)
+	) unless $newSetID =~ m/^[-a-zA-Z0-9_.]*$/;
+	return $c->tag(
+		'div',
+		class => 'alert alert-danger p-1 mb-0',
+		$c->maketext(
+			'The set name "[_1]" is already in use. Pick a different name if you would like to start a new set. '
+				. 'No set created.',
+			$newSetID
+		)
 	) if $db->existsGlobalSet($newSetID);
 
 	my $newSetRecord = $db->newGlobalSet;


### PR DESCRIPTION
A faculty member at my institution just tried to create a set with a colon in the name.  This resulted in an error.  Since I have the MIN_HTML_ERRORS option turned on, all she got was "An error occured while processing your request" with the error record identifier and time.  This should not happen.  Instead this checks for invalid characters before trying to craete the set and shows a message in that case.

This has probably been this way for a long time.  I tested on 2.17, and got the same error.

I also made the messages in this area a bit more consistent in terms of punctuation and capitalization.