### PR TITLE
Admin nav tweaks

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -192,8 +192,9 @@ $layout-divider-color: #aaa !default;
 		padding: 0.5rem 0 0.25rem 1rem;
 		color: black;
 		font-weight: bold;
-		font-size: 0.9rem;
+		font-size: 1.3rem;
 		background-color: var(--bs-primary, #038);
+		opacity: 0.85;
 		color: var(--ww-primary-foreground-color, white);
 	}
 

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,8 +1,5 @@
 <h2 class="navbar-brand mb-0"><%= maketext('Admin Menu') %></h2>
 <ul class="nav flex-column">
-	<li class="list-group-item list-group-item-primary nav-item">
-		<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
-	</li>
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
 	<li class="list-group-item nav-item">
 		<%= $makelink->(

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -7,14 +7,14 @@
 	<li class="list-group-item nav-item">
 		<%= $makelink->(
 			'set_list',
-			text   => maketext('Course Administration'),
+			text   => maketext('Course Listings'),
 			active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
 		) %>
 	</li>
 	% for (
 		% [
 		% 	'add_course',
-		% 	maketext('Add Course'),
+		% 	maketext('Add Courses'),
 		% 	{
 		% 		add_admin_users      => 1,
 		% 		add_config_file      => 1,
@@ -22,13 +22,13 @@
 		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
 		% 	}
 		% ],
-		% [ 'rename_course',        maketext('Rename Course') ],
-		% [ 'delete_course',        maketext('Delete Course') ],
-		% [ 'archive_course',       maketext('Archive Course') ],
-		% [ 'unarchive_course',     maketext('Unarchive Course') ],
+		% [ 'rename_course',        maketext('Rename Courses') ],
+		% [ 'delete_course',        maketext('Delete Courses') ],
+		% [ 'archive_course',       maketext('Archive Courses') ],
+		% [ 'unarchive_course',     maketext('Unarchive Courses') ],
 		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
-		% [ 'manage_locations',     maketext('Manage Locations') ],
 		% [ 'hide_inactive_course', maketext('Hide Courses') ],
+		% [ 'manage_locations',     maketext('Manage Locations') ],
 	% )
 	% {
 		<li class="list-group-item nav-item">

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -3,7 +3,8 @@
 	<li class="list-group-item list-group-item-primary nav-item">
 		<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
 	</li>
-	<li class="list-group-item list-group-item-primary nav-item">
+	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
+	<li class="list-group-item nav-item">
 		<%= $makelink->(
 			'set_list',
 			text   => maketext('Course Administration'),
@@ -30,7 +31,7 @@
 		% [ 'hide_inactive_course', maketext('Hide Courses') ],
 	% )
 	% {
-		<li class="list-group-item list-group-item-primary nav-item">
+		<li class="list-group-item nav-item">
 			<%= $makelink->(
 				'set_list',
 				text              => $_->[1],
@@ -39,14 +40,13 @@
 			) %>
 		</li>
 	% }
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_user_list') %></li>
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_mail_merge') %></li>
-	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('instructor_file_manager') %></li>
-	<li class="list-group-item list-group-item-primary nav-item">
+	<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
+	<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+	<li class="list-group-item nav-item"><%= $makelink->('instructor_file_manager') %></li>
+	<li class="list-group-item nav-item">
 		<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
 	</li>
-	<li class="list-group-item list-group-item-primary nav-item">
+	<li class="list-group-item nav-item">
 		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
 	</li>
 </ul>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -6,11 +6,6 @@
 % }
 <h2 class="navbar-brand mb-0"><%= maketext('Main Menu') %></h2>
 <ul class="nav flex-column">
-	% unless ($restricted_navigation) {
-		<li class="list-group-item list-group-item-primary nav-item">
-			<%= link_to maketext('Courses') => 'root', class => 'nav-link' %>
-		</li>
-	% }
 	% if (defined $courseID && $authen->was_verified) {
 		% # Homework Sets or Course Administration
 		<li class="list-group-item list-group-item-primary nav-item">

--- a/templates/HelpFiles/admin_links.html.ep
+++ b/templates/HelpFiles/admin_links.html.ep
@@ -25,6 +25,10 @@
 </p>
 
 <dl>
+	<dt><%= maketext('User Settings') %></dt>
+	<dd><%= maketext('Use this page to change your password.') =%></dd>
+	<dt><%= maketext('Course Listings') %></dt>
+	<dd><%= maketext('View/access current and archived courses.') =%></dd>
 	<dt><%= maketext('Add Course') %></dt>
 	<dd><%= maketext('Create a new course on this server.') =%></dd>
 	<dt><%= maketext('Rename Course') %></dt>
@@ -37,12 +41,10 @@
 	<dd><%= maketext(q{Restore a .tar.gz archive.}) =%></dd>
 	<dt><%= maketext('Upgrade Courses') %></dt>
 	<dd><%= maketext('Upgrade courses from a previous version of WeBWorK.') =%></dd>
-	<dt><%= maketext('Manage Locations') %></dt>
-	<dd><%= maketext('Configure ip ranges (locations) that can used to restrict set access.') =%></dd>
 	<dt><%= maketext('Hide Courses') %></dt>
-	<dd><%= maketext('Configure which course links appear on the main "Courses" page.') =%></dd>
-	<dt><%= maketext('User Settings') %></dt>
-	<dd><%= maketext('Use this page to change your password.') =%></dd>
+	<dd><%= maketext('Configure which course links appear on the site landing page.') =%></dd>
+	<dt><%= maketext('Manage Locations') %></dt>
+	<dd><%= maketext('Configure ip ranges (locations) that can be used to restrict set access.') =%></dd>
 	<dt><%= maketext('Classlist Editor') %></dt>
 	<dd>
 		<%= maketext('Manage instructors.  When instructors are added to a newly created course, they are also '


### PR DESCRIPTION
The commit messages describe what this does.

For removing 'Courses', I grew the size of "MAIN MENU" to 1.3 rem and brough back the opacity setting, but at 0.85. It gets AAA contrast rating this way, even in green. And for me at least it is visually clear that "MAIN MENU" is separate from the first item. But it may need more tweaking.

<img width="1369" alt="Screen Shot 2023-06-02 at 10 47 27 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/a830ae41-60a7-439e-8b09-301d3e2304b6">

<img width="1369" alt="Screen Shot 2023-06-02 at 10 48 36 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/87f4cea4-75f0-4ea2-8e7a-34c60cb4f9cd">

Of course things will look a little different in combination with #2020, #2021, or #2022

BTW I tried a border line under MAIN MENU and to me it looked bad...