### PR TITLE
Admin menu perm check

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -770,8 +770,7 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 	modify_problem_template_files  => "professor",
 	manage_course_files            => "professor",
 	edit_achievements              => "professor",
-	create_and_delete_courses      => "professor",
-	fix_course_databases           => "professor",
+	create_and_delete_courses      => "admin",
 	modify_tags                    => "admin",
 	edit_restricted_files          => "admin",
 

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -260,6 +260,14 @@ sub hasPermissions {
 		if (defined $activity_role) {
 			if (exists $userRoles->{$activity_role}) {
 				my $role_permlevel = $userRoles->{$activity_role};
+				# Elevate all permissions greater than a student in the admin course to the
+				# create_and_delete_courses level.  This way a user either has access to all
+				# or only student level permissions tools in the admin course.
+				if (defined($ce->{courseName}) && $ce->{courseName} eq 'admin') {
+					my $admin_permlevel = $userRoles->{ $permissionLevels->{create_and_delete_courses} };
+					$role_permlevel = $admin_permlevel
+						if $role_permlevel > $userRoles->{student} && $role_permlevel < $admin_permlevel;
+				}
 				if (defined $role_permlevel) {
 					if ($exactness eq 'ge') {
 						return $permission_level >= $role_permlevel;

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,54 +1,55 @@
 <ul class="nav flex-column">
 	<li class="list-group-item list-group-item-primary nav-item"><%= $makelink->('options') %></li>
-	<li class="list-group-item nav-item">
-		<%= $makelink->(
-			'set_list',
-			text   => maketext('Course Listings'),
-			active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
-		) %>
-	</li>
-	% for (
-		% [
-		% 	'add_course',
-		% 	maketext('Add Courses'),
-		% 	{
-		% 		add_admin_users      => 1,
-		% 		add_config_file      => 1,
-		% 		add_dbLayout         => 'sql_single',
-		% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
-		% 	}
-		% ],
-		% [ 'rename_course',        maketext('Rename Courses') ],
-		% [ 'delete_course',        maketext('Delete Courses') ],
-		% [ 'archive_course',       maketext('Archive Courses') ],
-		% [ 'unarchive_course',     maketext('Unarchive Courses') ],
-		% [ 'upgrade_course',       maketext('Upgrade Courses') ],
-		% [ 'hide_inactive_course', maketext('Hide Courses') ],
-		% [ 'manage_locations',     maketext('Manage Locations') ],
-	% )
-	% {
+	% if ($authz->hasPermissions($userID, 'create_and_delete_courses')) {
 		<li class="list-group-item nav-item">
 			<%= $makelink->(
 				'set_list',
-				text              => $_->[1],
-				systemlink_params => { subDisplay => $_->[0], %{ $_->[2] // {} } },
-				active            => (param('subDisplay') // '') eq $_->[0],
+				text   => maketext('Course Listings'),
+				active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
 			) %>
 		</li>
+		% for (
+			% [
+			% 	'add_course',
+			% 	maketext('Add Courses'),
+			% 	{
+			% 		add_admin_users      => 1,
+			% 		add_config_file      => 1,
+			% 		add_dbLayout         => 'sql_single',
+			% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
+			% 	}
+			% ],
+			% [ 'rename_course',        maketext('Rename Courses') ],
+			% [ 'delete_course',        maketext('Delete Courses') ],
+			% [ 'archive_course',       maketext('Archive Courses') ],
+			% [ 'unarchive_course',     maketext('Unarchive Courses') ],
+			% [ 'upgrade_course',       maketext('Upgrade Courses') ],
+			% [ 'hide_inactive_course', maketext('Hide Courses') ],
+			% [ 'manage_locations',     maketext('Manage Locations') ],
+		% )
+		% {
+			<li class="list-group-item nav-item">
+				<%= $makelink->(
+					'set_list',
+					text              => $_->[1],
+					systemlink_params => { subDisplay => $_->[0], %{ $_->[2] // {} } },
+					active            => (param('subDisplay') // '') eq $_->[0],
+				) %>
+			</li>
+		% }
+		<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
+		<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+		<li class="list-group-item nav-item">
+			<%= $makelink->(
+				'instructor_file_manager',
+				systemlink_params => { pwd => '.', unpack => 0, autodelete => 0 }
+			) %>
+		</li>
+		<li class="list-group-item nav-item">
+			<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
+		</li>
+		<li class="list-group-item nav-item">
+			<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
+		</li>
 	% }
-	<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
-	<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
-	<li class="list-group-item nav-item">
-		<%= $makelink->(
-			'instructor_file_manager',
-			systemlink_params => { pwd => '.', unpack => 0, autodelete => 0 }
-		) %>
-	</li>
-	<li class="list-group-item nav-item"><%= $makelink->('instructor_file_manager') %></li>
-	<li class="list-group-item nav-item">
-		<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
-	</li>
-	<li class="list-group-item nav-item">
-		<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
-	</li>
 </ul>


### PR DESCRIPTION
This updates the `create_and_delete_courses` default permission to be `admin` and deletes an unused `fix_courses_database` permission (the upgrade tool just checks `create_and_delete_courses`).  I also don't show any of the admin or instructor tools in the admin menu unless the `create_and_delete_courses` menu is there.

This address the issue mentioned in https://github.com/openwebwork/webwork2/issues/2009#issuecomment-1573859258, though `professor` (and to some lesser extent `ta`) can still access the instructor tools if they type out the url in the admin course.  Probably still best to not have any users except students and admins in this course.  Another option is to setup a new permission hash for the admin course that will then lock professors out of the standard instructor tools too.

I have built this on top of #2027 which put the user settings as the top link instead of doing any modifications of the menu here.